### PR TITLE
For GCC 5/6 compiling arith128_test_i128.c (test_4b) with -g causes an ICE

### DIFF
--- a/src/testsuite/arith128_test_i128.c
+++ b/src/testsuite/arith128_test_i128.c
@@ -885,6 +885,20 @@ test_4b (void)
 #endif
   rc += check_vint256 ("vec_mul10ecuq:", l, k, (vui128_t) ec, (vui128_t) e);
 
+  return (rc);
+}
+
+
+/* Needed to split these tests into a separate function to avoid a ICE
+   in GCC 6.3 / AT10.  */
+int
+test_4b1 (void)
+{
+  vui32_t i, e, em, ec;
+  vui128_t j, k, l, m, n;
+  int ii;
+  int rc = 0;
+
   i = (vui32_t )CONST_VINT32_W(0x33333333, 0x33333333, 0x33333333, 0x33333333);
   j = (vui128_t) ((vui32_t )CONST_VINT32_W(0, 0, 0, 0));
   e = (vui32_t )

--- a/src/testsuite/arith128_test_i128.h
+++ b/src/testsuite/arith128_test_i128.h
@@ -39,6 +39,9 @@ extern int
 test_4b (void);
 
 extern int
+test_4b1 (void);
+
+extern int
 test_4c (void);
 
 extern int

--- a/src/testsuite/pveclib_test.c
+++ b/src/testsuite/pveclib_test.c
@@ -51,6 +51,7 @@ main (void)
 #if 1
   rc += test_4 ();
   rc += test_4b ();
+  rc += test_4b1 ();
 #endif
 #if 1
   rc += test_4c ();


### PR DESCRIPTION
As this only effects older GCC vertions (GCC 7 and later are OK),
and there are simple work arounds, the GCC maintainers do not think it
is worth fixing.

For now we should just split arith128_test_i128.c (test_4b) into two
smaller functions: test_4b and test_4b1. This requires updates to
arith128_test_i128.h (extern for test_4b1) and pveclib_test.c
(add call to test_4b1).

This avoids the ICE for GCC5 (AT9.0) and GCC6 (AT10.0).

	* src/testsuite/arith128_test_i128.c (test_4b): Split function
	into two smaller functions named test_4b and test_4b1.
	* src/testsuite/arith128_test_i128.h: Add test_4b1 extern.
	* src/testsuite/pveclib_test.c (main): Add call to test_4b1.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>