### PR TITLE
Fix slqi srqi revb feb18

### DIFF
--- a/src/testsuite/arith128_test_i128.c
+++ b/src/testsuite/arith128_test_i128.c
@@ -1643,3 +1643,1908 @@ test_43 (void)
 
   return (rc);
 }
+
+//#define __DEBUG_PRINT__ 1
+int
+test_44 (void)
+{
+  vui32_t i, e;
+  vui128_t k;
+  int rc = 0;
+
+  printf ("\ntest_44 Vector shift right quadword immediate\n");
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 0);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 0   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 0 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128 ("vec_srqi (  0):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 8);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 8   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 8 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00ffffff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128x ("vec_srqi (  8):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 16);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 16   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 16 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x0000ffff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128x ("vec_srqi ( 16):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 24);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 24   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 24 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x000000ff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128x ("vec_srqi ( 24):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 32);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 32   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 32 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128x ("vec_srqi ( 32):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 40);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 40   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 40 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, 0x00ffffff, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128x ("vec_srqi ( 40):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 48);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 48   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 48 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, 0x0000ffff, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128x ("vec_srqi ( 48):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 56);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 56   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 56 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, 0x000000ff, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128x ("vec_srqi ( 56):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 64);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 64   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 64 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, 0x00000000, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128x ("vec_srqi ( 64):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 72);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 72   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 72 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, 0x00000000, 0x00ffffff,
+			   __UINT32_MAX__);
+  rc += check_vuint128x ("vec_srqi ( 72):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 80);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 80   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 80 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, 0x00000000, 0x0000ffff,
+			   __UINT32_MAX__);
+  rc += check_vuint128x ("vec_srqi ( 80):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 88);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 88   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 88 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, 0x00000000, 0x000000ff,
+			   __UINT32_MAX__);
+  rc += check_vuint128x ("vec_srqi ( 88):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 96);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 96   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 96 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000,
+			   __UINT32_MAX__);
+  rc += check_vuint128x ("vec_srqi ( 96):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 104);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 104   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 104 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000,
+			   0x00ffffff);
+  rc += check_vuint128x ("vec_srqi (104):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 112);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 112   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 112 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000,
+			   0x0000ffff);
+  rc += check_vuint128x ("vec_srqi (112):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 120);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 120   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 120 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000,
+			   0x000000ff);
+  rc += check_vuint128x ("vec_srqi (120):", (vui128_t) k, (vui128_t) e);
+#if 1
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 128);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 128   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 128 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000,
+			   0x00000000);
+  rc += check_vuint128x ("vec_srqi (128):", (vui128_t) k, (vui128_t) e);
+#endif
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 1);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 1   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 1 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x7fffffff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128 ("vec_srqi (  1):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 2);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 2   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 2 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x3fffffff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128 ("vec_srqi (  2):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 3);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 3   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 3 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x1fffffff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128 ("vec_srqi (  3):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 4);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 4   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 4 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x0fffffff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128 ("vec_srqi (  4):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 5);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 5   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 5 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x07ffffff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128 ("vec_srqi (  5):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 6);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 6   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 6 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x03ffffff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128 ("vec_srqi (  6):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 7);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 7   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 7 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x01ffffff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128 ("vec_srqi (  7):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 9);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 9   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 9 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x007fffff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128 ("vec_srqi (  9):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 12);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 12   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 12 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x000fffff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128 ("vec_srqi ( 12):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 15);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 15   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 15 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x0001ffff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128 ("vec_srqi ( 15):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 17);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 17   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 17 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00007fff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128 ("vec_srqi ( 17):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 20);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 20   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 20 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000fff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128 ("vec_srqi ( 20):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 23);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 23   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 23 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x000001ff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128 ("vec_srqi ( 23):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 123);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 123   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 123 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000,
+			   0x0000001f);
+  rc += check_vuint128 ("vec_srqi (123):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 127);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 127   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 127 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000,
+			   0x00000001);
+  rc += check_vuint128 ("vec_srqi (127):", (vui128_t) k, (vui128_t) e);
+#if 1
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_srqi ((vui128_t) i, 129);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 >> 129   ", (vui128_t) i);
+  print_vint128x ("2E128-1 >> 129 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000,
+			   0x00000000);
+  rc += check_vuint128x ("vec_srqi (129):", (vui128_t) k, (vui128_t) e);
+#endif
+
+  return (rc);
+}
+
+//#define __DEBUG_PRINT__ 1
+int
+test_45 (void)
+{
+  vui32_t i, e;
+  vui128_t k;
+  int rc = 0;
+
+  printf ("\ntest_45 Vector shift left quadword immediate\n");
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 0);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 0   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 0 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128 ("vec_slqi (  0):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 8);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 8   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 8 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xffffff00);
+  rc += check_vuint128x ("vec_slqi (  8):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 16);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 16   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 16 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xffff0000);
+  rc += check_vuint128x ("vec_slqi ( 16):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 24);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 24   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 24 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xff000000);
+  rc += check_vuint128x ("vec_slqi ( 24):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 32);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 32   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 32 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0x00000000);
+  rc += check_vuint128x ("vec_slqi ( 32):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 40);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 40   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 40 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, 0xffffff00,
+			   0x00000000);
+  rc += check_vuint128x ("vec_slqi ( 40):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 48);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 48   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 48 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, 0xffff0000,
+			   0x00000000);
+  rc += check_vuint128x ("vec_slqi ( 48):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 56);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 56   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 56 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, 0xff000000,
+			   0x00000000);
+  rc += check_vuint128x ("vec_slqi ( 56):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 64);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 64   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 64 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, 0x00000000,
+			   0x00000000);
+  rc += check_vuint128x ("vec_slqi ( 64):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 72);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 72   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 72 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, 0xffffff00, 0x00000000,
+			   0x00000000);
+  rc += check_vuint128x ("vec_slqi ( 72):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 80);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 80   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 80 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, 0xffff0000, 0x00000000,
+			   0x00000000);
+  rc += check_vuint128x ("vec_slqi ( 80):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 88);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 88   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 88 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, 0xff000000, 0x00000000,
+			   0x00000000);
+  rc += check_vuint128x ("vec_slqi ( 88):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 96);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 96   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 96 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, 0x00000000, 0x00000000,
+			   0x00000000);
+  rc += check_vuint128x ("vec_slqi ( 96):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 104);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 104   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 104 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0xffffff00, 0x00000000, 0x00000000,
+			   0x00000000);
+  rc += check_vuint128x ("vec_slqi (104):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 112);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 112   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 112 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0xffff0000, 0x00000000, 0x00000000,
+			   0x00000000);
+  rc += check_vuint128x ("vec_slqi (112):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 120);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 120   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 120 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0xff000000, 0x00000000, 0x00000000,
+			   0x00000000);
+  rc += check_vuint128x ("vec_slqi (120):", (vui128_t) k, (vui128_t) e);
+#if 1
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 128);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 128   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 128 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000,
+			   0x00000000);
+  rc += check_vuint128x ("vec_slqi (128):", (vui128_t) k, (vui128_t) e);
+#endif
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 1);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 1   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 1 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xfffffffe);
+  rc += check_vuint128 ("vec_slqi (  1):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 2);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 2   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 2 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xfffffffc);
+  rc += check_vuint128 ("vec_slqi (  2):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 3);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 3   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 3 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xfffffff8);
+  rc += check_vuint128 ("vec_slqi (  3):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 4);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 4   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 4 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xfffffff0);
+  rc += check_vuint128 ("vec_slqi (  4):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 5);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 5   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 5 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xffffffe0);
+  rc += check_vuint128 ("vec_slqi (  5):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 6);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 6   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 6 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xffffffc0);
+  rc += check_vuint128 ("vec_slqi (  6):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 7);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 7   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 7 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xffffff80);
+  rc += check_vuint128 ("vec_slqi (  7):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 9);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 9   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 9 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xfffffe00);
+  rc += check_vuint128 ("vec_slqi (  9):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 12);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 12   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 12 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xfffff000);
+  rc += check_vuint128 ("vec_slqi ( 12):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 15);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 15   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 15 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xffff8000);
+  rc += check_vuint128 ("vec_slqi ( 15):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 17);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 17   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 17 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xfffe0000);
+  rc += check_vuint128 ("vec_slqi ( 17):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 20);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 20   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 20 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xfff00000);
+  rc += check_vuint128 ("vec_slqi ( 20):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 23);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 23   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 23 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xff800000);
+  rc += check_vuint128 ("vec_slqi ( 23):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 123);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 123   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 123 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0xf8000000, 0x00000000, 0x00000000,
+			   0x00000000);
+  rc += check_vuint128 ("vec_slqi (123):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 127);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 127   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 127 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x80000000, 0x00000000, 0x00000000,
+			   0x00000000);
+  rc += check_vuint128 ("vec_slqi (127):", (vui128_t) k, (vui128_t) e);
+#if 1
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  k = vec_slqi ((vui128_t) i, 129);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1 << 129   ", (vui128_t) i);
+  print_vint128x ("2E128-1 << 129 = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000,
+			   0x00000000);
+  rc += check_vuint128x ("vec_slqi (129):", (vui128_t) k, (vui128_t) e);
+#endif
+
+  return (rc);
+}
+
+//#define __DEBUG_PRINT__ 1
+int
+test_46 (void)
+{
+  vui32_t i, j, e;
+  vui128_t k;
+  int rc = 0;
+
+  printf ("\ntest_46 Vector shift right quadword\n");
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t)
+	    CONST_VINT32_W(0, 0, 0, 0);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128 ("vec_srq (  0):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 8);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00ffffff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128x ("vec_srq (  8):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 16);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x0000ffff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128x ("vec_srq ( 16):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 24);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x000000ff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128x ("vec_srq ( 24):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 32);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128x ("vec_srq ( 32):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 40);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, 0x00ffffff, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128x ("vec_srq ( 40):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 48);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, 0x0000ffff, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128x ("vec_srq ( 48):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 56);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, 0x000000ff, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128x ("vec_srq ( 56):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 64);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, 0x00000000, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128x ("vec_srq ( 64):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 72);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, 0x00000000, 0x00ffffff,
+			   __UINT32_MAX__);
+  rc += check_vuint128x ("vec_srq ( 72):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 80);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, 0x00000000, 0x0000ffff,
+			   __UINT32_MAX__);
+  rc += check_vuint128x ("vec_srq ( 80):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 88);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, 0x00000000, 0x000000ff,
+			   __UINT32_MAX__);
+  rc += check_vuint128x ("vec_srq ( 88):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 96);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000,
+			   __UINT32_MAX__);
+  rc += check_vuint128x ("vec_srq ( 96):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 104);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000,
+			   0x00ffffff);
+  rc += check_vuint128x ("vec_srq (104):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 112);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000,
+			   0x0000ffff);
+  rc += check_vuint128x ("vec_srq (112):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 120);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000,
+			   0x000000ff);
+  rc += check_vuint128x ("vec_srq (120):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 128);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128x ("vec_srq (128):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 1);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x7fffffff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128 ("vec_srq (  1):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 2);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x3fffffff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128 ("vec_srq (  2):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 3);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x1fffffff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128 ("vec_srq (  3):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 4);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x0fffffff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128 ("vec_srq (  4):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 5);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x07ffffff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128 ("vec_srq (  5):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 6);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x03ffffff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128 ("vec_srq (  6):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 7);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x01ffffff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128 ("vec_srq (  7):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 9);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x007fffff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128 ("vec_srq (  9):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 12);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x000fffff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128 ("vec_srq ( 12):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 15);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x0001ffff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128 ("vec_srq ( 15):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 17);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00007fff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128 ("vec_srq ( 17):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 20);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000fff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128 ("vec_srq ( 20):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 23);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x000001ff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128 ("vec_srq ( 23):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 123);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000,
+			   0x0000001f);
+  rc += check_vuint128 ("vec_srq (123):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 127);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000,
+			   0x00000001);
+  rc += check_vuint128 ("vec_srq (127):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 129);
+  k = vec_srq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        >> ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x7fffffff, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128x ("vec_srq (129):", (vui128_t) k, (vui128_t) e);
+
+  return (rc);
+}
+
+//#define __DEBUG_PRINT__ 1
+int
+test_47 (void)
+{
+  vui32_t i, j, e;
+  vui128_t k;
+  int rc = 0;
+
+  printf ("\ntest_47 Vector shift left quadword\n");
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 0);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128 ("vec_slq (  0):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 8);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xffffff00);
+  rc += check_vuint128x ("vec_slq (  8):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 16);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xffff0000);
+  rc += check_vuint128x ("vec_slq ( 16):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 24);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xff000000);
+  rc += check_vuint128x ("vec_slq ( 24):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 32);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0x00000000);
+  rc += check_vuint128x ("vec_slq ( 32):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 40);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, 0xffffff00,
+			   0x00000000);
+  rc += check_vuint128x ("vec_slq ( 40):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 48);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, 0xffff0000,
+			   0x00000000);
+  rc += check_vuint128x ("vec_slq ( 48):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 56);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, 0xff000000,
+			   0x00000000);
+  rc += check_vuint128x ("vec_slq ( 56):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 64);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, 0x00000000,
+			   0x00000000);
+  rc += check_vuint128x ("vec_slq ( 64):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 72);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, 0xffffff00, 0x00000000,
+			   0x00000000);
+  rc += check_vuint128x ("vec_slq ( 72):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 80);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, 0xffff0000, 0x00000000,
+			   0x00000000);
+  rc += check_vuint128x ("vec_slq ( 80):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 88);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, 0xff000000, 0x00000000,
+			   0x00000000);
+  rc += check_vuint128x ("vec_slq ( 88):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 96);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, 0x00000000, 0x00000000,
+			   0x00000000);
+  rc += check_vuint128x ("vec_slq ( 96):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 104);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0xffffff00, 0x00000000, 0x00000000,
+			   0x00000000);
+  rc += check_vuint128x ("vec_slq (104):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 112);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0xffff0000, 0x00000000, 0x00000000,
+			   0x00000000);
+  rc += check_vuint128x ("vec_slq (112):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 120);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0xff000000, 0x00000000, 0x00000000,
+			   0x00000000);
+  rc += check_vuint128x ("vec_slq (120):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 128);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128x ("vec_slq (128):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 1);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xfffffffe);
+  rc += check_vuint128 ("vec_slq (  1):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 2);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xfffffffc);
+  rc += check_vuint128 ("vec_slq (  2):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 3);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xfffffff8);
+  rc += check_vuint128 ("vec_slq (  3):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 4);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xfffffff0);
+  rc += check_vuint128 ("vec_slq (  4):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 5);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xffffffe0);
+  rc += check_vuint128 ("vec_slq (  5):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 6);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xffffffc0);
+  rc += check_vuint128 ("vec_slq (  6):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 7);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xffffff80);
+  rc += check_vuint128 ("vec_slq (  7):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 9);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xfffffe00);
+  rc += check_vuint128 ("vec_slq (  9):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 12);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xfffff000);
+  rc += check_vuint128 ("vec_slq ( 12):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 15);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xffff8000);
+  rc += check_vuint128 ("vec_slq ( 15):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 17);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xfffe0000);
+  rc += check_vuint128 ("vec_slq ( 17):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 20);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xfff00000);
+  rc += check_vuint128 ("vec_slq ( 20):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 23);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xff800000);
+  rc += check_vuint128 ("vec_slq ( 23):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 123);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0xf8000000, 0x00000000, 0x00000000,
+			   0x00000000);
+  rc += check_vuint128 ("vec_slq (123):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 127);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x80000000, 0x00000000, 0x00000000,
+			   0x00000000);
+  rc += check_vuint128 ("vec_slq (127):", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 129);
+  k = vec_slq ((vui128_t) i, (vui128_t) j);
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("2E128-1    ", (vui128_t) i);
+  print_vint128x ("        << ", (vui128_t) j);
+  print_vint128x ("         = ", k);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xfffffffe);
+  rc += check_vuint128x ("vec_slq (129):", (vui128_t) k, (vui128_t) e);
+
+  return (rc);
+}

--- a/src/testsuite/arith128_test_i128.h
+++ b/src/testsuite/arith128_test_i128.h
@@ -56,4 +56,16 @@ test_8 (void);
 extern int
 test_43 (void);
 
+extern int
+test_44 (void);
+
+extern int
+test_45 (void);
+
+extern int
+test_46 (void);
+
+extern int
+test_47 (void);
+
 #endif /* TEST_ARITH128_TEST_I128_H_ */

--- a/src/testsuite/pveclib_test.c
+++ b/src/testsuite/pveclib_test.c
@@ -73,6 +73,10 @@ main (void)
   rc += test_8 ();
 #endif
 
+#if 1
+  rc += test_43 ();
+#endif
+
   if (rc > 0)
     printf ("%d failures reported\n", rc);
   return (rc);

--- a/src/testsuite/pveclib_test.c
+++ b/src/testsuite/pveclib_test.c
@@ -77,6 +77,13 @@ main (void)
   rc += test_43 ();
 #endif
 
+#if 1
+  rc += test_44 ();
+  rc += test_45 ();
+  rc += test_46 ();
+  rc += test_47 ();
+#endif
+
   if (rc > 0)
     printf ("%d failures reported\n", rc);
   return (rc);

--- a/src/testsuite/vec_int128_dummy.c
+++ b/src/testsuite/vec_int128_dummy.c
@@ -23,6 +23,146 @@
 #include <vec_int128_ppc.h>
 
 vui128_t
+test_vec_slqi_0 (vui128_t __A)
+{
+  return vec_slqi (__A, 0);
+}
+
+vui128_t
+test_vec_slqi_4 (vui128_t __A)
+{
+  return vec_slqi (__A, 4);
+}
+
+vui128_t
+test_vec_slqi_7 (vui128_t __A)
+{
+  return vec_slqi (__A, 7);
+}
+
+vui128_t
+test_vec_slqi_8 (vui128_t __A)
+{
+  return vec_slqi (__A, 8);
+}
+
+vui128_t
+test_vec_slqi_14 (vui128_t __A)
+{
+  return vec_slqi (__A, 14);
+}
+
+vui128_t
+test_vec_slqi_16 (vui128_t __A)
+{
+  return vec_slqi (__A, 16);
+}
+#if 1
+
+vui128_t
+test_vec_slqi_17 (vui128_t __A)
+{
+  return vec_slqi (__A, 17);
+}
+vui128_t
+test_vec_slqi_31 (vui128_t __A)
+{
+  return vec_slqi (__A, 31);
+}
+
+vui128_t
+test_vec_slqi_48 (vui128_t __A)
+{
+  return vec_slqi (__A, 48);
+}
+
+vui128_t
+test_vec_slqi_120 (vui128_t __A)
+{
+  return vec_slqi (__A, 120);
+}
+
+vui128_t
+test_vec_slqi_128 (vui128_t __A)
+{
+  return vec_slqi (__A, 128);
+}
+
+vui128_t
+test_vec_slqi_129 (vui128_t __A)
+{
+  return vec_slqi (__A, 129);
+}
+#endif
+
+vui128_t
+test_vec_srqi_0 (vui128_t __A)
+{
+  return vec_srqi (__A, 0);
+}
+
+vui128_t
+test_vec_srqi_4 (vui128_t __A)
+{
+  return vec_srqi (__A, 4);
+}
+
+vui128_t
+test_vec_srqi_7 (vui128_t __A)
+{
+  return vec_srqi (__A, 7);
+}
+
+vui128_t
+test_vec_srqi_8 (vui128_t __A)
+{
+  return vec_srqi (__A, 8);
+}
+
+vui128_t
+test_vec_srqi_14 (vui128_t __A)
+{
+  return vec_srqi (__A, 14);
+}
+
+vui128_t
+test_vec_srqi_16 (vui128_t __A)
+{
+  return vec_srqi (__A, 16);
+}
+#if 1
+vui128_t
+test_vec_srqi_31 (vui128_t __A)
+{
+  return vec_srqi (__A, 31);
+}
+
+vui128_t
+test_vec_srqi_48 (vui128_t __A)
+{
+  return vec_srqi (__A, 48);
+}
+
+vui128_t
+test_vec_srqi_120 (vui128_t __A)
+{
+  return vec_srqi (__A, 120);
+}
+
+vui128_t
+test_vec_srqi_128 (vui128_t __A)
+{
+  return vec_srqi (__A, 128);
+}
+
+vui128_t
+test_vec_srqi_129 (vui128_t __A)
+{
+  return vec_srqi (__A, 129);
+}
+#endif
+
+vui128_t
 test_vsl4 (vui128_t a)
 {
 	return (vec_slq4(a));


### PR DESCRIPTION
The set of patches to fix the implementation of vec_srqi and vec_slqi and add the missing test cases, Also add the missing call to test_44 which test the reverse byte vector intrinsics

Fixes #7 