### PR TITLE
First chunk of the power9 integer enablement. Starting with new files,

### DIFF
--- a/src/vec_common_ppc.h
+++ b/src/vec_common_ppc.h
@@ -122,6 +122,13 @@ typedef union
 #define CONST_VINT128_W(__w0, __w1, __w2, __w3) (vui32_t){__w3, __w2, __w1, __w0}
 /*! \brief Arrange elements of word initializer in high->low order.  */
 #define CONST_VINT32_W(__w0, __w1, __w2, __w3) {__w3, __w2, __w1, __w0}
+/*! \brief Arrange word elements of a unsigned int initializer in
+ * high->low order.  May require an explicit cast.  */
+#define CONST_VINT128_H(__hw0, __hw1, __hw2, __hw3, __hw4, __hw5, __hw6, __hw7) \
+    {__hw7, __hw6, __hw5, __hw4, __hw3, __hw2, __hw1, __hw0}
+/*! \brief Arrange elements of word initializer in high->low order.  */
+#define CONST_VINT16_H(__hw0, __hw1, __hw2, __hw3, __hw4, __hw5, __hw6, __hw7) \
+    {__hw7, __hw6, __hw5, __hw4, __hw3, __hw2, __hw1, __hw0}
 /*! \brief Element index for high order dword.  */
 #define VEC_DW_H 1
 /*! \brief Element index for low order dword.  */
@@ -144,6 +151,10 @@ typedef union
 #define VEC_HW_L 0
 /*! \brief Element index for lowest order byte.  */
 #define VEC_BYTE_L 0
+/*! \brief Element index for lowest order byte of the high dword.  */
+#define VEC_BYTE_L_DWH 8
+/*! \brief Element index for lowest order byte of the low dword.  */
+#define VEC_BYTE_L_DWL 0
 /*! \brief Element index for highest order byte.  */
 #define VEC_BYTE_H 15
 /*! \brief Element index for second lowest order byte.  */
@@ -154,6 +165,13 @@ typedef union
 #define CONST_VINT128_DW128(__dw0, __dw1) (vui128_t)((vui64_t){__dw0, __dw1})
 #define CONST_VINT128_W(__w0, __w1, __w2, __w3) (vui32_t){__w0, __w1, __w2, __w3}
 #define CONST_VINT32_W(__w0, __w1, __w2, __w3) {__w0, __w1, __w2, __w3}
+/*! \brief Arrange word elements of a unsigned int initializer in
+ * high->low order.  May require an explicit cast.  */
+#define CONST_VINT128_H(__hw0, __hw1, __hw2, __hw3, __hw4, __hw5, __hw6, __hw7) \
+    {__hw0, __hw1, __hw2, __hw3, __hw4, __hw5, __hw6, __hw7}
+/*! \brief Arrange elements of word initializer in high->low order.  */
+#define CONST_VINT16_H(__hw0, __hw1, __hw2, __hw3, __hw4, __hw5, __hw6, __hw7) \
+    {__hw0, __hw1, __hw2, __hw3, __hw4, __hw5, __hw6, __hw7}
 #define VEC_DW_H 0
 #define VEC_DW_L 1
 #define VEC_W_H 0
@@ -165,6 +183,10 @@ typedef union
 #define VEC_HW_H 0
 #define VEC_HW_L 7
 #define VEC_BYTE_L 15
+/*! \brief Element index for lowest order byte of the high dword.  */
+#define VEC_BYTE_L_DWH 7
+/*! \brief Element index for lowest order byte of the low dword.  */
+#define VEC_BYTE_L_DWL 15
 #define VEC_BYTE_H 0
 #define VEC_BYTE_HHW 1
 #endif

--- a/src/vec_common_ppc.h
+++ b/src/vec_common_ppc.h
@@ -1,5 +1,5 @@
 /*
- Copyright [2017] IBM Corporation.
+ Copyright (c) [2017] IBM Corporation.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/vec_common_ppc.h
+++ b/src/vec_common_ppc.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) [2017] IBM Corporation.
+ Copyright (c) [2017, 2018] IBM Corporation.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/vec_f32_ppc.h
+++ b/src/vec_f32_ppc.h
@@ -1,5 +1,5 @@
 /*
- Copyright [2017] IBM Corporation.
+ Copyright (c) [2017] IBM Corporation.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/vec_f64_ppc.h
+++ b/src/vec_f64_ppc.h
@@ -1,5 +1,5 @@
 /*
- Copyright [2017] IBM Corporation.
+ Copyright (c) [2017] IBM Corporation.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/vec_f64_ppc.h
+++ b/src/vec_f64_ppc.h
@@ -123,7 +123,8 @@ vec_isinff64 (__vf64 vf64)
 	const vui64_t signmask = CONST_VINT128_DW(0x8000000000000000, 0x8000000000000000);
 	tmp = vec_andc ((vui64_t)vf64, signmask);
 #endif
-	result = (__f64_bool)vec_cmpeq (tmp, expmask);
+// TODO need a P7 equivalent to vcmpequd
+	result = (__f64_bool)vec_cmpeq ((vui32_t)tmp, (vui32_t)expmask);
 
 	return (result);
 }
@@ -155,10 +156,17 @@ vec_isnormalf64 (__vf64 vf64)
 	tmp2 = vec_andc ((vui64_t)vf64, signmask);
 #endif
 	tmp = vec_and ((vui64_t)vf64, expmask);
+#ifdef _ARCH_PWR8
 	tmp2 = (vui64_t)vec_cmpeq(tmp2, vec_zero);
 	tmp = (vui64_t)vec_cmpeq(tmp, expmask);
 	result = (__f64_bool)vec_nor (tmp, tmp2);
-
+#else
+	tmp2 = (vui64_t)vec_cmpeq((vui32_t)tmp2, (vui32_t)vec_zero);
+	tmp = (vui64_t)vec_cmpeq((vui32_t)tmp, (vui32_t)expmask);
+	result = (__f64_bool)vec_nor (tmp, tmp2);
+	// TODO need a P7- equivallent to vmrgew
+//	result = (__f64_bool)vec_mergee ((vui32_t)result, (vui32_t)result);
+#endif
 	return (result);
 }
 

--- a/src/vec_int16_ppc.h
+++ b/src/vec_int16_ppc.h
@@ -1,5 +1,5 @@
 /*
- Copyright [2018] IBM Corporation.
+ Copyright (c) [2018] IBM Corporation.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@
  * \brief Header package containing a collection of 128-bit SIMD
  * operations over 16-bit integer elements.
  *
- * Most vector short (16-bit integer) operations are are already
+ * Most vector short (16-bit integer) operations are already
  * covered by the original VMX (AKA Altivec) instructions.
  * VMX intrinsic (compiler built-ins) operations are defined in
  * <altivec.h> and described in the compiler documentation.
@@ -43,13 +43,13 @@
  * target, and produce correct results.
  *
  * This header serves to fill in functional gaps for older
- * (Power7, Power8) processors and provides a in-line assembler
+ * (POWER7, POWER8) processors and provides an in-line assembler
  * implementation for older compilers that do not
  * provide the build-ins.
  *
  * This header covers operations that are either:
  *
- * - Operations implemented in hardware instructions for later
+ * - Implemented in hardware instructions for later
  * processors and useful to programmers, on slightly older processors,
  * even if the equivalent function requires more instructions.
  * Examples include Count Leading Zeros, Population Count and Byte
@@ -58,7 +58,7 @@
  * <altivec.n> provided by available compilers in common use.
  * Examples include Count Leading Zeros, Population Count and Byte
  * Reverse.
- * - Are commonly used operations, not covered by the ABI or
+ * - Commonly used operations, not covered by the ABI or
  * <altivec.h>, and require multiple instructions or
  * are not obvious.
  * Examples include the shift immediate operations.
@@ -72,7 +72,7 @@
  *  Count the number of leading '0' bits (0-16) within each halfword
  *  element of a 128-bit vector.
  *
- *  For Power8 (PowerISA 2.07B) or later use the Vector Count Leading
+ *  For POWER8 (PowerISA 2.07B) or later use the Vector Count Leading
  *  Zeros Halfword instruction <B>vclzh</B>. Otherwise use sequence of pre
  *  2.07 VMX instructions.
  *  SIMDized count leading zeros inspired by:
@@ -154,7 +154,7 @@ vec_clzh (vui16_t vra)
  *  Count the number of '1' bits (0-16) within each byte element of
  *  a 128-bit vector.
  *
- *  For Power8 (PowerISA 2.07B) or later use the Vector Population
+ *  For POWER8 (PowerISA 2.07B) or later use the Vector Population
  *  Count Halfword instruction. Otherwise use simple Vector (VMX)
  *  instructions to count bits in bytes in parallel.
  *  SIMDized population count inspired by:
@@ -176,7 +176,7 @@ vec_popcnth (vui16_t vra)
 #ifndef vec_vpopcnth
   __asm__(
       "vpopcnth %0,%1;"
-      : "=v" (t)
+      : "=v" (r)
       : "v" (vra)
       : );
 #else
@@ -220,6 +220,7 @@ vec_popcnth (vui16_t vra)
   return (r);
 }
 #else
+/* Work around for GCC PR85830.  */
 #undef vec_popcnth
 #define vec_popcnth __builtin_vec_vpopcnth
 #endif
@@ -283,7 +284,7 @@ vec_slhi (vui16_t vra, const unsigned int shb)
     {
       /* Load the shift const in a vector.  The element shifts require
          a shift amount for each element. For the immediate form the
-         shift constant is splated to all elements of the
+         shift constant is splatted to all elements of the
          shift control.  */
       if (__builtin_constant_p(shb))
 	lshift = (vui16_t) vec_splat_s16(shb);
@@ -324,7 +325,7 @@ vec_srhi (vui16_t vra, const unsigned int shb)
     {
       /* Load the shift const in a vector.  The element shifts require
          a shift amount for each element. For the immediate form the
-         shift constant is splated to all elements of the
+         shift constant is splatted to all elements of the
          shift control.  */
       if (__builtin_constant_p(shb))
 	lshift = (vui16_t) vec_splat_s16(shb);
@@ -365,7 +366,7 @@ vec_srahi (vi16_t vra, const unsigned int shb)
     {
       /* Load the shift const in a vector.  The element shifts require
          a shift amount for each element. For the immediate form the
-         shift constant is splated to all elements of the
+         shift constant is splatted to all elements of the
          shift control.  */
       if (__builtin_constant_p(shb))
 	lshift = (vui16_t) vec_splat_s16(shb);

--- a/src/vec_int16_ppc.h
+++ b/src/vec_int16_ppc.h
@@ -1,0 +1,391 @@
+/*
+ Copyright [2018] IBM Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ vec_int32_ppc.h
+
+ Contributors:
+      IBM Corporation, Steven Munroe
+      Created on: Apr 06, 2018
+ */
+
+#ifndef VEC_INT16_PPC_H_
+#define VEC_INT16_PPC_H_
+
+#include <vec_char_ppc.h>
+
+/*!
+ * \file  vec_int16_ppc.h
+ * \brief Header package containing a collection of 128-bit SIMD
+ * operations over 16-bit integer elements.
+ *
+ * Most vector short (16-bit integer) operations are are already
+ * covered by the original VMX (AKA Altivec) instructions.
+ * VMX intrinsic (compiler built-ins) operations are defined in
+ * <altivec.h> and described in the compiler documentation.
+ *
+ * \note The compiler disables associated <altivec.h> built-ins if the
+ * <B>mcpu</B> target does not enable the specific instruction.
+ * For example if you compile with <B>-mcpu=power7</B>, vec_vclz and
+ * vec_vclzh will not be defined.  But vec_clzh is always defined in
+ * this header, will generate the minimum code, appropriate for the
+ * target, and produce correct results.
+ *
+ * This header serves to fill in functional gaps for older
+ * (Power7, Power8) processors and provides a in-line assembler
+ * implementation for older compilers that do not
+ * provide the build-ins.
+ *
+ * This header covers operations that are either:
+ *
+ * - Operations implemented in hardware instructions for later
+ * processors and useful to programmers, on slightly older processors,
+ * even if the equivalent function requires more instructions.
+ * Examples include Count Leading Zeros, Population Count and Byte
+ * Reverse.
+ * - Defined in the OpenPOWER ABI but <I>not</I> yet defined in
+ * <altivec.n> provided by available compilers in common use.
+ * Examples include Count Leading Zeros, Population Count and Byte
+ * Reverse.
+ * - Are commonly used operations, not covered by the ABI or
+ * <altivec.h>, and require multiple instructions or
+ * are not obvious.
+ * Examples include the shift immediate operations.
+ *
+ */
+
+
+/** \brief Count leading zeros for a vector unsigned short (halfword)
+ *  elements.
+ *
+ *  Count the number of leading '0' bits (0-16) within each halfword
+ *  element of a 128-bit vector.
+ *
+ *  For Power8 (PowerISA 2.07B) or later use the Vector Count Leading
+ *  Zeros Halfword instruction <B>vclzh</B>. Otherwise use sequence of pre
+ *  2.07 VMX instructions.
+ *  SIMDized count leading zeros inspired by:
+ *
+ *  Warren, Henry S. Jr and <I>Hacker's Delight</I>, 2nd Edition,
+ *  Addison Wesley, 2013. Chapter 5 Counting Bits, Figure 5-12.
+ *
+ *  @param vra 128-bit vector treated as 8 x 16-bit integer (halfword)
+ *  elements.
+ *  @return 128-bit vector with the Leading Zeros count for each
+ *  halfword element.
+ */
+static inline vui16_t
+vec_clzh (vui16_t vra)
+{
+  vui16_t r;
+#ifdef _ARCH_PWR8
+#ifndef vec_vclzh
+  __asm__(
+      "vclzh %0,%1;"
+      : "=v" (r)
+      : "v" (vra)
+      : );
+#else
+  r = vec_vclzh (vra);
+#endif
+#else
+//#warning Implememention pre power8
+  vui16_t n, nt, y, x, s, m;
+  vui16_t z= { 0,0,0,0, 0,0,0,0};
+  vui16_t one = { 1,1,1,1, 1,1,1,1};
+
+  /* n = 16 s = 8 */
+  s = vec_splat_u16(8);
+  n = vec_add (s, s);
+  x = vra;
+
+  /* y=x>>8 if (y!=0) (n=n-8 x=y)  */
+  y = vec_sr(x, s);
+  nt = vec_sub(n,s);
+  m = (vui16_t)vec_cmpgt(y, z);
+  s = vec_sr(s,one);
+  x = vec_sel (x , y, m);
+  n = vec_sel (n , nt, m);
+
+  /* y=x>>4 if (y!=0) (n=n-4 x=y)  */
+  y = vec_sr(x, s);
+  nt = vec_sub(n,s);
+  m = (vui16_t)vec_cmpgt(y, z);
+  s = vec_sr(s,one);
+  x = vec_sel (x , y, m);
+  n = vec_sel (n , nt, m);
+
+  /* y=x>>2 if (y!=0) (n=n-2 x=y)  */
+  y = vec_sr(x, s);
+  nt = vec_sub(n,s);
+  m = (vui16_t)vec_cmpgt(y, z);
+  s = vec_sr(s,one);
+  x = vec_sel (x , y, m);
+  n = vec_sel (n , nt, m);
+
+  /* y=x>>1 if (y!=0) return (n=n-2)   */
+  y = vec_sr(x, s);
+  nt = vec_sub(n,s);
+  nt = vec_sub(nt,s);
+  m = (vui16_t)vec_cmpgt(y, z);
+  n = vec_sel (n , nt, m);
+
+  /* else return (x-n)  */
+  nt = vec_sub (n, x);
+  r = vec_sel (nt , n, m);
+#endif
+
+  return (r);
+}
+
+/** \brief Vector Population Count halfword.
+ *
+ *  Count the number of '1' bits (0-16) within each byte element of
+ *  a 128-bit vector.
+ *
+ *  For Power8 (PowerISA 2.07B) or later use the Vector Population
+ *  Count Halfword instruction. Otherwise use simple Vector (VMX)
+ *  instructions to count bits in bytes in parallel.
+ *  SIMDized population count inspired by:
+ *
+ *  Warren, Henry S. Jr and <I>Hacker's Delight</I>, 2nd Edition,
+ *  Addison Wesley, 2013. Chapter 5 Counting Bits, Figure 5-2.
+ *
+ *  @param vra 128-bit vector treated as 8 x 16-bit integers (halfword)
+ *  elements.
+ *  @return 128-bit vector with the population count for each halfword
+ *  element.
+ */
+#ifndef vec_popcnth
+static inline vui16_t
+vec_popcnth (vui16_t vra)
+{
+  vui16_t r;
+#ifdef _ARCH_PWR8
+#ifndef vec_vpopcnth
+  __asm__(
+      "vpopcnth %0,%1;"
+      : "=v" (t)
+      : "v" (vra)
+      : );
+#else
+  r = vec_vpopcnth (vra);
+#endif
+#else
+  //#warning Implememention pre power8
+    __vector unsigned short n, x1, x2, x, s;
+    __vector unsigned short ones = { 1,1,1,1, 1,1,1,1};
+    __vector unsigned short fives =
+        {0x5555,0x5555,0x5555,0x5555, 0x5555,0x5555,0x5555,0x5555};
+    __vector unsigned short threes =
+        {0x3333,0x3333,0x3333,0x3333, 0x3333,0x3333,0x3333,0x3333};
+    __vector unsigned short fs =
+        {0x0f0f,0x0f0f,0x0f0f,0x0f0f, 0x0f0f,0x0f0f,0x0f0f,0x0f0f};
+    /* n = 8 s = 4 */
+    s = ones;
+    x = vra;
+
+    /* x = x - ((x >> 1) & 0x5555)  */
+    x2 = vec_and (vec_sr (x, s), fives);
+    n = vec_sub (x, x2);
+    s = vec_add (s, s);
+
+    /* x = (x & 0x3333) + ((x & 0xcccc) >> 2)  */
+    x1 = vec_and (n, threes);
+    x2 = vec_andc (n, threes);
+    n = vec_add (x1, vec_sr (x2, s));
+    s = vec_add (s, s);
+
+    /* x = (x + (x >> 4)) & 0x0f0f)  */
+    x1 = vec_add (n, vec_sr (n, s));
+    n  = vec_and (x1, fs);
+    s = vec_add (s, s);
+
+    /* This avoids the extra load const.  */
+    /* x = (x + (x << 8)) >> 8)  */
+    x1 = vec_add (n, vec_sl (n, s));
+    r  = vec_sr (x1, s);
+#endif
+  return (r);
+}
+#else
+#undef vec_popcnth
+#define vec_popcnth __builtin_vec_vpopcnth
+#endif
+
+/*! \brief byte reverse each halfword of a vector unsigned short.
+ *
+ *	For each halfword of the input vector, reverse the order of
+ *	bytes / octets within the halfword.
+ *
+ *	@param vra a 128-bit vector unsigned short.
+ *	@return a 128-bit vector with the bytes of each halfword
+ *	reversed.
+ */
+static inline vui16_t
+vec_revbh (vui16_t vra)
+{
+  vui16_t result;
+
+#ifdef _ARCH_PWR9
+#ifndef vec_revb
+  __asm__(
+      "xxbrh %x0,%x1;"
+      : "=wa" (result)
+      : "wa" (vra)
+      : );
+#else
+  result = vec_revb (vra);
+#endif
+#else
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  const vui64_t vconstp = CONST_VINT64_DW(0x0100030205040706UL, 0x09080B0A0D0C0F0EUL);
+#else
+  const vui64_t vconstp =
+      CONST_VINT64_DW(0x0E0F0C0D0A0B0809UL, 0x0607040502030001UL);
+#endif
+  result = (vui16_t) vec_perm ((vui8_t) vra, (vui8_t) vra, (vui8_t) vconstp);
+#endif
+
+  return (result);
+}
+
+/** \brief Vector Shift left Halfword Immediate.
+ *
+ *	Vector Shift left Halfwords each element [0-7], 0-15 bits,
+ *	as specified by an immediate value.
+ *	The shift amount is a const unsigned int in the range 0-15.
+ *	A shift count of 0 returns the original value of vra.
+ *	Shift counts greater then 15 bits return zero.
+ *
+ *	@param vra a 128-bit vector treated as a vector unsigned short.
+ *	@param shb Shift amount in the range 0-15.
+ *	@return 128-bit vector unsigned short, shifted left shb bits.
+ */
+static inline vui16_t
+vec_slhi (vui16_t vra, const unsigned int shb)
+{
+  vui16_t lshift;
+  vui16_t result;
+
+  if (shb < 16)
+    {
+      /* Load the shift const in a vector.  The element shifts require
+         a shift amount for each element. For the immediate form the
+         shift constant is splated to all elements of the
+         shift control.  */
+      if (__builtin_constant_p(shb))
+	lshift = (vui16_t) vec_splat_s16(shb);
+      else
+	lshift = vec_splats ((unsigned short) shb);
+
+      /* Vector Shift right bytes based on the lower 4-bits of
+         corresponding element of lshift.  */
+      result = vec_vslh (vra, lshift);
+    }
+  else
+    { /* shifts greater then 15 bits return zeros.  */
+      result = vec_xor ((vui16_t) vra, (vui16_t) vra);
+    }
+
+  return (vui16_t) result;
+}
+
+/** \brief Vector Shift Right Halfword Immediate.
+ *
+ *	Vector Shift right Halfwords each element [0-7], 0-15 bits,
+ *	as specified by an immediate value.
+ *	The shift amount is a const unsigned int in the range 0-15.
+ *	A shift count of 0 returns the original value of vra.
+ *	Shift counts greater then 15 bits return zero.
+ *
+ *	@param vra a 128-bit vector treated as a vector unsigned short.
+ *	@param shb Shift amount in the range 0-15.
+ *	@return 128-bit vector unsigned short, shifted right shb bits.
+ */
+static inline vui16_t
+vec_srhi (vui16_t vra, const unsigned int shb)
+{
+  vui16_t lshift;
+  vui16_t result;
+
+  if (shb < 16)
+    {
+      /* Load the shift const in a vector.  The element shifts require
+         a shift amount for each element. For the immediate form the
+         shift constant is splated to all elements of the
+         shift control.  */
+      if (__builtin_constant_p(shb))
+	lshift = (vui16_t) vec_splat_s16(shb);
+      else
+	lshift = vec_splats ((unsigned short) shb);
+
+      /* Vector Shift right bytes based on the lower 4-bits of
+         corresponding element of lshift.  */
+      result = vec_vsrh (vra, lshift);
+    }
+  else
+    { /* shifts greater then 15 bits return zeros.  */
+      result = vec_xor ((vui16_t) vra, (vui16_t) vra);
+    }
+  return (vui16_t) result;
+}
+
+/** \brief Vector Shift Right Algebraic Halfword Immediate.
+ *
+ *  Vector Shift Right Algebraic Halfwords each element [0-7],
+ *  0-15 bits, as specified by an immediate value.
+ *  The shift amount is a const unsigned int in the range 0-15.
+ *  A shift count of 0 returns the original value of vra.
+ *  Shift counts greater then 7 bits return the sign bit
+ *  propagated to each bit of each element.
+ *
+ *  @param vra a 128-bit vector treated as a vector signed char.
+ *  @param shb Shift amount in the range 0-7.
+ *  @return 128-bit vector signed short, shifted right shb bits.
+ */
+static inline vi16_t
+vec_srahi (vi16_t vra, const unsigned int shb)
+{
+  vui16_t lshift;
+  vi16_t result;
+
+  if (shb < 16)
+    {
+      /* Load the shift const in a vector.  The element shifts require
+         a shift amount for each element. For the immediate form the
+         shift constant is splated to all elements of the
+         shift control.  */
+      if (__builtin_constant_p(shb))
+	lshift = (vui16_t) vec_splat_s16(shb);
+      else
+	lshift = vec_splats ((unsigned short) shb);
+
+      /* Vector Shift Right Algebraic Halfwords based on the lower 4-bits
+         of corresponding element of lshift.  */
+      result = vec_vsrah (vra, lshift);
+    }
+  else
+    { /* shifts greater then 15 bits returns the sign bit propagated to
+         all bits.   This is equivalent to shift Right Algebraic of
+         15 bits.  */
+      lshift = (vui16_t) vec_splat_s16(15);
+      result = vec_vsrah (vra, lshift);
+    }
+
+  return (vi16_t) result;
+}
+
+
+#endif /* VEC_INT16_PPC_H_ */

--- a/src/vec_int16_ppc.h
+++ b/src/vec_int16_ppc.h
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 
- vec_int32_ppc.h
+ vec_int16_ppc.h
 
  Contributors:
       IBM Corporation, Steven Munroe
@@ -45,7 +45,7 @@
  * This header serves to fill in functional gaps for older
  * (POWER7, POWER8) processors and provides an in-line assembler
  * implementation for older compilers that do not
- * provide the build-ins.
+ * provide the built-ins.
  *
  * This header covers operations that are either:
  *
@@ -55,18 +55,17 @@
  * Examples include Count Leading Zeros, Population Count and Byte
  * Reverse.
  * - Defined in the OpenPOWER ABI but <I>not</I> yet defined in
- * <altivec.n> provided by available compilers in common use.
+ * <altivec.h> provided by available compilers in common use.
  * Examples include Count Leading Zeros, Population Count and Byte
  * Reverse.
  * - Commonly used operations, not covered by the ABI or
  * <altivec.h>, and require multiple instructions or
  * are not obvious.
  * Examples include the shift immediate operations.
- *
  */
 
 
-/** \brief Count leading zeros for a vector unsigned short (halfword)
+/** \brief Count Leading Zeros for a vector unsigned short (halfword)
  *  elements.
  *
  *  Count the number of leading '0' bits (0-16) within each halfword
@@ -305,7 +304,7 @@ vec_slhi (vui16_t vra, const unsigned int shb)
 
 /** \brief Vector Shift Right Halfword Immediate.
  *
- *	Vector Shift right Halfwords each element [0-7], 0-15 bits,
+ *	Shift right each halfword element [0-7], 0-15 bits,
  *	as specified by an immediate value.
  *	The shift amount is a const unsigned int in the range 0-15.
  *	A shift count of 0 returns the original value of vra.
@@ -332,7 +331,7 @@ vec_srhi (vui16_t vra, const unsigned int shb)
       else
 	lshift = vec_splats ((unsigned short) shb);
 
-      /* Vector Shift right bytes based on the lower 4-bits of
+      /* Vector Shift right halfword based on the lower 4-bits of
          corresponding element of lshift.  */
       result = vec_vsrh (vra, lshift);
     }
@@ -345,7 +344,7 @@ vec_srhi (vui16_t vra, const unsigned int shb)
 
 /** \brief Vector Shift Right Algebraic Halfword Immediate.
  *
- *  Vector Shift Right Algebraic Halfwords each element [0-7],
+ *  Shift right algebraic each halfword element [0-7],
  *  0-15 bits, as specified by an immediate value.
  *  The shift amount is a const unsigned int in the range 0-15.
  *  A shift count of 0 returns the original value of vra.
@@ -379,7 +378,7 @@ vec_srahi (vi16_t vra, const unsigned int shb)
     }
   else
     { /* shifts greater then 15 bits returns the sign bit propagated to
-         all bits.   This is equivalent to shift Right Algebraic of
+         all bits.  This is equivalent to shift Right Algebraic of
          15 bits.  */
       lshift = (vui16_t) vec_splat_s16(15);
       result = vec_vsrah (vra, lshift);
@@ -387,6 +386,5 @@ vec_srahi (vi16_t vra, const unsigned int shb)
 
   return (vi16_t) result;
 }
-
 
 #endif /* VEC_INT16_PPC_H_ */

--- a/src/vec_int16_ppc.h
+++ b/src/vec_int16_ppc.h
@@ -263,7 +263,7 @@ vec_revbh (vui16_t vra)
 
 /** \brief Vector Shift left Halfword Immediate.
  *
- *	Vector Shift left Halfwords each element [0-7], 0-15 bits,
+ *	Shift left each halfword element [0-7], 0-15 bits,
  *	as specified by an immediate value.
  *	The shift amount is a const unsigned int in the range 0-15.
  *	A shift count of 0 returns the original value of vra.

--- a/src/vec_int32_ppc.h
+++ b/src/vec_int32_ppc.h
@@ -1,0 +1,649 @@
+/*
+ Copyright [2018] IBM Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ vec_int32_ppc.h
+
+ Contributors:
+      IBM Corporation, Steven Munroe
+      Created on: Mar 29, 2018
+ */
+
+#ifndef VEC_INT32_PPC_H_
+#define VEC_INT32_PPC_H_
+
+#include <vec_int16_ppc.h>
+
+/*!
+ * \file  vec_int32_ppc.h
+ * \brief Header package containing a collection of 128-bit SIMD
+ * operations over 32-bit integer elements.
+ *
+ * Most vector int (32-bit integer word) operations are implemented
+ * with PowerISA VMX instructions either defined by the original VMX
+ * (AKA Altivec) or added to later versions of the PowerISA.
+ * Power8 added several multiply word operations not included in the
+ * original VMX.
+ *
+ * Also some useful word wise merge, shift, and splat operations where
+ * added with VSX in PowerISA 2.06B.
+ * Most of these intrinsic (compiler built-ins) operations are defined
+ * in <altivec.h> and described in the compiler documentation.
+ *
+ * \note The compiler disables associated <altivec.h> built-ins if the
+ * <B>mcpu</B> target does not enable the specific instruction.
+ * For example if you compile with <B>-mcpu=power7</B>, vec_vclz and
+ * vec_vclzw will not be defined.  But vec_clzw is always defined in
+ * this header, will generate the minimum code, appropriate for the
+ * target, and produce correct results.
+ *
+ * Most of these operations are implemented in a single instruction
+ * on newer (Power8/Power9) processors.
+ * This header serves to fill in functional gaps for older
+ * (Power7, Power8) processors and provides a in-line assembler
+ * implementation for older compilers that do not
+ * provide the build-ins.
+ *
+ * This header covers operations that are either:
+ *
+ * - Operations implemented in hardware instructions for later
+ * processors and useful to programmers, on slightly older processors,
+ * even if the equivalent function requires more instructions.
+ * Examples include the multiply even/odd/modulo word operations.
+ * - Defined in the OpenPOWER ABI but <I>not</I> yet defined in
+ * <altivec.n> provided by available compilers in common use.
+ * Examples include Count Leading Zeros, Population Count and Byte
+ * Reverse.
+ * - Are commonly used operations, not covered by the ABI or
+ * <altivec.h>, and require multiple instructions or
+ * are not obvious.
+ * Examples include the shift immediate operations.
+ *
+ */
+
+/** \brief Vector Count Leading Zeros word.
+ *
+ *  Count the number of leading '0' bits (0-32) within each word
+ *  element of a 128-bit vector.
+ *
+ *  For Power8 (PowerISA 2.07B) or later use the Vector Count Leading
+ *  Zeros Word instruction <B>vclzw</B>. Otherwise use sequence of pre
+ *  2.07 VMX instructions.
+ *  SIMDized count leading zeros inspired by:
+ *
+ *  Warren, Henry S. Jr and <I>Hacker's Delight</I>, 2nd Edition,
+ *  Addison Wesley, 2013. Chapter 5 Counting Bits, Figure 5-12.
+ *
+ *  @param vra 128-bit vector treated as 4 x 32-bit integer (words)
+ *  elements.
+ *  @return 128-bit vector with the Leading Zeros count for each word
+ *  element.
+ */
+static inline vui32_t
+vec_clzw (vui32_t vra)
+{
+  vui32_t r;
+#ifdef _ARCH_PWR8
+#ifndef vec_vclzw
+  __asm__(
+      "vclzw %0,%1;"
+      : "=v" (r)
+      : "v" (vra)
+      : );
+#else
+  r = vec_vclzw (vra);
+#endif
+#else
+//#warning Implememention pre power8
+  vui32_t n, nt, y, x, s, m;
+  vui32_t z= { 0,0,0,0};
+  vui32_t one = { 1,1,1,1};
+
+  /* n = 32 s = 16 */
+  s = vec_splat_u32(8);
+  s = vec_add (s, s);
+  n = vec_add (s, s);
+
+  x = vra;
+  /* y=x>>16 if (y!=0) (n=n-16 x=y)  */
+  y = vec_sr(x, s);
+  nt = vec_sub(n,s);
+  m = (vui32_t)vec_cmpgt(y, z);
+  s = vec_sr(s,one);
+  x = vec_sel (x , y, m);
+  n = vec_sel (n , nt, m);
+
+  /* y=x>>8 if (y!=0) (n=n-8 x=y)  */
+  y = vec_sr(x, s);
+  nt = vec_sub(n,s);
+  m = (vui32_t)vec_cmpgt(y, z);
+  s = vec_sr(s,one);
+  x = vec_sel (x , y, m);
+  n = vec_sel (n , nt, m);
+
+  /* y=x>>4 if (y!=0) (n=n-4 x=y)  */
+  y = vec_sr(x, s);
+  nt = vec_sub(n,s);
+  m = (vui32_t)vec_cmpgt(y, z);
+  s = vec_sr(s,one);
+  x = vec_sel (x , y, m);
+  n = vec_sel (n , nt, m);
+
+  /* y=x>>2 if (y!=0) (n=n-2 x=y)  */
+  y = vec_sr(x, s);
+  nt = vec_sub(n,s);
+  m = (vui32_t)vec_cmpgt(y, z);
+  s = vec_sr(s,one);
+  x = vec_sel (x , y, m);
+  n = vec_sel (n , nt, m);
+
+  /* y=x>>1 if (y!=0) return (n=n-2)   */
+  y = vec_sr(x, s);
+  nt = vec_sub(n,s);
+  nt = vec_sub(nt,s);
+  m = (vui32_t)vec_cmpgt(y, z);
+  n = vec_sel (n , nt, m);
+
+  /* else return (x-n)  */
+  nt = vec_sub (n, x);
+  n = vec_sel (nt , n, m);
+  r = n;
+#endif
+  return ((vui32_t) r);
+}
+
+/** \brief Vector multiply even signed words.
+ *
+ * Multiple the even words of two vector signed int values and return
+ * the signed long product of the even words.
+ *
+ * @param a 128-bit vector signed int.
+ * @param b 128-bit vector signed int.
+ * @return vector signed long product of the even words of a and b.
+ */
+static inline vi64_t
+vec_mulesw (vi32_t a, vi32_t b)
+{
+  vi64_t res;
+#if 0
+  /* Not supported in GCC yet.  ETA GCC-8.  */
+  res = vec_mule (a, b);
+#else
+  __asm__(
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+      "vmulosw %0,%1,%2;\n"
+#else
+      "vmulesw %0,%1,%2;\n"
+#endif
+      : "=v" (res)
+      : "v" (a),
+      "v" (b)
+      : );
+#endif
+  return (res);
+}
+
+/** \brief Vector multiply odd signed words.
+ *
+ * Multiple the odd words of two vector signed int values and return
+ * the signed long product of the odd words..
+ *
+ * @param a 128-bit vector signed int.
+ * @param b 128-bit vector signed int.
+ * @return vector signed long product of the odd words of a and b.
+ */
+static inline vi64_t
+vec_mulosw (vi32_t a, vi32_t b)
+{
+  vi64_t res;
+#if 0
+  /* Not supported in GCC yet.  ETA GCC-8.  */
+  res = vec_mulo (a, b);
+#else
+  __asm__(
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+      "vmulesw %0,%1,%2;\n"
+#else
+      "vmulosw %0,%1,%2;\n"
+#endif
+      : "=v" (res)
+      : "v" (a),
+      "v" (b)
+      : );
+#endif
+  return (res);
+}
+
+/** \brief Vector multiply even unsigned words.
+ *
+ * Multiple the even words of two vector unsigned int values and return
+ * the unsigned long product of the even words.
+ *
+ * @param a 128-bit vector unsigned int.
+ * @param b 128-bit vector unsigned int.
+ * @return vector unsigned long product of the even words of a and b.
+ */
+static inline vui64_t
+vec_muleuw (vui32_t a, vui32_t b)
+{
+  vui64_t res;
+#ifdef _ARCH_PWR8
+#if 0
+  /* Not supported in GCC yet.  ETA GCC-8.  */
+  res = vec_mule (a, b);
+#else
+  __asm__(
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+      "vmulouw %0,%1,%2;\n"
+#else
+      "vmuleuw %0,%1,%2;\n"
+#endif
+      : "=v" (res)
+      : "v" (a),
+      "v" (b)
+      : );
+#endif
+#else
+  const vui32_t zero = {0,0,0,0};
+  const vui32_t ones = {-1,-1,-1,-1};
+  vui32_t wmask01;
+  vui32_t p0, p1, pp10, pp01, resw;
+  vui16_t m0, m1, mt, mth, mtl;
+
+  /* generate {0,-1,0,-1}  mask.  */
+  wmask01 = vec_vmrghw (zero, ones);
+
+  mt = (vui16_t)b;
+  mtl = vec_mergeh (mt, mt);
+  mth = vec_mergel (mt, mt);
+
+#ifdef _ARCH_PWR7
+  m0 = (vui16_t)vec_xxpermdi ((vui64_t)mtl, (vui64_t)mth, 0);
+#else
+  {
+    vui32_t temp;
+    temp = vec_sld ((vui32_t) mtl, (vui32_t) mth, 8);
+    m0 = (vui16_t) vec_sld (temp, (vui32_t) mth, 8);
+  }
+#endif
+
+  resw = vec_sld (a, a, 12);
+  resw = vec_sel (a, resw, wmask01);
+  m1 = (vui16_t)resw;
+
+  p0 = vec_vmuleuh (m1, m0);
+  p1 = vec_vmulouh (m1, m0);
+  resw = vec_sel (p0, p1, wmask01);
+  res = (vui64_t)resw;
+
+  pp10 = vec_sld (p1, p1, 12);
+  pp01 = p0;
+  /* pp01 = vec_addudm (pp01, pp10).  */
+  {
+    vui32_t c;
+    vui32_t xmask;
+    xmask = vec_sld (wmask01, wmask01, 2);
+    c    = vec_vaddcuw (pp01, pp10);
+    pp01 = vec_vadduwm (pp01, pp10);
+    c    = vec_sld (c, c, 6);
+    pp01 = vec_sld (pp01, pp01, 2);
+    pp01 = vec_sel (c, pp01, xmask);
+  }
+  /* res = vec_addudm (pp01, res).  */
+  {
+    vui32_t c, r;
+    c = vec_vaddcuw (pp01, (vui32_t)res);
+    r = vec_vadduwm (pp01, (vui32_t)res);
+    c = vec_sld (c, zero, 4);
+    res = (vui64_t)vec_vadduwm (r, c);
+  }
+#endif
+  return (res);
+}
+
+/** \brief Vector multiply odd unsigned words.
+ *
+ *	Multiple the odd words of two vector unsigned int values and return
+ *	the unsigned long product of the odd words..
+ *
+ *	@param a 128-bit vector unsigned int.
+ *	@param b 128-bit vector unsigned int.
+ *	@return vector unsigned long product of the odd words of a and b.
+ */
+static inline vui64_t
+vec_mulouw (vui32_t a, vui32_t b)
+{
+  vui64_t res;
+#ifdef _ARCH_PWR8
+#if 0
+  /* Not supported in GCC yet.  ETA GCC-8.  */
+  res = vec_mulo (a, b);
+#else
+  __asm__(
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+      "vmuleuw %0,%1,%2;\n"
+#else
+      "vmulouw %0,%1,%2;\n"
+#endif
+      : "=v" (res)
+      : "v" (a),
+      "v" (b)
+      : );
+#endif
+#else
+  const vui32_t zero = {0,0,0,0};
+  const vui32_t ones = {-1,-1,-1,-1};
+  vui32_t wmask01;
+  vui32_t p0, p1, pp10, pp01, resw;
+  vui16_t m0, m1, mt, mth, mtl;
+  /* generate {0,-1,0,-1}  mask.  */
+  wmask01 = vec_vmrghw (zero, ones);
+
+  mt = (vui16_t)b;
+  mtl = vec_mergel (mt, mt);
+  mth = vec_mergeh (mt, mt);
+#ifdef _ARCH_PWR7
+  m0 = (vui16_t)vec_xxpermdi ((vui64_t)mth, (vui64_t)mtl, 3);
+#else
+  {
+    vui32_t temp;
+    temp = vec_sld ((vui32_t) mtl, (vui32_t) mtl, 8);
+    result = (vui64_t) vec_sld ((vui32_t) mth, temp, 8);
+  }
+#endif
+
+  resw = vec_sld (a, a, 4);
+  m1 = (vui16_t)vec_sel (resw, a, wmask01);
+
+  p0 = vec_vmuleuh (m1, m0);
+  p1 = vec_vmulouh (m1, m0);
+
+  resw = vec_sel (p0, p1, wmask01);
+  res = (vui64_t)resw;
+
+  pp10 = vec_sld (p1, p1, 12);
+  pp01 = p0;
+  /* pp01 = vec_addudm (pp01, pp10).  */
+  {
+    vui32_t c;
+    vui32_t xmask;
+    xmask = vec_sld (wmask01, wmask01, 2);
+    c    = vec_vaddcuw (pp01, pp10);
+    pp01 = vec_vadduwm (pp01, pp10);
+    c    = vec_sld (c, c, 6);
+    pp01 = vec_sld (pp01, pp01, 2);
+    pp01 = vec_sel (c, pp01, xmask);
+  }
+  /* res = vec_addudm (pp01, res).  */
+  {
+    vui32_t c, r;
+    c = vec_vaddcuw (pp01, (vui32_t)res);
+    r = vec_vadduwm (pp01, (vui32_t)res);
+    c = vec_sld (c, zero, 4);
+    res = (vui64_t)vec_vadduwm (r, c);
+  }
+#endif
+  return (res);
+}
+
+/** \brief Vector Multiply Unsigned Word Modulo.
+ *
+ *  Multiple the corresponding word elements of two vector unsigned int
+ *  values and return the low order 32-bits of the 64-bit product for
+ *  each element.
+ *
+ *  @param a 128-bit vector signed int.
+ *  @param b 128-bit vector signed int.
+ *  @return vector low order 32-bit of the product of the word elements
+ *  of a and b.
+ */
+static inline vui32_t
+vec_muluwm (vui32_t a, vui32_t b)
+{
+#if __GNUC__ >= 7
+  return vec_mul (a, b);
+#else
+  vui32_t r;
+#ifdef _ARCH_PWR8
+  __asm__(
+      "vmuluwm %0,%1,%2;\n"
+      : "=v" (r)
+      : "v" (a),
+      "v" (b)
+      : );
+#else
+  vui32_t s16 = (vui32_t)vec_vspltisw (-16);
+  vui32_t z = (vui32_t)vec_vspltisw (0);
+  vui32_t t4;
+  vui32_t t2, t3;
+  vui16_t t1;
+
+  t1 = (vui16_t)vec_vrlw (b, s16);
+  t2 = vec_vmulouh ((vui16_t)a, (vui16_t)b);
+  t3 = vec_vmsumuhm ((vui16_t)a, t1, z);
+  t4 = vec_vslw (t3, s16);
+  r = (vui32_t)vec_vadduwm (t4, t2);
+#endif
+  return (r);
+#endif
+}
+
+/** \brief Vector Population Count word.
+ *
+ *  Count the number of '1' bits (0-32) within each word element of
+ *  a 128-bit vector.
+ *
+ *  For Power8 (PowerISA 2.07B) or later use the Vector Population
+ *  Count Word instruction. Otherwise use the pveclib vec_popcntb
+ *  to count each byte then sum across with Vector Sum across Quarter
+ *  Unsigned Byte Saturate.
+ *
+ *  @param vra 128-bit vector treated as 4 x 32-bit integer (words)
+ *  elements.
+ *  @return 128-bit vector with the population count for each word
+ *  element.
+ */
+#ifndef vec_popcntw
+static inline vui32_t
+vec_popcntw (vui32_t vra)
+{
+  vui32_t r;
+#ifdef _ARCH_PWR8
+#ifndef vec_vpopcntw
+  __asm__(
+      "vpopcntw %0,%1;"
+      : "=v" (t)
+      : "v" (vra)
+      : );
+#else
+  r = vec_vpopcntw (vra);
+#endif
+#else
+//#warning Implememention pre power8
+  vui32_t z= { 0,0,0,0};
+  vui8_t x;
+  x = vec_popcntb ((vui8_t)vra);
+  r = vec_vsum4ubs (x, z);
+#endif
+  return (r);
+}
+#else
+#undef vec_popcntw
+#define vec_popcntw __builtin_vec_vpopcntw
+#endif
+
+/*! \brief byte reverse each word of a vector unsigned int.
+ *
+ *	For each word of the input vector, reverse the order of
+ *	bytes / octets within the word.
+ *
+ *	@param vra a 128-bit vector unsigned int.
+ *	@return a 128-bit vector with the bytes of each word
+ *	reversed.
+ */
+static inline vui32_t
+vec_revbw (vui32_t vra)
+{
+  vui32_t result;
+
+#ifdef _ARCH_PWR9
+#ifndef vec_revb
+  __asm__(
+      "xxbrw %x0,%x1;"
+      : "=wa" (result)
+      : "wa" (vra)
+      : );
+#else
+  result = vec_revb (vra);
+#endif
+#else
+  const vui64_t vconstp =
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+      CONST_VINT64_DW(0x0302010007060504UL, 0x0B0A09080F0E0D0CUL);
+#else
+      CONST_VINT64_DW(0x0C0D0E0F08090A0BUL, 0x0405060700010203UL);
+#endif
+  result = (vui32_t) vec_perm ((vui8_t) vra, (vui8_t) vra, (vui8_t) vconstp);
+#endif
+
+  return (result);
+}
+
+/** \brief Vector Shift left Word Immediate.
+ *
+ *	Vector Shift left Words each element [0-3], 0-31 bits,
+ *	as specified by an immediate value.
+ *	The shift amount is a const unsigned int in the range 0-31.
+ *	A shift count of 0 returns the original value of vra.
+ *	Shift counts greater then 31 bits return zero.
+ *
+ *	@param vra a 128-bit vector treated as a vector unsigned int.
+ *	@param shb Shift amount in the range 0-31.
+ *	@return 128-bit vector unsigned int, shifted left shb bits.
+ */
+static inline vui32_t
+vec_slwi (vui32_t vra, const unsigned int shb)
+{
+  vui32_t lshift;
+  vui32_t result;
+
+  if (shb < 32)
+    {
+      /* Load the shift const in a vector.  The element shifts require
+         a shift amount for each element. For the immediate form the
+         shift constant is splated to all elements of the
+         shift control.  */
+      if (__builtin_constant_p (shb) && (shb < 16))
+	lshift = (vui32_t) vec_splat_s32(shb);
+      else
+	lshift = vec_splats ((unsigned int) shb);
+
+      /* Vector Shift right bytes based on the lower 5-bits of
+         corresponding element of lshift.  */
+      result = vec_vslw (vra, lshift);
+    }
+  else
+    { /* shifts greater then 31 bits return zeros.  */
+      result = vec_xor ((vui32_t) vra, (vui32_t) vra);
+    }
+
+  return (vui32_t) result;
+}
+
+/** \brief Vector Shift Right Algebraic Word Immediate.
+ *
+ *  Vector Shift Right Algebraic Words each element [0-3],
+ *  0-31 bits, as specified by an immediate value.
+ *  The shift amount is a const unsigned int in the range 0-31.
+ *  A shift count of 0 returns the original value of vra.
+ *  Shift counts greater then 31 bits return the sign bit
+ *  propagated to each bit of each element.
+ *
+ *  @param vra a 128-bit vector treated as a vector signed int.
+ *  @param shb Shift amount in the range 0-31.
+ *  @return 128-bit vector signed int, shifted right shb bits.
+ */
+static inline vi32_t
+vec_srawi (vi32_t vra, const unsigned int shb)
+{
+  vui32_t lshift;
+  vi32_t result;
+
+  if (shb < 32)
+    {
+      /* Load the shift const in a vector.  The element shifts require
+         a shift amount for each element. For the immediate form the
+         shift constant is splated to all elements of the
+         shift control.  */
+      if (__builtin_constant_p (shb) && (shb < 16))
+	lshift = (vui32_t) vec_splat_s32(shb);
+      else
+	lshift = vec_splats ((unsigned int) shb);
+
+      /* Vector Shift Right Algebraic Words based on the lower 5-bits
+         of corresponding element of lshift.  */
+      result = vec_vsraw (vra, lshift);
+    }
+  else
+    { /* shifts greater then 31 bits returns the sign bit propagated to
+         all bits.   This is equivalent to shift Right Algebraic of
+         31 bits.  */
+      lshift = (vui32_t) vec_splats(31);
+      result = vec_vsraw (vra, lshift);
+    }
+
+  return (vi32_t) result;
+}
+
+/** \brief Vector Shift Right Word Immediate.
+ *
+ *	Vector Shift right Words each element [0-3], 0-31 bits,
+ *	as specified by an immediate value.
+ *	The shift amount is a const unsigned int in the range 0-31.
+ *	A shift count of 0 returns the original value of vra.
+ *	Shift counts greater then 31 bits return zero.
+ *
+ *	@param vra a 128-bit vector treated as a vector unsigned char.
+ *	@param shb Shift amount in the range 0-31.
+ *	@return 128-bit vector unsigned int, shifted right shb bits.
+ */
+static inline vui32_t
+vec_srwi (vui32_t vra, const unsigned int shb)
+{
+  vui32_t lshift;
+  vui32_t result;
+
+  if (shb < 32)
+    {
+      /* Load the shift const in a vector.  The element shifts require
+         a shift amount for each element. For the immediate form the
+         shift constant is splated to all elements of the
+         shift control.  */
+      if (__builtin_constant_p (shb) && (shb < 16))
+	lshift = (vui32_t) vec_splat_s32(shb);
+      else
+	lshift = vec_splats ((unsigned int) shb);
+
+      /* Vector Shift right bytes based on the lower 5-bits of
+         corresponding element of lshift.  */
+      result = vec_vsrw (vra, lshift);
+    }
+  else
+    { /* shifts greater then 31 bits return zeros.  */
+      result = vec_xor ((vui32_t) vra, (vui32_t) vra);
+    }
+  return (vui32_t) result;
+}
+
+#endif /* VEC_INT32_PPC_H_ */

--- a/src/vec_int32_ppc.h
+++ b/src/vec_int32_ppc.h
@@ -523,7 +523,7 @@ vec_revbw (vui32_t vra)
 
 /** \brief Vector Shift left Word Immediate.
  *
- *	Vector Shift left Words each element [0-3], 0-31 bits,
+ *	Shift left each word element [0-3], 0-31 bits,
  *	as specified by an immediate value.
  *	The shift amount is a const unsigned int in the range 0-31.
  *	A shift count of 0 returns the original value of vra.
@@ -564,7 +564,7 @@ vec_slwi (vui32_t vra, const unsigned int shb)
 
 /** \brief Vector Shift Right Algebraic Word Immediate.
  *
- *  Vector Shift Right Algebraic Words each element [0-3],
+ *  Shift Right Algebraic each word element [0-3],
  *  0-31 bits, as specified by an immediate value.
  *  The shift amount is a const unsigned int in the range 0-31.
  *  A shift count of 0 returns the original value of vra.
@@ -609,7 +609,7 @@ vec_srawi (vi32_t vra, const unsigned int shb)
 
 /** \brief Vector Shift Right Word Immediate.
  *
- *	Vector Shift right Words each element [0-3], 0-31 bits,
+ *	Shift right each word element [0-3], 0-31 bits,
  *	as specified by an immediate value.
  *	The shift amount is a const unsigned int in the range 0-31.
  *	A shift count of 0 returns the original value of vra.

--- a/src/vec_int32_ppc.h
+++ b/src/vec_int32_ppc.h
@@ -1,5 +1,5 @@
 /*
- Copyright [2018] IBM Corporation.
+ Copyright (c) [2018] IBM Corporation.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -33,10 +33,10 @@
  * Most vector int (32-bit integer word) operations are implemented
  * with PowerISA VMX instructions either defined by the original VMX
  * (AKA Altivec) or added to later versions of the PowerISA.
- * Power8 added several multiply word operations not included in the
+ * POWER8 added several multiply word operations not included in the
  * original VMX.
  *
- * Also some useful word wise merge, shift, and splat operations where
+ * Also some useful word wise merge, shift, and splat operations were
  * added with VSX in PowerISA 2.06B.
  * Most of these intrinsic (compiler built-ins) operations are defined
  * in <altivec.h> and described in the compiler documentation.
@@ -49,15 +49,15 @@
  * target, and produce correct results.
  *
  * Most of these operations are implemented in a single instruction
- * on newer (Power8/Power9) processors.
+ * on newer (POWER8/POWER9) processors.
  * This header serves to fill in functional gaps for older
- * (Power7, Power8) processors and provides a in-line assembler
+ * (POWER7, POWER8) processors and provides a in-line assembler
  * implementation for older compilers that do not
  * provide the build-ins.
  *
  * This header covers operations that are either:
  *
- * - Operations implemented in hardware instructions for later
+ * - Implemented in hardware instructions for later
  * processors and useful to programmers, on slightly older processors,
  * even if the equivalent function requires more instructions.
  * Examples include the multiply even/odd/modulo word operations.
@@ -65,7 +65,7 @@
  * <altivec.n> provided by available compilers in common use.
  * Examples include Count Leading Zeros, Population Count and Byte
  * Reverse.
- * - Are commonly used operations, not covered by the ABI or
+ * - Commonly used operations, not covered by the ABI or
  * <altivec.h>, and require multiple instructions or
  * are not obvious.
  * Examples include the shift immediate operations.
@@ -77,7 +77,7 @@
  *  Count the number of leading '0' bits (0-32) within each word
  *  element of a 128-bit vector.
  *
- *  For Power8 (PowerISA 2.07B) or later use the Vector Count Leading
+ *  For POWER8 (PowerISA 2.07B) or later use the Vector Count Leading
  *  Zeros Word instruction <B>vclzw</B>. Otherwise use sequence of pre
  *  2.07 VMX instructions.
  *  SIMDized count leading zeros inspired by:
@@ -105,10 +105,10 @@ vec_clzw (vui32_t vra)
   r = vec_vclzw (vra);
 #endif
 #else
-//#warning Implememention pre power8
+//#warning Implememention pre POWER8
   vui32_t n, nt, y, x, s, m;
-  vui32_t z= { 0,0,0,0};
-  vui32_t one = { 1,1,1,1};
+  vui32_t z= {0,0,0,0};
+  vui32_t one = {1,1,1,1};
 
   /* n = 32 s = 16 */
   s = vec_splat_u32(8);
@@ -121,43 +121,43 @@ vec_clzw (vui32_t vra)
   nt = vec_sub(n,s);
   m = (vui32_t)vec_cmpgt(y, z);
   s = vec_sr(s,one);
-  x = vec_sel (x , y, m);
-  n = vec_sel (n , nt, m);
+  x = vec_sel (x, y, m);
+  n = vec_sel (n, nt, m);
 
   /* y=x>>8 if (y!=0) (n=n-8 x=y)  */
   y = vec_sr(x, s);
   nt = vec_sub(n,s);
   m = (vui32_t)vec_cmpgt(y, z);
   s = vec_sr(s,one);
-  x = vec_sel (x , y, m);
-  n = vec_sel (n , nt, m);
+  x = vec_sel (x, y, m);
+  n = vec_sel (n, nt, m);
 
   /* y=x>>4 if (y!=0) (n=n-4 x=y)  */
   y = vec_sr(x, s);
   nt = vec_sub(n,s);
   m = (vui32_t)vec_cmpgt(y, z);
   s = vec_sr(s,one);
-  x = vec_sel (x , y, m);
-  n = vec_sel (n , nt, m);
+  x = vec_sel (x, y, m);
+  n = vec_sel (n, nt, m);
 
   /* y=x>>2 if (y!=0) (n=n-2 x=y)  */
   y = vec_sr(x, s);
   nt = vec_sub(n,s);
   m = (vui32_t)vec_cmpgt(y, z);
   s = vec_sr(s,one);
-  x = vec_sel (x , y, m);
-  n = vec_sel (n , nt, m);
+  x = vec_sel (x, y, m);
+  n = vec_sel (n, nt, m);
 
   /* y=x>>1 if (y!=0) return (n=n-2)   */
   y = vec_sr(x, s);
   nt = vec_sub(n,s);
   nt = vec_sub(nt,s);
   m = (vui32_t)vec_cmpgt(y, z);
-  n = vec_sel (n , nt, m);
+  n = vec_sel (n, nt, m);
 
   /* else return (x-n)  */
   nt = vec_sub (n, x);
-  n = vec_sel (nt , n, m);
+  n = vec_sel (nt, n, m);
   r = n;
 #endif
   return ((vui32_t) r);
@@ -197,7 +197,7 @@ vec_mulesw (vi32_t a, vi32_t b)
 /** \brief Vector multiply odd signed words.
  *
  * Multiple the odd words of two vector signed int values and return
- * the signed long product of the odd words..
+ * the signed long product of the odd words.
  *
  * @param a 128-bit vector signed int.
  * @param b 128-bit vector signed int.
@@ -444,7 +444,7 @@ vec_muluwm (vui32_t a, vui32_t b)
  *  Count the number of '1' bits (0-32) within each word element of
  *  a 128-bit vector.
  *
- *  For Power8 (PowerISA 2.07B) or later use the Vector Population
+ *  For POWER8 (PowerISA 2.07B) or later use the Vector Population
  *  Count Word instruction. Otherwise use the pveclib vec_popcntb
  *  to count each byte then sum across with Vector Sum across Quarter
  *  Unsigned Byte Saturate.
@@ -463,7 +463,7 @@ vec_popcntw (vui32_t vra)
 #ifndef vec_vpopcntw
   __asm__(
       "vpopcntw %0,%1;"
-      : "=v" (t)
+      : "=v" (r)
       : "v" (vra)
       : );
 #else
@@ -479,6 +479,7 @@ vec_popcntw (vui32_t vra)
   return (r);
 }
 #else
+/* Work around for GCC PR85830.  */
 #undef vec_popcntw
 #define vec_popcntw __builtin_vec_vpopcntw
 #endif
@@ -529,7 +530,7 @@ vec_revbw (vui32_t vra)
  *	Shift counts greater then 31 bits return zero.
  *
  *	@param vra a 128-bit vector treated as a vector unsigned int.
- *	@param shb Shift amount in the range 0-31.
+ *	@param shb shift amount in the range 0-31.
  *	@return 128-bit vector unsigned int, shifted left shb bits.
  */
 static inline vui32_t
@@ -542,7 +543,7 @@ vec_slwi (vui32_t vra, const unsigned int shb)
     {
       /* Load the shift const in a vector.  The element shifts require
          a shift amount for each element. For the immediate form the
-         shift constant is splated to all elements of the
+         shift constant is splatted to all elements of the
          shift control.  */
       if (__builtin_constant_p (shb) && (shb < 16))
 	lshift = (vui32_t) vec_splat_s32(shb);
@@ -571,7 +572,7 @@ vec_slwi (vui32_t vra, const unsigned int shb)
  *  propagated to each bit of each element.
  *
  *  @param vra a 128-bit vector treated as a vector signed int.
- *  @param shb Shift amount in the range 0-31.
+ *  @param shb shift amount in the range 0-31.
  *  @return 128-bit vector signed int, shifted right shb bits.
  */
 static inline vi32_t
@@ -584,7 +585,7 @@ vec_srawi (vi32_t vra, const unsigned int shb)
     {
       /* Load the shift const in a vector.  The element shifts require
          a shift amount for each element. For the immediate form the
-         shift constant is splated to all elements of the
+         shift constant is splatted to all elements of the
          shift control.  */
       if (__builtin_constant_p (shb) && (shb < 16))
 	lshift = (vui32_t) vec_splat_s32(shb);
@@ -615,7 +616,7 @@ vec_srawi (vi32_t vra, const unsigned int shb)
  *	Shift counts greater then 31 bits return zero.
  *
  *	@param vra a 128-bit vector treated as a vector unsigned char.
- *	@param shb Shift amount in the range 0-31.
+ *	@param shb shift amount in the range 0-31.
  *	@return 128-bit vector unsigned int, shifted right shb bits.
  */
 static inline vui32_t
@@ -628,7 +629,7 @@ vec_srwi (vui32_t vra, const unsigned int shb)
     {
       /* Load the shift const in a vector.  The element shifts require
          a shift amount for each element. For the immediate form the
-         shift constant is splated to all elements of the
+         shift constant is splatted to all elements of the
          shift control.  */
       if (__builtin_constant_p (shb) && (shb < 16))
 	lshift = (vui32_t) vec_splat_s32(shb);

--- a/src/vec_int64_ppc.h
+++ b/src/vec_int64_ppc.h
@@ -724,7 +724,7 @@ static inline vi64_t vec_vsrad (vi64_t vra, vui64_t vrb);
 
 /** \brief Vector Shift left Doubleword Immediate.
  *
- *	Vector Shift left Doublewords each element [0-1], 0-63 bits,
+ *	Shift left each doubleword element [0-1], 0-63 bits,
  *	as specified by an immediate value.
  *	The shift amount is a const unsigned long int in the range 0-63.
  *	A shift count of 0 returns the original value of vra.
@@ -805,7 +805,7 @@ vec_spltd (vui64_t vra, const int ctl)
 
 /** \brief Vector Shift Right Doubleword Immediate.
  *
- *	Vector Shift Right Doublewords each element [0-1], 0-63 bits,
+ *	Shift Right each doubleword element [0-1], 0-63 bits,
  *	as specified by an immediate value.
  *	The shift amount is a const unsigned int in the range 0-63.
  *	A shift count of 0 returns the original value of vra.
@@ -845,7 +845,7 @@ vec_srdi (vui64_t vra, const unsigned int shb)
 
 /** \brief Vector Shift Right Algebraic Doubleword Immediate.
  *
- *  Vector Shift Right Algebraic Doublewords each element [0-1],
+ *  Shift Right Algebraic each doubleword element [0-1],
  *  0-63 bits, as specified by an immediate value.
  *  The shift amount is a const unsigned int in the range 0-63.
  *  A shift count of 0 returns the original value of vra.

--- a/src/vec_int64_ppc.h
+++ b/src/vec_int64_ppc.h
@@ -1,0 +1,1128 @@
+/*
+ Copyright [2018] IBM Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ vec_int32_ppc.h
+
+ Contributors:
+      IBM Corporation, Steven Munroe
+      Created on: Mar 29, 2018
+ */
+
+#ifndef VEC_INT64_PPC_H_
+#define VEC_INT64_PPC_H_
+
+#include <vec_int32_ppc.h>
+
+/*!
+ * \file  vec_int64_ppc.h
+ * \brief Header package containing a collection of 128-bit SIMD
+ * operations over 64-bit integer elements.
+ *
+ * The original VMX (AKA Altivec) did not define any doubleword element
+ * (long long integer or double float) operations.
+ * The VSX facility (introduced with Power7) added vector double float
+ * but did not add any integer doubleword (64-bit) operations.  However
+ * it did add a useful doubleword permute immediate and word wise;
+ * merge, shift, and splat immediate operations.
+ * Otherwise vector long int (64-bit elements) operations
+ * have to be implemented using VMX word and halfword element integer
+ * operations for Power7.
+ *
+ * Power8 (PowerISA 2.07B) adds important doubleword integer (add,
+ * subtract, compare, shift, rotate, ...) VMX operations. Power8 also
+ * added multiply word operations that produce the full doubleword
+ * product and full quadword add / subtract (with carry extend).
+ *
+ * Power9 (PowerISA 3.0B) adds the <B>Vector Multiply-Sum unsigned
+ * Doubleword Modulo</B> instruction. This is not the expected
+ * multiple even/odd/modulo doubleword nor a full multiply modulo
+ * quadword. But with a few extra (permutes and splat zero)
+ * instructions you can get equivalent function.
+ *
+ * Most of these intrinsic (compiler built-ins) operations are defined
+ * in <altivec.h> and described in the compiler documentation.
+ *
+ * \note The compiler disables associated <altivec.h> built-ins if the
+ * <B>mcpu</B> target does not enable the specific instruction.
+ * For example if you compile with <B>-mcpu=power7</B>, vec_vclz and
+ * vec_vclzd will not be defined.  But vec_clzd is always defined in
+ * this header, will generate the minimum code, appropriate for the
+ * target, and produce correct results.
+ *
+ * Most of these
+ * operations are implemented in a single instruction on newer
+ * (Power8/Power9) processors. So this header serves to fill in
+ * functional gaps for older (Power7, Power8) processors and provides
+ * a in-line assembler implementation for older compilers that do not
+ * provide the build-ins.
+ *
+ * This header covers operations that are either:
+ *
+ * - Operations implemented in hardware instructions for later
+ * processors and useful to programmers, on slightly older processors,
+ * even if the equivalent function requires more instructions.
+ * Examples include the multiply even/odd/modulo word operations.
+ * - Defined in the OpenPOWER ABI but <I>not</I> yet defined in
+ * <altivec.n> provided by available compilers in common use.
+ * Examples include Count Leading Zeros, Population Count and Byte
+ * Reverse.
+ * - Are commonly used operations, not covered by the ABI or
+ * <altivec.h>, and require multiple instructions or
+ * are not obvious.  Examples include the shift immediate operations.
+ *
+ * \note The Multiply even/odd doubleword operations are
+ * currently implemented in <vec_int128_ppc.h> which resolves a
+ * dependency on Add Quadword. These functions (vec_msumudm,
+ * vec_muleud, vec_muloud) all produce a quadword results and need
+ * vec_adduqm to sum partial products and earlier power platforms.
+ * \sa vec_adduqm, vec_muleud, vec_muloud, and vec_msumudm
+ */
+
+/** \brief Vector Add Unsigned Doubleword Modulo.
+ *
+ *  Add two vector long int values and return modulo 64-bits result.
+ *
+ *  @param a 128-bit vector long int.
+ *  @param b 128-bit vector long int.
+ *  @return vector long int sums of a and b.
+ */
+static inline
+vui64_t
+vec_addudm(vui64_t a, vui64_t b)
+{
+  vui32_t r;
+
+#ifdef _ARCH_PWR8
+#ifndef vec_vaddudm
+  __asm__(
+      "vaddudm %0,%1,%2;"
+      : "=v" (r)
+      : "v" (a),
+      "v" (b)
+      : );
+#else
+  r = (vui32_t) vec_vaddudm (a, b);
+#endif
+#else
+  vui32_t c;
+  vui32_t z= { 0,0,0,0};
+  vui32_t cm= { 0,1,0,1};
+
+  c = vec_vaddcuw ((vui32_t)a, (vui32_t)b);
+  r = vec_vadduwm ((vui32_t)a, (vui32_t)b);
+  c = vec_and (c, cm);
+  c = vec_sld (c, z, 4);
+  r = vec_vadduwm (r, c);
+#endif
+  return ((vui64_t) r);
+}
+
+/** \brief Count leading zeros for a vector unsigned long int.
+ *
+ *	Count leading zeros for a vector __int128 and return the count in a
+ *	vector suitable for use with vector shift (left|right) and vector
+ *	shift (left|right) by octet instructions.
+ *
+ *	@param vra a 128-bit vector treated a __int128.
+ *	@return a 128-bit vector with bits 121:127 containing the count of
+ *	leading zeros.
+ */
+static inline vui64_t
+vec_clzd (vui64_t vra)
+{
+  vui64_t r;
+#ifdef _ARCH_PWR8
+#ifndef vec_vclzd
+  __asm__(
+      "vclzd %0,%1;"
+      : "=v" (r)
+      : "v" (vra)
+      : );
+#else
+  r = vec_vclzd (vra);
+#endif
+#else
+  //#warning Implememention pre power8
+  vui32_t n, nt, y, x, m;
+  vui32_t z = { 0, 0, 0, 0 };
+  vui32_t dlwm = { 0, -1, 0, -1 };
+
+  x = (vui32_t) vra;
+
+  m = (vui32_t) vec_cmpgt (x, z);
+  n = vec_sld (z, m, 12);
+  y = vec_and (n, dlwm);
+  nt = vec_or (x, y);
+
+  n = vec_clzw (nt);
+  r = (vui64_t)vec_sum2s ((vi32_t)n, (vi32_t)z);
+#endif
+  return (r);
+}
+
+/** \brief Vector Compare Equal Unsigned Doubleword.
+ *
+ *  Compare each unsigned long (64-bit) integer and return all '1's,
+ *  if a[i] == b[i], otherwise all '0's.
+ *
+ *  For Power8 (PowerISA 2.07B) or later use the Vector Population
+ *  Count DoubleWord (<B>vcmpequd</B>) instruction. Otherwise use
+ *  boolean logic using word compares.
+ *
+ *  @param a 128-bit vector treated as 2 x 64-bit unsigned long
+ *  integer (dword) elements.
+ *  @param b 128-bit vector treated as 2 x 64-bit unsigned long
+ *  integer (dword) elements.
+ *  @return 128-bit vector with each dword boolean reflecting compare
+ *  equal result for each element.
+ */
+static inline
+vui64_t
+vec_cmpequd (vui64_t a, vui64_t b)
+{
+  vui64_t result;
+#ifdef _ARCH_PWR8
+#if __GNUC__ >= 7
+  result = (vui64_t)vec_cmpeq((__vector bool long long)a, (__vector bool long long)b);
+#else
+  __asm__(
+      "vcmpequd %0,%1,%2;\n"
+      : "=v" (result)
+      : "v" (a),
+      "v" (b)
+      : );
+#endif
+#else
+  /*
+   * Don't have vector compare equal unsigned doubleword until power8.
+   * So we have to compare word and unless all_eq we need to do some
+   * extra work, ie the words may have different truth values.  So we
+   * rotate each doubleword by 32-bits (here we use permute as we don't
+   * have rotate doubleword either). Then vand the original word
+   * compare and rotated value to get the final value.
+   */
+  vui8_t permute =
+    { 0x04,0x05,0x6,0x7, 0x00,0x01,0x2,0x03, 0x0C,0x0D,0x0E,0x0F, 0x08,0x09,0x0A,0x0B};
+  vui32_t r, rr;
+  r = (vui32_t)vec_cmpeq((vui32_t)a, (vui32_t)b);
+  if (vec_any_ne((vui32_t)a, (vui32_t)b))
+    {
+       rr = vec_perm (r, r, permute);
+       r= vec_and (r, rr);
+    }
+  result = (vui64_t)r;
+#endif
+  return (result);
+}
+
+/** \brief Vector Compare all Equal Unsigned Doubleword.
+ *
+ *  Compare each unsigned long (64-bit) integer and return true if all
+ *  elements of a and b are equal.
+ *
+ *  For Power8 (PowerISA 2.07B) or later use the vec_all_eq built-in predicate directly.
+ *  Otherwise case to unsigned word and use the same predicate generating (<B>vcmpequw</B>).
+ *
+ *  @param a 128-bit vector treated as 2 x 64-bit unsigned long
+ *  integer (dword) elements.
+ *  @param b 128-bit vector treated as 2 x 64-bit unsigned long
+ *  integer (dword) elements.
+ *  @return boolean int for all 128-bits, true if equal, false otherwise.
+ */
+static inline
+int
+vec_cmpud_all_eq (vui64_t a, vui64_t b)
+{
+  int result;
+#ifdef _ARCH_PWR8
+#if __GNUC__ >= 7
+  result = vec_all_eq((__vector bool long long)a, (__vector bool long long)b);
+#else
+  result = vec_all_eq((vui32_t)a, (vui32_t)b);
+#endif
+#else
+  result = vec_all_eq((vui32_t)a, (vui32_t)b);
+#endif
+  return (result);
+}
+
+/** \brief Vector Compare Greater Than Unsigned Doubleword.
+ *
+ *  Compare each unsigned long (64-bit) integer and return all '1's,
+ *  if a[i] > b[i], otherwise all '0's.
+ *
+ *  For Power8 (PowerISA 2.07B) or later use the Vector Population
+ *  Count DoubleWord (<B>vcmpgtud</B>) instruction. Otherwise use
+ *  boolean logic using word compares.
+ *
+ *  @param a 128-bit vector treated as 2 x 64-bit unsigned long
+ *  integer (dword) elements.
+ *  @param b 128-bit vector treated as 2 x 64-bit unsigned long
+ *  integer (dword) elements.
+ *  @return 128-bit vector with each dword boolean reflecting compare
+ *  greater result for each element.
+ */
+static inline
+vui64_t
+vec_cmpgtud (vui64_t a, vui64_t b)
+{
+  vui64_t result;
+#ifdef _ARCH_PWR8
+#if __GNUC__ >= 7
+  result = (vui64_t)vec_cmpgt(a, b);
+#else
+  __asm__(
+      "vcmpgtud %0,%1,%2;\n"
+      : "=v" (result)
+      : "v" (a),
+      "v" (b)
+      : );
+#endif
+#else
+  /*
+   * Don't have vector compare greater than unsigned doubleword until
+   * power8.  So we have to use compare word and logic to compute the
+   * doubleword truth values.
+   */
+  __vector unsigned int r, x, y;
+  __vector unsigned int c0, c1, c01;
+  __vector unsigned int eq, gt, a32, b32;
+
+  /* c10 = {0, -1, 0, -1}  */
+  c0 = vec_splat_u32 (0);
+  c1 = vec_splat_u32 (-1);
+  c01 = vec_mergeh (c0, c1);
+
+  a32 = (__vector unsigned int)a;
+  b32 = (__vector unsigned int)b;
+
+  gt = (__vector unsigned int)vec_cmpgt (a32, b32);
+  eq = (__vector unsigned int)vec_cmpeq (a32, b32);
+  /* GTxw = GThw | (EQhw & GTlw)  */
+  x = vec_sld (gt, c0, 4);
+  y = vec_and (eq, x);
+  x = vec_or  (gt, y);
+  /* Duplicate result word to dword width.  */
+  y = vec_sld (c0, x, 12);
+  r = vec_sel (x, y, c01);
+  result = (vui64_t)r;
+#endif
+  return (result);
+}
+
+/** \brief Vector Compare all Greater Than Unsigned Doubleword.
+ *
+ *  Compare each unsigned long (64-bit) integer and return true if all
+ *  elements of a > b.
+ *
+ *  For Power8 (PowerISA 2.07B) or later use the vec_all_eq built-in predicate directly.
+ *  Otherwise case to unsigned word and use the same predicate generating (<B>vcmpequw</B>).
+ *
+ *  @param a 128-bit vector treated as 2 x 64-bit unsigned long
+ *  integer (dword) elements.
+ *  @param b 128-bit vector treated as 2 x 64-bit unsigned long
+ *  integer (dword) elements.
+ *  @return boolean int for all 128-bits, true if all Greater Than,
+ *  false otherwise.
+ */
+static inline
+int
+vec_cmpud_any_gt (vui64_t a, vui64_t b)
+{
+  int result;
+#ifdef _ARCH_PWR8
+#if __GNUC__ >= 7
+  result = vec_any_gt(a, b);
+#else
+  vui32_t wt= { -1, -1, -1, -1};
+  vui64_t gt_bool= vec_cmpgtud (a, b);
+  result = vec_any_eq((vui32_t)gt_bool, wt);
+#endif
+#else
+  vui32_t wt= { -1, -1, -1, -1};
+  vui64_t gt_bool= vec_cmpgtud (a, b);
+  result = vec_any_eq((vui32_t)gt_bool, wt);
+#endif
+  return (result);
+}
+
+/** \brief Vector Compare all Greater Than Unsigned Doubleword.
+ *
+ *  Compare each unsigned long (64-bit) integer and return true if all
+ *  elements of a > b.
+ *
+ *  For Power8 (PowerISA 2.07B) or later use the vec_all_eq built-in predicate directly.
+ *  Otherwise case to unsigned word and use the same predicate generating (<B>vcmpequw</B>).
+ *
+ *  @param a 128-bit vector treated as 2 x 64-bit unsigned long
+ *  integer (dword) elements.
+ *  @param b 128-bit vector treated as 2 x 64-bit unsigned long
+ *  integer (dword) elements.
+ *  @return boolean int for all 128-bits, true if all Greater Than,
+ *  false otherwise.
+ */
+static inline
+int
+vec_cmpud_all_gt (vui64_t a, vui64_t b)
+{
+  int result;
+#ifdef _ARCH_PWR8
+#if __GNUC__ >= 7
+  result = vec_all_gt(a, b);
+#else
+  vui32_t wt= { -1, -1, -1, -1};
+  vui64_t gt_bool= vec_cmpgtud (a, b);
+  result = vec_all_eq((vui32_t)gt_bool, wt);
+#endif
+#else
+  vui32_t wt= { -1, -1, -1, -1};
+  vui64_t gt_bool= vec_cmpgtud (a, b);
+  result = vec_all_eq((vui32_t)gt_bool, wt);
+#endif
+  return (result);
+}
+
+
+/** \brief Vector Compare Less Than Equal Unsigned Doubleword.
+ *
+ *  Compare each unsigned long (64-bit) integer and return all '1's,
+ *  if a[i] > b[i], otherwise all '0's.
+ *
+ *  For Power8 (PowerISA 2.07B) or later use the Vector Population
+ *  Count DoubleWord (<B>vcmpgtud</B>) instruction. Otherwise use
+ *  boolean logic using word compares.
+ *
+ *  @param a 128-bit vector treated as 2 x 64-bit unsigned long
+ *  integer (dword) elements.
+ *  @param b 128-bit vector treated as 2 x 64-bit unsigned long
+ *  integer (dword) elements.
+ *  @return 128-bit vector with each dword boolean reflecting compare
+ *  greater result for each element.
+ */
+static inline
+vui64_t
+vec_cmpleud (vui64_t a, vui64_t b)
+{
+  vui64_t result;
+#ifdef _ARCH_PWR8
+#if __GNUC__ >= 7
+  result = (vui64_t)vec_cmple(a, b);
+#else
+  __asm__(
+      "vcmpgtud %0,%1,%2;\n"
+      "xxlnor %0,%0,%0;\n"
+      : "=&v" (result)
+      : "v" (a),
+      "v" (b)
+      : );
+#endif
+#else
+  vui64_t r = vec_cmpgtud (a, b);
+  result = vec_nor(r, r);;
+#endif
+  return (result);
+}
+
+/** \brief Vector Compare all Less than equal Unsigned Doubleword.
+ *
+ *  Compare each unsigned long (64-bit) integer and return true if all
+ *  elements of a > b.
+ *
+ *  For Power8 (PowerISA 2.07B) or later use the vec_all_eq built-in predicate directly.
+ *  Otherwise case to unsigned word and use the same predicate generating (<B>vcmpequw</B>).
+ *
+ *  @param a 128-bit vector treated as 2 x 64-bit unsigned long
+ *  integer (dword) elements.
+ *  @param b 128-bit vector treated as 2 x 64-bit unsigned long
+ *  integer (dword) elements.
+ *  @return boolean int for all 128-bits, true if all Greater Than,
+ *  false otherwise.
+ */
+static inline
+int
+vec_cmpud_all_le (vui64_t a, vui64_t b)
+{
+  int result;
+#ifdef _ARCH_PWR8
+#if __GNUC__ >= 7
+  result = vec_all_le(a, b);
+#else
+  vui32_t wt= { -1, -1, -1, -1};
+  vui64_t gt_bool= vec_cmpleud (a, b);
+  result = vec_all_eq((vui32_t)gt_bool, wt);
+#endif
+#else
+  vui32_t wt= { -1, -1, -1, -1};
+  vui64_t gt_bool= vec_cmpleud (a, b);
+  result = vec_all_eq((vui32_t)gt_bool, wt);
+#endif
+  return (result);
+}
+
+static inline vui64_t
+vec_permdi (vui64_t vra, vui64_t vrb, const int ctl);
+
+/** \brief Vector Merge High Doubleword.
+ *  Merge the high doubleword elements from two vectors into the high
+ *  and low doubleword elements of the result.
+ *
+ *  @param __VA a 128-bit vector as the source of the
+ *  high order doubleword.
+ *  @param __VB a 128-bit vector as the source of the
+ *  low order doubleword.
+ *  @return The original vector with the doubleword elements swapped.
+ */
+static inline vui64_t
+vec_mrghd (vui64_t __VA, vui64_t __VB)
+{
+  vui64_t result;
+  /*
+   result[0] = __VA[0];
+   result[1] = __VB[0];
+   */
+  result = vec_permdi (__VA, __VB, 0);
+
+  return (result);
+}
+
+/** \brief Vector Merge Low Doubleword.
+ *  Merge the low doubleword elements from two vectors into the high
+ *  and low doubleword elements of the result.
+ *
+ *  @param __VA a 128-bit vector as the source of the
+ *  high order doubleword.
+ *  @param __VB a 128-bit vector as the source of the
+ *  low order doubleword.
+ *  @return The original vector with the doubleword elements swapped.
+ */
+static inline vui64_t
+vec_mrgld (vui64_t __VA, vui64_t __VB)
+{
+  vui64_t result;
+  /*
+   result[0] = __VA[1];
+   result[1] = __VB[1];
+   */
+  result = vec_permdi (__VA, __VB, 3);
+
+  return (result);
+}
+
+/** \brief Vector doubleword paste.
+ *	Concatenate the high doubleword of the 1st vector with the
+ *	low double word of the 2nd vector.
+ *
+ *	@param __VH a 128-bit vector as the source of the
+ * 	high order doubleword.
+ *	@param __VL a 128-bit vector as the source of the
+ * 	low order doubleword.
+ *	@return The combined 128-bit vector composed of the high order
+ *	doubleword of __VH and the low order doubleword of __VL.
+ */
+static inline vui64_t
+vec_pasted (vui64_t __VH, vui64_t __VL)
+{
+  vui64_t result;
+  /*
+   result[1] = __VH[1];
+   result[0] = __VL[0];
+   */
+  result = vec_permdi (__VH, __VL, 1);
+
+  return (result);
+}
+
+/** \brief Vector Permute Doubleword Immediate.
+ *  Combine a doubleword selected from the 1st (vra) vector with
+ *  a doubleword selected from the 2nd (vrb) vector. The 2-bit control
+ *  operand (ctl) selects which doubleword from the 1st and 2nd
+ *  vector operands are transfered to the result vector.
+ *
+ *  ctl |  vrt[0:63]  | vrt[64:127]
+ *  :-: | :---------: | :----------:
+ *   0  |  vra[0:63]  | vrb[0:63]
+ *   1  |  vra[0:63]  | vrb[64:127]
+ *   2  | vra[64:127] | vrb[0:63]
+ *   3  | vra[64:127] | vrb[64:127]
+ *
+ *  @param vra a 128-bit vector as the source of the
+ *  high order doubleword of the result.
+ *  @param vrb a 128-bit vector as the source of the
+ *  low order doubleword of the result.
+ *  @param ctl const integer where the low order 2 bits control the
+ *  selection of doublewords from input vector vra and vrb.
+ *  @return The combined 128-bit vector composed of the high order
+ *  doubleword of vra and the low order doubleword of vrb.
+ */
+static inline vui64_t
+vec_permdi (vui64_t vra, vui64_t vrb, const int ctl)
+{
+  vui64_t result;
+#ifdef _ARCH_PWR7
+  switch (ctl & 3)
+    {
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    case 0:
+      result = vec_xxpermdi (vra, vrb, 0);
+      break;
+    case 1:
+      result = vec_xxpermdi (vra, vrb, 1);
+      break;
+    case 2:
+      result = vec_xxpermdi (vra, vrb, 2);
+      break;
+    case 3:
+      result = vec_xxpermdi (vra, vrb, 3);
+      break;
+#else
+    case 0:
+      result = vec_xxpermdi (vrb, vra, 3);
+      break;
+    case 1:
+      result = vec_xxpermdi (vrb, vra, 1);
+      break;
+    case 2:
+      result = vec_xxpermdi (vrb, vra, 2);
+      break;
+    case 3:
+      result = vec_xxpermdi (vrb, vra, 0);
+      break;
+#endif
+    default:
+      result = (vui64_t){ 0, 0 };
+    }
+#else
+  /* Current compilers don't accept vector unsigned long int as vector
+   * parms to vec_sld, so use vector unsigned int.  The vsldoi
+   * instruction does not care).  */
+  vui32_t temp;
+  switch (ctl & 3)
+    {
+      case 0:
+      temp = vec_sld ((vui32_t) vra, (vui32_t) vra, 8);
+      result = (vui64_t) vec_sld (temp, (vui32_t) vrb, 8);
+      break;
+      case 1:
+      temp = vec_sld ((vui32_t) vrb, (vui32_t) vra, 8);
+      result = (vui64_t) vec_sld (temp, temp, 8);
+      break;
+      case 2:
+      result = (vui64_t) vec_sld ((vui32_t) vra, (vui32_t) vrb, 8);
+      break;
+      case 3:
+      temp = vec_sld ((vui32_t) vrb, (vui32_t) vrb, 8);
+      result = (vui64_t) vec_sld ((vui32_t) vra, temp, 8);
+      break;
+    }
+#endif
+  return (result);
+}
+
+/** \brief Vector Population Count doubleword.
+ *
+ *  Count the number of '1' bits (0-64) within each doubleword element
+ *  of a 128-bit vector.
+ *
+ *  For Power8 (PowerISA 2.07B) or later use the Vector Population
+ *  Count DoubleWord (<B>vpopcntd</B>) instruction. Otherwise use the
+ *  pveclib vec_popcntw to count each word then sum across with Vector
+ *  Sum across Half Signed Word Saturate (<B>vsum2sws</B>).
+ *
+ *  @param vra 128-bit vector treated as 2 x 64-bit integer (dwords)
+ *  elements.
+ *  @return 128-bit vector with the population count for each dword
+ *  element.
+ */
+#ifndef vec_popcntd
+static inline vui64_t
+vec_popcntd (vui64_t vra)
+{
+  vui64_t r;
+#ifdef _ARCH_PWR8
+#ifndef vec_vpopcntd
+  __asm__(
+      "vpopcntd %0,%1;"
+      : "=v" (t)
+      : "v" (vra)
+      : );
+#else
+  r = vec_vpopcntd (vra);
+#endif
+#else
+  //#warning Implememention pre power8
+  vui32_t z= { 0,0,0,0};
+  vui32_t x;
+  x = vec_popcntw ((vui32_t)vra);
+  r = (vui64_t)vec_sum2s ((vi32_t)x, (vi32_t)z);
+#endif
+  return (r);
+}
+#else
+#undef vec_popcntd
+#define vec_popcntd __builtin_vec_vpopcntd
+#endif
+
+/*! \brief byte reverse each doubleword for a vector unsigned long int.
+ *
+ *	For each doubleword of the input vector, reverse the order of
+ *	bytes / octets within the doubleword.
+ *
+ *	@param vra a 128-bit vector unsigned long int.
+ *	@return a 128-bit vector with the bytes of each doubleword
+ *	reversed.
+ */
+static inline vui64_t
+vec_revbd (vui64_t vra)
+{
+  vui64_t result;
+
+#ifdef _ARCH_PWR9
+#ifndef vec_revb
+  __asm__(
+      "xxbrd %x0,%x1;"
+      : "=wa" (result)
+      : "wa" (vra)
+      : );
+#else
+  result = vec_revb (vra);
+#endif
+#else
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  const vui64_t vconstp = CONST_VINT64_DW(0x0706050403020100UL, 0x0F0E0D0C0B0A0908UL);
+#else
+  const vui64_t vconstp =
+      CONST_VINT64_DW(0x08090A0B0C0D0E0FUL, 0x0001020304050607UL);
+#endif
+  result = (vui64_t) vec_perm ((vui8_t) vra, (vui8_t) vra, (vui8_t) vconstp);
+#endif
+
+  return (result);
+}
+
+#ifndef vec_vsld
+static inline vui64_t vec_vsld (vui64_t vra, vui64_t vrb);
+static inline vui64_t vec_vsrd (vui64_t vra, vui64_t vrb);
+static inline vi64_t vec_vsrad (vi64_t vra, vui64_t vrb);
+#endif
+
+
+/** \brief Vector Shift left Doubleword Immediate.
+ *
+ *	Vector Shift left Doublewords each element [0-1], 0-63 bits,
+ *	as specified by an immediate value.
+ *	The shift amount is a const unsigned long int in the range 0-63.
+ *	A shift count of 0 returns the original value of vra.
+ *	Shift counts greater then 63 bits return zero.
+ *
+ *	@param vra a 128-bit vector treated as a vector unsigned long int.
+ *	@param shb Shift amount in the range 0-63.
+ *	@return 128-bit vector unsigned long int, shifted left shb bits.
+ */
+static inline vui64_t
+vec_sldi (vui64_t vra, const unsigned int shb)
+{
+  vui64_t lshift;
+  vui64_t result;
+
+  if (shb < 64)
+    {
+      /* Load the shift const in a vector.  The element shifts require
+         a shift amount for each element. For the immediate form the
+         shift constant is splated to all elements of the
+         shift control.  */
+      if (__builtin_constant_p (shb) && (shb < 16))
+	lshift = (vui64_t) vec_splat_s32(shb);
+      else
+	lshift = vec_splats ((unsigned long) shb);
+
+      /* Vector Shift right bytes based on the lower 6-bits of
+         corresponding element of lshift.  */
+      result = vec_vsld (vra, lshift);
+    }
+  else
+    { /* shifts greater then 31 bits return zeros.  */
+      result = vec_xor ((vui64_t) vra, (vui64_t) vra);
+    }
+
+  return (vui64_t) result;
+}
+
+/** \brief Vector splat doubleword.
+ *  Duplicate the selected doubleword element across the doubleword
+ *  elements of the result.
+ *
+ *  ctl |  vrt[0:63]  | vrt[64:127]
+ *  :-: | :---------: | :----------:
+ *   0  |  vra[0:63]  | vra[0:63]
+ *   1  | vra[64:127] | vra[64:127]
+ *
+ *  @param vra a 128-bit vector.
+ *  @param ctl a const integer encoding the source doubleword.
+ *  @return The original vector with the doubleword elements swapped.
+ */
+static inline vui64_t
+vec_spltd (vui64_t vra, const int ctl)
+{
+  vui64_t result;
+  /* Don't need to reverse the cases for LE because vec_permdi handles
+     that.  */
+  switch (ctl & 1)
+    {
+    case 0:
+      /*
+       result[1] = vra[0];
+       result[0] = vra[0];
+       */
+      result = vec_permdi (vra, vra, 0);
+      break;
+    case 1:
+      /*
+       result[1] = vra[1];
+       result[0] = vra[1];
+       */
+      result = vec_permdi (vra, vra, 3);
+      break;
+    }
+
+  return (result);
+}
+
+/** \brief Vector Shift Right Doubleword Immediate.
+ *
+ *	Vector Shift right Doublewords each element [0-1], 0-63 bits,
+ *	as specified by an immediate value.
+ *	The shift amount is a const unsigned int in the range 0-63.
+ *	A shift count of 0 returns the original value of vra.
+ *	Shift counts greater then 63 bits return zero.
+ *
+ *	@param vra a 128-bit vector treated as a vector unsigned long int.
+ *	@param shb Shift amount in the range 0-63.
+ *	@return 128-bit vector unsigned long int, shifted right shb bits.
+ */
+static inline vui64_t
+vec_srdi (vui64_t vra, const unsigned int shb)
+{
+  vui64_t lshift;
+  vui64_t result;
+
+  if (shb < 32)
+    {
+      /* Load the shift const in a vector.  The element shifts require
+         a shift amount for each element. For the immediate form the
+         shift constant is splated to all elements of the
+         shift control.  */
+      if (__builtin_constant_p (shb) && (shb < 16))
+	lshift = (vui64_t) vec_splat_s32(shb);
+      else
+	lshift = vec_splats ((unsigned long) shb);
+
+      /* Vector Shift right bytes based on the lower 6-bits of
+         corresponding element of lshift.  */
+      result = vec_vsrd (vra, lshift);
+    }
+  else
+    { /* shifts greater then 63 bits return zeros.  */
+      result = vec_xor ((vui64_t) vra, (vui64_t) vra);
+    }
+  return (vui64_t) result;
+}
+
+/** \brief Vector Shift Right Algebraic Doubleword Immediate.
+ *
+ *  Vector Shift Right Algebraic Doublewords each element [0-1],
+ *  0-63 bits, as specified by an immediate value.
+ *  The shift amount is a const unsigned int in the range 0-63.
+ *  A shift count of 0 returns the original value of vra.
+ *  Shift counts greater then 63 bits return the sign bit
+ *  propagated to each bit of each element.
+ *
+ *  @param vra a 128-bit vector treated as a vector signed long int.
+ *  @param shb Shift amount in the range 0-63.
+ *  @return 128-bit vector signed long int, shifted right shb bits.
+ */
+static inline vi64_t
+vec_sradi (vi64_t vra, const unsigned int shb)
+{
+  vui64_t lshift;
+  vi64_t result;
+
+  if (shb < 64)
+    {
+      /* Load the shift const in a vector.  The element shifts require
+         a shift amount for each element. For the immediate form the
+         shift constant is splated to all elements of the
+         shift control.  */
+      if (__builtin_constant_p (shb) && (shb < 16))
+	lshift = (vui64_t) vec_splat_s32(shb);
+      else
+	lshift = vec_splats ((unsigned long) shb);
+
+      /* Vector Shift Right Algebraic Doublewords based on the lower 6-bits
+         of corresponding element of lshift.  */
+      result = vec_vsrad (vra, lshift);
+    }
+  else
+    { /* shifts greater then 63 bits returns the sign bit propagated to
+         all bits.   This is equivalent to shift Right Algebraic of
+         63 bits.  */
+      lshift = (vui64_t) vec_splats(63);
+      result = vec_vsrad (vra, lshift);
+    }
+
+  return (vi64_t) result;
+}
+
+/** \brief Vector Subtract Unsigned Doubleword Modulo.
+ *
+ *  For each unsigned long (64-bit) integer element c[i] = a[i] +
+ *  NOT(b[i]) + 1.
+ *
+ *  For Power8 (PowerISA 2.07B) or later use the Vector Subtract
+ *  Unsigned Doubleword Modulo (<B>vsubudm</B>) instruction. Otherwise
+ *  use vector add word modulo forms and propagate the carry bits.
+ *
+ *  @param a 128-bit vector treated as 2 X unsigned long int.
+ *  @param b 128-bit vector treated as 2 X unsigned long int.
+ *  @return  vector unsigned long int sum of a[0] + NOT(b[0]) + 1
+ *  and a[1] + NOT(b[1]) + 1.
+ */
+static inline
+vui64_t
+vec_subudm(vui64_t a, vui64_t b)
+{
+  vui32_t r;
+
+#ifdef _ARCH_PWR8
+#ifndef vec_vsubudm
+  __asm__(
+      "vsubudm %0,%1,%2;"
+      : "=v" (r)
+      : "v" (a),
+      "v" (b)
+      : );
+#else
+  r = (vui32_t) vec_vsubudm (a, b);
+#endif
+#else
+  vui32_t c;
+  vui32_t z= { 0,0,0,0};
+  vui32_t cm= { 0,1,0,1};
+
+  c = vec_vsubcuw ((vui32_t)a, (vui32_t)b);
+  r = vec_vsubuwm ((vui32_t)a, (vui32_t)b);
+  c = vec_andc (cm, c);
+  c = vec_sld (c, z, 4);
+  r = vec_vsubuwm (r, c);
+#endif
+  return ((vui64_t) r);
+}
+
+/** \brief Vector doubleword swap.
+ *  Exchange the high and low doubleword elements of a vector.
+ *
+ *  @param vra a 128-bit vector.
+ *  @return The original vector with the doubleword elements swapped.
+ */
+static inline vui64_t
+vec_swapd (vui64_t vra)
+{
+  vui64_t result;
+  /*
+   result[1] = vra[0];
+   result[0] = vra[1];
+   */
+  result = vec_permdi (vra, vra, 2);
+
+  return (result);
+}
+
+/** \brief Vector Shift Left Doubleword.
+ *
+ *  Vector Shift Left Doubleword 0-63 bits.
+ *  The shift amount is from bits 58-63 and 122-127 of vrb.
+ *
+ *  \note Can not use vec_sld naming here as that would conflict
+ *  with the generic Shift Left Double Vector. Use vec_vsld but only
+ *  if the compiler does not define it in <altivec.h>.
+ *
+ *  @param vra a 128-bit vector treated as 2 x unsigned long integers.
+ *  @param vrb Shift amount in bits 58:63 and 122:127.
+ *  @return Left shifted vector unsigned long.
+ */
+#ifndef vec_vsld
+static inline vui64_t
+vec_vsld (vui64_t vra, vui64_t vrb)
+{
+  vui64_t result;
+
+#ifdef _ARCH_PWR8
+  __asm__(
+      "vsld %0,%1,%2;"
+      : "=v" (result)
+      : "v" (vra),
+      "v" (vrb)
+      : );
+#else
+  vui8_t  vsh_h, vsh_l;
+  vui8_t  vr_h, vr_l;
+  vui64_t sel_mask = CONST_VINT128_DW(0, -1LL);
+  vui64_t shft_mask = CONST_VINT128_DW(63, 63);
+
+  /* constrain the dword shift amounts to 0-63.  */
+  vsh_l = vec_and ((vui8_t)vrb, (vui8_t)shft_mask);
+  /* Isolate the high dword so that bits from the low dword,
+   * do not contaminate the result.  */
+  vr_h = vec_andc ((vui8_t)vra, (vui8_t)sel_mask);
+#if 0
+  vr_l  = vec_and ((vui8_t)vra, (vui8_t)sel_mask);
+#else
+  vr_l  = (vui8_t)vra;
+#endif
+  /* The vsr instruction only works correctly if the bit shift
+   * value is splatted to each byte of the vector.  */
+  vsh_h = vec_splat (vsh_l, VEC_BYTE_L_DWH);
+  vsh_l = vec_splat (vsh_l, VEC_BYTE_L_DWL);
+//  vsht_splat = vec_splat ((vui8_t) vrb, VEC_BYTE_L);
+  /* Shift the high dword by vsh_h.  */
+  vr_h = vec_vslo (vr_h,  vsh_h);
+  vr_h = vec_vsl  (vr_h, vsh_h);
+  /* Shift the low dword by vsh_l.  */
+  vr_l = vec_vslo (vr_l,  vsh_l);
+  vr_l = vec_vsl  (vr_l, vsh_l);
+  /* Merge the dwords after shift.  */
+  result = (vui64_t)vec_sel (vr_h, vr_l, (vui8_t)sel_mask);
+#endif
+  return ((vui64_t) result);
+}
+#endif
+
+/** \brief Vector Shift Right Algebraic Doubleword.
+ *
+ *  Vector Shift Right Algebraic Doubleword 0-63 bits.
+ *  The shift amount is from bits 58-63 and 122-127 of vrb.
+ *
+ *  \note Use the vec_vsrad for consistency with vec_vsld above.
+ *  Define vec_vsrad only if the compiler does not define it in
+ *  <altivec.h>.
+ *
+ *  @param vra a 128-bit vector treated as 2 x unsigned long integers.
+ *  @param vrb Shift amount in bits 58:63 and 122:127.
+ *  @return Right shifted vector unsigned long.
+ */
+#ifndef vec_vsrad
+static inline vi64_t
+vec_vsrad (vi64_t vra, vui64_t vrb)
+{
+  vi64_t result;
+
+#ifdef _ARCH_PWR8
+  __asm__(
+      "vsrad %0,%1,%2;"
+      : "=v" (result)
+      : "v" (vra),
+      "v" (brb)
+      : );
+#else
+  vui8_t  vsh_h, vsh_l;
+  vui8_t  vr_h, vr_l;
+  vi32_t exsa;
+  vui32_t shw31 = CONST_VINT128_W (-1, -1, -1, -1);
+  vui64_t exsah, exsal;
+  vui64_t shft_mask = CONST_VINT128_DW(63, 63);
+
+  /* Need to extend each signed long int to __int128. So the unsigned
+   * (128-bit) shift right behaves as a arithmetic (64-bit) shift.  */
+  exsa = vec_vsraw ((vi32_t)vra, shw31);
+  exsah = (vui64_t)vec_vmrghw (exsa, exsa);
+  exsal = (vui64_t)vec_vmrglw (exsa, exsa);
+  /* constrain the dword shift amounts to 0-63.  */
+  vsh_l = vec_and ((vui8_t)vrb, (vui8_t)shft_mask);
+  /* The vsr instruction only works correctly if the bit shift
+   * value is splatted to each byte of the vector.  */
+  vsh_h = vec_splat (vsh_l, VEC_BYTE_L_DWH);
+  vsh_l = vec_splat (vsh_l, VEC_BYTE_L_DWL);
+  /* Merge the extended sign with high dword.  */
+  exsah = vec_mrghd (exsah, (vui64_t)vra);
+  /* Shift the high dword by vsh_h.  */
+  vr_h = vec_vsro ((vui8_t)exsah,  vsh_h);
+  vr_h = vec_vsr  (vr_h, vsh_h);
+  /* Merge the extended sign with high dword.  */
+  exsal = vec_pasted (exsal, (vui64_t)vra);
+  /* Shift the low dword by vsh_l.  */
+  vr_l = vec_vsro ((vui8_t)exsal, vsh_l);
+  vr_l = vec_vsr  (vr_l, vsh_l);
+  /* Merge the dwords after shift.  */
+  result = (vi64_t)vec_mrgld ((vui64_t)vr_h, (vui64_t)vr_l);
+#endif
+  return ((vi64_t) result);
+}
+#endif
+
+/** \brief Vector Shift Right Doubleword.
+ *
+ *  Vector Shift Right Doubleword 0-63 bits.
+ *  The shift amount is from bits 58-63 and 122-127 of vrb.
+ *
+ *  \note Use the vec_vsrd for consistency with vec_vsld above.
+ *  Define vec_vsrd only if the compiler does not define it in
+ *  <altivec.h>.
+ *
+ *  @param vra a 128-bit vector treated as 2 x unsigned long integers.
+ *  @param vrb Shift amount in bits 58:63 and 122:127.
+ *  @return Right shifted vector unsigned long.
+ */
+#ifndef vec_vsrd
+static inline vui64_t
+vec_vsrd (vui64_t vra, vui64_t vrb)
+{
+  vui64_t result;
+
+#ifdef _ARCH_PWR8
+  __asm__(
+      "vsrd %0,%1,%2;"
+      : "=v" (result)
+      : "v" (vra),
+      "v" (brb)
+      : );
+#else
+  vui8_t  vsh_h, vsh_l;
+  vui8_t  vr_h, vr_l;
+  vui64_t sel_mask = CONST_VINT128_DW(0, -1LL);
+  vui64_t shft_mask = CONST_VINT128_DW(63, 63);
+
+  /* constrain the dword shift amounts to 0-63.  */
+  vsh_l = vec_and ((vui8_t)vrb, (vui8_t)shft_mask);
+  /* Isolate the low dword so that bits from the high dword,
+   * do not contaminate the result.  */
+  vr_l  = vec_and ((vui8_t)vra, (vui8_t)sel_mask);
+  /* The vsr instruction only works correctly if the bit shift
+   * value is splatted to each byte of the vector.  */
+  vsh_h = vec_splat (vsh_l, VEC_BYTE_L_DWH);
+  vsh_l = vec_splat (vsh_l, VEC_BYTE_L_DWL);
+//  vsht_splat = vec_splat ((vui8_t) vrb, VEC_BYTE_L);
+  /* Shift the high dword by vsh_h.  */
+  vr_h = vec_vsro ((vui8_t)vra,  vsh_h);
+  vr_h = vec_vsr  (vr_h, vsh_h);
+  /* Shift the low dword by vsh_l.  */
+  vr_l = vec_vsro (vr_l,  vsh_l);
+  vr_l = vec_vsr  (vr_l, vsh_l);
+  /* Merge the dwords after shift.  */
+  result = (vui64_t)vec_sel (vr_h, vr_l, (vui8_t)sel_mask);
+#endif
+  return ((vui64_t) result);
+}
+#endif
+
+#endif /* VEC_INT64_PPC_H_ */

--- a/src/vec_int64_ppc.h
+++ b/src/vec_int64_ppc.h
@@ -731,7 +731,7 @@ static inline vi64_t vec_vsrad (vi64_t vra, vui64_t vrb);
  *	Shift counts greater then 63 bits return zero.
  *
  *	@param vra a 128-bit vector treated as a vector unsigned long int.
- *	@param shb Shift amount in the range 0-63.
+ *	@param shb shift amount in the range 0-63.
  *	@return 128-bit vector unsigned long int, shifted left shb bits.
  */
 static inline vui64_t
@@ -962,7 +962,7 @@ vec_swapd (vui64_t vra)
  *  if the compiler does not define it in <altivec.h>.
  *
  *  @param vra a 128-bit vector treated as 2 x unsigned long integers.
- *  @param vrb Shift amount in bits 58:63 and 122:127.
+ *  @param vrb shift amount in bits 58:63 and 122:127.
  *  @return Left shifted vector unsigned long.
  */
 #ifndef vec_vsld
@@ -1021,7 +1021,7 @@ vec_vsld (vui64_t vra, vui64_t vrb)
  *  <altivec.h>.
  *
  *  @param vra a 128-bit vector treated as 2 x unsigned long integers.
- *  @param vrb Shift amount in bits 58:63 and 122:127.
+ *  @param vrb shift amount in bits 58:63 and 122:127.
  *  @return Right shifted vector unsigned long.
  */
 #ifndef vec_vsrad
@@ -1083,7 +1083,7 @@ vec_vsrad (vi64_t vra, vui64_t vrb)
  *  <altivec.h>.
  *
  *  @param vra a 128-bit vector treated as 2 x unsigned long integers.
- *  @param vrb Shift amount in bits 58:63 and 122:127.
+ *  @param vrb shift amount in bits 58:63 and 122:127.
  *  @return Right shifted vector unsigned long.
  */
 #ifndef vec_vsrd

--- a/src/vec_int64_ppc.h
+++ b/src/vec_int64_ppc.h
@@ -45,7 +45,7 @@
  * added multiply word operations that produce the full doubleword
  * product and full quadword add / subtract (with carry extend).
  *
- * POWER9 (PowerISA 3.0B) adds the <B>Vector Multiply-Sum unsigned
+ * POWER9 (PowerISA 3.0B) adds the <B>Vector Multiply-Sum Unsigned
  * Doubleword Modulo</B> instruction. This is not the expected
  * multiply even/odd/modulo doubleword nor a full multiply modulo
  * quadword. But with a few extra (permutes and splat zero)
@@ -347,8 +347,8 @@ vec_cmpud_any_gt (vui64_t a, vui64_t b)
 #if __GNUC__ >= 7
   result = vec_any_gt(a, b);
 #else
-  vui32_t wt= { -1, -1, -1, -1};
-  vui64_t gt_bool= vec_cmpgtud (a, b);
+  vui32_t wt = { -1, -1, -1, -1};
+  vui64_t gt_bool = vec_cmpgtud (a, b);
   result = vec_any_eq((vui32_t)gt_bool, wt);
 #endif
 #else
@@ -384,8 +384,8 @@ vec_cmpud_all_gt (vui64_t a, vui64_t b)
 #if __GNUC__ >= 7
   result = vec_all_gt(a, b);
 #else
-  vui32_t wt= { -1, -1, -1, -1};
-  vui64_t gt_bool= vec_cmpgtud (a, b);
+  vui32_t wt = { -1, -1, -1, -1};
+  vui64_t gt_bool = vec_cmpgtud (a, b);
   result = vec_all_eq((vui32_t)gt_bool, wt);
 #endif
 #else
@@ -462,7 +462,7 @@ vec_cmpud_all_le (vui64_t a, vui64_t b)
 #if __GNUC__ >= 7
   result = vec_all_le(a, b);
 #else
-  vui32_t wt= { -1, -1, -1, -1};
+  vui32_t wt = { -1, -1, -1, -1};
   vui64_t gt_bool = vec_cmpleud (a, b);
   result = vec_all_eq((vui32_t)gt_bool, wt);
 #endif

--- a/src/vec_int64_ppc.h
+++ b/src/vec_int64_ppc.h
@@ -1,5 +1,5 @@
 /*
- Copyright [2018] IBM Corporation.
+ Copyright (c) [2018] IBM Corporation.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -32,26 +32,26 @@
  *
  * The original VMX (AKA Altivec) did not define any doubleword element
  * (long long integer or double float) operations.
- * The VSX facility (introduced with Power7) added vector double float
+ * The VSX facility (introduced with POWER7) added vector double float
  * but did not add any integer doubleword (64-bit) operations.  However
  * it did add a useful doubleword permute immediate and word wise;
  * merge, shift, and splat immediate operations.
  * Otherwise vector long int (64-bit elements) operations
  * have to be implemented using VMX word and halfword element integer
- * operations for Power7.
+ * operations for POWER7.
  *
- * Power8 (PowerISA 2.07B) adds important doubleword integer (add,
- * subtract, compare, shift, rotate, ...) VMX operations. Power8 also
+ * POWER8 (PowerISA 2.07B) adds important doubleword integer (add,
+ * subtract, compare, shift, rotate, ...) VMX operations. POWER8 also
  * added multiply word operations that produce the full doubleword
  * product and full quadword add / subtract (with carry extend).
  *
- * Power9 (PowerISA 3.0B) adds the <B>Vector Multiply-Sum unsigned
+ * POWER9 (PowerISA 3.0B) adds the <B>Vector Multiply-Sum unsigned
  * Doubleword Modulo</B> instruction. This is not the expected
- * multiple even/odd/modulo doubleword nor a full multiply modulo
+ * multiply even/odd/modulo doubleword nor a full multiply modulo
  * quadword. But with a few extra (permutes and splat zero)
  * instructions you can get equivalent function.
  *
- * Most of these intrinsic (compiler built-ins) operations are defined
+ * Most of these intrinsic (compiler built-in) operations are defined
  * in <altivec.h> and described in the compiler documentation.
  *
  * \note The compiler disables associated <altivec.h> built-ins if the
@@ -63,14 +63,14 @@
  *
  * Most of these
  * operations are implemented in a single instruction on newer
- * (Power8/Power9) processors. So this header serves to fill in
- * functional gaps for older (Power7, Power8) processors and provides
+ * (POWER8/POWER9) processors. So this header serves to fill in
+ * functional gaps for older (POWER7, POWER8) processors and provides
  * a in-line assembler implementation for older compilers that do not
  * provide the build-ins.
  *
  * This header covers operations that are either:
  *
- * - Operations implemented in hardware instructions for later
+ * - Implemented in hardware instructions for later
  * processors and useful to programmers, on slightly older processors,
  * even if the equivalent function requires more instructions.
  * Examples include the multiply even/odd/modulo word operations.
@@ -78,7 +78,7 @@
  * <altivec.n> provided by available compilers in common use.
  * Examples include Count Leading Zeros, Population Count and Byte
  * Reverse.
- * - Are commonly used operations, not covered by the ABI or
+ * - Commonly used operations, not covered by the ABI or
  * <altivec.h>, and require multiple instructions or
  * are not obvious.  Examples include the shift immediate operations.
  *
@@ -86,7 +86,7 @@
  * currently implemented in <vec_int128_ppc.h> which resolves a
  * dependency on Add Quadword. These functions (vec_msumudm,
  * vec_muleud, vec_muloud) all produce a quadword results and need
- * vec_adduqm to sum partial products and earlier power platforms.
+ * vec_adduqm to sum partial products on earlier Power platforms.
  * \sa vec_adduqm, vec_muleud, vec_muloud, and vec_msumudm
  */
 
@@ -177,7 +177,7 @@ vec_clzd (vui64_t vra)
  *  Compare each unsigned long (64-bit) integer and return all '1's,
  *  if a[i] == b[i], otherwise all '0's.
  *
- *  For Power8 (PowerISA 2.07B) or later use the Vector Population
+ *  For POWER8 (PowerISA 2.07B) or later use the Vector Population
  *  Count DoubleWord (<B>vcmpequd</B>) instruction. Otherwise use
  *  boolean logic using word compares.
  *
@@ -232,8 +232,9 @@ vec_cmpequd (vui64_t a, vui64_t b)
  *  Compare each unsigned long (64-bit) integer and return true if all
  *  elements of a and b are equal.
  *
- *  For Power8 (PowerISA 2.07B) or later use the vec_all_eq built-in predicate directly.
- *  Otherwise case to unsigned word and use the same predicate generating (<B>vcmpequw</B>).
+ *  For POWER8 (PowerISA 2.07B) or later use the vec_all_eq built-in
+ *  predicate directly.  Otherwise cast to unsigned word and use the
+ *  same predicate generating (<B>vcmpequw</B>).
  *
  *  @param a 128-bit vector treated as 2 x 64-bit unsigned long
  *  integer (dword) elements.
@@ -263,7 +264,7 @@ vec_cmpud_all_eq (vui64_t a, vui64_t b)
  *  Compare each unsigned long (64-bit) integer and return all '1's,
  *  if a[i] > b[i], otherwise all '0's.
  *
- *  For Power8 (PowerISA 2.07B) or later use the Vector Population
+ *  For POWER8 (PowerISA 2.07B) or later use the Vector Population
  *  Count DoubleWord (<B>vcmpgtud</B>) instruction. Otherwise use
  *  boolean logic using word compares.
  *
@@ -327,7 +328,7 @@ vec_cmpgtud (vui64_t a, vui64_t b)
  *  Compare each unsigned long (64-bit) integer and return true if all
  *  elements of a > b.
  *
- *  For Power8 (PowerISA 2.07B) or later use the vec_all_eq built-in predicate directly.
+ *  For POWER8 (PowerISA 2.07B) or later use the vec_all_eq built-in predicate directly.
  *  Otherwise case to unsigned word and use the same predicate generating (<B>vcmpequw</B>).
  *
  *  @param a 128-bit vector treated as 2 x 64-bit unsigned long
@@ -363,8 +364,9 @@ vec_cmpud_any_gt (vui64_t a, vui64_t b)
  *  Compare each unsigned long (64-bit) integer and return true if all
  *  elements of a > b.
  *
- *  For Power8 (PowerISA 2.07B) or later use the vec_all_eq built-in predicate directly.
- *  Otherwise case to unsigned word and use the same predicate generating (<B>vcmpequw</B>).
+ *  For POWER8 (PowerISA 2.07B) or later use the vec_all_eq built-in
+ *  predicate directly.  Otherwise cast to unsigned word and use the
+ *  same predicate generating (<B>vcmpequw</B>).
  *
  *  @param a 128-bit vector treated as 2 x 64-bit unsigned long
  *  integer (dword) elements.
@@ -400,7 +402,7 @@ vec_cmpud_all_gt (vui64_t a, vui64_t b)
  *  Compare each unsigned long (64-bit) integer and return all '1's,
  *  if a[i] > b[i], otherwise all '0's.
  *
- *  For Power8 (PowerISA 2.07B) or later use the Vector Population
+ *  For POWER8 (PowerISA 2.07B) or later use the Vector Population
  *  Count DoubleWord (<B>vcmpgtud</B>) instruction. Otherwise use
  *  boolean logic using word compares.
  *
@@ -440,8 +442,9 @@ vec_cmpleud (vui64_t a, vui64_t b)
  *  Compare each unsigned long (64-bit) integer and return true if all
  *  elements of a > b.
  *
- *  For Power8 (PowerISA 2.07B) or later use the vec_all_eq built-in predicate directly.
- *  Otherwise case to unsigned word and use the same predicate generating (<B>vcmpequw</B>).
+ *  For POWER8 (PowerISA 2.07B) or later use the vec_all_eq built-in
+ *  predicate directly.  Otherwise cast to unsigned word and use the
+ *  same predicate generating (<B>vcmpequw</B>).
  *
  *  @param a 128-bit vector treated as 2 x 64-bit unsigned long
  *  integer (dword) elements.
@@ -460,7 +463,7 @@ vec_cmpud_all_le (vui64_t a, vui64_t b)
   result = vec_all_le(a, b);
 #else
   vui32_t wt= { -1, -1, -1, -1};
-  vui64_t gt_bool= vec_cmpleud (a, b);
+  vui64_t gt_bool = vec_cmpleud (a, b);
   result = vec_all_eq((vui32_t)gt_bool, wt);
 #endif
 #else
@@ -635,7 +638,7 @@ vec_permdi (vui64_t vra, vui64_t vrb, const int ctl)
  *  Count the number of '1' bits (0-64) within each doubleword element
  *  of a 128-bit vector.
  *
- *  For Power8 (PowerISA 2.07B) or later use the Vector Population
+ *  For POWER8 (PowerISA 2.07B) or later use the Vector Population
  *  Count DoubleWord (<B>vpopcntd</B>) instruction. Otherwise use the
  *  pveclib vec_popcntw to count each word then sum across with Vector
  *  Sum across Half Signed Word Saturate (<B>vsum2sws</B>).
@@ -654,7 +657,7 @@ vec_popcntd (vui64_t vra)
 #ifndef vec_vpopcntd
   __asm__(
       "vpopcntd %0,%1;"
-      : "=v" (t)
+      : "=v" (r)
       : "v" (vra)
       : );
 #else
@@ -670,6 +673,7 @@ vec_popcntd (vui64_t vra)
   return (r);
 }
 #else
+/* Work around for GCC PR85830.  */
 #undef vec_popcntd
 #define vec_popcntd __builtin_vec_vpopcntd
 #endif
@@ -740,7 +744,7 @@ vec_sldi (vui64_t vra, const unsigned int shb)
     {
       /* Load the shift const in a vector.  The element shifts require
          a shift amount for each element. For the immediate form the
-         shift constant is splated to all elements of the
+         shift constant is splatted to all elements of the
          shift control.  */
       if (__builtin_constant_p (shb) && (shb < 16))
 	lshift = (vui64_t) vec_splat_s32(shb);
@@ -801,14 +805,14 @@ vec_spltd (vui64_t vra, const int ctl)
 
 /** \brief Vector Shift Right Doubleword Immediate.
  *
- *	Vector Shift right Doublewords each element [0-1], 0-63 bits,
+ *	Vector Shift Right Doublewords each element [0-1], 0-63 bits,
  *	as specified by an immediate value.
  *	The shift amount is a const unsigned int in the range 0-63.
  *	A shift count of 0 returns the original value of vra.
  *	Shift counts greater then 63 bits return zero.
  *
  *	@param vra a 128-bit vector treated as a vector unsigned long int.
- *	@param shb Shift amount in the range 0-63.
+ *	@param shb shift amount in the range 0-63.
  *	@return 128-bit vector unsigned long int, shifted right shb bits.
  */
 static inline vui64_t
@@ -821,7 +825,7 @@ vec_srdi (vui64_t vra, const unsigned int shb)
     {
       /* Load the shift const in a vector.  The element shifts require
          a shift amount for each element. For the immediate form the
-         shift constant is splated to all elements of the
+         shift constant is splatted to all elements of the
          shift control.  */
       if (__builtin_constant_p (shb) && (shb < 16))
 	lshift = (vui64_t) vec_splat_s32(shb);
@@ -849,7 +853,7 @@ vec_srdi (vui64_t vra, const unsigned int shb)
  *  propagated to each bit of each element.
  *
  *  @param vra a 128-bit vector treated as a vector signed long int.
- *  @param shb Shift amount in the range 0-63.
+ *  @param shb shift amount in the range 0-63.
  *  @return 128-bit vector signed long int, shifted right shb bits.
  */
 static inline vi64_t
@@ -862,7 +866,7 @@ vec_sradi (vi64_t vra, const unsigned int shb)
     {
       /* Load the shift const in a vector.  The element shifts require
          a shift amount for each element. For the immediate form the
-         shift constant is splated to all elements of the
+         shift constant is splatted to all elements of the
          shift control.  */
       if (__builtin_constant_p (shb) && (shb < 16))
 	lshift = (vui64_t) vec_splat_s32(shb);
@@ -889,7 +893,7 @@ vec_sradi (vi64_t vra, const unsigned int shb)
  *  For each unsigned long (64-bit) integer element c[i] = a[i] +
  *  NOT(b[i]) + 1.
  *
- *  For Power8 (PowerISA 2.07B) or later use the Vector Subtract
+ *  For POWER8 (PowerISA 2.07B) or later use the Vector Subtract
  *  Unsigned Doubleword Modulo (<B>vsubudm</B>) instruction. Otherwise
  *  use vector add word modulo forms and propagate the carry bits.
  *
@@ -982,14 +986,13 @@ vec_vsld (vui64_t vra, vui64_t vrb)
 
   /* constrain the dword shift amounts to 0-63.  */
   vsh_l = vec_and ((vui8_t)vrb, (vui8_t)shft_mask);
-  /* Isolate the high dword so that bits from the low dword,
+  /* Isolate the high dword so that bits from the low dword
    * do not contaminate the result.  */
   vr_h = vec_andc ((vui8_t)vra, (vui8_t)sel_mask);
-#if 0
-  vr_l  = vec_and ((vui8_t)vra, (vui8_t)sel_mask);
-#else
+  /* The low dword is just vra as the 128-bit shift left generates
+   * '0's on the right and the final merge (vec_sel)
+   * cleans up 64-bit overflow on the left.  */
   vr_l  = (vui8_t)vra;
-#endif
   /* The vsr instruction only works correctly if the bit shift
    * value is splatted to each byte of the vector.  */
   vsh_h = vec_splat (vsh_l, VEC_BYTE_L_DWH);


### PR DESCRIPTION
dependant changed to vec_common_ppc.h, and more fixes. These will not
be activated until parts change Makefile.am.

2018-05-27 Steven Munroe <munroesj52@gmail.com>

        * src/vec_int16_ppc.h: New File.
        * src/vec_int32_ppc.h: New File.
        * src/vec_int64_ppc.h: New File.
        * src/vec_common_ppc.h (CONST_VINT128_H, CONST_VINT16_H,
        VEC_BYTE_L_DWH, VEC_BYTE_L_DWL): new Macro.
        * src/vec_f64_ppc.h: Minor fixup.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>