### PR TITLE
Fix the doxygen docs: Add a complete introduction; laying out the

### DIFF
--- a/doc/pveclib-doxygen-pveclib.doxy
+++ b/doc/pveclib-doxygen-pveclib.doxy
@@ -737,7 +737,8 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = $(SRCDIR)/doc/pveclibmaindox.h \
-                         $(SRCDIR)/src/vec_int128_ppc.h \ 
+                         $(SRCDIR)/src/vec_int128_ppc.h \
+                         $(SRCDIR)/src/vec_bcd_ppc.h \
                          $(SRCDIR)/src/vec_common_ppc.h
 
 # This tag can be used to specify the character encoding of the source files
@@ -2300,3 +2301,4 @@ GENERATE_LEGEND        = YES
 # This tag requires that the tag HAVE_DOT is set to YES.
 
 DOT_CLEANUP            = YES
+

--- a/doc/pveclibmaindox.h
+++ b/doc/pveclibmaindox.h
@@ -20,46 +20,708 @@
 #ifndef __PVECLIB_MAIN_DOX_H
 #define __PVECLIB_MAIN_DOX_H
 
-/** \mainpage POWER Vector Library
+/** \mainpage POWER Vector Library (pveclib)
 * \brief library of useful vector functions for POWER. This library
-* fills in the gap between the PowerPC vector intrinsic functions
-* (as implemented by altivec.h) and major libraries like ESSL and MASSV.
+* fills in the gap between the instructions defined in the POWER
+* Instruction Set Architecture (<B>PowerISA</B>) and major application
+* libraries like ESSL and MASSV.
+* The C/C++ language compilers (that support PowerISA) may implement
+* vector intrinsic functions (compiler built-ins as embodied by
+* altivec.h). These vector intrinsics offer an alternative to
+* assembler programming, but do not offer higher function then that
+* already provided by the PowerISA.
 *
 *  \authors Steven Munroe
 *
 *  \section Rationale
 *
-*  Higher level vector intrinsic operations are needed.
-*  For example the PowerISA provides population count and count
-*  leading zero operations on vectors of doubleword but not on the
-*  whole vector as a __int128 value.
-*  Another example the ISA 2.07 provides vector multiply on even/odd
-*  unsigned int values but does not directly provide a full __int128
-*  by __int128 multiply producing a 256-bit product.
-*  Also some useful operations can be constructed from existing PowerISA
-*  instructions and GCC Altivec Intrinsic built-ins but the
-*  implementation may not be obvious. And finally the optimum sequence will
-*  vary across the PowerISA levels as new instructions are added.
+*  Higher level vector intrinsic operations are needed. One key reason
+*  is to smooth over the high complexity of the evolving PowerISA and
+*  compiler support.
 *
-*  So the goal of this project to provide well crafted
+*  For example: the PowerISA 2.07 (Power8) provides population count
+*  and count leading zero operations on vectors of byte, halfword,
+*  word, and doubleword elements but not on the whole vector as a
+*  __int128 value. Before PowerISA 2.07, neither operation was
+*  supported, for any element size.
+*
+*  Another example: The original <B>Altivec</B>
+*  (AKA Vector Multimedia Extension (<B>VMX</B>))
+*  provided Vector Multiply Odd / Even operations for signed / unsigned
+*  byte and halfword elements.  The PowerISA 2.07 added Vector Multiply
+*  Even/Odd operations for signed / unsigned word elements.  This
+*  release also added a Vector Multiply Unsigned Word Modulo operation.
+*  This was important to allow auto vectorization of C loops using
+*  32-bit (int) multiply.
+*
+*  But PowerISA 2.07 did not add support for doubleword or quadword
+*  (__int128) multiply directly.  Nor did it fill in the missing
+*  multiply modulo operations for byte and halfword.  However it
+*  did add support for doubleword and quadword add / subtract modulo,
+*  This can be helpful, if you are willing to apply grade school
+*  arithmetic (add, carry the 1) to vector elements.
+*
+*  PowerISA 3.0 (Power9) did add a Vector Multiply-Sum Unsigned
+*  Doubleword Modulo operation.  With this instruction (and a generated
+*  vector of zeros as input) you can effectively implement the simple
+*  doubleword integer multiply modulo operation in a few instructions.
+*  Similarly for Vector Multiply-Sum Unsigned Halfword Modulo.
+*  But this may not be obvious.
+*
+*  This history embodies a set of trade-offs negotiated between the
+*  Software and Processor design architects at specific points in time.
+*  But most programmers would prefer to use a set of operators applied
+*  across the supported element types and sizes.
+*
+*  \subsection mainpage_sub0 POWER Vector Library Goals
+*
+*  Obviously many useful operations can be constructed from existing
+*  PowerISA operations and GCC <altivec.h> built-ins but the
+*  implementation may not be obvious. The optimum sequence will
+*  vary across the PowerISA levels as new instructions are added.
+*  And finally the compiler's built-in support for new PowerISA
+*  instructions evolves with the compiler's release cycle.
+*
+*  So the goal of this project is to provide well crafted
 *  implementations of useful vector and large number operations.
 *
 *  - Provide equivalent functions across versions of the PowerISA.
-*  For example the Vector Multiply-by-10 Unsigned Quadword operations
-*  introduced in PowerISA 3.0 (POWER9) can be implement in a few vector
-*  instructions on earlier PowerISA versions.
+*  This includes some of the most useful vector instructions added to
+*  Power9 (PowerISA 3.0B).
+*  Many of these operations can be implemented as in-line function in
+*  a few vector instructions on earlier PowerISA versions.
 *  - Provide equivalent functions across versions of the compiler.
-*  For example builtins provided in later versions of the compiler
-*  can be implemented as inline functions with inline asm in earlier
+*  For example built-ins provided in later versions of the compiler
+*  can be implemented as in-line functions with in-line asm in earlier
 *  compiler versions.
+*  - Provide complete arithmetic operations across supported C types.
+*  For example multiply modulo and even/odd for int, long, and __int128.
+*  - Provide complete extended arithmetic (carry / extend /
+*  multiple high) operations across supported C types.
+*  For example add / subtract with carry and extent for int, long,
+*  and __int128.
 *  - Provide higher order functions not provided directly by the PowerISA.
-*  For example vector SIMI implementation for ASCII __isalpha, etc.
+*  For example vector SIMD implementation for ASCII __isalpha, etc.
 *  Another example full __int128 implementations of Count Leading Zeros,
-*  Population Count, and Multiply.
+*  Population Count, Shift left/right immediate, and integer divide.
+*  - Such implementations should be small enough to in-line and allow
+*  the compiler opportunity to apply common optimization techniques.
 *
-*  \subsection POWER Vector Library Intrinsic headerss
+*  \subsubsection mainpage_sub0_1 POWER Vector Library Intrinsic headers
+*
+*  The POWER Vector Library will be primarily delivered as C language
+*  in-line functions in headers files.
 *  - vec_common_ppc.h Typedefs and helper macros
 *  - vec_int128_ppc.h Operations on vector __int128 values
+*  - vec_int64_ppc.h Operations on vector long int (64-bit) values
+*  - vec_int32_ppc.h Operations on vector int (32-bit) values
+*  - vec_char_ppc.h Operations on vector char (values) values
+*  - vec_bcd_ppc.h Operations on vectors of Binary Code Decimal
+*  and Zoned Decimal values
+*  - vec_f128_ppc.h Operations on vector _Float128 values
+*  - vec_f64_ppc.h Operations on vector double values
+*  - vec_f32_ppc.h Operations on vector float values
+*
+*  \note The list above more of an aspiration at this time.
+*  You will not find all of these headers or complete operation set
+*  and platform coverage in the current public github.
+*  But many of these headers do exist in private trees as we work
+*  on completing function and testing across compilers and PowerISA
+*  versions.
+*
+*  The goal is to provide high quality implementations that adapt to
+*  the specifics of the compile target (-mcpu=) and compiler
+*  (<altive.h>) version you are using. Initially pveclib will focus on
+*  the GCC compiler and -mcpu=[power7|power8|power9] for Linux.
+*  Testing will focus on Little Endian (<B>powerpc64le</B> for power8
+*  and power9 targets.  Any testing for Big Endian (<B>powerpc64</B>
+*  will be initially restricted to power7 and power8 targets.
+*
+*  Expanding pveclib support beyond this list to include:
+*  - additional compilers (ie Clang)
+*  - additional PPC platforms (970, power6, ...)
+*  - Larger functions that just happen to use vector registers
+*  (Checksum, Crypto, compress/decompress, lower precision neural networks, ...)
+*  .
+*  will largely depend on additional skilled practitioners joining this
+*  project and contributing (code and platform testing)
+*  on a sustained basis.
+*
+*  \subsection mainpage_sub1 How pveclib is different from compiler vector built-ins
+*
+*  The PowerPC vector build-ins evolved from the original
+*  <a href="https://www.nxp.com/docs/en/reference-manual/ALTIVECPIM.pdf">
+*  AltiVec (TM) Technology Programming Interface Manual</a> (PIM).
+*  The PIM defined the minimal extensions to the application binary
+*  interface (ABI) required to support the Vector Facility.
+*  This included new keywords (vector, pixel, bool) for defining
+*  new vector types, and new operators (build-in functions) required
+*  for any supporting and compliant C language compiler.
+*
+*  The vector build-in function support included:
+*  - generic AltiVec operations, like vec_add()
+*  - specific AltiVec operations (instructions, like vec_vaddubm())
+*  - predicates computed from a AltiVec operations, like vec_all_eq()
+*  which are also generic
+*
+*  See \ref mainpage_sub_1_3 for more details.
+*
+*  There are clear advantages with the compiler implementing the
+*  vector operations as built-ins:
+*  - The compiler can access the C language type information and
+*  vector extensions to implement the function overloading
+*  required to process generic operations.
+*  - Built-ins can be generated in-line, which eliminates function
+*  call overhead and allows more compact code generation.
+*  - The compiler can then apply higher order optimization across
+*  built-ins including:
+*  Local and global register allocation.
+*  Global common subexpression elimination.
+*  Loop-invariant code motion.
+*  - The compiler can automatically select the best instructions
+*  for the <I>target</I> processor ISA level
+*  (from the -mcpu compiler option).
+*
+*  While this is an improvement over writing assembler code,  it does
+*  not provide much function beyond the specific operations specified in
+*  the PowerISA.
+*
+*  Another issue is that generic operations where not
+*  uniformly applicable across vector types.
+*  For example:
+*  - vec_add / vec_sub applied to float, int, short and char.
+*  - Later compilers added support for double
+*  (with POWER7 and the Vector Scalar Extensions (VSX) facility)
+*  - Integer long (64-bit) and __int128 support for POWER8
+*  (PowerISA 2.07B).
+*
+*  But vec_mul vec_div did not:
+*  - vec_mul applied to float (and later double, with POWER7 VSX).
+*  - vec_mule / vec_mulo (Multiply even / odd elements)
+*  applied to [signed | unsigned] integer short and char.
+*  Later compilers added support for vector int after
+*  Power8 added vector multiply word instructions.
+*  - vec_div was not included in the original PIM as
+*  Altivec (VMX) only included vector reciprocal estimate for float
+*  and no vector integer divide for any size.
+*  Later compilers added support for vec_div float / double after
+*  POWER7 (VSX) added vector divide single/double-precision instructions.
+*
+*  \note While the processor you (plan to) use,  may support the
+*  specific instructions you want to exploit,  the compiler you are
+*  using may not support,  the generic or specific vector operations,
+*  for the element size/types, you want to use.
+*  This is common for GCC versions installed by "Enterprise Linux"
+*  distributions. They tend to freeze the GCC version early and
+*  maintain that GCC version for long term stability.
+*  One solution is to use the
+*  <a href="https://developer.ibm.com/linuxonpower/advance-toolchain/">
+*  IBM Advance toolchain for Linux on Power</a> (AT).
+*  AT is free for download and new AT versions are released yearly
+*  (usually in August) with the latest stable GCC from that spring.
+*
+*  This all can be very frustrating, at minimum,  or even a show
+*  stopper, if you are on a tight schedule for you project.
+*  Especially if you are not familiar with the evolving history of the
+*  PowerISA and supporting compilers.
+*
+*  \subsubsection mainpage_sub_1_1 What can we do about this?
+*
+*  First the Binutils assembler is usually updated within weeks of the
+*  public release of the PowerISA document. So while your compiler
+*  may not support the latest vector operations as built-in operations,
+*  an older compiler with an updated assembler,
+*  may support the instructions as in-line assembler.
+*
+*  Sequences of in-line assembler instructions can be wrapped within
+*  C language static inline functions and placed in a header files
+*  for shared use. If you are careful with the input / output register
+*  <I>constraints</I> the GCC compiler can provide local register
+*  allocation and minimize parameter marshaling overhead. This is very
+*  close (in function) to a specific Altivec (built-in) operation.
+*
+*  \note Using GCC's in-line assembler can be challenging even for the
+*  experienced programmer. The register constraints have grown in
+*  complexity as new facilities and categories where added.
+*  The fact that some (VMX) instructions are restricted to the original
+*  32 Vector Registers (<B>VRs</B>) (the high half of the Vector-Scalar
+*  Registers <B>VSRs</B>), while others (Binary and Decimal
+*  Floating-Point) are restricted to the original 32 Floating-Point
+*  Registers (<B>FPRs</B> (overlapping the low half of the VSRs), and
+*  the new VSX instructions can access all 64 VSRs, is just one source
+*  of complexity.
+*  So it is very important to get your input/output constraints correct
+*  if you want in-line assembler code to work correctly.
+*
+*  In-line assembler should be
+*  reserved for the first implementation using the latest PowerISA.
+*  Where possible you should use existing vector built-ins to implement
+*  specific operations for wider element types, support older hardware,
+*  or higher order operations.
+*  Again wrapping these implementations in static inline functions for
+*  collection in header files for reuse and distribution is recommended.
+*
+*  The PowerISA vector facility has all the instructions you need to
+*  implement extended precision operations for add, subtract,
+*  and multiply. Add / subtract with carry-out and permute or
+*  double vector shift and grade-school arithmetic is all you need.
+*
+*  For example the Vector Add Unsigned Quadword Modulo introduced in
+*  POWER8 (PowerISA 2.07B) can be implemented for POWER7 and earlier
+*  machines in 10-11 instructions. This uses a combination of
+*  Vector Add Unsigned Word Modulo (vadduwm), Vector Add and Write
+*  Carry-Out Unsigned Word (vaddcuw), and Vector Shift Left Double by
+*  Octet Immediate (sldoi), to propagate the word carries through the
+*  quadword.
+*
+*  For Power8 and later, C vector integer (modulo) multiply can be
+*  implemented in a single Vector Unsigned Word Modulo (<B>vmuluwm</B>)
+*  instruction. This was added explicitly to address vectorizing loops
+*  using int multiply in C language code.  And some newer compilers do
+*  support generic vec_mul() for vector int. But this is not
+*  documented. Similarly for char (byte) and short (halfword) elements.
+*
+*  Power8 also introduced Vector Multiply Even Signed Word
+*  (<B>vmulesw</B>) and Vector Multiply Odd Signed Word
+*  (<B>vmulosw</B>) instructions.  So you would expect the generic
+*  vec_mule and vec_mulo operations to be extended to support
+*  <I>vector int</I>,  as these operations have long been supported for
+*  char and short.  Sadly this is not supported as of GCC 7.3.
+*  We hope to see this implemented for GCC 8.
+*
+*  So what will the compiler do for vector multiply int (modulo, even,
+*  or odd) for targeting power7?  Older compilers will reject this as a
+*  <I>invalid parameter combination ...</I>.  A newer compiler may
+*  implement the equivalent function in a short sequence of VMX
+*  instructions from PowerISA 2.06 or earlier.
+*  And GCC 7.3 does support vec_mul for element types char,
+*  short, and int. These sequences are in the 2-7 instruction range
+*  depending on the operation and element type. This includes some
+*  constant loads and permute control vectors that can be factored
+*  and reused across operations.
+*
+*  Once the pattern is understood it is not hard to write equivalent
+*  sequences using operations from the original <altivec.h>.  With a
+*  little care these sequences will be compatible with older compilers
+*  and older PowerISA versions.
+*  These concepts can be extended to operations that PowerISA and the
+*  compiler does not support yet.  For example; a processor that may
+*  not have multiply even/odd/modulo of the required width (word,
+*  doubleword, or quadword). This it might take 10-12 instructions to
+*  implement the next element size bigger then the current processor.
+*  A full 128-bit by 128-bit multiply with 256-bit result only
+*  requires 32 instructions on a Power8 (using multiple word even/odd).
+*
+*  Also many of the operations missing from the vector facility,
+*  exist in the Fixed-point, Floating-point,
+*  or Decimal Floating-point scalar facilities.
+*  There will some loss of efficiency in the data transfer but
+*  compared to a complex operation like divide or decimal conversions,
+*  this can be a workable solution.
+*  On older POWER processors (before power7/8) transfers between
+*  register banks (GPR, FPR, VR) had to go through memory.
+*  But with the VSX facility (Power7) FPRs and VRs overlap with the
+*  lower and upper halves of the 64 VSR registers.
+*  So FPR <-> VSR transfer are 0-2 cycles latency.
+*  And with power8 we GPR <-> FPR | VR | VSR direct transfer
+*  instructions in the 4-5 cycle latency range.
+*
+*  For example Power8 added Binary Coded Decimal (<B>BCD</B>)
+*  add/subtract for signed 31 digit vector values. The vector unit
+*  does not support BCD multiply / divide.
+*  But the Decimal Floating-Point (<B>DFP</B>) facility (introduced
+*  with PowerISA 2.05 and Power6) supports up to 34-digit
+*  (__Decimal128) precision and all the expected
+*  (add/subtract/multiply/divide/...) arithmetic operations. DFP also
+*  supports conversion to/from 31-digit BCD and __Decimal128 precision.
+*  This is all supported with a hardware Decimal Floating-Point Unit
+*  (<B>DFU</B>).
+*
+*  So bcd_add / bcd_sub can be generated as a single instruction on
+*  Power8 and later, and 10-11 instructions for Power6/7.
+*  This count include the VSR <-> FPRp transfers,
+*  BCD <-> DFP conversions, and DFP add/sub.
+*  Similarly bcd_mul / bcd_div are implemented in 11 instructions using
+*  register transfer and the DFU operations for Power6/7/8.
+*
+*  \note So why does anybody care about BCD and DFP? Sometimes you get
+*  large numbers in decimal that you need converted to binary for
+*  extended computation. Sometimes you need to display the results of
+*  your extended binary computation in decimal. The multiply by 10 and
+*  BCD vector operations help simplify and speed-up these conversions.
+*
+*  And finally: Henry S. Warren's wonderful book Hacker's Delight
+*  provides inspiration for SIMD versions of; count leading zeros,
+*  population count, parity, etc.
+*
+*  \subsubsection  mainpage_sub_1_2 So what can the Power Vector Library project do?
+*
+*  Clearly the PowerISA provides multiple, extensive, and powerful
+*  computational facilities that continue to evolve and grow.
+*  But the best instruction sequence for a specific computation depends
+*  on which POWER processor(s) you have or plan to support.
+*  It can also depend on the specific compiler version you use, unless
+*  you are willing to write some of your application code in assembler.
+*  Even then you need to be aware of The PowerISA versions and when
+*  specific instructions where introduced.  This can be frustrating if
+*  you just want to port you application to POWER for a quick
+*  evaluation.
+*
+*  So you would like to start evaluating how to leverage this power
+*  for key algorithms at the heart of your application.
+*  - But you are working with older POWER processor
+*  (until the latest POWER box is delivered).
+*  - Or the latest POWER machine just arrived at your site (or cloud)
+*  but you are stuck using an older/stable Linux distro version
+*  (with an older distro compiler).
+*  - Or you need extended precision multiply for your crypto code
+*  but you are not really an assembler level programmer
+*  (or don't want to be).
+*  - Or you would like to program with higher level operations to
+*  improve your own productivity.
+*
+*  Someone with the right background (knowledge of the; PowerISA,
+*  assembler level programming, compilers and the vector built-ins,
+*  ...) can solve any of the issues described above. But you don't
+*  have time for this.
+*
+*  There should be an easier way to exploit the POWER vector hardware
+*  without getting lost in the details. And this extends beyond
+*  classical vector (Single Instruction Multiple Data (SIMD))
+*  programming to exploiting; larger data width (128-bit and beyond),
+*  and larger register space (64 x 128 Vector Scalar Registers)
+*
+*  Here is an example of what can be done: \code
+static inline vui128_t
+vec_adduqm (vui128_t a, vui128_t b)
+{
+  vui32_t t;
+#ifdef _ARCH_PWR8
+#ifndef vec_vadduqm
+  __asm__(
+      "vadduqm %0,%1,%2;"
+      : "=v" (t)
+      : "v" (a),
+      "v" (b)
+      : );
+#else
+  t = (vui32_t) vec_vadduqm (a, b);
+#endif
+#else
+  vui32_t c, c2;
+  vui32_t z= { 0,0,0,0};
+
+  c = vec_vaddcuw ((vui32_t)a, (vui32_t)b);
+  t = vec_vadduwm ((vui32_t)a, (vui32_t)b);
+  c = vec_sld (c, z, 4);
+  c2 = vec_vaddcuw (t, c);
+  t = vec_vadduwm (t, c);
+  c = vec_sld (c2, z, 4);
+  c2 = vec_vaddcuw (t, c);
+  t = vec_vadduwm (t, c);
+  c = vec_sld (c2, z, 4);
+  t = vec_vadduwm (t, c);
+#endif
+  return ((vui128_t) t);
+}
+*  \endcode
+*
+*  The <B>_ARCH_PWR8</B> macro is defined by the compiler when it targets
+*  POWER8 (PowerISA 2.07) or later. This is the first processor and
+*  PowerISA level to support vector quadword add/subtract. Otherwise we
+*  need to use the vector word add modulo and vector word add and
+*  write carry-out word, to add 32-bit chunks and propagate the
+*  carries through the quadword.
+*
+*  One little detail remains. Support for vec_vadduqm was added to GCC
+*  in March of 2014, after GCC 4.8 was released and GCC 4.9's feature
+*  freeze.  So the only guarantee is that this feature is in GCC
+*  5.0 and later.  At some point this change was backported to GCC 4.8
+*  and 4.9 as it is included in the current GCC 4.8/4.9 documentation.
+*  When or if these backports where propagated to a specific Linux
+*  Distro version or update is difficult to determine.
+*  So support for this vector built-in dependes on the specific
+*  version of the GCC compiler, or if specific Distro update includes
+*  these specific backports for the GCC 4.8/4.9 compiler they support.
+*  The: \code
+*  #ifndef vec_vadduqm
+*  \endcode
+*  C preprocessor conditional checks if the <B>vec_vadduqm</B>
+*  is defined in <altivec.h>. If defined we can assume that the
+*  compiler implements <B>__builtin_vec_vadduqm</B> and that
+*  <altivec.h> includes the macro definition: \code
+#define vec_vadduqm __builtin_vec_vadduqm
+*  \endcode
+*  For <B>_ARCH_PWR7</B> and earlier we need a little grade school
+*  arithmetic using Vector Add Unsigned Word Modulo (<B>vadduwm</B>)
+*  and Vector Add and Write Carry-Out Unsigned Word (<B>vaddcuw</B>).
+*  This treats the vector __int128 as 4 32-bit binary digits.
+*  The first instruction sums each (32-bit digit) column and the second
+*  records the carry out of the high order bit.  This leaves the carry
+*  bit in the original (word) column, so use a shift left to line up
+*  the carries with the next higher word.
+*
+*  To propagate any carries across all 4 (word) digits,  repeat this
+*  (add / carry / shift) sequence three times.
+*  Then a final add modulo word to complete the 128-bit add.
+*  This sequence requires 10-11 instructions. The 11th instruction is
+*  a vector splat word 0 immediate, which in needed in the shift left
+*  (vsldoi) instructions. This common in vector codes and the compile
+*  can usually reuse this register across several blocks of code and
+*  in-line functions.
+*
+*  For Power7/8 these instructions are all 2 cycle latency and 2 per
+*  cycle throughput.  The vadduwm / vaddcuw instruction pairs should
+*  issue in the same cycle and execute in parallel.
+*  So the expected a latency for this sequence is 14 cycles.
+*  For Power8 the vadduqm instruction has a 4 cycle latency.
+*
+*  Similarly for the carry / extend forms which can be combined to
+*  support wider (256, 512, 1024, ...) extended arithmetic.
+*  \sa vec_addcuq, vec_addeuqm, and vec_addecuq
+*
+*  Another example <B>Vector Multiply-by-10 Unsigned Quadword</B>:
+*  \code
+static inline vui128_t
+vec_mul10uq (vui128_t a)
+{
+  vui32_t t;
+#ifdef _ARCH_PWR9
+  __asm__(
+      "vmul10uq %0,%1;\n"
+      : "=v" (t)
+      : "v" (a)
+      : );
+#else
+  vui16_t ts = (vui16_t) a;
+  vui16_t t10;
+  vui32_t t_odd, t_even;
+  vui32_t z = { 0, 0, 0, 0 };
+  t10 = vec_splat_u16(10);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  t_even = vec_vmulouh (ts, t10);
+  t_odd = vec_vmuleuh (ts, t10);
+#else
+  t_even = vec_vmuleuh(ts, t10);
+  t_odd = vec_vmulouh(ts, t10);
+#endif
+  t_even = vec_sld (t_even, z, 2);
+#ifdef _ARCH_PWR8
+  t = (vui32_t) vec_vadduqm ((vui128_t) t_even, (vui128_t) t_odd);
+#else
+  t = (vui32_t) vec_adduqm ((vui128_t) t_even, (vui128_t) t_odd);
+#endif
+#endif
+  return ((vui128_t) t);
+}
+*  \endcode
+*
+*  PowerISA 3.0 added this instruction and it's extend / carry forms
+*  to speed up decimal to binary conversion for large numbers.
+*
+*  Notice that under the <B>_ARCH_PWR9</B> conditional, there is no
+*  check for the specific <B>vec_vmul10uq</B> built-in.  As of this
+*  writing <B>vec_vmul10uq</B> is not included in the
+*  <I>OpenPOWER ELF2 ABI</I> documentation nor in the latest GCC trunk
+*  source code.
+*
+*  \note The <I>OpenPOWER ELF2 ABI</I> does define <B>bcd_mul10</B>
+*  which (from the description) will actually generate Decimal Shift
+*  (<B>bcds</B>). This instruction shifts 4-bit nibbles (BCD digits)
+*  left or right while preserving the BCD sign nibble in bits 124-127,
+*  While this is a handy instruction to have, it is not the same
+*  operation as <B>vec_vmul10uq</B>, which is a true 128-bit binary
+*  multiply by 10.  As of this writing <B>bcd_mul10</B> support is not
+*  included in the latest GCC trunk source code.
+*
+*  For <B>_ARCH_PWR8</B> and earlier we need a little grade school
+*  arithmetic using <B>Vector Multiply Even/Odd Unsigned Halfword</B>.
+*  This treats the vector __int128 as 8 16-bit binary digits.  We
+*  multiply each of these 16-bit digits by 10, which is done in two
+*  (even and odd) parts. The result is 4 32-bit (2 16-bit digits)
+*  partial products for the even digits and 4 32-bit products for the
+*  odd digits. The vector register the even product elements are the
+*  higher order elements and odd product element are lower order.
+*
+*  The even digit partial products are offset right by 16-bits in the
+*  register.  If we shift the even products left 1 (16-bit) digit,
+*  the even digits are lined up in columns with the odd digits.  Now
+*  we can sum across partial products to get the final 128 bit product.
+*
+*  Notice also the conditional code for endian around the
+*  <B>vec_vmulouh</B> and <B>vec_vmuleuh</B> built-ins: \code
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+*  \endcode
+*  This is due to the explicit decision to support little endian
+*  (<B>LE</B>) element ordering for ELF V2 LE targets. This also
+*  changes the meaning of even / odd element numbering and the
+*  relationship to high and low (digit ordering).
+*  Basically in <B>LE</B> it is the opposite of what the corresponding
+*  instructions actually do.  So EVF V2 compilers will swap even and
+*  odd during code generation.  This can be helpful for porting Intel
+*  vector intrinsic codes to PowerISA.
+*
+*  But this is the wrong thing to do for this computation.  For LE
+*  targets the compiler will generate code that swaps the high and low
+*  order partial products. This miss-aligns the digit columns and
+*  produces incorrect results.  So the pveclib implementation needs to
+*  be endian sensitive and pre-swaps the partial product multiplies
+*  for LE, to get the correct results.
+*
+*  Now we are ready to sum the partial product <I>digits</I> while
+*  propagating the digit carries across the 128-bit product.
+*  For <B>_ARCH_PWR8</B> we can use <B>Vector Add Unsigned Quadword
+*  Modulo</B> which handles all the internal carries in hardware.
+*  Before <B>_ARCH_PWR8</B> we only have <B>Vector Add Unsigned Word
+*  Modulo</B> and <B>Vector Add and Write Carry-Out Unsigned Word</B>.
+*
+*  We see these instructions used in the <B>else</B> leg of the
+*  pveclib <B>vec_adduqm</B> implementation above. We can assume that
+*  this implementation is correct and tested for supported platforms.
+*  So here we use another pveclib function to complete the
+*  implementation of <B>Vector Multiply-by-10 Unsigned Quadword</B>
+*
+*  Again similarly for the carry / extend forms which can be combined
+*  to support wider (256, 512,  1024, ...) extended decimal to binary
+*  conversions.
+*  \sa vec_mul10cuq, vec_mul10euq, and vec_mul10ecuq
+*
+*  And similarly for full 128-bit x 128-bit multiply which combined
+*  with the add quadword carry / extended forms above can be used to
+*  implement wider (256, 512, 1024, ...) multiply operations.
+*  \sa vec_mulluq and vec_muludq
+*
+*  \subsubsection mainpage_sub_1_3 Background on the evolution  of <altivec.h>
+*
+*  The original
+*  <a href="https://www.nxp.com/docs/en/reference-manual/ALTIVECPIM.pdf">
+*  AltiVec (TM) Technology Programming Interface Manual</a>
+*  defined the minimal vector extensions to the application binary
+*  interface (ABI), new keywords (vector, pixel, bool) for defining
+*  new vector types, and new operators (build-in functions).
+*
+*  - generic AltiVec operations, like vec_add()
+*  - specific AltiVec operations (instructions, like vec_addubm())
+*  - predicates computed from a AltiVec operation like vec_all_eq()
+*
+*  A generic operation generates specific instructions based on
+*  the types of the actual parameters.
+*  So a generic vec_add operation, with vector char parameters,
+*  will generate the (specific) vector add unsigned byte modulo
+*  (vaddubm) instruction.
+*  Predicates are used within if statement conditional clauses
+*  to access the condition code from vector operations that set
+*  Condition Register 6 (vector SIMD compares and Decimal Integer
+*  arithmetic and format conversions).
+*
+*  The PIM defined a set of compiler built-ins for vector instructions
+*  (see section "4.4 Generic and Specific AltiVec Operations")
+*  that compilers should support.
+*  The document suggests that any requires typedefs and supporting
+*  macros definitions be collected into an include file named <altivec.h>.
+*
+*  The built-ins defined by the PIM closely match the vector
+*  instructions of the underlying PowerISA.
+*  For example: vec_mul, vec_mule / vec_mulo, and vec_muleub / vec_muloub.
+*  - vec_mul is defined for float and double and will (usually)
+*  generate a single instruction for the type. This is a simpler case
+*  as floating point operations usually stay in their lanes
+*  (result elements are the same size as the input operand elements).
+*  - vec_mule / vec_mulo (multiply even / odd) are defined for
+*  integer multiply as integer products require twice as many bits
+*  as the inputs (the results don't stay in their lane).
+*  \par
+*  The RISC philosophy resists and POWER Architecture avoids
+*  instructions that write to more then one register.
+*  So the hardware and PowerISA vector integer multiply generate
+*  even and odd product results (from even and odd input elements)
+*  from two instructions executing separately.
+*  The PIM defines and compiler supports
+*  these operation as overloaded built-ins
+*  and selects the specific instructions based on the operand
+*  (char or short) type.
+*
+*  This is complicated as the PowerISA evolves.
+*  The the original Altivec (VMX) provided vector multiply (even / odd)
+*  operations for byte (char) and halfword (short) integers.
+*  Multiple even / odd word (int) instruction where not introduced
+*  until PowerISA V2.07 (POWER8). PowerISA 2.07 also introduced vector
+*  multiply word modulo which is included under the generic vec_mul.
+*
+*  As the PowerISA evolved adding; new vector (VMX) instructions,
+*  new facilities (Vector Scalar Extended (VSX)),
+*  and specialized vector categories (little endian, AES, SHA2, RAID),
+*  these new operators where added to <altivec.h>.
+*  This included new specific and generic operations and
+*  additional vector element types (long (64-bit) int, __int128,
+*  double and quad precision (__Float128) float).
+*
+*  However the PIM documents where primarily focused on embedded
+*  processors and where not updated to include the vector extensions
+*  implemented by the server processors.
+*  So any documentation for new vector operations where relegated to
+*  the various compilers.  This was a haphazard process and some
+*  divergence in operation naming did occur between compilers.
+*
+*  In the run up to the POWER8 launch and the OpenPOWER initiative it
+*  was recognized that switching to Little Endian would require and
+*  new and well documented Application Binary Interface (<B>ABI</B>).
+*  It was also recognized that new <altivec.h> extensions needed to be
+*  documented in a common place so the various compilers could
+*  implement a common vector build-in API. So ...
+*
+*  The
+*  <a href="https://openpowerfoundation.org/?resource_lib=64-bit-elf-v2-abi-specification-power-architecture">
+*  OpenPOWER ELF V2 application binary interface (ABI)</a>:
+*  Chapter 6. Vector Programming Interfaces and Appendix A.
+*  Predefined Functions for Vector Programming document the
+*  current and proposed vector built-ins we expect all C/C++
+*  compilers to implement for the PowerISA.
+*
+*  The ABI also defines many overloaded built-in functions as
+*  generic operations. Here the compiler selects a specific PowerISA
+*  implementation based on the operand (vector element) types.
+*  The ABI also defines the (big/little) endian behavior and the
+*  compiler may select different instructions based on the endian
+*  of the target.
+*
+*  Also note that the vector element numbering
+*  changes between big and little endian, and so does the meaning of
+*  even and odd. Both effect what the compiler supports and the
+*  instruction sequence generated.
+*  - <B>vec_muleub</B> and <B>vec_muloub</B> (multiply even / odd
+*  unsigned byte) are examples of non-overloaded built-ins provided by
+*  the GCC compiler but not defined in the ABI.
+*  One would assume these built-ins will generate the matching
+*  instruction, however the GCC compiler will adjust the generated
+*  instruction based on the target endian
+*  (even / odd is reversed for little endian).
+*
+*  The ABI also defines vec_mul as an overloaded operation on integer
+*  types, where only the low order half (modulo element size)
+*  of the product is returned.
+*  The PowerISA does not provide a direct multiply modulo instructions
+*  for all the integer sizes / types. So this requires a multiple
+*  instruction sequence to implement.
+*  Also integer vec_mul is defined in the ABI as "phased in" and is
+*  only implemented in the latest GCC versions.
+*
+*  This is a small sample of the complexity we encounter programming
+*  at this low level (vector intrinsic) API. Partially this due to
+*  RISC design philosophy where there is a trade-off software
+*  complexity for simpler (hopefully faster) hardware design.
+*
+*  \subsection mainpage_sub2 pveclib is not a vector math library
+*
+*  The pveclib does not implement general purpose vector math operations.
+*  These should continue to be developed and improved within existing
+*  projects (ie LAPACK, OpenBLAS, ATLAS and libmvec).
+*
+*  We believe that pveclib will be helpful to implementors of vector
+*  math libraries by providing a higher level, more portable,
+*  and more consistent vector interface for the PowerISA.
+*  Similarly for implementors of extended arithmetic, cryptographic,
+*  compression/decompression, and pattern matching / search libraries.
 *
 **/
 

--- a/src/testsuite/arith128_print.c
+++ b/src/testsuite/arith128_print.c
@@ -996,7 +996,7 @@ db_sdiv_qrnnd (int64_t *remainder, int64_t high_num, int64_t low_num,
 }
 
 #ifdef __DEBUG_PRINT__
-
+#ifdef _ARCH_PWR8
 vui128_t
 db_vec_clzq (vui128_t vra)
 {
@@ -1031,6 +1031,7 @@ db_vec_clzq (vui128_t vra)
 
   return ((vui128_t) result);
 }
+#endif
 
 /*
  * Return a vector boolean char with a true indicator for any character
@@ -1157,6 +1158,7 @@ db_vec_tolower (vui8_t vec_str)
   return (result);
 }
 
+#ifdef _ARCH_PWR8
 vui32_t
 db_vec_mulluq (vui32_t a, vui32_t b)
 {
@@ -1342,10 +1344,12 @@ db_vec_mulluq (vui32_t a, vui32_t b)
       "v" (t_odd)
       : );
 #else
-#error Implememention pre power8
+#warning Implememention pre power8
 #endif
   return (tmq);
 }
+#endif
+
 vui32_t
 db_vec_muludq (vui32_t *mulu, vui32_t a, vui32_t b)
 {
@@ -1550,7 +1554,7 @@ db_vec_muludq (vui32_t *mulu, vui32_t a, vui32_t b)
       : );
   print_vint128 (" t      = ", (vui128_t)t);
 #else
-#error Implememention pre power8 missing
+#warning Implememention pre power8 missing
 #endif
   *mulu = t;
   return (tmq);
@@ -1573,11 +1577,11 @@ db_vec_addeuqm (vui32_t a, vui32_t b, vui32_t c)
   vui32_t z = { 0, 0, 0, 0 };
   vui32_t m = { 0, 0, 0, 1 };
   printf ("db_vec_addeuqm\n");
-  print_vint128 ("  a = ", a);
-  print_vint128 ("  b = ", b);
-  print_vint128 ("  c = ", c);
-  print_vint128 ("  z = ", z);
-  print_vint128 ("  m = ", m);
+  print_vint128 ("  a = ", (vui128_t)a);
+  print_vint128 ("  b = ", (vui128_t)b);
+  print_vint128 ("  c = ", (vui128_t)c);
+  print_vint128 ("  z = ", (vui128_t)z);
+  print_vint128 ("  m = ", (vui128_t)m);
   __asm__(
       "vand %2,%1,%6;\n"
       "\tvaddcuw %1,%3,%4;\n"
@@ -1602,9 +1606,9 @@ db_vec_addeuqm (vui32_t a, vui32_t b, vui32_t c)
       "v" (z), /* 5 */
       "v" (m) /* 6 */
       : );
-  print_vint128 ("  t = ", t);
-  print_vint128 ("  c = ", c);
-  print_vint128 ("  c2= ", c2);
+  print_vint128 ("  t = ", (vui128_t)t);
+  print_vint128 ("  c = ", (vui128_t)c);
+  print_vint128 ("  c2= ", (vui128_t)c2);
 #endif
   return (t);
 }
@@ -1630,11 +1634,11 @@ db_vec_addeq (vui32_t *cout, vui32_t a, vui32_t b, vui32_t c)
   co = (vui32_t ) { 0, 0, 0, 1 };
 
   printf ("db_vec_addeq\n");
-  print_vint128 ("  a = ", a);
-  print_vint128 ("  b = ", b);
-  print_vint128 ("  c = ", c);
-  print_vint128 ("  z = ", z);
-  print_vint128 ("  co= ", co);
+  print_vint128 ("  a = ", (vui128_t)a);
+  print_vint128 ("  b = ", (vui128_t)b);
+  print_vint128 ("  c = ", (vui128_t)c);
+  print_vint128 ("  z = ", (vui128_t)z);
+  print_vint128 ("  co= ", (vui128_t)co);
   __asm__(
       "vand %3,%1,%2;\n"
       "\tvaddcuw %2,%4,%5;\n"
@@ -1665,10 +1669,10 @@ db_vec_addeq (vui32_t *cout, vui32_t a, vui32_t b, vui32_t c)
       "v" (b), /* 5 */
       "v" (z) /* 6 */
       : );
-  print_vint128 ("  t = ", t);
-  print_vint128 ("  c = ", c);
-  print_vint128 ("  co= ", co);
-  print_vint128 ("  c2= ", c2);
+  print_vint128 ("  t = ", (vui128_t)t);
+  print_vint128 ("  c = ", (vui128_t)c);
+  print_vint128 ("  co= ", (vui128_t)co);
+  print_vint128 ("  c2= ", (vui128_t)c2);
 #endif
   *cout = co;
   return (t);

--- a/src/testsuite/arith128_test_i128.c
+++ b/src/testsuite/arith128_test_i128.c
@@ -150,6 +150,235 @@ test_1 (void)
 }
 
 int
+test_addcq (void)
+{
+  vui32_t i, j, k, l, m;
+  vui32_t e, ec;
+  int rc = 0;
+
+  printf ("\ntest_2 Vector add carry int128\n");
+
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
+  j = (vui32_t)
+	CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+	    __UINT32_MAX__);
+  k = (vui32_t) vec_addcq ((vui128_t*)&l, (vui128_t) i, (vui128_t) j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("1 + 2E128-1", k, i, j);
+  print_vint128x ("  c = ", (vui128_t) l);
+#endif
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  rc += check_vuint128x ("vec_addcq=:", (vui128_t) k, (vui128_t) e);
+  rc += check_vuint128x ("       co :", (vui128_t) l, (vui128_t) ec);
+
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
+  j = (vui32_t)
+	CONST_VINT32_W(0xfffeffff, __UINT32_MAX__, __UINT32_MAX__,
+	    __UINT32_MAX__);
+  k = (vui32_t) vec_addcq ((vui128_t*)&l, (vui128_t) i, (vui128_t) j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("1 + 2E128-2E102", k, i, j);
+  print_vint128x ("  c = ", (vui128_t) l);
+#endif
+  e = (vui32_t)CONST_VINT32_W(0xffff0000, 0x00000000, 0x00000000, 0x00000000);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vuint128x ("vec_addcq=:", (vui128_t) k, (vui128_t) e);
+  rc += check_vuint128x ("       co :", (vui128_t) l, (vui128_t) ec);
+
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
+  j = (vui32_t)
+	CONST_VINT32_W(0xfffffffe, __UINT32_MAX__, __UINT32_MAX__,
+	    __UINT32_MAX__);
+  k = (vui32_t) vec_addcq ((vui128_t*)&l, (vui128_t) i, (vui128_t) j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("1 + 2E128-2E96", k, i, j);
+  print_vint128x ("  c = ", (vui128_t) l);
+#endif
+  e = (vui32_t
+	)CONST_VINT32_W(__UINT32_MAX__, 0x00000000, 0x00000000, 0x00000000);
+  ec = (vui32_t
+	)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vuint128x ("vec_addcq=:", (vui128_t) k, (vui128_t) e);
+  rc += check_vuint128x ("       co :", (vui128_t) l, (vui128_t) ec);
+
+  i = (vui32_t)CONST_VINT32_W(0, 0, 1, 0);
+  j = (vui32_t)
+	CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+	    0);
+  k = (vui32_t) vec_addcq ((vui128_t*)&l, (vui128_t) i, (vui128_t) j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("1 + 2E128-2E32-1", k, i, j);
+  print_vint128x ("  c = ", (vui128_t) l);
+#endif
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  rc += check_vuint128x ("vec_addcq=:", (vui128_t) k, (vui128_t) e);
+  rc += check_vuint128x ("       co :", (vui128_t) l, (vui128_t) ec);
+
+  i = (vui32_t)CONST_VINT32_W(0, 1, 2, 3);
+  j = (vui32_t)
+	CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, 0, 0);
+  k = (vui32_t) vec_addcq ((vui128_t*)&l, (vui128_t) i, (vui128_t) j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("1 + 2E128-2E64-1", k, i, j);
+  print_vint128x ("  c = ", (vui128_t) l);
+#endif
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 2, 3);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  rc += check_vuint128x ("vec_addcq=:", (vui128_t) k, (vui128_t) e);
+  rc += check_vuint128x ("       co :", (vui128_t) l, (vui128_t) ec);
+
+  i = (vui32_t
+	)CONST_VINT32_W(1, 2, 3, 4);
+  j = (vui32_t
+	)
+	CONST_VINT32_W(__UINT32_MAX__, 0, 0,
+	    0);
+  k = (vui32_t) vec_addcq ((vui128_t*)&l, (vui128_t) i, (vui128_t) j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("1 + 2E128-2E96-1", k, i, j);
+  print_vint128x ("  c = ", (vui128_t) l);
+#endif
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 2, 3, 4);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  rc += check_vuint128x ("vec_addcq=:", (vui128_t) k, (vui128_t) e);
+  rc += check_vuint128x ("       co :", (vui128_t) l, (vui128_t) ec);
+
+  return (rc);
+}
+
+//#define __DEBUG_PRINT__ 1
+int
+test_addeq (void)
+{
+  vui32_t i, j, k, l, m;
+  vui32_t e, ec;
+  int rc = 0;
+
+  printf ("\ntest_2 Vector add extend carry int128\n");
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
+  j = (vui32_t )CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
+  l = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  k = (vui32_t) vec_addeq ((vui128_t*) &m, (vui128_t) i, (vui128_t) j,
+                           (vui128_t) l);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_extend ("extent 2E32-1 + 2E32-1 + c=1", k, m, i, j, l);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000001, 0xffffffff);
+  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint256 ("vec_addeq:", (vui128_t) m, (vui128_t) k, (vui128_t) ec,
+                       (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  j = (vui32_t )
+          CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+                         __UINT32_MAX__);
+  l = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  k = (vui32_t) vec_addeq ((vui128_t*) &m, (vui128_t) i, (vui128_t) j,
+                           (vui128_t) l);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_extend ("extend 1 + 2E128-1 + c=0", k, m, i, j, l);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  rc += check_vint256 ("vec_addeq:", (vui128_t) m, (vui128_t) k, (vui128_t) ec,
+                       (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  j = (vui32_t )
+          CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+                         __UINT32_MAX__);
+  l = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  k = (vui32_t) vec_addeq ((vui128_t*) &m, (vui128_t) i, (vui128_t) j,
+                           (vui128_t) l);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_extend ("extend 0 + 2E128-1 + c=1", k, m, i, j, l);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  rc += check_vint256 ("vec_addeq:", (vui128_t) m, (vui128_t) k, (vui128_t) ec,
+                       (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 2);
+  j = (vui32_t )
+          CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+                         __UINT32_MAX__);
+  l = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  k = (vui32_t) vec_addeq ((vui128_t*) &m, (vui128_t) i, (vui128_t) j,
+                           (vui128_t) l);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_extend ("extend 2 + 2E128-1 + c=1", k, m, i, j, l);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000002);
+  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  rc += check_vint256 ("vec_addeq:", (vui128_t) m, (vui128_t) k, (vui128_t) ec,
+                       (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 1, 0);
+  j = (vui32_t )
+          CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+                         0);
+  l = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  k = (vui32_t) vec_addeq ((vui128_t*) &m, (vui128_t) i, (vui128_t) j,
+                           (vui128_t) l);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_extend ("extend 2E32 + 2E128-1-2E32-1 + c=1", k, m, i, j, l);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  rc += check_vint256 ("vec_addeq:", (vui128_t) m, (vui128_t) k, (vui128_t) ec,
+                       (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  j = (vui32_t )
+          CONST_VINT32_W(0xfffeffff, __UINT32_MAX__, __UINT32_MAX__,
+                         __UINT32_MAX__);
+  l = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  k = (vui32_t) vec_addeq ((vui128_t*) &m, (vui128_t) i, (vui128_t) j,
+                           (vui128_t) l);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_extend ("extend 0 + 2E128-1-2E102 + c=1", k, m, i, j, l);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0xffff0000, 0x00000000, 0x00000000, 0x00000000);
+  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint256 ("vec_addeq:", (vui128_t) m, (vui128_t) k, (vui128_t) ec,
+                       (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  j = (vui32_t )
+          CONST_VINT32_W(0xfffeffff, __UINT32_MAX__, __UINT32_MAX__,
+                         __UINT32_MAX__);
+  l = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  k = (vui32_t) vec_addeq ((vui128_t*) &m, (vui128_t) i, (vui128_t) j,
+                           (vui128_t) l);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_extend ("extend 1 + 2E128-1-2E102 + c=1", k, m, i, j, l);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0xffff0000, 0x00000000, 0x00000000, 0x00000001);
+  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint256 ("vec_addeq:", (vui128_t) m, (vui128_t) k, (vui128_t) ec,
+                       (vui128_t) e);
+
+  return (rc);
+}
+//#undef __DEBUG_PRINT__
+
+int
 test_2 (void)
 {
 #ifdef __DEBUG_PRINT__
@@ -158,6 +387,10 @@ test_2 (void)
   vui32_t i, j, k, l, m;
   vui32_t e, ec;
   int rc = 0;
+
+  rc += test_addcq ();
+
+  rc += test_addeq ();
 
   printf ("\ntest_2 Vector add __int128\n");
 
@@ -246,12 +479,112 @@ test_2 (void)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          __UINT32_MAX__);
   k = (vui32_t) vec_adduqm ((vui128_t) i, (vui128_t) j);
+  l = (vui32_t) vec_addcuq ((vui128_t) i, (vui128_t) j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("1 + 2E128-1", k, i, j);
+  print_vint128x     ("  c = ", (vui128_t)l);
 #endif
   e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
   rc += check_vuint128x ("vec_adduqm:", (vui128_t) k, (vui128_t) e);
+  rc += check_vuint128x ("vec_addcuq:", (vui128_t) l, (vui128_t) ec);
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 1, 0);
+  j = (vui32_t )
+          CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+                         0);
+  k = (vui32_t) vec_adduqm ((vui128_t) i, (vui128_t) j);
+  l = (vui32_t) vec_addcuq ((vui128_t) i, (vui128_t) j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("1 + 2E128-1", k, i, j);
+  print_vint128x     ("  c = ", (vui128_t)l);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  rc += check_vuint128x ("vec_adduqm:", (vui128_t) k, (vui128_t) e);
+  rc += check_vuint128x ("vec_addcuq:", (vui128_t) l, (vui128_t) ec);
+
+  i = (vui32_t )CONST_VINT32_W(0, 1, 0, 0);
+  j = (vui32_t )
+          CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, 0,
+                         0);
+  k = (vui32_t) vec_adduqm ((vui128_t) i, (vui128_t) j);
+  l = (vui32_t) vec_addcuq ((vui128_t) i, (vui128_t) j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("1 + 2E128-1", k, i, j);
+  print_vint128x     ("  c = ", (vui128_t)l);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  rc += check_vuint128x ("vec_adduqm:", (vui128_t) k, (vui128_t) e);
+  rc += check_vuint128x ("vec_addcuq:", (vui128_t) l, (vui128_t) ec);
+
+  i = (vui32_t )CONST_VINT32_W(1, 0, 0, 0);
+  j = (vui32_t )
+          CONST_VINT32_W(__UINT32_MAX__, 0, 0,
+                         0);
+  k = (vui32_t) vec_adduqm ((vui128_t) i, (vui128_t) j);
+  l = (vui32_t) vec_addcuq ((vui128_t) i, (vui128_t) j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("1 + 2E128-1", k, i, j);
+  print_vint128x     ("  c = ", (vui128_t)l);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  rc += check_vuint128x ("vec_adduqm:", (vui128_t) k, (vui128_t) e);
+  rc += check_vuint128x ("vec_addcuq:", (vui128_t) l, (vui128_t) ec);
+
+  i = (vui32_t )CONST_VINT32_W(1, 1, 1, 1);
+  j = (vui32_t )
+          CONST_VINT32_W(__UINT32_MAX__, 0, 0,
+                         0);
+  k = (vui32_t) vec_adduqm ((vui128_t) i, (vui128_t) j);
+  l = (vui32_t) vec_addcuq ((vui128_t) i, (vui128_t) j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("1 + 2E128-1", k, i, j);
+  print_vint128x     ("  c = ", (vui128_t)l);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000001, 0x00000001, 0x00000001);
+  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  rc += check_vuint128x ("vec_adduqm:", (vui128_t) k, (vui128_t) e);
+  rc += check_vuint128x ("vec_addcuq:", (vui128_t) l, (vui128_t) ec);
+
+  i = (vui32_t )CONST_VINT32_W(1, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
+  j = (vui32_t )
+          CONST_VINT32_W(__UINT32_MAX__, 0, 0,
+                         0);
+  k = (vui32_t) vec_adduqm ((vui128_t) i, (vui128_t) j);
+  l = (vui32_t) vec_addcuq ((vui128_t) i, (vui128_t) j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("1 + 2E128-1", k, i, j);
+  print_vint128x     ("  c = ", (vui128_t)l);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
+  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  rc += check_vuint128x ("vec_adduqm:", (vui128_t) k, (vui128_t) e);
+  rc += check_vuint128x ("vec_addcuq:", (vui128_t) l, (vui128_t) ec);
+
+  i = (vui32_t )CONST_VINT32_W(0, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
+  j = (vui32_t )
+          CONST_VINT32_W(__UINT32_MAX__, 0, 0,
+                         0);
+  k = (vui32_t) vec_adduqm ((vui128_t) i, (vui128_t) j);
+  l = (vui32_t) vec_addcuq ((vui128_t) i, (vui128_t) j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("1 + 2E128-1", k, i, j);
+  print_vint128x     ("  c = ", (vui128_t)l);
+#endif
+  e = (vui32_t )CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
+  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vuint128x ("vec_adduqm:", (vui128_t) k, (vui128_t) e);
+  rc += check_vuint128x ("vec_addcuq:", (vui128_t) l, (vui128_t) ec);
 
   i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
   j = (vui32_t )CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
@@ -286,20 +619,6 @@ test_2 (void)
   e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
   rc += check_vuint128x ("vec_addecuq:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
-  l = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
-  k = (vui32_t) vec_addeq ((vui128_t*) &m, (vui128_t) i, (vui128_t) j,
-                           (vui128_t) l);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x_extend ("extent 2E32-1 + 2E32-1 + c=1", k, m, i, j, l);
-#endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000001, 0xffffffff);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
-  rc += check_vint256 ("vec_addeq:", (vui128_t) m, (vui128_t) k, (vui128_t) ec,
-                       (vui128_t) e);
-
   i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
   j = (vui32_t )
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
@@ -325,22 +644,6 @@ test_2 (void)
 #endif
   e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
   rc += check_vuint128x ("vec_addecuq:", (vui128_t) k, (vui128_t) e);
-
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
-  j = (vui32_t )
-          CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
-                         __UINT32_MAX__);
-  l = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
-  k = (vui32_t) vec_addeq ((vui128_t*) &m, (vui128_t) i, (vui128_t) j,
-                           (vui128_t) l);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x_extend ("extend 1 + 2E128-1 + c=0", k, m, i, j, l);
-#endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
-  rc += check_vint256 ("vec_addeq:", (vui128_t) m, (vui128_t) k, (vui128_t) ec,
-                       (vui128_t) e);
 
   i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
   j = (vui32_t )
@@ -368,22 +671,6 @@ test_2 (void)
   e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
   rc += check_vuint128x ("vec_addecuq:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
-  j = (vui32_t )
-          CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
-                         __UINT32_MAX__);
-  l = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
-  k = (vui32_t) vec_addeq ((vui128_t*) &m, (vui128_t) i, (vui128_t) j,
-                           (vui128_t) l);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x_extend ("extend 0 + 2E128-1 + c=1", k, m, i, j, l);
-#endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
-  rc += check_vint256 ("vec_addeq:", (vui128_t) m, (vui128_t) k, (vui128_t) ec,
-                       (vui128_t) e);
-
   i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
   j = (vui32_t )
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
@@ -409,22 +696,6 @@ test_2 (void)
 #endif
   e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
   rc += check_vuint128x ("vec_addecuq:", (vui128_t) k, (vui128_t) e);
-
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 2);
-  j = (vui32_t )
-          CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
-                         __UINT32_MAX__);
-  l = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
-  k = (vui32_t) vec_addeq ((vui128_t*) &m, (vui128_t) i, (vui128_t) j,
-                           (vui128_t) l);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x_extend ("extend 2 + 2E128-1 + c=1", k, m, i, j, l);
-#endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000002);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
-  rc += check_vint256 ("vec_addeq:", (vui128_t) m, (vui128_t) k, (vui128_t) ec,
-                       (vui128_t) e);
 
   return (rc);
 }
@@ -679,6 +950,7 @@ test_4 (void)
   return (rc);
 }
 
+//#define __DEBUG_PRINT__ 1
 int
 test_4b (void)
 {
@@ -700,6 +972,7 @@ test_4b (void)
   j = vec_mul10cuq ((vui128_t) i);
 
 #ifdef __DEBUG_PRINT__
+  print_vint128 ("\n2E128-1 = ec ", (vui128_t)ec);
   print_vint128 ("2E128-1 * 10 ", k);
   print_vint128 ("2E128-1 *10c ", j);
   print_vint128x("2E128-1 * 10 ", k);
@@ -717,12 +990,13 @@ test_4b (void)
   j = vec_mul10cuq ((vui128_t) i);
 
 #ifdef __DEBUG_PRINT__
+  print_vint128 ("\n2E128-1 = ec ", (vui128_t)ec);
   print_vint128 ("2E128-1 * 10 ", k);
   print_vint128 ("2E128-1 *10c ", j);
   print_vint128x("2E128-1 * 10 ", k);
   print_vint128x("2E128-1 *10c ", j);
 #endif
-  rc += check_vint256 ("vec_mul10cuq:", j, k, (vui128_t) ec, (vui128_t) e);
+  rc += check_vint256 ("vec_mul10cuq 1:", j, k, (vui128_t) ec, (vui128_t) e);
 
   i = (vui32_t )CONST_VINT32_W(0x19999999, 0x99999999, 0x99999999, 0x9999999a);
   e = (vui32_t )CONST_VINT32_W(0, 0, 0, 4);
@@ -732,12 +1006,13 @@ test_4b (void)
   j = vec_mul10cuq ((vui128_t) i);
 
 #ifdef __DEBUG_PRINT__
+  print_vint128 ("\n2E128-1 = ec ", (vui128_t)ec);
   print_vint128 ("2E128-1 * 10 ", k);
   print_vint128 ("2E128-1 *10c ", j);
   print_vint128x("2E128-1 * 10 ", k);
   print_vint128x("2E128-1 *10c ", j);
 #endif
-  rc += check_vint256 ("vec_mul10cuq:", j, k, (vui128_t) ec, (vui128_t) e);
+  rc += check_vint256 ("vec_mul10cuq 2:", j, k, (vui128_t) ec, (vui128_t) e);
 
   i = (vui32_t )
           CONST_VINT32_W(0x7fffffff, __UINT32_MAX__, __UINT32_MAX__,
@@ -751,12 +1026,13 @@ test_4b (void)
   j = vec_mul10cuq ((vui128_t) i);
 
 #ifdef __DEBUG_PRINT__
+  print_vint128 ("\n2E128-1 = ec ", (vui128_t)ec);
   print_vint128 ("2E128-1 * 10 ", k);
   print_vint128 ("2E128-1 *10c ", j);
   print_vint128x("2E128-1 * 10 ", k);
   print_vint128x("2E128-1 *10c ", j);
 #endif
-  rc += check_vint256 ("vec_mul10cuq:", j, k, (vui128_t) ec, (vui128_t) e);
+  rc += check_vint256 ("vec_mul10cuq 3:", j, k, (vui128_t) ec, (vui128_t) e);
 
   i = (vui32_t )
           CONST_VINT32_W(0x7fffffff, __UINT32_MAX__, __UINT32_MAX__,
@@ -770,7 +1046,7 @@ test_4b (void)
   print_vint128 ("2E128-1*10+e ", k);
   print_vint128x("2E128-1*10+e ", k);
 #endif
-  rc += check_vuint128 ("vec_mul10euq:", k, (vui128_t) e);
+  rc += check_vuint128 ("vec_mul10euq 4:", k, (vui128_t) e);
 
   i = (vui32_t )
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
@@ -784,7 +1060,7 @@ test_4b (void)
   print_vint128 ("2E128-1*10+e ", k);
   print_vint128x("2E128-1*10+e ", k);
 #endif
-  rc += check_vuint128 ("vec_mul10euq:", k, (vui128_t) e);
+  rc += check_vuint128 ("vec_mul10euq 5:", k, (vui128_t) e);
   i = (vui32_t )
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          __UINT32_MAX__);
@@ -798,7 +1074,7 @@ test_4b (void)
   print_vint128 ("2E128-1*10+e ", k);
   print_vint128x("2E128-1*10+e ", k);
 #endif
-  rc += check_vuint128 ("vec_mul10euq:", k, (vui128_t) e);
+  rc += check_vuint128 ("vec_mul10euq 6:", k, (vui128_t) e);
 
   i = (vui32_t )
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
@@ -812,7 +1088,7 @@ test_4b (void)
   print_vint128 ("2E128-1*10+e ", k);
   print_vint128x("2E128-1*10+e ", k);
 #endif
-  rc += check_vuint128 ("vec_mul10euq:", k, (vui128_t) e);
+  rc += check_vuint128 ("vec_mul10euq 7:", k, (vui128_t) e);
 
   i = (vui32_t )
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
@@ -830,7 +1106,7 @@ test_4b (void)
   print_vint128 ("2E128-1 *10c ", l);
   print_vint128x("2E128-1 *10c ", l);
 #endif
-  rc += check_vint256 ("vec_mul10ecuq:", l, k, (vui128_t) ec, (vui128_t) e);
+  rc += check_vint256 ("vec_mul10ecuq 8:", l, k, (vui128_t) ec, (vui128_t) e);
 
   i = (vui32_t )CONST_VINT32_W(0x19999999, 0x99999999, 0x99999999, 0x99999999);
   j = (vui128_t) (vui32_t ) { 0, 0, 0, 0 };
@@ -847,7 +1123,7 @@ test_4b (void)
   print_vint128 ("2E128-1 *10c ", l);
   print_vint128x("2E128-1 *10c ", l);
 #endif
-  rc += check_vint256 ("vec_mul10ecuq:", l, k, (vui128_t) ec, (vui128_t) e);
+  rc += check_vint256 ("vec_mul10ecuq 9:", l, k, (vui128_t) ec, (vui128_t) e);
 
   i = (vui32_t )CONST_VINT32_W(0x19999999, 0x99999999, 0x99999999, 0x99999999);
   j = (vui128_t) ((vui32_t )CONST_VINT32_W(0, 0, 0, 1));
@@ -864,7 +1140,7 @@ test_4b (void)
   print_vint128 ("2E128-1 *10c ", l);
   print_vint128x("2E128-1 *10c ", l);
 #endif
-  rc += check_vint256 ("vec_mul10ecuq:", l, k, (vui128_t) ec, (vui128_t) e);
+  rc += check_vint256 ("vec_mul10ecuq 10:", l, k, (vui128_t) ec, (vui128_t) e);
 
   i = (vui32_t )CONST_VINT32_W(0x19999999, 0x99999999, 0x99999999, 0x99999999);
   j = (vui128_t) ((vui32_t )CONST_VINT32_W(0, 0, 0, 6));
@@ -879,11 +1155,12 @@ test_4b (void)
   print_vint128 ("2E128-1 *10c ", l);
   print_vint128x("2E128-1 *10c ", l);
 #endif
-  rc += check_vint256 ("vec_mul10ecuq:", l, k, (vui128_t) ec, (vui128_t) e);
+  rc += check_vint256 ("vec_mul10ecuq 11:", l, k, (vui128_t) ec, (vui128_t) e);
 
   return (rc);
 }
-
+#undef __DEBUG_PRINT__
+//#define __DEBUG_PRINT__ 1
 /* Needed to split these tests into a separate function to avoid a ICE
    in GCC 6.3 / AT10.  */
 int
@@ -909,7 +1186,7 @@ test_4b1 (void)
   print_vint128 ("2E128-1 *10c ", l);
   print_vint128x("2E128-1 *10c ", l);
 #endif
-  rc += check_vint256 ("vec_mul10ecuq:", l, k, (vui128_t) ec, (vui128_t) e);
+  rc += check_vint256 ("vec_mul10ecuq 12:", l, k, (vui128_t) ec, (vui128_t) e);
 
   i = (vui32_t )CONST_VINT32_W(0x33333333, 0x33333333, 0x33333333, 0x33333333);
   j = (vui128_t) ((vui32_t )CONST_VINT32_W(0, 0, 0, 1));
@@ -926,7 +1203,7 @@ test_4b1 (void)
   print_vint128 ("2E128-1 *10c ", l);
   print_vint128x("2E128-1 *10c ", l);
 #endif
-  rc += check_vint256 ("vec_mul10ecuq:", l, k, (vui128_t) ec, (vui128_t) e);
+  rc += check_vint256 ("vec_mul10ecuq 13:", l, k, (vui128_t) ec, (vui128_t) e);
 
   i = (vui32_t )CONST_VINT32_W(0x33333333, 0x33333333, 0x33333333, 0x33333333);
   j = (vui128_t) ((vui32_t )CONST_VINT32_W(0, 0, 0, 2));
@@ -941,7 +1218,7 @@ test_4b1 (void)
   print_vint128 ("2E128-1 *10c ", l);
   print_vint128x("2E128-1 *10c ", l);
 #endif
-  rc += check_vint256 ("vec_mul10ecuq:", l, k, (vui128_t) ec, (vui128_t) e);
+  rc += check_vint256 ("vec_mul10ecuq 14:", l, k, (vui128_t) ec, (vui128_t) e);
 
   i = (vui32_t )CONST_VINT32_W(0x33333333, 0x33333333, 0x33333333, 0x33333333);
   j = (vui128_t) ((vui32_t )CONST_VINT32_W(0, 0, 0, 9));
@@ -956,7 +1233,7 @@ test_4b1 (void)
   print_vint128 ("2E128-1 *10c ", l);
   print_vint128x("2E128-1 *10c ", l);
 #endif
-  rc += check_vint256 ("vec_mul10ecuq:", l, k, (vui128_t) ec, (vui128_t) e);
+  rc += check_vint256 ("vec_mul10ecuq 15:", l, k, (vui128_t) ec, (vui128_t) e);
 
   i = (vui32_t )
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
@@ -974,7 +1251,7 @@ test_4b1 (void)
   print_vint128 ("2E128-1 *10c ", l);
   print_vint128x("2E128-1 *10c ", l);
 #endif
-  rc += check_vint256 ("vec_mul10ecuq:", l, k, (vui128_t) ec, (vui128_t) e);
+  rc += check_vint256 ("vec_mul10ecuq 16:", l, k, (vui128_t) ec, (vui128_t) e);
 
   i = (vui32_t )
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
@@ -992,7 +1269,7 @@ test_4b1 (void)
   print_vint128 ("2E128-1 *10c ", l);
   print_vint128x("2E128-1 *10c ", l);
 #endif
-  rc += check_vint256 ("vec_mul10ecuq:", l, k, (vui128_t) ec, (vui128_t) e);
+  rc += check_vint256 ("vec_mul10ecuq 17:", l, k, (vui128_t) ec, (vui128_t) e);
 
   i = (vui32_t )CONST_VINT32_W(0, 0, 0, 10);
   m = (vui128_t) (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
@@ -1010,7 +1287,7 @@ test_4b1 (void)
 #endif
       i = (vui32_t) k;
     }
-  rc += check_vint256 ("vec_mul10euq:", m, k, (vui128_t) ec, (vui128_t) e);
+  rc += check_vint256 ("vec_mul10euq 18:", m, k, (vui128_t) ec, (vui128_t) e);
 
   n = (vui128_t) (vui32_t ) { 0, 0, 0, 0 };
   e = (vui32_t )CONST_VINT32_W(0xae8a0000, 0x00000000, 0x00000000 , 0x00000000);
@@ -1030,11 +1307,12 @@ test_4b1 (void)
 
       i = (vui32_t) k;
     }
-  rc += check_vint384 ("vec_mul10ecuq:", n, m, k, (vui128_t) ec, (vui128_t) em,
+  rc += check_vint384 ("vec_mul10ecuq 19:", n, m, k, (vui128_t) ec, (vui128_t) em,
                        (vui128_t) e);
 
   return (rc);
 }
+#undef __DEBUG_PRINT__
 
 int
 test_4c (void)
@@ -1056,7 +1334,7 @@ test_4c (void)
 #endif
   e = (vui32_t )CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffff9c);
   ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000063);
-  rc += check_vint256 ("vec_cmul100cuq:", (vui128_t) j, (vui128_t) k,
+  rc += check_vint256 ("vec_cmul100cuq 1:", (vui128_t) j, (vui128_t) k,
                        (vui128_t) ec, (vui128_t) e);
 
   i = (vui32_t )
@@ -1070,7 +1348,7 @@ test_4c (void)
 #endif
   e = (vui32_t )CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffff9c);
   ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000063);
-  rc += check_vint256 ("vec_cmul100ecuq:", (vui128_t) l, (vui128_t) k,
+  rc += check_vint256 ("vec_cmul100ecuq 2:", (vui128_t) l, (vui128_t) k,
                        (vui128_t) ec, (vui128_t) e);
 
   i = (vui32_t ) { __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
@@ -1096,7 +1374,7 @@ test_4c (void)
 #endif
   e = (vui32_t )CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffa5);
   ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000063);
-  rc += check_vint256 ("vec_cmul100ecuq:", (vui128_t) l, (vui128_t) k,
+  rc += check_vint256 ("vec_cmul100ecuq 3:", (vui128_t) l, (vui128_t) k,
                        (vui128_t) ec, (vui128_t) e);
 
   i = (vui32_t ) { __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
@@ -1109,7 +1387,7 @@ test_4c (void)
 #endif
   e = (vui32_t )CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffa6);
   ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000063);
-  rc += check_vint256 ("vec_cmul100ecuq:", (vui128_t) l, (vui128_t) k,
+  rc += check_vint256 ("vec_cmul100ecuq 4:", (vui128_t) l, (vui128_t) k,
                        (vui128_t) ec, (vui128_t) e);
 
   i = (vui32_t ) { __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
@@ -1122,7 +1400,7 @@ test_4c (void)
 #endif
   e = (vui32_t )CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
   ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000063);
-  rc += check_vint256 ("vec_cmul100ecuq:", (vui128_t) l, (vui128_t) k,
+  rc += check_vint256 ("vec_cmul100ecuq 5:", (vui128_t) l, (vui128_t) k,
                        (vui128_t) ec, (vui128_t) e);
 
   i = (vui32_t )CONST_VINT32_W(0, 0, 0, 100);
@@ -1139,7 +1417,7 @@ test_4c (void)
 #endif
       i = (vui32_t) k;
     }
-  rc += check_vint256 ("vec_mul10euq:", m, k, (vui128_t) ec, (vui128_t) e);
+  rc += check_vint256 ("vec_cmul100euq 6:", m, k, (vui128_t) ec, (vui128_t) e);
 
   n = (vui128_t) (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
   e = (vui32_t )CONST_VINT32_W (0xd1640000, 0000000000, 0x00000000, 0x00000000);
@@ -1157,7 +1435,7 @@ test_4c (void)
 #endif
       i = (vui32_t) k;
     }
-  rc += check_vint384 ("vec_mul10ecuq:", n, m, k, (vui128_t) ec, (vui128_t) em,
+  rc += check_vint384 ("vec_cmul100ecuq 7:", n, m, k, (vui128_t) ec, (vui128_t) em,
                        (vui128_t) e);
 
   return (rc);

--- a/src/testsuite/vec_int128_dummy.c
+++ b/src/testsuite/vec_int128_dummy.c
@@ -23,6 +23,72 @@
 #include <vec_int128_ppc.h>
 
 vui128_t
+test_vec_add256 (vui128_t *out, vui128_t a0, vui128_t a1, vui128_t b0, vui128_t b1)
+{
+  vui128_t c0, c1;
+  out[1] = vec_addcq (&c1, a1, b1);
+  out[0] = vec_addeq (&c0, a0, b0, c1);
+  return (c0);
+}
+
+vui128_t
+test_vec_addeuqm_ecuq (vui128_t *p, vui128_t a, vui128_t b, vui128_t ci)
+{
+  *p = vec_addecuq (a, b, ci);
+  return vec_addeuqm (a, b, ci);
+}
+
+vui128_t
+test_vec_adduqm_cuq (vui128_t *p, vui128_t a, vui128_t b)
+{
+  *p = vec_addcuq (a, b);
+   return vec_adduqm (a, b);
+}
+
+vui128_t
+test_vec_mul10uq_cuq (vui128_t *p, vui128_t a)
+{
+  *p = vec_mul10cuq (a);
+   return vec_mul10uq (a);
+}
+
+vui128_t
+test_vec_addeq (vui128_t *cout, vui128_t a, vui128_t b, vui128_t c)
+{
+  return (vec_addeq (cout, a, b, c));
+}
+
+vui128_t
+test_vec_addcq (vui128_t *cout, vui128_t a, vui128_t b)
+{
+  return (vec_addcq (cout, a, b));
+}
+
+vui128_t
+test_vec_addecuq (vui128_t a, vui128_t b, vui128_t c)
+{
+  return (vec_addecuq (a, b, c));
+}
+
+vui128_t
+test_vec_addeuqm (vui128_t a, vui128_t b, vui128_t ci)
+{
+  return (vec_addeuqm (a, b, ci));
+}
+
+vui128_t
+test_vec_adduqm (vui128_t a, vui128_t b)
+{
+  return (vec_adduqm (a, b));
+}
+
+vui128_t
+test_vec_addcuq (vui128_t a, vui128_t b)
+{
+  return (vec_addcuq (a, b));
+}
+
+vui128_t
 test_vec_slqi_0 (vui128_t __A)
 {
   return vec_slqi (__A, 0);
@@ -163,6 +229,101 @@ test_vec_srqi_129 (vui128_t __A)
 #endif
 
 vui128_t
+test_vec_vsumsws (vui128_t vra)
+{
+  const __vector unsigned long long vzero =
+    { 0, 0 };
+  return (vui128_t) __builtin_altivec_vsumsws ((__vector int)vra, (__vector int)vzero);
+}
+
+vui128_t
+test_vec_clzq (vui128_t vra)
+{
+  return vec_clzq (vra);
+}
+
+vui128_t
+test_vec_popcntq (vui128_t vra)
+{
+  return vec_popcntq (vra);
+}
+
+vui128_t
+test_cmul10uq (vui128_t *cout, vui128_t a)
+{
+  *cout = vec_mul10cuq (a);
+  return vec_mul10uq (a);
+}
+
+vui128_t
+test_cmul10euq (vui128_t *cout, vui128_t a, vui128_t cin)
+{
+  *cout = vec_mul10ecuq (a, cin);
+  return vec_mul10euq (a, cin);
+}
+
+vui128_t
+test_vec_mul10uq_c (vui128_t *p, vui128_t a)
+{
+  *p = vec_mul10uq (a);
+  return vec_mul10uq (a);
+}
+
+vui128_t
+test_vec_mul10uq (vui128_t a)
+{
+	return vec_mul10uq (a);
+}
+
+vui128_t
+test_vec_mul10euq (vui128_t a, vui128_t cin)
+{
+	return vec_mul10euq (a, cin);
+}
+
+vui128_t
+test_vec_mul10cuq (vui128_t a)
+{
+	return vec_mul10cuq (a);
+}
+
+vui128_t
+test_vec_mul10ecuq (vui128_t a, vui128_t cin)
+{
+	return vec_mul10ecuq (a, cin);
+}
+
+vui128_t
+test_vec_revq (vui128_t a)
+{
+	return vec_revq(a);
+}
+
+void
+test_vec_load_store (vui128_t *a, vui128_t *b)
+  {
+    vui64_t temp;
+
+    temp = vec_ld (0, (vui64_t *)a);
+    vec_st (temp, 0, (vui64_t *)b);
+  }
+
+vui64_t
+test_vpaste (vui64_t __VH, vui64_t __VL)
+{
+	return (vec_pasted(__VH, __VL));
+}
+
+vui64_t
+test_vpaste_x (vui64_t __VH, vui64_t __VL)
+{
+  vui64_t result;
+  result[1] = __VH[1];
+  result[0] = __VL[0];
+  return (result);
+}
+
+vui128_t
 test_vsl4 (vui128_t a)
 {
 	return (vec_slq4(a));
@@ -190,42 +351,6 @@ vui128_t
 test_vec_slq  (vui128_t a, vui128_t sh)
 {
   return (vec_slq (a, sh));
-}
-
-vui128_t
-test_vec_adduqm (vui128_t a, vui128_t b)
-{
-  return (vec_adduqm (a, b));
-}
-
-vui128_t
-test_vec_addcuq (vui128_t a, vui128_t b)
-{
-  return (vec_addcuq (a, b));
-}
-
-vui128_t
-test_vec_addcq (vui128_t *cout, vui128_t a, vui128_t b)
-{
-  return (vec_addcq (cout, a, b));
-}
-
-vui128_t
-test_vec_addeuqm (vui128_t a, vui128_t b, vui128_t c)
-{
-  return (vec_addeuqm (a, b, c));
-}
-
-vui128_t
-test_vec_addecuq (vui128_t a, vui128_t b, vui128_t c)
-{
-  return (vec_addecuq (a, b, c));
-}
-
-vui128_t
-test_vec_addeq (vui128_t *cout, vui128_t a, vui128_t b, vui128_t c)
-{
-  return (vec_addeq (cout, a, b, c));
 }
 
 vui128_t
@@ -266,4 +391,52 @@ test_mul4uq (vui128_t *__restrict__ mulu, vui128_t m1h, vui128_t m1l, vui128_t m
   mulu[1] = mplh;
   mulu[2] = mphl;
   mulu[3] = mphh;
+}
+
+#ifdef _ARCH_PWR8
+vui128_t
+test_clzq (vui128_t vra)
+{
+	__vector unsigned long long result, vt1, vt3;
+	__vector unsigned long long vt2;
+	const __vector unsigned long long vzero = {0,0};
+	const __vector unsigned long long v64 = {64, 64};
+
+	vt1 = vec_vclz ((__vector unsigned long long)vra);
+	vt2 = (__vector unsigned long long)vec_cmpeq (vt1, v64);
+	vt3 = (__vector unsigned long long)vec_sld ((__vector unsigned char)vzero, (__vector unsigned char)vt2, 8);
+	result = vec_andc(vt1, vt3);
+	result = (__vector unsigned long long)vec_sums ((__vector int)result, (__vector int)vzero);
+
+	return ((vui128_t)result);
+}
+#endif
+vui128_t
+test_shift_leftdo (vui128_t vrw, vui128_t vrx, vui128_t vrb)
+{
+	__vector unsigned char result, vt1, vt2, vt3;
+	const __vector unsigned char vzero = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+
+	vt1 = vec_slo ((__vector unsigned char)vrw, (__vector unsigned char)vrb);
+	vt3 = vec_sub (vzero, (__vector unsigned char)vrb);
+	vt2 = vec_sro ((__vector unsigned char)vrx, vt3);
+	result = vec_or (vt1, vt2);
+
+	return ((vui128_t)result);
+}
+
+vui128_t
+test_shift_leftdq (vui128_t vrw, vui128_t vrx, vui128_t vrb)
+{
+	__vector unsigned char result, vt1, vt2, vt3;
+	const __vector unsigned char vzero = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+
+	vt1 = vec_slo ((__vector unsigned char)vrw, (__vector unsigned char)vrb);
+	vt1 = vec_sll (vt1, (__vector unsigned char)vrb);
+	vt3 = vec_sub (vzero, (__vector unsigned char)vrb);
+	vt2 = vec_sro ((__vector unsigned char)vrx, vt3);
+	vt2 = vec_srl (vt2, vt3);
+	result = vec_or (vt1, vt2);
+
+	return ((vui128_t)result);
 }

--- a/src/vec_bcd_ppc.h
+++ b/src/vec_bcd_ppc.h
@@ -23,8 +23,27 @@
 #ifndef VEC_BCD_PPC_H_
 #define VEC_BCD_PPC_H_
 
-#include <altivec.h>
+#include <vec_common_ppc.h>
 
+/*!
+ * \file  vec_bcd_ppc.h
+ * \brief Header package containing a collection of Binary Coded
+ * Decimal (<B>BCD</B> computation functions implemented
+ * with PowerISA VMX, VSX, and DFP instructions.
+ */
+
+/** \brief Quantize (truncate) a _Decimal128 value before convert to
+ * BCD.
+ *
+ * The truncate (round toward 0) and justify right the input
+ * _Decimal128 value so that the unit digit is in the right most
+ * position.  This supports BCD multiply and divide using DFP
+ * instructions by truncating fractional digits before conversion
+ * back to BCD.
+ *
+ * @param val a _Decimal128 value.
+ * @return The quantized __Decimal128 value in a double float pair.
+ */
 static inline _Decimal128
 bcd_qauntize0 (_Decimal128 val)
 {
@@ -46,8 +65,8 @@ bcd_qauntize0 (_Decimal128 val)
  * The BCD vector is permuted into a double float pair before
  * conversion to DPD format via the DFP Encode BCD To DPD Quad.
  *
- *	@param val a 128-bit vector treated a signed BCD 31 digit value.
- *	@return a __Decimal128 in a double float pair.
+ * @param val a 128-bit vector treated a signed BCD 31 digit value.
+ * @return a __Decimal128 in a double float pair.
  */
 static inline _Decimal128
 vec_BCD2DFP (vui32_t val)
@@ -77,8 +96,8 @@ vec_BCD2DFP (vui32_t val)
  * in a double float register pair and so is permuted into single
  * vector register for use.
  *
- *	@param val a __Decimal128 in a double float pair.
- *	@return a 128-bit vector treated a signed BCD 31 digit value.
+ * @param val a __Decimal128 in a double float pair.
+ * @return a 128-bit vector treated a signed BCD 31 digit value.
  */
 static inline vui32_t
 vec_DFP2BCD (_Decimal128 val)
@@ -113,9 +132,9 @@ vec_DFP2BCD (_Decimal128 val)
  * Two Signed 31 digit values are added and lower 31 digits of the
  * sum are returned.  Overflow (carry-out) is ignored.
  *
- *	@param a a 128-bit vector treated a signed BCD 31 digit value.
- *	@param b a 128-bit vector treated a signed BCD 31 digit value.
- *	@return a 128-bit vector which is the lower 31 digits of (a + b).
+ * @param a a 128-bit vector treated a signed BCD 31 digit value.
+ * @param b a 128-bit vector treated a signed BCD 31 digit value.
+ * @return a 128-bit vector which is the lower 31 digits of (a + b).
  */
 static inline vui32_t
 vec_bcdadd (vui32_t a, vui32_t b)
@@ -148,9 +167,9 @@ vec_bcdadd (vui32_t a, vui32_t b)
  * Subtract Signed 31 digit values and return the lower 31 digits of
  * of the result.  Overflow (carry-out/barrow) is ignored.
  *
- *	@param a a 128-bit vector treated a signed BCD 31 digit value.
- *	@param b a 128-bit vector treated a signed BCD 31 digit value.
- *	@return a 128-bit vector which is the lower 31 digits of (a - b).
+ * @param a a 128-bit vector treated a signed BCD 31 digit value.
+ * @param b a 128-bit vector treated a signed BCD 31 digit value.
+ * @return a 128-bit vector which is the lower 31 digits of (a - b).
  */
 static inline vui32_t
 vec_bcdsub (vui32_t a, vui32_t b)
@@ -178,14 +197,14 @@ vec_bcdsub (vui32_t a, vui32_t b)
  * Two Signed 31 digit values are multiplied and lower 31 digits of the
  * product are returned.  Overflow is ignored.
  *
- *  \todu This is tricky as the product can be up to 62 digits and
- *  _Decimal128 can only hold 36 digits. So products that are more
- *  than 36 digits will loose precision on the right during the
- *  conversion back to BCD.
+ * \todo This is tricky as the product can be up to 62 digits and
+ * _Decimal128 can only hold 34 digits. So products that are more
+ * than 34 digits will loose precision on the right during the
+ * conversion back to BCD.
  *
- *	@param a a 128-bit vector treated a signed BCD 31 digit value.
- *	@param b a 128-bit vector treated a signed BCD 31 digit value.
- *	@return a 128-bit vector which is the lower 31 digits of (a * b).
+ * @param a a 128-bit vector treated a signed BCD 31 digit value.
+ * @param b a 128-bit vector treated a signed BCD 31 digit value.
+ * @return a 128-bit vector which is the lower 31 digits of (a * b).
  */
 static inline vui32_t
 vec_bcdmul (vui32_t a, vui32_t b)
@@ -204,9 +223,9 @@ vec_bcdmul (vui32_t a, vui32_t b)
  * One Signed 31 digit value is divided by a second 31 digit value
  * and the quotient is returned.
  *
- *	@param a a 128-bit vector treated a signed BCD 31 digit value.
- *	@param b a 128-bit vector treated a signed BCD 31 digit value.
- *	@return a 128-bit vector which is the lower 31 digits of (a / b).
+ * @param a a 128-bit vector treated a signed BCD 31 digit value.
+ * @param b a 128-bit vector treated a signed BCD 31 digit value.
+ * @return a 128-bit vector which is the lower 31 digits of (a / b).
  */
 static inline vui32_t
 vec_bcddiv (vui32_t a, vui32_t b)

--- a/src/vec_common_ppc.h
+++ b/src/vec_common_ppc.h
@@ -75,16 +75,27 @@ typedef __vector unsigned int vui128_t;
  * non-vector types. */
 typedef union
 {
+  /*! \brief Signed 128-bit integer from pair of 64-bit GPRs.  */
   unsigned __int128 i128;
+  /*! \brief Unsigned 128-bit integer from pair of 64-bit GPRs.  */
   unsigned __int128 ui128;
+  /*! \brief 128 bit Decimal Float from pair of double float registers.  */
   _Decimal128 dpd128;
+  /*! \brief IBM long double float from pair of double float registers.  */
   long double ldbl128;
+  /*! \brief 128 bit Vector of 16 unsigned char elements.  */
   vui8_t vx16;
+  /*! \brief 128 bit Vector of 8 unsigned short int elements.  */
   vui16_t vx8;
+  /*! \brief 128 bit Vector of 4 unsigned int elements.  */
   vui32_t vx4;
+  /*! \brief 128 bit Vector of 2 unsigned long int (64-bit) elements.  */
   vui64_t vx2;
+  /*! \brief 128 bit Vector of 1 unsigned __int128 element.  */
   vui128_t vx1;
+  /*! \brief 128 bit Vector of 2 double float elements.  */
   vf64_t vf2;
+  /*! \brief Struct of two unsigned long int (64-bit GPR) fields.  */
   struct
   {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__

--- a/src/vec_int128_ppc.h
+++ b/src/vec_int128_ppc.h
@@ -27,13 +27,13 @@
 
 /*!
  * \file  vec_int128_ppc.h
- * \brief Header package a collection of 128-bit computation functions
- * implemented with PowerISA VMX and VSX instructions.
+ * \brief Header package containing a collection of 128-bit computation
+ * functions implemented with PowerISA VMX and VSX instructions.
  */
 
-/** \brief byte reverse quadword for a vector __int128.
+/*! \brief byte reverse quadword for a vector __int128.
  *
- * Return the bytes / octets of a 128-bit vector in reverse order.
+ *	Return the bytes / octets of a 128-bit vector in reverse order.
  *
  *	@param vra a 128-bit vector treated a __int128.
  *	@return a 128-bit vector with the bytes in reserve order.
@@ -62,10 +62,10 @@ vec_revq (vui128_t vra)
   return (result);
 }
 
-/** \brief byte reverse each doubleword for a vector unsigned long int.
+/*! \brief byte reverse each doubleword for a vector unsigned long int.
  *
- * For each doubleword of the input vector, reverse the order of
- * bytes / octets within the doubleword.
+ *	For each doubleword of the input vector, reverse the order of
+ *	bytes / octets within the doubleword.
  *
  *	@param vra a 128-bit vector unsigned long int.
  *	@return a 128-bit vector with the bytes of each doubleword
@@ -95,10 +95,10 @@ vec_revd (vui64_t vra)
   return (result);
 }
 
-/** \brief byte reverse each word of a vector unsigned int.
+/*! \brief byte reverse each word of a vector unsigned int.
  *
- * For each word of the input vector, reverse the order of
- * bytes / octets within the word.
+ *	For each word of the input vector, reverse the order of
+ *	bytes / octets within the word.
  *
  *	@param vra a 128-bit vector unsigned int.
  *	@return a 128-bit vector with the bytes of each word
@@ -128,10 +128,10 @@ vec_revw (vui32_t vra)
   return (result);
 }
 
-/** \brief byte reverse each halfword of a vector unsigned short.
+/*! \brief byte reverse each halfword of a vector unsigned short.
  *
- * For each halfword of the input vector, reverse the order of
- * bytes / octets within the halfword.
+ *	For each halfword of the input vector, reverse the order of
+ *	bytes / octets within the halfword.
  *
  *	@param vra a 128-bit vector unsigned short.
  *	@return a 128-bit vector with the bytes of each halfword
@@ -163,9 +163,9 @@ vec_revh (vui16_t vra)
 
 /** \brief Count leading zeros for a vector __int128.
  *
- * Count leading zeros for a vector __int128 and return the count in a
- * vector suitable for use with vector shift (left|right) and vector
- * shift (left|right) by octet instructions.
+ *	Count leading zeros for a vector __int128 and return the count in a
+ *	vector suitable for use with vector shift (left|right) and vector
+ *	shift (left|right) by octet instructions.
  *
  *	@param vra a 128-bit vector treated a __int128.
  *	@return a 128-bit vector with bits 121:127 containing the count of
@@ -222,8 +222,8 @@ vec_clzq (vui128_t vra)
 }
 /** \brief Population Count vector __int128.
  *
- * Count leading zeros for a vector __int128 and return the count in a
- * vector .
+ *	Count the number of '1' bits within a vector __int128 and return
+ *	the count (0-128) in a vector __int128.
  *
  *	@param vra a 128-bit vector treated a __int128.
  *	@return a 128-bit vector with bits 121:127 containing the
@@ -267,10 +267,10 @@ vec_popcntq (vui128_t vra)
 
 /** \brief Vector Shift Left double Quadword.
  *
- * Vector Shift Left double Quadword 0-127 bits.
- * Return a vector __int128 that is the left most 128-bits after
- * shifting left 0-127-bits of the 32-byte double vector
- * (vrw||vrx).  The shift amount is from bits 121:127 of vrb.
+ *	Vector Shift Left double Quadword 0-127 bits.
+ *	Return a vector __int128 that is the left most 128-bits after
+ *	shifting left 0-127-bits of the 32-byte double vector
+ *	(vrw||vrx).  The shift amount is from bits 121:127 of vrb.
  *
  *	@param vrw upper 128-bits of the 256-bit double vector.
  *	@param vrx lower 128-bits of the 256-bit double vector.
@@ -301,12 +301,12 @@ vec_sldq (vui128_t vrw, vui128_t vrx, vui128_t vrb)
 
 /** \brief Vector Shift right Quadword Immediate.
  *
- * Vector Shift right Quadword 0-127 bits.
- * The shift amount is a const unsigned int in the range 0-127.
- * A shift count of 0 returs the original value of vra.
- * Shift counts greater then 127 bits return zero.
+ *	Vector Shift right Quadword 0-127 bits.
+ *	The shift amount is a const unsigned int in the range 0-127.
+ *	A shift count of 0 returns the original value of vra.
+ *	Shift counts greater then 127 bits return zero.
  *
- *	@param vra a 128-bit vector treated a __int128.
+ *	@param vra a 128-bit vector treated as a __int128.
  *	@param shb Shift amount in the range 0-127.
  *	@return 128-bit vector shifted right shb bits.
  */
@@ -365,10 +365,10 @@ vec_srqi (vui128_t vra, const unsigned int shb)
 
 /** \brief Vector Shift right Quadword.
  *
- * Vector Shift Right Quadword 0-127 bits.
- * The shift amount is from bits 121-127 of vrb.
+ *	Vector Shift Right Quadword 0-127 bits.
+ *	The shift amount is from bits 121-127 of vrb.
  *
- *	@param vra a 128-bit vector treated a __int128.
+ *	@param vra a 128-bit vector treated as a __int128.
  *	@param vrb Shift amount in bits 121:127.
  *	@return Right shifted vector.
  */
@@ -390,16 +390,16 @@ vec_srq (vui128_t vra, vui128_t vrb)
 
 /** \brief Vector Shift left Quadword Immediate.
  *
- * Vector Shift left Quadword 0-127 bits.
- * The shift amount is a const unsigned int in the range 0-127.
- * A shift count of 0 returs the original value of vra.
- * Shift counts greater then 127 bits return zero.
+ *	Vector Shift left Quadword 0-127 bits.
+ *	The shift amount is a const unsigned int in the range 0-127.
+ *	A shift count of 0 returns the original value of vra.
+ *	Shift counts greater then 127 bits return zero.
  *
- *	@param vra a 128-bit vector treated a __int128.
+ *	@param vra a 128-bit vector treated as a __int128.
  *	@param shb Shift amount in the range 0-127.
  *	@return 128-bit vector shifted left shb bits.
  */
-static inline vui128_t __attribute__((__gnu_inline__, __always_inline__, __artificial__))
+static inline vui128_t
 vec_slqi (vui128_t vra, const unsigned int shb)
 {
   vui8_t lshift;
@@ -449,10 +449,10 @@ vec_slqi (vui128_t vra, const unsigned int shb)
 
 /** \brief Vector Shift Left Quadword.
  *
- * Vector Shift Left Quadword 0-127 bits.
- * The shift amount is from bits 121-127 of vrb.
+ *	Vector Shift Left Quadword 0-127 bits.
+ *	The shift amount is from bits 121-127 of vrb.
  *
- *	@param vra a 128-bit vector treated a __int128.
+ *	@param vra a 128-bit vector treated as a __int128.
  *	@param vrb Shift amount in bits 121:127.
  *	@return Left shifted vector.
  */
@@ -472,75 +472,75 @@ vec_slq (vui128_t vra, vui128_t vrb)
   return ((vui128_t) result);
 }
 
-/** \brief Vector Shift right 4-bits Quadword.
+/** \deprecated Vector Shift right 4-bits Quadword.
+ * Replaced by vec_srqi with shb param = 4.
  *
  * Vector Shift Right Quadword 0-127 bits.
  * The shift amount is from bits 121-127 of vrb.
  *
- *	@param vra a 128-bit vector treated a __int128.
- *	@return Right shifted vector.
+ * @param vra a 128-bit vector treated as a __int128.
+ * @return Right shifted vector.
  */
 static inline vui128_t
 vec_srq4 (vui128_t vra)
 {
   __vector unsigned char result, vsht_splat;
 
-  /* For some reason we let the processor jockies write they
-   * hardware bug into the ISA.  The vsr instruction only works
-   * correctly if the bit shift value is splatted to each byte
-   * of the vector.  */
+  /* The vsr instruction only works correctly if the bit shift value
+   * is splatted to each byte of the vector.  */
   vsht_splat = vec_splat_u8(4);
   result = vec_srl ((__vector unsigned char) vra, vsht_splat);
 
   return ((vui128_t) result);
 }
 
-/** \brief Vector Shift Left 4-bits Quadword.
+/** \deprecated Vector Shift Left 4-bits Quadword.
+ * Replaced by vec_slqi with shb param = 4.
+ *
  * Vector Shift Left Quadword 0-127 bits.
  * The shift amount is from bits 121-127 of vrb.
  *
- *	@param vra a 128-bit vector treated a __int128.
- *	@return Left shifted vector.
+ * @param vra a 128-bit vector treated a __int128.
+ * @return Left shifted vector.
  */
 static inline vui128_t
 vec_slq4 (vui128_t vra)
 {
   __vector unsigned char result, vsht_splat;
 
-  /* For some reason we let the processor jockies write they
-   * hardware bug into the ISA.  The vsl instruction only works
-   * correctly if the bit shift value is splatted to each byte
-   * of the vector.  */
+  /* The vsl instruction only works correctly if the bit shift value
+   * is splatted to each byte of the vector.  */
   vsht_splat = vec_splat_u8(4);
   result = vec_sll ((__vector unsigned char) vra, vsht_splat);
 
   return ((vui128_t) result);
 }
 
-/** \brief Vector Shift right 4-bits Quadword.
+/** \deprecated Vector Shift right 5-bits Quadword.
+ * Replaced by vec_srqi with shb param = 5.
  *
  * Vector Shift Right Quadword 0-127 bits.
  * The shift amount is from bits 121-127 of vrb.
  *
- *	@param vra a 128-bit vector treated a __int128.
- *	@return Right shifted vector.
+ * @param vra a 128-bit vector treated a __int128.
+ * @return Right shifted vector.
  */
 static inline vui128_t
 vec_srq5 (vui128_t vra)
 {
   __vector unsigned char result, vsht_splat;
 
-  /* For some reason we let the processor jockies write they
-   * hardware bug into the ISA.  The vsr instruction only works
-   * correctly if the bit shift value is splatted to each byte
-   * of the vector.  */
+  /* The vsr instruction only works correctly if the bit shift value
+   * is splatted to each byte of the vector.  */
   vsht_splat = vec_splat_u8(5);
   result = vec_srl ((__vector unsigned char) vra, vsht_splat);
 
   return ((vui128_t) result);
 }
 
-/** \brief Vector Shift Left 4-bits Quadword.
+/** \deprecated Vector Shift Left 5-bits Quadword.
+ * Replaced by vec_slqi with shb param = 5.
+ *
  * Vector Shift Left Quadword 0-127 bits.
  * The shift amount is from bits 121-127 of vrb.
  *
@@ -552,10 +552,8 @@ vec_slq5 (vui128_t vra)
 {
   __vector unsigned char result, vsht_splat;
 
-  /* For some reason we let the processor jockies write they
-   * hardware bug into the ISA.  The vsl instruction only works
-   * correctly if the bit shift value is splatted to each byte
-   * of the vector.  */
+  /* The vsl instruction only works correctly if the bit shift value
+   * is splatted to each byte of the vector.  */
   vsht_splat = vec_splat_u8(5);
   result = vec_sll ((__vector unsigned char) vra, vsht_splat);
 
@@ -563,14 +561,15 @@ vec_slq5 (vui128_t vra)
 }
 
 /** \brief Vector doubleword paste.
- * Combine the high doubleword of the 1st vector with the
- * low double word of the 2nd vector.
+ *	Combine the high doubleword of the 1st vector with the
+ *	low double word of the 2nd vector.
  *
- * @param __VH a 128-bit vector as the source of the
+ *	@param __VH a 128-bit vector as the source of the
  * 	high order doubleword.
- * @param __VL a 128-bit vector as the source of the
+ *	@param __VL a 128-bit vector as the source of the
  * 	low order doubleword.
- * @return The combined 128-bit vector.
+ *	@return The combined 128-bit vector composed of the high order
+ *	doubleword of __VH and the low order doubleword of __VL.
  */
 static inline vui64_t
 vec_pasted (vui64_t __VH, vui64_t __VL)
@@ -587,12 +586,12 @@ vec_pasted (vui64_t __VH, vui64_t __VL)
 
 /** \brief Vector multiply odd unsigned words.
  *
- * Multiple the odd words of two vector unsigned int values and return
- * the unsigned long product of the odd words..
+ *	Multiple the odd words of two vector unsigned int values and return
+ *	the unsigned long product of the odd words..
  *
- * @param a 128-bit vector unsigned int.
- * @param b 128-bit vector unsigned int.
- * @return vector unsigned long product of the odd words of a and b.
+ *	@param a 128-bit vector unsigned int.
+ *	@param b 128-bit vector unsigned int.
+ *	@return vector unsigned long product of the odd words of a and b.
  */
 static inline vui64_t
 vec_mulouw (vui32_t a, vui32_t b)
@@ -711,7 +710,7 @@ vec_mulesw (vi32_t a, vi32_t b)
 
 /** \brief Vector Add Unsigned Quadword Modulo.
  *
- * Add two vector __int128 values and return result modulo 128-bits.
+ *	Add two vector __int128 values and return result modulo 128-bits.
  *
  *	@param a 128-bit vector treated a __int128.
  *	@param b 128-bit vector treated a __int128.
@@ -734,33 +733,25 @@ vec_adduqm (vui128_t a, vui128_t b)
 #endif
 #else
   vui32_t c, c2;
-  vui32_t z=
-    { 0,0,0,0};
-  __asm__(
-      "vaddcuw %1,%3,%4;\n"
-      "\tvadduwm %0,%3,%4;\n"
-      "\tvsldoi %1,%1,%5,4;\n"
-      "\tvaddcuw %2,%0,%1;\n"
-      "\tvadduwm %0,%0,%1;\n"
-      "\tvsldoi %1,%2,%5,4;\n"
-      "\tvaddcuw %2,%0,%1;\n"
-      "\tvadduwm %0,%0,%1;\n"
-      "\tvsldoi %1,%2,%5,4;\n"
-      "\tvadduwm %0,%0,%1;\n"
-      : "=&v" (t),
-      "=&v" (c),
-      "=&v" (c2)
-      : "v" (a),
-      "v" (b),
-      "v" (z)
-      : );
+  vui32_t z= { 0,0,0,0};
+
+  c = vec_vaddcuw ((vui32_t)a, (vui32_t)b);
+  t = vec_vadduwm ((vui32_t)a, (vui32_t)b);
+  c = vec_sld (c, z, 4);
+  c2 = vec_vaddcuw (t, c);
+  t = vec_vadduwm (t, c);
+  c = vec_sld (c2, z, 4);
+  c2 = vec_vaddcuw (t, c);
+  t = vec_vadduwm (t, c);
+  c = vec_sld (c2, z, 4);
+  t = vec_vadduwm (t, c);
 #endif
   return ((vui128_t) t);
 }
 
 /** \brief Vector Add & write Carry Unsigned Quadword.
  *
- * Add two vector __int128 values and return the carry out.
+ *	Add two vector __int128 values and return the carry out.
  *
  *	@param a 128-bit vector treated a __int128.
  *	@param b 128-bit vector treated a __int128.
@@ -769,51 +760,43 @@ vec_adduqm (vui128_t a, vui128_t b)
 static inline vui128_t
 vec_addcuq (vui128_t a, vui128_t b)
 {
-  vui32_t t;
+  vui32_t co;
 #ifdef _ARCH_PWR8
 #ifndef vec_vaddcuq
   __asm__(
       "vaddcuq %0,%1,%2;"
-      : "=v" (t)
+      : "=v" (co)
       : "v" (a),
       "v" (b)
       : );
 #else
-  t = (vui32_t) vec_vaddcuq (a, b);
+  co = (vui32_t) vec_vaddcuq (a, b);
 #endif
 #else
-  vui32_t c, c2, co;
-  vui32_t z=
-    { 0,0,0,0};
-  __asm__(
-      "vaddcuw %3,%4,%5;\n"
-      "\tvadduwm %0,%4,%5;\n"
-      "\tvsldoi %1,%3,%6,4;\n"
-      "\tvaddcuw %2,%0,%1;\n"
-      "\tvadduwm %0,%0,%1;\n"
-      "\tvor %3,%3,%2;\n"
-      "\tvsldoi %1,%2,%6,4;\n"
-      "\tvaddcuw %2,%0,%1;\n"
-      "\tvadduwm %0,%0,%1;\n"
-      "\tvor %3,%3,%2;\n"
-      "\tvsldoi %1,%2,%6,4;\n"
-      "\tvadduwm %0,%0,%1;\n"
-      : "=&v" (t), /* 0 */
-      "=&v" (c), /* 1 */
-      "=&v" (c2), /* 2 */
-      "=&v" (co) /* 3 */
-      : "v" (a), /* 4 */
-      "v" (b), /* 5 */
-      "v" (z) /* 6 */
-      : );
-  t = co;
+  vui32_t c, c2, t;
+  vui32_t z= { 0,0,0,0};
+
+  co = vec_vaddcuw ((vui32_t)a, (vui32_t)b);
+  t = vec_vadduwm ((vui32_t)a, (vui32_t)b);
+  c = vec_sld (co, z, 4);
+  c2 = vec_vaddcuw (t, c);
+  t = vec_vadduwm (t, c);
+  co = vec_vor (co, c2);
+  c = vec_sld (c2, z, 4);
+  c2 = vec_vaddcuw (t, c);
+  t = vec_vadduwm (t, c);
+  co = vec_vor (co, c2);
+  c = vec_sld (c2, z, 4);
+  c2 = vec_vaddcuw (t, c);
+  co = vec_vor (co, c2);
+  co = vec_sld (z, co, 4);
 #endif
-  return ((vui128_t) t);
+  return ((vui128_t) co);
 }
 
 /** \brief Vector Add with carry Unsigned Quadword.
  *
- * Add two vector __int128 values and return sum and the carry out.
+ *	Add two vector __int128 values and return sum and the carry out.
  *
  *	@param *cout carry out from the sum of a and b.
  *	@param a 128-bit vector treated a __int128.
@@ -840,31 +823,23 @@ vec_addcq (vui128_t *cout, vui128_t a, vui128_t b)
 #endif
 #else
   vui32_t c, c2;
-  vui32_t z=
-    { 0,0,0,0};
-  __asm__(
-      "vaddcuw %3,%4,%5;\n"
-      "\tvadduwm %0,%4,%5;\n"
-      "\tvsldoi %1,%3,%6,4;\n"
-      "\tvaddcuw %2,%0,%1;\n"
-      "\tvadduwm %0,%0,%1;\n"
-      "\tvor %3,%3,%2;\n"
-      "\tvsldoi %1,%2,%6,4;\n"
-      "\tvaddcuw %2,%0,%1;\n"
-      "\tvadduwm %0,%0,%1;\n"
-      "\tvor %3,%3,%2;\n"
-      "\tvsldoi %1,%2,%6,4;\n"
-      "\tvadduwm %0,%0,%1;\n"
-      "\tvsldoi %3,%6,%3,4;\n"
-      : "=&v" (t), /* 0 */
-      "=&v" (c), /* 1 */
-      "=&v" (c2), /* 2 */
-      "=&v" (co) /* 3 */
-      : "v" (a), /* 4 */
-      "v" (b), /* 5 */
-      "v" (z) /* 6 */
-      : );
-  t = co;
+  vui32_t z= { 0,0,0,0};
+
+  co = vec_vaddcuw ((vui32_t)a, (vui32_t)b);
+  t = vec_vadduwm ((vui32_t)a, (vui32_t)b);
+  c = vec_sld (co, z, 4);
+  c2 = vec_vaddcuw (t, c);
+  t = vec_vadduwm (t, c);
+  co = vec_vor (co, c2);
+  c = vec_sld (c2, z, 4);
+  c2 = vec_vaddcuw (t, c);
+  t = vec_vadduwm (t, c);
+  co = vec_vor (co, c2);
+  c = vec_sld (c2, z, 4);
+  c2 = vec_vaddcuw (t, c);
+  t = vec_vadduwm (t, c);
+  co = vec_vor (co, c2);
+  co = vec_sld (z, co, 4);
 #endif
   *cout = (vui128_t) co;
   return ((vui128_t) t);
@@ -872,16 +847,16 @@ vec_addcq (vui128_t *cout, vui128_t a, vui128_t b)
 
 /** \brief Vector Add Extended Unsigned Quadword Modulo.
  *
- * Add two vector __int128 values plus a carry (0|1) and return
- * the modulo 128-bit result.
+ *	Add two vector __int128 values plus a carry (0|1) and return
+ *	the modulo 128-bit result.
  *
  *	@param a 128-bit vector treated a __int128.
  *	@param b 128-bit vector treated a __int128.
- *	@param c Carry-in from vector bit[127].
+ *	@param ci Carry-in from vector bit[127].
  *	@return __int128 sum of a + b + c, modulo 128-bits.
  */
 static inline vui128_t
-vec_addeuqm (vui128_t a, vui128_t b, vui128_t c)
+vec_addeuqm (vui128_t a, vui128_t b, vui128_t ci)
 {
   vui32_t t;
 #ifdef _ARCH_PWR8
@@ -891,125 +866,103 @@ vec_addeuqm (vui128_t a, vui128_t b, vui128_t c)
       : "=v" (t)
       : "v" (a),
       "v" (b),
-      "v" (c)
+      "v" (ci)
       : );
 #else
-  t = (vui32_t) vec_vaddeuqm (a, b, c);
+  t = (vui32_t) vec_vaddeuqm (a, b, ci);
 #endif
 #else
-  vui32_t c2;
-  vui32_t z=
-    { 0,0,0,0};
-  vui32_t m=
-    { 0,0,0,1};
-  __asm__(
-      "vand %2,%1,%6;\n"
-      "\tvaddcuw %1,%3,%4;\n"
-      "\tvsldoi %2,%2,%5,12;\n"
-      "\tvsldoi %1,%1,%2,4;\n"
-      "\tvadduwm %0,%3,%4;\n"
-      "\tvaddcuw %2,%0,%1;\n"
-      "\tvadduwm %0,%0,%1;\n"
-      "\tvsldoi %1,%2,%5,4;\n"
-      "\tvaddcuw %2,%0,%1;\n"
-      "\tvadduwm %0,%0,%1;\n"
-      "\tvsldoi %1,%2,%5,4;\n"
-      "\tvaddcuw %2,%0,%1;\n"
-      "\tvadduwm %0,%0,%1;\n"
-      "\tvsldoi %1,%2,%5,4;\n"
-      "\tvadduwm %0,%0,%1;\n"
-      : "=&v" (t), /* 0 */
-      "+&v" (c), /* 1 */
-      "=&v" (c2) /* 2 */
-      : "v" (a), /* 3 */
-      "v" (b), /* 4 */
-      "v" (z), /* 5 */
-      "v" (m) /* 6 */
-      : );
+  vui32_t c2, c;
+  vui32_t z  = { 0,0,0,0};
+  vui32_t co = { 1,1,1,1};
+
+  c2 = vec_and ((vui32_t)ci, co);
+  c2 = vec_sld ((vui32_t)ci, z, 12);
+  co = vec_vaddcuw ((vui32_t)a, (vui32_t)b);
+  t = vec_vadduwm ((vui32_t)a, (vui32_t)b);
+  c = vec_sld (co, c2, 4);
+  c2 = vec_vaddcuw (t, c);
+  t = vec_vadduwm (t, c);
+  c = vec_sld (c2, z, 4);
+  c2 = vec_vaddcuw (t, c);
+  t = vec_vadduwm (t, c);
+  c = vec_sld (c2, z, 4);
+  c2 = vec_vaddcuw (t, c);
+  t = vec_vadduwm (t, c);
+  c = vec_sld (c2, z, 4);
+  t = vec_vadduwm (t, c);
 #endif
   return ((vui128_t) t);
 }
 
 /** \brief Vector Add Extended & write Carry Unsigned Quadword.
  *
- * Add two vector __int128 values plus a carry-in (0|1) and return
- * the carry out bit.
+ *	Add two vector __int128 values plus a carry-in (0|1) and return
+ *	the carry out bit.
  *
  *	@param a 128-bit vector treated a __int128.
  *	@param b 128-bit vector treated a __int128.
- *	@param c Carry-in from vector bit[127].
+ *	@param ci Carry-in from vector bit[127].
  *	@return carry-out in bit[127] of the sum of a + b + c.
  */
 static inline vui128_t
-vec_addecuq (vui128_t a, vui128_t b, vui128_t c)
+vec_addecuq (vui128_t a, vui128_t b, vui128_t ci)
 {
-  vui32_t t;
+  vui32_t co;
 #ifdef _ARCH_PWR8
 #ifndef vec_vaddecuq
   __asm__(
       "vaddecuq %0,%1,%2,%3;"
-      : "=v" (t)
+      : "=v" (co)
       : "v" (a),
       "v" (b),
-      "v" (c)
+      "v" (ci)
       : );
 #else
-  t = (vui32_t) vec_vaddecuq (a, b, c);
+  co = (vui32_t) vec_vaddecuq (a, b, ci);
 #endif
 #else
-  vui32_t c2;
-  vui32_t z=
-    { 0,0,0,0};
-  vui32_t co=
-    { 0,0,0,1};
-  __asm__(
-      "vand %3,%1,%2;\n"
-      "\tvaddcuw %2,%4,%5;\n"
-      "\tvsldoi %3,%3,%5,12;\n"
-      "\tvsldoi %1,%2,%3,4;\n"
-      "\tvadduwm %0,%4,%5;\n"
-      "\tvaddcuw %3,%0,%1;\n"
-      "\tvadduwm %0,%0,%1;\n"
-      "\tvor %2,%2,%3;\n"
-      "\tvsldoi %1,%3,%6,4;\n"
-      "\tvaddcuw %3,%0,%1;\n"
-      "\tvadduwm %0,%0,%1;\n"
-      "\tvor %2,%2,%3;\n"
-      "\tvsldoi %1,%3,%6,4;\n"
-      "\tvaddcuw %3,%0,%1;\n"
-      "\tvadduwm %0,%0,%1;\n"
-      "\tvor %2,%2,%3;\n"
-      "\tvsldoi %1,%3,%6,4;\n"
-      "\tvaddcuw %3,%0,%1;\n"
-      "\tvadduwm %0,%0,%1;\n"
-      "\tvor %2,%2,%3;\n"
-      "\tvsldoi %2,%6,%2,4;\n"
-      : "=&v" (t), /* 0 */
-      "+&v" (c), /* 1 */
-      "+&v" (co), /* 2 */
-      "=&v" (c2) /* 3 */
-      : "v" (a), /* 4 */
-      "v" (b), /* 5 */
-      "v" (z) /* 6 */
-      : );
-  t = co;
+  vui32_t c, c2, t;
+  vui32_t z = { 0, 0, 0, 0 };
+  co = (vui32_t){ 1, 1, 1, 1 };
+
+  c2 = vec_and ((vui32_t) ci, co);
+  c2 = vec_sld ((vui32_t) c2, z, 12);
+  co = vec_vaddcuw ((vui32_t) a, (vui32_t) b);
+  t = vec_vadduwm ((vui32_t) a, (vui32_t) b);
+  c = vec_sld (co, c2, 4);
+  c2 = vec_vaddcuw (t, c);
+  t = vec_vadduwm (t, c);
+  co = vec_vor (co, c2);
+  c = vec_sld (c2, z, 4);
+  c2 = vec_vaddcuw (t, c);
+  t = vec_vadduwm (t, c);
+  co = vec_vor (co, c2);
+  c = vec_sld (c2, z, 4);
+  c2 = vec_vaddcuw (t, c);
+  t = vec_vadduwm (t, c);
+  co = vec_vor (co, c2);
+  c = vec_sld (c2, z, 4);
+  c2 = vec_vaddcuw (t, c);
+  co = vec_vor (co, c2);
+  co = vec_sld (z, co, 4);
 #endif
-  return ((vui128_t) t);
+  return ((vui128_t) co);
 }
 
 /** \brief Vector Add Extend with carry Unsigned Quadword.
  *
- * Add two vector __int128 values plus a carry-in (0|1)
- * and return sum and the carry out.
+ *	Add two vector __int128 values plus a carry-in (0|1)
+ *	and return sum and the carry out.
  *
  *	@param *cout carry out from the sum of a and b.
  *	@param a 128-bit vector treated a __int128.
  *	@param b 128-bit vector treated a __int128.
- *	@param c Carry-in from vector bit[127].
+ *	@param ci Carry-in from vector bit[127].
  *	@return __int128 (lower 128-bits) sum of a + b + c.
  */
 static inline vui128_t
-vec_addeq (vui128_t *cout, vui128_t a, vui128_t b, vui128_t c)
+vec_addeq (vui128_t *cout, vui128_t a, vui128_t b, vui128_t ci)
 {
   vui32_t t, co;
 #ifdef _ARCH_PWR8
@@ -1024,46 +977,35 @@ vec_addeq (vui128_t *cout, vui128_t a, vui128_t b, vui128_t c)
       "v" (c)
       : );
 #else
-  t = (vui32_t) vec_vaddeuqm (a, b, c);
-  co = (vui32_t) vec_vaddecuq (a, b, c);
+  t = (vui32_t) vec_vaddeuqm (a, b, ci);
+  co = (vui32_t) vec_vaddecuq (a, b, ci);
 #endif
 #else
-  vui32_t c2;
-  vui32_t z=
-    { 0,0,0,0};
+  vui32_t c, c2;
+  vui32_t z= { 0,0,0,0};
+  co = (vui32_t){ 1,1,1,1};
 
-  co= (vui32_t)
-    { 0,0,0,1};
-  __asm__(
-      "vand %3,%1,%2;\n"
-      "\tvaddcuw %2,%4,%5;\n"
-      "\tvsldoi %3,%3,%5,12;\n"
-      "\tvsldoi %1,%2,%3,4;\n"
-      "\tvadduwm %0,%4,%5;\n"
-      "\tvaddcuw %3,%0,%1;\n"
-      "\tvadduwm %0,%0,%1;\n"
-      "\tvor %2,%2,%3;\n"
-      "\tvsldoi %1,%3,%6,4;\n"
-      "\tvaddcuw %3,%0,%1;\n"
-      "\tvadduwm %0,%0,%1;\n"
-      "\tvor %2,%2,%3;\n"
-      "\tvsldoi %1,%3,%6,4;\n"
-      "\tvaddcuw %3,%0,%1;\n"
-      "\tvadduwm %0,%0,%1;\n"
-      "\tvor %2,%2,%3;\n"
-      "\tvsldoi %1,%3,%6,4;\n"
-      "\tvaddcuw %3,%0,%1;\n"
-      "\tvadduwm %0,%0,%1;\n"
-      "\tvor %2,%2,%3;\n"
-      "\tvsldoi %2,%6,%2,4;\n"
-      : "=&v" (t), /* 0 */
-      "+&v" (c), /* 1 */
-      "+&v" (co), /* 2 */
-      "=&v" (c2) /* 3 */
-      : "v" (a), /* 4 */
-      "v" (b), /* 5 */
-      "v" (z) /* 6 */
-      : );
+  c2 = vec_and ((vui32_t)ci, co);
+  c2 = vec_sld ((vui32_t)c2, z, 12);
+  co = vec_vaddcuw ((vui32_t)a, (vui32_t)b);
+  t = vec_vadduwm ((vui32_t)a, (vui32_t)b);
+  c = vec_sld (co, c2, 4);
+  c2 = vec_vaddcuw (t, c);
+  t = vec_vadduwm (t, c);
+  co = vec_vor (co, c2);
+  c = vec_sld (c2, z, 4);
+  c2 = vec_vaddcuw (t, c);
+  t = vec_vadduwm (t, c);
+  co = vec_vor (co, c2);
+  c = vec_sld (c2, z, 4);
+  c2 = vec_vaddcuw (t, c);
+  t = vec_vadduwm (t, c);
+  co = vec_vor (co, c2);
+  c = vec_sld (c2, z, 4);
+  c2 = vec_vaddcuw (t, c);
+  t = vec_vadduwm (t, c);
+  co = vec_vor (co, c2);
+  co = vec_sld (z, co, 4);
 #endif
   *cout = (vui128_t) co;
   return ((vui128_t) t);
@@ -1148,10 +1090,10 @@ vec_muleud (vui64_t a, vui64_t b)
   return ((vui128_t) res);
 }
 
-/** \brief Vector Multiply Unsigned Quadword.
+/** \brief Vector Multiply Low Unsigned Quadword.
  *
- * compute the 256 bit product of two 128 bit values a, b.
- * Only the low order 128 bits of the product are returned.
+ *	compute the 256 bit product of two 128 bit values a, b.
+ *	Only the low order 128 bits of the product are returned.
  *
  *	@param a 128-bit vector treated a __int128.
  *	@param b 128-bit vector treated a __int128.
@@ -1205,9 +1147,7 @@ vec_mulluq (vui128_t a, vui128_t b)
   t_odd = (vui32_t)vec_mulouw((vui32_t)a, tsw);
 #endif
   /* Sum the low 128 bits of odd previous partial products */
-  /* todo is there a possible carry out of this */
   t_odd = (vui32_t) vec_adduqm ((vui128_t) t_odd, (vui128_t) t);
-
   /* rotate right the low 32-bits into tmq */
   tmq = vec_sld (t_odd, tmq, 12);
   /* shift the low 128 bits of partial product right 32-bits */
@@ -1264,8 +1204,8 @@ vec_mulluq (vui128_t a, vui128_t b)
 
 /** \brief Vector Multiply Unsigned double Quadword.
  *
- * compute the 256 bit product of two 128 bit values a, b.
- * Only the low order 128 bits of the product are returned.
+ *	compute the 256 bit product of two 128 bit values a, b.
+ *	Only the low order 128 bits of the product are returned.
  *
  *	@param *mulu pointer to upper 128-bits of the product.
  *	@param a 128-bit vector treated a __int128.
@@ -1382,8 +1322,8 @@ vec_muludq (vui128_t *mulu, vui128_t a, vui128_t b)
 
 /** \brief Vector Multiply by 10 Unsigned Quadword.
  *
- * compute the product of a 128 bit value a * 10.
- * Only the low order 128 bits of the product are returned.
+ *	compute the product of a 128 bit value a * 10.
+ *	Only the low order 128 bits of the product are returned.
  *
  *	@param a 128-bit vector treated as a __int128.
  *	@return __int128 (lower 128-bits) a * 10.
@@ -1417,19 +1357,8 @@ vec_mul10uq (vui128_t a)
 #ifdef _ARCH_PWR8
   t = (vui32_t) vec_vadduqm ((vui128_t) t_even, (vui128_t) t_odd);
 #else
-  vui32_t c, c2;
-  __asm__(
-      "vaddcuw %1,%3,%4;\n"
-      "\tvadduwm %0,%3,%4;\n"
-      "\tvsldoi %1,%1,%5,4;\n"
-      "\tvadduwm %0,%0,%1;\n"
-      : "=&v" (t),
-      "=&v" (c),
-      "=&v" (c2)
-      : "v" (t_even),
-      "v" (t_odd),
-      "v" (z)
-      : );
+  /* Use pveclib addcuq implementation for pre _ARCH_PWR8.  */
+  t = (vui32_t) vec_adduqm ((vui128_t) t_even, (vui128_t) t_odd);
 #endif
 #endif
   return ((vui128_t) t);
@@ -1437,8 +1366,8 @@ vec_mul10uq (vui128_t a)
 
 /** \brief Vector Multiply by 10 extended Unsigned Quadword.
  *
- * compute the product of a 128 bit value a * 10 + digit(cin).
- * Only the low order 128 bits of the extended product are returned.
+ *	compute the product of a 128 bit value a * 10 + digit(cin).
+ *	Only the low order 128 bits of the extended product are returned.
  *
  *	@param a 128-bit vector treated as a unsigned __int128.
  *	@param cin values 0-9 in bits 124:127 of a vector.
@@ -1477,19 +1406,8 @@ vec_mul10euq (vui128_t a, vui128_t cin)
 #ifdef _ARCH_PWR8
   t = (vui32_t) vec_vadduqm ((vui128_t) t_even, (vui128_t) t_odd);
 #else
-  vui32_t c, c2;
-  __asm__(
-      "vaddcuw %1,%3,%4;\n"
-      "\tvadduwm %0,%3,%4;\n"
-      "\tvsldoi %1,%1,%5,4;\n"
-      "\tvadduwm %0,%0,%1;\n"
-      : "=&v" (t),
-      "=&v" (c),
-      "=&v" (c2)
-      : "v" (t_even),
-      "v" (t_odd),
-      "v" (z)
-      : );
+  /* Use pveclib addcuq implementation for pre _ARCH_PWR8.  */
+  t = (vui32_t) vec_adduqm ((vui128_t) t_even, (vui128_t) t_odd);
 #endif
 #endif
   return ((vui128_t) t);
@@ -1497,10 +1415,10 @@ vec_mul10euq (vui128_t a, vui128_t cin)
 
 /** \brief Vector Multiply by 10 & write Carry Unsigned Quadword.
  *
- * compute the product of a 128 bit value a * 10.
- * Only the high order 128 bits of the product are returned.
- * This will be binary coded decimal value 0-9 in bits 124-127,
- * Bits 0-123 will be '0'.
+ *	compute the product of a 128 bit value a * 10.
+ *	Only the high order 128 bits of the product are returned.
+ *	This will be binary coded decimal value 0-9 in bits 124-127,
+ *	Bits 0-123 will be '0'.
  *
  *	@param a 128-bit vector treated as a __int128.
  *	@return __int128 (upper 128-bits of the 256-bit product) a * 10 >> 128.
@@ -1535,30 +1453,13 @@ vec_mul10cuq (vui128_t a)
   /* then add the even/odd sub-products to generate the final product */
 #ifdef _ARCH_PWR8
   /* Any compiler that supports ARCH_PWR8 should support these builtins.  */
-//        t = (vui32_t)vec_vadduqm ((vui128_t)t_even, (vui128_t)t_odd);
   t_carry = (vui32_t) vec_vaddcuq ((vui128_t) t_even, (vui128_t) t_odd);
   t_carry = (vui32_t) vec_vadduqm ((vui128_t) t_carry, (vui128_t) t_high);
 #else
-  vui32_t c, c2, t;
-  __asm__(
-      "vaddcuw %1,%3,%4;\n"
-      "\tvadduwm %0,%3,%4;\n"
-      "\tvsldoi %2,%5,%1,4;\n"
-      "\tvsldoi %1,%1,%5,4;\n"
-      "\tvadduwm %0,%0,%1;\n"
-      : "=&v" (t),
-      "=&v" (c),
-      "=&v" (c2)
-      : "v" (t_even),
-      "v" (t_odd),
-      "v" (z)
-      : );
-  __asm__(
-      "vadduwm %0,%1,%2;\n"
-      : "=v" (t_carry)
-      : "v" (t_high),
-      "v" (c2)
-      : );
+  /* Use pveclib addcuq implementation for pre _ARCH_PWR8.  */
+  t_carry = (vui32_t) vec_addcuq ((vui128_t) t_even, (vui128_t) t_odd);
+  /* The final carry is small (0-9) so use word add, ignore carries.  */
+  t_carry = vec_vadduwm (t_carry, t_high);
 #endif
 #endif
   return ((vui128_t) t_carry);
@@ -1566,8 +1467,8 @@ vec_mul10cuq (vui128_t a)
 
 /** \brief Vector Multiply by 10 Extended & write Carry Unsigned Quadword.
  *
- * Compute the product of a 128 bit value a * 10 + digit(cin).
- * Only the low order 128 bits of the extended product are returned.
+ *	Compute the product of a 128 bit value a * 10 + digit(cin).
+ *	Only the low order 128 bits of the extended product are returned.
  *
  *	@param a 128-bit vector treated as a unsigned __int128.
  *	@param cin values 0-9 in bits 124:127 of a vector.
@@ -1613,26 +1514,10 @@ vec_mul10ecuq (vui128_t a, vui128_t cin)
   t_carry = (vui32_t) vec_vaddcuq ((vui128_t) t_even, (vui128_t) t_odd);
   t_carry = (vui32_t) vec_vadduqm ((vui128_t) t_carry, (vui128_t) t_high);
 #else
-  vui32_t c, c2, t;
-  __asm__(
-      "vaddcuw %1,%3,%4;\n"
-      "\tvadduwm %0,%3,%4;\n"
-      "\tvsldoi %2,%5,%1,4;\n"
-      "\tvsldoi %1,%1,%5,4;\n"
-      "\tvadduwm %0,%0,%1;\n"
-      : "=&v" (t),
-      "=&v" (c),
-      "=&v" (c2)
-      : "v" (t_even),
-      "v" (t_odd),
-      "v" (z)
-      : );
-  __asm__(
-      "vadduwm %0,%1,%2;\n"
-      : "=v" (t_carry)
-      : "v" (t_high),
-      "v" (c2)
-      : );
+  /* Use pveclib addcuq implementation for pre _ARCH_PWR8.  */
+  t_carry = (vui32_t) vec_addcuq ((vui128_t) t_even, (vui128_t) t_odd);
+  /* The final carry is small (0-9) so use word add, ignore carries.  */
+  t_carry = vec_vadduwm (t_carry, t_high);
 #endif
 #endif
   return ((vui128_t) t_carry);
@@ -1640,8 +1525,8 @@ vec_mul10ecuq (vui128_t a, vui128_t cin)
 
 /** \brief Vector combined Multiply by 10 Extended & write Carry Unsigned Quadword.
  *
- * Compute the product of a 128 bit value a * 10 + digit(cin).
- * Only the low order 128 bits of the extended product are returned.
+ *	Compute the product of a 128 bit value a * 10 + digit(cin).
+ *	Only the low order 128 bits of the extended product are returned.
  *
  *	@param *cout pointer to upper 128-bits of the product.
  *	@param a 128-bit vector treated as a unsigned __int128.
@@ -1685,24 +1570,12 @@ vec_cmul10ecuq (vui128_t *cout, vui128_t a, vui128_t cin)
   /* then add the even/odd sub-products to generate the final product */
 #ifdef _ARCH_PWR8
   /* Any compiler that supports ARCH_PWR8 should support these builtins.  */
-  t_carry = t_high; /* there is not carry into high */
+  t_carry = t_high; /* there is no carry into high */
   t = (vui32_t) vec_vadduqm ((vui128_t) t_even, (vui128_t) t_odd);
 #else
-  vui32_t c, c2;
-  __asm__(
-      "vaddcuw %1,%3,%4;\n"
-      "\tvadduwm %0,%3,%4;\n"
-      "\tvsldoi %2,%5,%1,4;\n"
-      "\tvsldoi %1,%1,%5,4;\n"
-      "\tvadduwm %0,%0,%1;\n"
-      : "=&v" (t),
-      "=&v" (c),
-      "=&v" (c2)
-      : "v" (t_even),
-      "v" (t_odd),
-      "v" (z)
-      : );
-  t_carry = t_high; /* there is not carry into high */
+  t_carry = t_high; /* there is no carry into high */
+  /* Use pveclib adduqm implementation for pre _ARCH_PWR8.  */
+  t = (vui32_t) vec_adduqm ((vui128_t) t_even, (vui128_t) t_odd);
 #endif
 #endif
   *cout = (vui128_t) t_carry;
@@ -1711,8 +1584,8 @@ vec_cmul10ecuq (vui128_t *cout, vui128_t a, vui128_t cin)
 
 /** \brief Vector combined Multiply by 10 & write Carry Unsigned Quadword.
  *
- * compute the product of a 128 bit values a * 10.
- * Only the low order 128 bits of the product are returned.
+ *	compute the product of a 128 bit values a * 10.
+ *	Only the low order 128 bits of the product are returned.
  *
  *	@param *cout pointer to upper 128-bits of the product.
  *	@param a 128-bit vector treated as a __int128.
@@ -1751,23 +1624,12 @@ vec_cmul10cuq (vui128_t *cout, vui128_t a)
   /* then add the even/odd sub-products to generate the final product */
 #ifdef _ARCH_PWR8
   /* Any compiler that supports ARCH_PWR8 should support these builtins.  */
-  t_carry = t_high; /* there is not carry into high */
+  t_carry = t_high; /* there is no carry into high */
   t = (vui32_t) vec_vadduqm ((vui128_t) t_even, (vui128_t) t_odd);
 #else
-  vui32_t c, c2;
-  __asm__(
-      "vaddcuw %1,%3,%4;\n"
-      "\tvadduwm %0,%3,%4;\n"
-      "\tvsldoi %2,%5,%1,4;\n"
-      "\tvsldoi %1,%1,%5,4;\n"
-      "\tvadduwm %0,%0,%1;\n"
-      : "=&v" (t),
-      "=&v" (c),
-      "=&v" (c2)
-      : "v" (t_even),
-      "v" (t_odd),
-      "v" (z)
-      : );
+  t_carry = t_high; /* there is no carry into high */
+  /* Use pveclib adduqm implementation for pre _ARCH_PWR8.  */
+  t = (vui32_t) vec_adduqm ((vui128_t) t_even, (vui128_t) t_odd);
 #endif
 #endif
   *cout = (vui128_t) t_carry;
@@ -1776,8 +1638,8 @@ vec_cmul10cuq (vui128_t *cout, vui128_t a)
 
 /** \brief Vector combined Multiply by 100 & write Carry Unsigned Quadword.
  *
- * compute the product of a 128 bit values a * 100.
- * Only the low order 128 bits of the product are returned.
+ *	compute the product of a 128 bit values a * 100.
+ *	Only the low order 128 bits of the product are returned.
  *
  *	@param *cout pointer to upper 128-bits of the product.
  *	@param a 128-bit vector treated as a __int128.
@@ -1834,23 +1696,12 @@ vec_cmul100cuq (vui128_t *cout, vui128_t a)
   /* then add the even/odd sub-products to generate the final product */
 #ifdef _ARCH_PWR8
   /* Any compiler that supports ARCH_PWR8 should support these builtins.  */
-  t_carry = t_high; /* there is not carry into high */
+  t_carry = t_high; /* there is no carry into high */
   t = (vui32_t) vec_vadduqm ((vui128_t) t_even, (vui128_t) t_odd);
 #else
-  vui32_t c, c2;
-  __asm__(
-      "vaddcuw %1,%3,%4;\n"
-      "\tvadduwm %0,%3,%4;\n"
-      "\tvsldoi %2,%5,%1,4;\n"
-      "\tvsldoi %1,%1,%5,4;\n"
-      "\tvadduwm %0,%0,%1;\n"
-      : "=&v" (t),
-      "=&v" (c),
-      "=&v" (c2)
-      : "v" (t_even),
-      "v" (t_odd),
-      "v" (z)
-      : );
+  t_carry = t_high; /* there is no carry into high */
+  /* Use pveclib adduqm implementation for pre _ARCH_PWR8.  */
+  t = (vui32_t) vec_adduqm ((vui128_t) t_even, (vui128_t) t_odd);
 #endif
 #endif
   *cout = (vui128_t) t_carry;
@@ -1859,10 +1710,10 @@ vec_cmul100cuq (vui128_t *cout, vui128_t a)
 
 /** \brief Vector combined Multiply by 100 Extended & write Carry Unsigned Quadword.
  *
- * Compute the product of a 128 bit value a * 100 + digit(cin).
- * The function return its low order 128 bits of the extended product.
- * The first parameter (*cout) it the address of the vector to receive
- * the generated carry out in the range 0-99.
+ *	Compute the product of a 128 bit value a * 100 + digit(cin).
+ *	The function return its low order 128 bits of the extended product.
+ *	The first parameter (*cout) it the address of the vector to receive
+ *	the generated carry out in the range 0-99.
  *
  *	@param *cout pointer to upper 128-bits of the product.
  *	@param a 128-bit vector treated as a unsigned __int128.
@@ -1925,24 +1776,12 @@ vec_cmul100ecuq (vui128_t *cout, vui128_t a, vui128_t cin)
   /* then add the even/odd sub-products to generate the final product */
 #ifdef _ARCH_PWR8
   /* Any compiler that supports ARCH_PWR8 should support these builtins.  */
-  t_carry = t_high; /* there is not carry into high */
+  t_carry = t_high; /* there is no carry into high */
   t = (vui32_t) vec_vadduqm ((vui128_t) t_even, (vui128_t) t_odd);
 #else
-  vui32_t c, c2;
-  __asm__(
-      "vaddcuw %1,%3,%4;\n"
-      "\tvadduwm %0,%3,%4;\n"
-      "\tvsldoi %2,%5,%1,4;\n"
-      "\tvsldoi %1,%1,%5,4;\n"
-      "\tvadduwm %0,%0,%1;\n"
-      : "=&v" (t),
-      "=&v" (c),
-      "=&v" (c2)
-      : "v" (t_even),
-      "v" (t_odd),
-      "v" (z)
-      : );
-  t_carry = t_high; /* there is not carry into high */
+  t_carry = t_high; /* there is no carry into high */
+  /* Use pveclib adduqm implementation for pre _ARCH_PWR8.  */
+  t = (vui32_t) vec_adduqm ((vui128_t) t_even, (vui128_t) t_odd);
 #endif
 #endif
   *cout = (vui128_t) t_carry;


### PR DESCRIPTION
Fix the doxygen docs: Add a complete introduction; laying out the
rationale, issues, and plans. Reduce the noise from make doxygen-doc
by adding doxygen \brief comment for every function, typedef, and
macro. Correct the doxygen function descriptions so text and parms
have the same alignment. To make the examples clearer, simplify the
code by replacing some long in-line assembler sequences with equivalent
built-in functions from altivec.h.

On branch Fix_doxygen_Feb18
Changes to be committed:
	modified:   doc/pveclib-doxygen-pveclib.doxy
	modified:   doc/pveclibmaindox.h
	modified:   src/testsuite/arith128_print.c
	modified:   src/testsuite/arith128_test_i128.c
	modified:   src/testsuite/vec_int128_dummy.c
	modified:   src/vec_bcd_ppc.h
	modified:   src/vec_common_ppc.h
	modified:   src/vec_int128_ppc.h

	* doc/pveclib-doxygen-pveclib.doxy (INPUT): Add vec_bcd_ppc.h.
	* doc/pveclibmaindox.h: Add more complete dscriptions of this
	project.

	* src/vec_bcd_ppc.h: Include vec_common_ppc.h instead of
	altivec.h directly.  Add \file and \brief description.  Add
	\brief description for bcd_quantize0.
	* src/vec_bcd_ppc.h (vec_BCD2DFP): Align indentation of comment
	body with @param and @return descriptions that follow.
	* src/vec_bcd_ppc.h (vec_DFP2DFP, vec_bcdadd, vec_bcdsub,
	vec_bcdmul, vec_bcddiv): Likewise.

	* src/vec_common_ppc.h (union __VEC_U_128): Add doxygen \brief
	comment for each field.

	* src/vec_int128_ppc.h (vec_revq): Align indentation of comment
	body with @param and @return descriptions that follow. Reword
	some comments for clarity, grammer and spelling.
	* src/vec_int128_ppc.h (vec_revd, vec_revw, vec_revh, vec_clzq,
	vec_popcntq, vec_sldq, vec_srqi, vec_srq, vec_slqi, vec_slq):
	Likewise.
	* src/vec_int128_ppc.h (vec_srq4, vec_slq4, vec_srq5, vec_slq5):
	Deprecated.
	* src/vec_int128_ppc.h (vec_pasted): Align indentation of
	comment	body with @param and @return descriptions that follow.
	Reword some comments for clarity, grammer and spelling.
	* src/vec_int128_ppc.h (vec_mulouw): Likewise.
	* src/vec_int128_ppc.h (vec_adduqm [!_ARCH_PWR8]): Replace
	in-line assembler with equivalent altivec.h built-ins.
	* src/vec_int128_ppc.h (vec_addcuq): Rename return variable t
	to co ("carry-out") for clarity.
	* src/vec_int128_ppc.h (vec_addcuq [!_ARCH_PWR8]): Replace
	in-line assembler with equivalent altivec.h built-ins.
	* src/vec_int128_ppc.h (vec_addcq [!_ARCH_PWR8]): Replace
	in-line assembler with equivalent altivec.h built-ins.
	* src/vec_int128_ppc.h (vec_addeuqm): Rename carry-in parm c
	to ci for clarity.
	* src/vec_int128_ppc.h (vec_addeuqm [!_ARCH_PWR8]): Replace
	in-line assembler with equivalent altivec.h built-ins.
	* src/vec_int128_ppc.h (vec_addecuq): Rename carry-in parm c
	to ci for clarity.  Rename return variable t to co
	("carry-out") for clarity.
	* src/vec_int128_ppc.h (vec_addecuq [!_ARCH_PWR8]): Replace
	in-line assembler with equivalent altivec.h built-ins.
	* src/vec_int128_ppc.h (vec_addeq): Rename carry-in parm c
	to ci for clarity.
	* src/vec_int128_ppc.h (vec_addeq [!_ARCH_PWR8]): Replace
	in-line assembler with equivalent altivec.h built-ins.

	* src/vec_int128_ppc.h (vec_mulluq): Align indentation of
	comment body with @param and @return descriptions that follow.
	Reword some comments for clarity, grammer and spelling.
	* src/vec_int128_ppc.h (vec_mul10uq, vec_mul10euq,
	vec_mul10cuq, vec_mul10ecuq, vec_cmul10cuq, vec_cmul10ecuq,
	vec_cmul100cuq, vec_cmul100ecuq,): Likewise.
	* src/vec_int128_ppc.h (vec_mul10uq [!_ARCH_PWR8]): Replace
	in-line assembler with equivalent and correct vec_adduqm.
	* src/vec_int128_ppc.h (vec_mul10euq [!_ARCH_PWR8]): Replace
	in-line assembler with equivalent and correct vec_adduqm.
	* src/vec_int128_ppc.h (vec_mul10cuq [!_ARCH_PWR8]): Replace
	in-line assembler with equivalent and correct vec_adduqm /
	vec_adduwm.
	* src/vec_int128_ppc.h (vec_mul10ecuq [!_ARCH_PWR8]): Replace
	in-line assembler with equivalent and correct vec_adduqm.
	* src/vec_int128_ppc.h (vec_cmul10ecuq [!_ARCH_PWR8]): Replace
	in-line assembler with equivalent and correct vec_adduqm.
	* src/vec_int128_ppc.h (vec_cmul100cuq [!_ARCH_PWR8]): Replace
	in-line assembler with equivalent and correct vec_adduqm.
	* src/vec_int128_ppc.h (vec_cmul100ecuq [!_ARCH_PWR8]): Replace
	in-line assembler with equivalent and correct vec_adduqm.

	* src/testsuite/arith128_print.c (db_vec_clzq) [_ARCH_PWR8]:
	Debug version of vec_clsq only for Power8 and later.
	* src/testsuite/arith128_print.c (db_vec_mulluq) [_ARCH_PWR8]:
	Debug version of vec_mulluq only for Power8 and later.
	* src/testsuite/arith128_print.c (db_vec_mulluq): Replace
	#error with #warning.
	* src/testsuite/arith128_print.c (db_vec_addeuqm): Cast vui32_t
	values to vui128_t for print_vint128.
	* src/testsuite/arith128_print.c (db_vec_addeq): Cast vui32_t
	values to vui128_t for print_vint128.

	* src/testsuite/arith128_test_i128.c (test_addcq): New
	function.
	* src/testsuite/arith128_test_i128.c (test_addeq): New
	function.
	* src/testsuite/arith128_test_i128.c (test_2): Call test_addcq
	and test_addeq.  Additional tests in-line.
	* src/testsuite/arith128_test_i128.c (test_4b): Improve
	formating of debug and "check_* failure text.
	* src/testsuite/arith128_test_i128.c (test_4b1): Likewise.
	* src/testsuite/arith128_test_i128.c (test_4c): Likewise.

	* src/testsuite/vec_int128_dummy.c (test_vec_add256): New
	function.
	* src/testsuite/vec_int128_dummy.c (test_vec_addeuqm_ecuq):
	Likewise.
	* src/testsuite/vec_int128_dummy.c (test_vec_adduqm_cuq):
	Likewise.
	* src/testsuite/vec_int128_dummy.c (test_vec_mul10uq_cuq):
	Likewise.
	* src/testsuite/vec_int128_dummy.c (test_vec_addeq,
	test_vec_addcq, test_vec_addecuq, test_vec_addeuqm,
	test_vec_adduqm, test_vec_addcuq):
	Moved within file for visability.
	* src/testsuite/vec_int128_dummy.c (test_vsl4, test_vsr4,
	test_sldq, test_vec_srq, test_vec_slq): Moved within file.
	* src/testsuite/vec_int128_dummy.c (test_vec_vsumsws): New
	function.
	* src/testsuite/vec_int128_dummy.c (test_vec_clzq,
	test_popcntq, test_cmul10uq, test_cmul10euq, test_mul10uq_c,
	test_mul10uq, test_mul10euq, test_mul10cuq, test_revq,
	test_vec_load_store, test_vpaste, test_vpaste_x, :
	Likewise.
	* src/testsuite/vec_int128_dummy.c [_ARCH_PWR8]:
	Define test_clzq.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>