### PR TITLE
Refactor the unit tests by type and element size. Here integer types.

### DIFF
--- a/src/testsuite/arith128_test_bcd.c
+++ b/src/testsuite/arith128_test_bcd.c
@@ -450,7 +450,7 @@ test_vec_bcd (void)
 {
   int rc = 0;
 
-  printf ("\ntest_vec_bcd\n");
+  printf ("\n%s\n", __FUNCTION__);
 
   rc += test_bcd_addsub ();
 

--- a/src/testsuite/arith128_test_bcd.c
+++ b/src/testsuite/arith128_test_bcd.c
@@ -1,0 +1,464 @@
+/*
+ * arith128_test_bcd.c
+ *
+ *  Created on: Apr 6, 2018
+ *      Author: sjmunroe
+ */
+/*
+ Copyright (c) [2017] IBM Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ arith128_test_bcd.c
+
+ Contributors:
+      IBM Corporation, Steven Munroe
+      Created on: Apr 6, 2018
+ */
+
+#define __STDC_WANT_DEC_FP__    1
+
+#include <stdint.h>
+#include <stdio.h>
+#include <fenv.h>
+#include <float.h>
+#include <math.h>
+
+//#define __DEBUG_PRINT__
+#include <vec_common_ppc.h>
+#include <vec_bcd_ppc.h>
+
+#include "arith128.h"
+#include <testsuite/arith128_print.h>
+
+#include <testsuite/arith128_test_bcd.h>
+
+vui8_t
+db_vec_BCD2i128 (vui8_t bcd32)
+{
+  vui8_t result = { 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+  vui8_t e_perm =
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    { 0x00, 0x10, 0x02, 0x12, 0x04, 0x14, 0x06, 0x16, 0x08, 0x18, 0x0a, 0x1a,
+	0x0c, 0x1c, 0x0e, 0x1e };
+#else
+    { 0x01, 0x11, 0x03, 0x13, 0x05, 0x15, 0x07, 0x17, 0x09, 0x19, 0x0b, 0x1b,
+	0x0d, 0x1d, 0x0f, 0x1f };
+#endif
+  vui8_t /*i,*/ j, k, l, m/**/;
+
+  print_vint8x ("32xBCD     ", bcd32);
+  print_vint8d ("           ", bcd32);
+
+  j = vec_srbi(bcd32, 4);
+  print_vint8x ("BCD >> 4   ", j);
+  print_vint8d (" high digit", j);
+
+  k = vec_splat_u8 ((unsigned char)0x06);
+  l = (vui8_t)vec_mule (j, k);
+  m = (vui8_t)vec_mulo (j, k);
+  print_vint8x (" hd*6 even ", l);
+  print_vint8d ("           ", l);
+  print_vint8x (" hd*6 odd  ", m);
+  print_vint8d ("           ", m);
+#if 0
+  j = vec_vpkuhum ((vui16_t)l, (vui16_t)m);
+  print_vint8x (" hd*6 pack ", j);
+  print_vint8d ("           ", j);
+#else
+  j = vec_perm (l, m, e_perm);
+  print_vint8x (" hd*6 perm ", j);
+  print_vint8d ("           ", j);
+#endif
+  result = vec_sub (bcd32, j);
+  print_vint8x ("BCD - hd*6 ", result);
+  print_vint8d ("           ", result);
+
+  return result;
+}
+
+vui16_t
+db_vec_BC100s2i128 (vui8_t bc100s16)
+{
+  vui16_t result = { 0,0,0,0,0,0,0,0};
+  vui8_t k;
+  vui16_t l;
+
+  print_vint8d  ("16xBC100s  ", bc100s16);
+  print_vint16d ("           ", (vui16_t)bc100s16);
+
+  k = vec_splats ((unsigned char)156);
+  l = vec_vmuleub (bc100s16, k);
+  print_vint16x (" hd*156 ev ", l);
+  print_vint16d ("           ", l);
+
+  result = vec_sub ((vui16_t)bc100s16, l);
+  print_vint16x ("BCD-hd*156 ", result);
+  print_vint16d ("           ", result);
+  return result;
+}
+
+vui32_t
+db_vec_BC10ks2i128 (vui16_t bc10k8)
+{
+  vui32_t result = { 0,0,0,0};
+  vui16_t k;
+  vui32_t l;
+
+  print_vint16d ("8xBC10ks   ", bc10k8);
+  print_vint32d ("           ", (vui32_t)bc10k8);
+
+  k = vec_splats ((unsigned short)55536);
+  l = vec_vmuleuh (bc10k8, k);
+  print_vint32x (" hd*156 ev ", l);
+  print_vint32d ("           ", l);
+
+  result = vec_sub ((vui32_t)bc10k8, l);
+  print_vint32x ("BCD-hd*10kc", result);
+  print_vint32d ("           ", result);
+  return result;
+}
+
+vui64_t
+db_vec_BC100ms2i128 (vui32_t bc100m4)
+{
+  vui64_t result = { 0,0};
+  vui32_t k;
+  vui64_t l;
+
+  print_vint32d ("4xBC100ms  ", bc100m4);
+  print_v2int64 ("           ", (vui64_t)bc100m4);
+
+  k = vec_splats ((unsigned int)4194967296);
+#ifdef vec_vmuleuw
+  l = vec_vmuleuw (bc100m4, k);
+#else
+  l = vec_muleuw (bc100m4, k);
+#endif
+  print_v2xint64 (" hd*100mc e", l);
+  print_v2int64  ("           ", l);
+
+  result = vec_subudm ((vui64_t)bc100m4, l);
+  print_v2xint64 ("BCD-hd*10T ", result);
+  print_v2int64  ("           ", result);
+  return result;
+}
+
+vui128_t
+db_vec_BC10ts2i128 (vui64_t bc10t2)
+{
+  vui128_t result;
+  vui64_t k;
+  vui128_t l;
+//  vui64_t cvt10t = {0xFFDC790D903F0000UL, 0xFFDC790D903F0000UL};
+
+  print_v2int64 ("2xBC10ts   ", (vui64_t)bc10t2);
+  print_v2xint64("           ", (vui64_t)bc10t2);
+  print_vint128 ("           ", (vui128_t)bc10t2);
+
+#if 0
+  vui128_t v10_16 = (vui128_t)CONST_VINT128_DW (0, 10000000000000000UL);
+  vui128_t v2_64 = (vui128_t)CONST_VINT128_DW (1, 0);
+  print_vint128x (" v2_64     ", v2_64);
+  print_vint128  ("           ", v2_64);
+  print_vint128x (" v10_16    ", v10_16);
+  print_vint128  ("           ", v10_16);
+
+  l = vec_sub (v2_64, v10_16);
+  print_vint128x (" cvt*10t   ", l);
+  print_vint128  ("           ", l);
+#endif
+  k = vec_splats ((unsigned long)0xFFDC790D903F0000UL);
+#if 0
+#ifdef vec_vmuleud
+  l = vec_vmuleud (bc10t2, k);
+#else
+  l = vec_muleud (bc10t2, k);
+  k = (vui64_t)l;
+#endif
+#else
+  print_vint128x (" cvt*10t k ", (vui128_t)k);
+
+  l = vec_srqi ((vui128_t)bc10t2, 64);
+
+  print_vint128x (" bc10t2>>64", l);
+  print_vint128  ("           ", l);
+  l = vec_mulluq (l, (vui128_t)k);
+#endif
+  print_vint128x (" hd*10t ev ", l);
+  print_vint128  ("           ", l);
+
+  result = vec_subuqm ((vui128_t)bc10t2, l);
+  print_vint128x ("BCD-hd*10x ", result);
+  print_vint128  ("           ", result);
+  return result;
+}
+
+//#define __DEBUG_PRINT__ 1
+#ifdef __DEBUG_PRINT__
+#define test_vec_bcdctb100s(_l)	db_vec_BCD2i128(_l)
+#else
+#define test_vec_bcdctb100s(_l)	vec_bcdctb100s(_l)
+#endif
+
+int
+test_48 (void)
+{
+  vui8_t i, j/*, k, l, m*/;
+  vui16_t /*i, j,*/ k/*, l, m*/;
+  vui32_t l;
+  vui64_t m;
+  vui128_t n;
+  int rc = 0;
+
+  i = (vui8_t){0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99};
+  j = test_vec_bcdctb100s (i);
+  print_vint8x ("BCD 9s     ", i);
+  print_vint8d ("           ", i);
+  print_vint8x ("BC100s     ", j);
+  print_vint8d ("           ", j);
+
+  k = db_vec_BC100s2i128 (j);
+  print_vint16d ("BC10Ks     ", k);
+
+  l = db_vec_BC10ks2i128 (k);
+  print_vint32d ("BC100Ms    ", l);
+
+  m = db_vec_BC100ms2i128 (l);
+  print_v2int64 ("BC10Ts     ", m);
+
+  n = db_vec_BC10ts2i128 (m);
+  print_vint128 ("BCD10x     ", n);
+
+  return (rc);
+}
+
+int
+test_cvtbcd2c100 (void)
+{
+  vui8_t i, j/*, k, l, m*/;
+  vui8_t e;
+  int rc = 0;
+
+  printf ("\ntest_48 Vector BCD convert\n");
+
+  i = (vui8_t){0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99};
+  e = (vui8_t){99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99};
+  j = test_vec_bcdctb100s (i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint8x ("BCD 9s     ", i);
+  print_vint8d ("           ", i);
+  print_vint8x ("BC100s     ", j);
+  print_vint8d ("           ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdctb100s:", (vui128_t) j, (vui128_t) e);
+
+  i = (vui8_t){0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+  e = (vui8_t){00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00};
+  j = test_vec_bcdctb100s (i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint8x ("BCD 0s     ", i);
+  print_vint8d ("           ", i);
+  print_vint8x ("BC100s     ", j);
+  print_vint8d ("           ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdctb100s:", (vui128_t) j, (vui128_t) e);
+
+  i = (vui8_t){0x01, 0x09, 0x10, 0x19, 0x20, 0x29, 0x30, 0x39, 0x40, 0x49, 0x50, 0x59, 0x60, 0x69, 0x70, 0x79};
+  e = (vui8_t){1, 9, 10, 19, 20, 29, 30, 39, 40, 49, 50, 59, 60, 69, 70, 79};
+  j = test_vec_bcdctb100s (i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint8x ("BCD 01-79  ", i);
+  print_vint8d ("           ", i);
+  print_vint8x ("BC100s     ", j);
+  print_vint8d ("           ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdctb100s:", (vui128_t) j, (vui128_t) e);
+
+  i = (vui8_t){0x80, 0x81, 0x82, 0x83, 0x86, 0x87, 0x88, 0x89, 0x90, 0x91, 0x92, 0x93, 0x95, 0x96, 0x97, 0x98};
+  e = (vui8_t){80, 81, 82, 83, 86, 87, 88, 89, 90, 91, 92, 93, 95, 96, 97, 98};
+  j = test_vec_bcdctb100s (i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint8x ("BCD 80-98  ", i);
+  print_vint8d ("           ", i);
+  print_vint8x ("BC100s     ", j);
+  print_vint8d ("           ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdctb100s:", (vui128_t) j, (vui128_t) e);
+
+  return (rc);
+}
+//#undef __DEBUG_PRINT__
+
+int
+test_bcd_addsub (void)
+{
+  vui32_t i, j, k /*, l, m*/;
+  vui32_t e, ex;
+  int rc = 0;
+
+  printf ("\ntest_3 Vector BCD +-\n");
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0x0000001c);
+  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 0x0000001c);
+  k = vec_bcdadd (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd (1+1)", k, i, j);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 0x2c);
+  rc += check_vuint128x ("vec_bcdadd:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0x9999999c);
+  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 0x0000001c);
+  k = vec_bcdadd (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd (9999999+1)", k, i, j);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0, 0, 0x1, 0x0000000c);
+  rc += check_vuint128x ("vec_bcdadd:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0x0000001c);
+  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 0x0000001c);
+  k = vec_bcdsub (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd (1-1)", k, i, j);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 0x0000000c);
+  ex = (vui32_t )CONST_VINT32_W(0, 0, 0, 0x0000000d);
+  if (vec_all_eq (k, ex))
+    {
+      printf ("vec_bcdsub: ignore negative zero. Likely QEMU artifact\n");
+      k = e;
+    }
+  rc += check_vuint128x ("vec_bcdsub:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0x9999999c);
+  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 0x0000001c);
+  k = vec_bcdsub (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd (9999999-1)", k, i, j);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 0x9999998c);
+  rc += check_vuint128x ("vec_bcdsub:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0x0000001c);
+  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 0x9999999c);
+  k = vec_bcdsub (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd (1-9999999)", k, i, j);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 0x9999998d);
+  rc += check_vuint128x ("vec_bcdsub:", (vui128_t) k, (vui128_t) e);
+
+  return rc;
+}
+
+
+ int
+ test_bcd_muldiv (void)
+ {
+  vui32_t i, j, k /*, l, m*/;
+  vui32_t e;
+  int rc = 0;
+
+  printf ("\ntest_3 Vector BCD */\n");
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0x0000001c);
+  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 0x9999999c);
+  k = vec_bcdmul (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd (1*9999999)", k, i, j);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 0x9999999c);
+  rc += check_vuint128x ("vec_bcdmul:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0x9999999c);
+  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 0x9999999c);
+  k = vec_bcdmul (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd (9999999*9999999)", k, i, j);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0, 0, 0x9999998, 0x0000001c);
+  rc += check_vuint128x ("vec_bcdmul:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0x99999999, 0x9999999c);
+  j = (vui32_t )CONST_VINT32_W(0, 0, 0x99999999, 0x9999999c);
+  k = vec_bcdmul (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd (999999999999999*999999999999999)", k, i, j);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0x09999999, 0x99999998, 0x00000000, 0x0000001c);
+  rc += check_vuint128x ("vec_bcdmul:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0x09999999, 0x99999998, 0x00000000, 0x0000001c);
+  j = (vui32_t )CONST_VINT32_W(0, 0, 0x99999999, 0x9999999c);
+  k = vec_bcddiv (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd (999999999999998000000000000001/999999999999999)", k, i, j);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x99999999, 0x9999999c);
+  rc += check_vuint128x ("vec_bcddiv:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0x99999999, 0x9999999c);
+  j = (vui32_t )CONST_VINT32_W(0, 0x99999999, 0x99999999, 0x9999999c);
+  k = vec_bcdmul (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd (999999999999999*99999999999999999999999)", k, i, j);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x0000000c);
+  rc += check_vuint128x ("vec_bcdmul:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0x00000001, 0x0000000c);
+  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 0x3c);
+  k = vec_bcddiv (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd (10000000/3)", k, i, j);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x3333333c);
+  rc += check_vuint128x ("vec_bcddiv:", (vui128_t) k, (vui128_t) e);
+
+  return rc;
+}
+
+int
+test_vec_bcd (void)
+{
+  int rc = 0;
+
+  printf ("\ntest_vec_bcd\n");
+
+  rc += test_bcd_addsub ();
+
+  rc += test_bcd_muldiv ();
+
+  rc += test_cvtbcd2c100 ();
+
+//  rc += test_48 ();
+
+  return (rc);
+}

--- a/src/testsuite/arith128_test_bcd.h
+++ b/src/testsuite/arith128_test_bcd.h
@@ -1,0 +1,28 @@
+/*
+ Copyright (c) [2017] IBM Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ arith128_test_bcd.h
+
+ Contributors:
+      IBM Corporation, Steven Munroe
+      Created on: Apr 5, 2018
+ */
+
+#ifndef TESTSUITE_ARITH128_TEST_BCD_H_
+#define TESTSUITE_ARITH128_TEST_BCD_H_
+
+extern int test_vec_bcd (void);
+
+#endif /* TESTSUITE_ARITH128_TEST_BCD_H_ */

--- a/src/testsuite/arith128_test_char.c
+++ b/src/testsuite/arith128_test_char.c
@@ -1,0 +1,298 @@
+/*
+   arith128_test_char.c
+  
+    Created on: Oct 25, 2017
+        Author: sjmunroe
+  */
+
+
+#define __STDC_WANT_DEC_FP__    1
+
+#include <stdint.h>
+#include <stdio.h>
+#if 0
+#include <dfp/fenv.h>
+#include <dfp/float.h>
+#include <dfp/math.h>
+#else
+#include <fenv.h>
+#include <float.h>
+#include <math.h>
+#endif
+
+//#define __DEBUG_PRINT__
+
+#include "arith128.h"
+#include <testsuite/arith128_print.h>
+#include <vec_char_ppc.h>
+
+#include <testsuite/arith128_test_char.h>
+
+/*
+ * Return a vector boolean char with a true indicator for any character
+ * that is either Lower Case Alpha ASCII or Upper Case ASCII.
+ * False otherwise.
+ */
+vui8_t
+db_vec_isalpha (vui8_t vec_str)
+{
+	vui8_t result;
+	const vui8_t UC_FIRST = {0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40};
+	const vui8_t UC_LAST  = {0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a};
+	const vui8_t LC_FIRST = {0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60};
+	const vui8_t LC_LAST  = {0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a};
+
+	vui8_t cmp1, cmp2, cmp3, cmp4, cmask1, cmask2;
+
+    printf ("db_vec_isalpha\n");
+	print_vint8 ("vec_str = ", vec_str);
+
+	cmp1 = (vui8_t)vec_cmpgt (vec_str, LC_FIRST);
+	cmp2 = (vui8_t)vec_cmpgt (vec_str, LC_LAST);
+
+	print_vint8 ("cmp1    = ", cmp1);
+	print_vint8 ("cmp2    = ", cmp2);
+
+	cmp3 = (vui8_t)vec_cmpgt (vec_str, UC_FIRST);
+	cmp4 = (vui8_t)vec_cmpgt (vec_str, UC_LAST);
+
+	print_vint8 ("cmp3    = ", cmp3);
+	print_vint8 ("cmp4    = ", cmp4);
+
+	cmask1 = vec_andc (cmp1, cmp2);
+	cmask2 = vec_andc (cmp3, cmp4);
+
+	print_vint8 ("lcmask1 = ", cmask1);
+	print_vint8 ("ucmask2 = ", cmask2);
+
+	result = vec_or (cmask1, cmask2);
+
+	print_vint8 ("result  = ", result);
+
+	return (result);
+}
+/*
+ * Convert any Lower Case Alpha ASCII characters within a vector
+ * unsigned char into the equivalent Upper Case character.
+ * Return the result as a vector unsigned char.
+ */
+vui8_t
+db_vec_toupper (vui8_t vec_str)
+{
+	vui8_t result;
+	const vui8_t UC_MASK  = {0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20};
+	const vui8_t LC_FIRST = {0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60};
+	const vui8_t LC_LAST  = {0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a};
+
+	vui8_t cmp1, cmp2, cmask;
+
+    printf ("db_vec_tolower\n");
+	print_vint8 ("vec_str = ", vec_str);
+
+	cmp1 = (vui8_t)vec_cmpgt (vec_str, LC_FIRST);
+	cmp2 = (vui8_t)vec_cmpgt (vec_str, LC_LAST);
+
+	print_vint8 ("cmp1    = ", cmp1);
+	print_vint8 ("cmp2    = ", cmp2);
+
+	cmask = vec_andc (cmp1, cmp2);
+	cmask = vec_and (cmask, UC_MASK);
+
+	print_vint8 ("cmask   = ", cmask);
+
+	result = vec_andc (vec_str, cmask);
+
+	print_vint8 ("result  = ", result);
+
+	return (result);
+}
+/*
+ * Convert any Upper Case Alpha ASCII characters within a vector
+ * unsigned char into the equivalent Lower Case character.
+ * Return the result as a vector unsigned char.
+ */
+vui8_t
+db_vec_tolower (vui8_t vec_str)
+{
+	vui8_t result;
+	const vui8_t UC_MASK  = {0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20};
+	const vui8_t UC_FIRST = {0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40};
+	const vui8_t UC_LAST  = {0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a};
+
+	vui8_t cmp1, cmp2, cmask;
+
+    printf ("db_vec_tolower\n");
+	print_vint8 ("vec_str = ", vec_str);
+
+	cmp1 = (vui8_t)vec_cmpgt (vec_str, UC_FIRST);
+	cmp2 = (vui8_t)vec_cmpgt (vec_str, UC_LAST);
+
+	print_vint8 ("cmp1    = ", cmp1);
+	print_vint8 ("cmp2    = ", cmp2);
+
+	cmask = vec_andc (cmp1, cmp2);
+	cmask = vec_and (cmask, UC_MASK);
+
+	print_vint8 ("cmask   = ", cmask);
+
+	result = vec_or (vec_str, cmask);
+
+	print_vint8 ("result  = ", result);
+
+	return (result);
+}
+
+#ifdef __DEBUG_PRINT__
+#define test_vec_tolower(_l)	db_vec_tolower(_l)
+#define test_vec_toupper(_l)	db_vec_toupper(_l)
+#define test_vec_isalpha(_l)	db_vec_isalpha(_l)
+#define test_vec_isalnum(_l)	db_vec_isalnum(_l)
+#define test_vec_isdigit(_l)	db_vec_isdigit(_l)
+#else
+#define test_vec_tolower(_l)	vec_tolower(_l)
+#define test_vec_toupper(_l)	vec_toupper(_l)
+#define test_vec_isalpha(_l)	vec_isalpha(_l)
+#define test_vec_isalnum(_l)	vec_isalnum(_l)
+#define test_vec_isdigit(_l)	vec_isdigit(_l)
+#endif
+
+int
+test_vec_ischar (void)
+{
+    vui8_t i, j, k/*, l, m*/;
+    vui8_t e;
+    int rc = 0;
+
+    printf ("\ntest_vec_ischar Vector tolower, toupper, ...\n");
+
+    i = (vui8_t){0x20, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x44, 0x61, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x5d};
+    e = (vui8_t){0x20, 0x40, 0x7a, 0x5b, 0x61, 0x62, 0x63, 0x64, 0x61, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x5d};
+    k = test_vec_tolower (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vchar ("tolower of ", i);
+    print_vchar ("         = ", k);
+#endif
+    rc += check_vui8 ("vec_tolower", k, e);
+
+    e = (vui8_t){0x20, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x44, 0x41, 0x42, 0x43, 0x44, 0x31, 0x39, 0x5c, 0x5d};
+    j = test_vec_toupper (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vchar ("toupper of ", i);
+    print_vchar ("         = ", j);
+#endif
+    rc += check_vui8 ("vec_toupper", j, e);
+
+    e = (vui8_t){0x00, 0x00, 0xff, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00};
+    k = test_vec_isalpha (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vchar  ("isalpha of ", i);
+    print_vbool8 ("         = ", k);
+#endif
+    rc += check_vui8 ("vec_isalpha", k, e);
+
+    e = (vui8_t){0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0x00, 0x00};
+    k = test_vec_isdigit (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vchar  ("isdigit of ", i);
+    print_vbool8 ("         = ", k);
+#endif
+    rc += check_vui8 ("vec_isdigit", k, e);
+
+    e = (vui8_t){0x00, 0x00, 0xff, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00};
+    k = test_vec_isalnum (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vchar  ("isalnum of ", i);
+    print_vbool8 ("         = ", k);
+#endif
+    rc += check_vui8 ("vec_isalnum", k, e);
+
+    return (rc);
+}
+
+int
+test_clzb (void)
+{
+  vui32_t i, e;
+  vui8_t j;
+  int rc = 0;
+
+  printf ("\ntest_clzb Vector Count Leading Zeros in bytes\n");
+
+  i = (vui32_t )CONST_VINT32_W(0x00010204, 0x08102040, 0x80882211, 0xf0ffaa55);
+  e = (vui32_t )CONST_VINT32_W(0x08070605, 0x04030201, 0x00000203, 0x00000001);
+  j = vec_clzb((vui8_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(0x00010204, 0x08102040, 0x80882211, 0xf0ffaa55) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzb:", (vui128_t)j, (vui128_t) e);
+
+  return (rc);
+}
+
+int
+test_popcntb (void)
+{
+  vui8_t i, e;
+  vui8_t j;
+  int rc = 0;
+
+  printf ("\ntest_popcntb Vector Pop Count bytes\n");
+
+  i = (vui8_t){0,1,2,3, 4,5,6,7, 8,9,10,11, 12,13,14,15};
+  e = (vui8_t){0,1,1,2, 1,2,2,3, 1,2,2,3, 2,3,3,4};
+  j = vec_popcntb((vui8_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntb({0,1,2,3, 4,5,6,7, 8,9,10,11, 12,13,14,15}) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntb:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui8_t){0,1,2,4, 8,16,32,64, 128,136,34,17, 240,255,170,85};
+  e = (vui8_t){0,1,1,1, 1,1,1,1, 1,2,2,2, 4,8,4,4};
+  j = vec_popcntb((vui8_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntb({0,1,2,4, 8,16,32,64, 128,136,34,17, 240,255,170,85}) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntb:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui8_t){7,224,168,133, 15,240,225,170, 31,248,79,229, 63,245,235,190};
+  e = (vui8_t){3,3,3,3, 4,4,4,4, 5,5,5,5, 6,6,6,6};
+  j = vec_popcntb((vui8_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntb({7,224,168,133, 15,240,225,170, 31,248,79,229, 63,245,235,190}) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntb:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui8_t){127,251,223,239, 255,0,255,0, 24,130,138,176, 49,165,23,60};
+  e = (vui8_t){7,7,7,7, 8,0,8,0, 2,2,3,3, 3,4,4,4};
+  j = vec_popcntb((vui8_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntb({127,251,223,239, 255,0,255,0, 24,130,138,176, 49,165,23,60}) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntb:", (vui128_t)j, (vui128_t) e);
+
+  return (rc);
+}
+
+int
+test_vec_char (void)
+{
+  int rc = 0;
+
+  printf ("\ntest_vec_char/i8\n");
+#if 1
+  rc += test_clzb ();
+  rc += test_popcntb();
+  rc += test_vec_ischar();
+#endif
+  return (rc);
+}

--- a/src/testsuite/arith128_test_char.c
+++ b/src/testsuite/arith128_test_char.c
@@ -301,7 +301,7 @@ test_vec_char (void)
 {
   int rc = 0;
 
-  printf ("\n__FUNCTION__\n");
+  printf ("\n%s\n", __FUNCTION__);
 #if 1
   rc += test_clzb ();
   rc += test_popcntb();

--- a/src/testsuite/arith128_test_char.c
+++ b/src/testsuite/arith128_test_char.c
@@ -10,15 +10,9 @@
 
 #include <stdint.h>
 #include <stdio.h>
-#if 0
-#include <dfp/fenv.h>
-#include <dfp/float.h>
-#include <dfp/math.h>
-#else
 #include <fenv.h>
 #include <float.h>
 #include <math.h>
-#endif
 
 //#define __DEBUG_PRINT__
 
@@ -36,40 +30,48 @@
 vui8_t
 db_vec_isalpha (vui8_t vec_str)
 {
-	vui8_t result;
-	const vui8_t UC_FIRST = {0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40};
-	const vui8_t UC_LAST  = {0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a};
-	const vui8_t LC_FIRST = {0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60};
-	const vui8_t LC_LAST  = {0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a};
+  vui8_t result;
+  const vui8_t UC_FIRST =
+    { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40,
+	0x40, 0x40, 0x40, 0x40 };
+  const vui8_t UC_LAST =
+    { 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a,
+	0x5a, 0x5a, 0x5a, 0x5a };
+  const vui8_t LC_FIRST =
+    { 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60,
+	0x60, 0x60, 0x60, 0x60 };
+  const vui8_t LC_LAST =
+    { 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a,
+	0x7a, 0x7a, 0x7a, 0x7a };
 
-	vui8_t cmp1, cmp2, cmp3, cmp4, cmask1, cmask2;
+  vui8_t cmp1, cmp2, cmp3, cmp4, cmask1, cmask2;
 
-    printf ("db_vec_isalpha\n");
-	print_vint8 ("vec_str = ", vec_str);
+  printf ("db_vec_isalpha\n");
+  print_vint8 ("vec_str = ", vec_str);
 
-	cmp1 = (vui8_t)vec_cmpgt (vec_str, LC_FIRST);
-	cmp2 = (vui8_t)vec_cmpgt (vec_str, LC_LAST);
+  cmp1 = (vui8_t) vec_cmpgt (vec_str, LC_FIRST);
+  cmp2 = (vui8_t) vec_cmpgt (vec_str, LC_LAST);
 
-	print_vint8 ("cmp1    = ", cmp1);
-	print_vint8 ("cmp2    = ", cmp2);
+  print_vint8 ("cmp1    = ", cmp1);
+  print_vint8 ("cmp2    = ", cmp2);
 
-	cmp3 = (vui8_t)vec_cmpgt (vec_str, UC_FIRST);
-	cmp4 = (vui8_t)vec_cmpgt (vec_str, UC_LAST);
+  cmp3 = (vui8_t) vec_cmpgt (vec_str, UC_FIRST);
+  cmp4 = (vui8_t) vec_cmpgt (vec_str, UC_LAST);
 
-	print_vint8 ("cmp3    = ", cmp3);
-	print_vint8 ("cmp4    = ", cmp4);
+  print_vint8 ("cmp3    = ", cmp3);
+  print_vint8 ("cmp4    = ", cmp4);
 
-	cmask1 = vec_andc (cmp1, cmp2);
-	cmask2 = vec_andc (cmp3, cmp4);
+  cmask1 = vec_andc (cmp1, cmp2);
+  cmask2 = vec_andc (cmp3, cmp4);
 
-	print_vint8 ("lcmask1 = ", cmask1);
-	print_vint8 ("ucmask2 = ", cmask2);
+  print_vint8 ("lcmask1 = ", cmask1);
+  print_vint8 ("ucmask2 = ", cmask2);
 
-	result = vec_or (cmask1, cmask2);
+  result = vec_or (cmask1, cmask2);
 
-	print_vint8 ("result  = ", result);
+  print_vint8 ("result  = ", result);
 
-	return (result);
+  return (result);
 }
 /*
  * Convert any Lower Case Alpha ASCII characters within a vector
@@ -79,32 +81,38 @@ db_vec_isalpha (vui8_t vec_str)
 vui8_t
 db_vec_toupper (vui8_t vec_str)
 {
-	vui8_t result;
-	const vui8_t UC_MASK  = {0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20};
-	const vui8_t LC_FIRST = {0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60};
-	const vui8_t LC_LAST  = {0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a};
+  vui8_t result;
+  const vui8_t UC_MASK =
+    { 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+	0x20, 0x20, 0x20, 0x20 };
+  const vui8_t LC_FIRST =
+    { 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60,
+	0x60, 0x60, 0x60, 0x60 };
+  const vui8_t LC_LAST =
+    { 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a,
+	0x7a, 0x7a, 0x7a, 0x7a };
 
-	vui8_t cmp1, cmp2, cmask;
+  vui8_t cmp1, cmp2, cmask;
 
-    printf ("db_vec_tolower\n");
-	print_vint8 ("vec_str = ", vec_str);
+  printf ("db_vec_tolower\n");
+  print_vint8 ("vec_str = ", vec_str);
 
-	cmp1 = (vui8_t)vec_cmpgt (vec_str, LC_FIRST);
-	cmp2 = (vui8_t)vec_cmpgt (vec_str, LC_LAST);
+  cmp1 = (vui8_t) vec_cmpgt (vec_str, LC_FIRST);
+  cmp2 = (vui8_t) vec_cmpgt (vec_str, LC_LAST);
 
-	print_vint8 ("cmp1    = ", cmp1);
-	print_vint8 ("cmp2    = ", cmp2);
+  print_vint8 ("cmp1    = ", cmp1);
+  print_vint8 ("cmp2    = ", cmp2);
 
-	cmask = vec_andc (cmp1, cmp2);
-	cmask = vec_and (cmask, UC_MASK);
+  cmask = vec_andc (cmp1, cmp2);
+  cmask = vec_and (cmask, UC_MASK);
 
-	print_vint8 ("cmask   = ", cmask);
+  print_vint8 ("cmask   = ", cmask);
 
-	result = vec_andc (vec_str, cmask);
+  result = vec_andc (vec_str, cmask);
 
-	print_vint8 ("result  = ", result);
+  print_vint8 ("result  = ", result);
 
-	return (result);
+  return (result);
 }
 /*
  * Convert any Upper Case Alpha ASCII characters within a vector
@@ -114,32 +122,38 @@ db_vec_toupper (vui8_t vec_str)
 vui8_t
 db_vec_tolower (vui8_t vec_str)
 {
-	vui8_t result;
-	const vui8_t UC_MASK  = {0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20};
-	const vui8_t UC_FIRST = {0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40};
-	const vui8_t UC_LAST  = {0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a};
+  vui8_t result;
+  const vui8_t UC_MASK =
+    { 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+	0x20, 0x20, 0x20, 0x20 };
+  const vui8_t UC_FIRST =
+    { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40,
+	0x40, 0x40, 0x40, 0x40 };
+  const vui8_t UC_LAST =
+    { 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a,
+	0x5a, 0x5a, 0x5a, 0x5a };
 
-	vui8_t cmp1, cmp2, cmask;
+  vui8_t cmp1, cmp2, cmask;
 
-    printf ("db_vec_tolower\n");
-	print_vint8 ("vec_str = ", vec_str);
+  printf ("db_vec_tolower\n");
+  print_vint8 ("vec_str = ", vec_str);
 
-	cmp1 = (vui8_t)vec_cmpgt (vec_str, UC_FIRST);
-	cmp2 = (vui8_t)vec_cmpgt (vec_str, UC_LAST);
+  cmp1 = (vui8_t) vec_cmpgt (vec_str, UC_FIRST);
+  cmp2 = (vui8_t) vec_cmpgt (vec_str, UC_LAST);
 
-	print_vint8 ("cmp1    = ", cmp1);
-	print_vint8 ("cmp2    = ", cmp2);
+  print_vint8 ("cmp1    = ", cmp1);
+  print_vint8 ("cmp2    = ", cmp2);
 
-	cmask = vec_andc (cmp1, cmp2);
-	cmask = vec_and (cmask, UC_MASK);
+  cmask = vec_andc (cmp1, cmp2);
+  cmask = vec_and (cmask, UC_MASK);
 
-	print_vint8 ("cmask   = ", cmask);
+  print_vint8 ("cmask   = ", cmask);
 
-	result = vec_or (vec_str, cmask);
+  result = vec_or (vec_str, cmask);
 
-	print_vint8 ("result  = ", result);
+  print_vint8 ("result  = ", result);
 
-	return (result);
+  return (result);
 }
 
 #ifdef __DEBUG_PRINT__
@@ -159,8 +173,7 @@ db_vec_tolower (vui8_t vec_str)
 int
 test_vec_ischar (void)
 {
-    vui8_t i, j, k/*, l, m*/;
-    vui8_t e;
+    vui8_t i, j, k, e;
     int rc = 0;
 
     printf ("\ntest_vec_ischar Vector tolower, toupper, ...\n");
@@ -288,7 +301,7 @@ test_vec_char (void)
 {
   int rc = 0;
 
-  printf ("\ntest_vec_char/i8\n");
+  printf ("\n__FUNCTION__\n");
 #if 1
   rc += test_clzb ();
   rc += test_popcntb();

--- a/src/testsuite/arith128_test_char.h
+++ b/src/testsuite/arith128_test_char.h
@@ -1,0 +1,30 @@
+/*
+   arith128_test_char.h
+  
+    Created on: Oct 25, 2017
+        Author: sjmunroe
+  */
+
+#ifndef TESTSUITE_ARITH128_TEST_CHAR_H_
+#define TESTSUITE_ARITH128_TEST_CHAR_H_
+
+#include "vec_char_ppc.h"
+
+#ifdef __DEBUG_PRINT__
+extern vui8_t
+db_vec_tolower (vui8_t vec_str);
+
+extern vui8_t
+db_vec_toupper (vui8_t vec_str);
+
+extern vui8_t
+db_vec_isalpha (vui8_t vec_str);
+#endif
+
+extern int test_vec_ischar (void);
+
+extern int test_48 (void);
+
+extern int test_vec_char (void);
+
+#endif /* TESTSUITE_ARITH128_TEST_CHAR_H_ */

--- a/src/testsuite/arith128_test_i16.c
+++ b/src/testsuite/arith128_test_i16.c
@@ -31,15 +31,12 @@
 #include <vec_common_ppc.h>
 #include <vec_int32_ppc.h>
 
-//#include "arith128.h"
 #include <testsuite/arith128_test_i16.h>
-
 
 int
 test_clzh (void)
 {
-  vui16_t i, e;
-  vui16_t j;
+  vui16_t i, e, j;
   int rc = 0;
 
   printf ("\ntest_clzh Vector Count Leading Zeros in halfwords\n");
@@ -172,7 +169,7 @@ test_revbh (void)
 
   i = (vui32_t ) { 0, 1, 2, 3 };
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000100, 0x00000200, 0x00000300);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000100, 0x00000200, 0x00000300);
 #else
   e = (vui32_t)CONST_VINT32_W(0x00000300, 0x00000200, 0x00000100, 0x00000000);
 #endif
@@ -184,8 +181,8 @@ test_revbh (void)
 #endif
   rc += check_vuint128x ("vec_revbh 1:", k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0x01020304, 0x11121314, 0x21222324, 0x31323334);
-  e = (vui32_t )CONST_VINT32_W(0x02010403, 0x12111413, 0x22212423, 0x32313433);
+  i = (vui32_t)CONST_VINT32_W(0x01020304, 0x11121314, 0x21222324, 0x31323334);
+  e = (vui32_t)CONST_VINT32_W(0x02010403, 0x12111413, 0x22212423, 0x32313433);
   k = (vui128_t) vec_revbh ((vui16_t) i);
 
 #ifdef __DEBUG_PRINT__
@@ -197,7 +194,7 @@ test_revbh (void)
   ip = (vui32_t*) mem;
   i = *ip;
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-  e = (vui32_t )CONST_VINT32_W(0xf1f0f3f2, 0xe1e0e3e2, 0xd1d0d3d2, 0xc1c0c3c2);
+  e = (vui32_t)CONST_VINT32_W(0xf1f0f3f2, 0xe1e0e3e2, 0xd1d0d3d2, 0xc1c0c3c2);
 #else
   e = (vui32_t)CONST_VINT32_W(0xc2c3c0c1, 0xd2d3d0d1, 0xe2e3e0e1, 0xf2f3f0f1);
 #endif
@@ -217,7 +214,7 @@ test_vec_i16 (void)
 {
   int rc = 0;
 
-  printf ("\ntest_vec_i16\n");
+  printf ("\n__FUNCTION__\n");
 #if 1
   rc += test_revbh ();
   rc += test_clzh ();
@@ -225,5 +222,3 @@ test_vec_i16 (void)
 #endif
   return (rc);
 }
-
-

--- a/src/testsuite/arith128_test_i16.c
+++ b/src/testsuite/arith128_test_i16.c
@@ -214,7 +214,7 @@ test_vec_i16 (void)
 {
   int rc = 0;
 
-  printf ("\n__FUNCTION__\n");
+  printf ("\n%s\n", __FUNCTION__);
 #if 1
   rc += test_revbh ();
   rc += test_clzh ();

--- a/src/testsuite/arith128_test_i16.c
+++ b/src/testsuite/arith128_test_i16.c
@@ -1,0 +1,229 @@
+/*
+ Copyright (c) [2017] IBM Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ arith128_test_i16.c
+
+ Contributors:
+      IBM Corporation, Steven Munroe
+      Created on: Apr 5, 2018
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <fenv.h>
+#include <float.h>
+#include <math.h>
+
+//#define __DEBUG_PRINT__
+#include <testsuite/arith128_print.h>
+#include <vec_common_ppc.h>
+#include <vec_int32_ppc.h>
+
+//#include "arith128.h"
+#include <testsuite/arith128_test_i16.h>
+
+
+int
+test_clzh (void)
+{
+  vui16_t i, e;
+  vui16_t j;
+  int rc = 0;
+
+  printf ("\ntest_clzh Vector Count Leading Zeros in halfwords\n");
+
+  i = (vui16_t )CONST_VINT16_H(0, 0, 0, 0, 0, 0, 0, 0);
+  e = (vui16_t )CONST_VINT16_H(16, 16, 16, 16, 16, 16, 16, 16);
+  j = vec_clzh(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(0) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzh:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui16_t )CONST_VINT16_H(0x8000, 0xc000, 0xe000, 0xf000, 0xf800, 0xfc00, 0xfe00, 0xff00);
+  e = (vui16_t )CONST_VINT16_H(0, 0, 0, 0, 0, 0, 0, 0);
+  j = vec_clzh(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(0x8000, 0xc000, 0xe000, 0xf000, 0xf800, 0xfc00, 0xfe00, 0xff00) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzh:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui16_t )CONST_VINT16_H(0, 1, 2, 4, 8, 16, 32, 64);
+  e = (vui16_t )CONST_VINT16_H(16, 15, 14, 13, 12, 11, 10, 9);
+  j = vec_clzh(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(0, 1, 2, 4, 8, 16, 32, 64) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzh:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui16_t )CONST_VINT16_H(128, 256, 256, 512, 1024, 2048, 4096, 8192);
+  e = (vui16_t )CONST_VINT16_H(8, 7, 7, 6, 5, 4, 3, 2);
+  j = vec_clzh(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(128, 256, 256, 512, 1024, 2048, 4096, 8192) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzh:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui16_t )CONST_VINT16_H(16384, 32768, 61440, 65280, 65520, 65535, 43690, 21845);
+  e = (vui16_t )CONST_VINT16_H(1, 0, 0, 0, 0, 0, 0, 1);
+  j = vec_clzh(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(16384, 32768, 61440, 65280, 65520, 65535, 43690, 21845) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzh:", (vui128_t)j, (vui128_t) e);
+
+  return (rc);
+}
+
+int
+test_popcnth (void)
+{
+  vui16_t i, e;
+  vui16_t j;
+  int rc = 0;
+
+  printf ("\ntest_popcnth Vector Pop Count halfword\n");
+
+  i = (vui16_t){0, 1, 2, 4, 8, 16, 32, 64};
+  e = (vui16_t){0, 1, 1, 1, 1, 1, 1, 1};
+  j = vec_popcnth(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcnth({0, 1, 2, 4, 8, 16, 32, 64}) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcnth:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui16_t){128, 256, 256, 512, 1024, 2048, 4096, 8192};
+  e = (vui16_t){1, 1, 1, 1, 1, 1, 1, 1};
+  j = vec_popcnth(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcnth({128, 256, 256, 512, 1024, 2048, 4096, 8192}) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcnth:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui16_t){16384, 32768, 61440, 65280, 65520, 65535, 43690, 21845};
+  e = (vui16_t){1, 1, 4, 8, 12, 16, 8, 8};
+  j = vec_popcnth(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcnth({16384, 32768, 61440, 65280, 65520, 65535, 43690, 21845}) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcnth:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui16_t){1, 516, 2064, 8256, 32904, 8721, 61695, 43605};
+  e = (vui16_t){1, 2, 2, 2, 3, 4, 12, 8};
+  j = vec_popcnth(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcnth({1, 516, 2064, 8256, 32904, 8721, 61695, 43605}) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcnth:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui16_t){2016, 43141, 4080, 57770, 8184, 20453, 16373, 60350};
+  e = (vui16_t){6, 6, 8, 8, 10, 10, 12, 12};
+  j = vec_popcnth(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcnth({2016, 43141, 4080, 57770, 8184, 20453, 16373, 60350}) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcnth:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui16_t){32763, 57327, 65280, 65280, 6274, 35504, 12709, 5948};
+  e = (vui16_t){14, 14, 8, 8, 4, 6, 7, 8};
+  j = vec_popcnth(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcnth({32763, 57327, 65280, 65280, 6274, 35504, 12709, 5948}) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcnth:", (vui128_t)j, (vui128_t) e);
+
+  return (rc);
+}
+
+int
+test_revbh (void)
+{
+  vui32_t i, e, *ip;
+  vui128_t k;
+  unsigned char mem[16] __attribute__ ((aligned (16))) = { 0xf0, 0xf1, 0xf2,
+      0xf3, 0xe0, 0xe1, 0xe2, 0xe3, 0xd0, 0xd1, 0xd2, 0xd3, 0xc0, 0xc1, 0xc2,
+      0xc3 };
+  int rc = 0;
+
+  printf ("\ntest_revbh Reverse Bytes in halfwords\n");
+
+  i = (vui32_t ) { 0, 1, 2, 3 };
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000100, 0x00000200, 0x00000300);
+#else
+  e = (vui32_t)CONST_VINT32_W(0x00000300, 0x00000200, 0x00000100, 0x00000000);
+#endif
+  k = (vui128_t) vec_revbh ((vui16_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_revbh i=", (vui128_t)i);
+  print_vint128x ("         k=", k);
+#endif
+  rc += check_vuint128x ("vec_revbh 1:", k, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0x01020304, 0x11121314, 0x21222324, 0x31323334);
+  e = (vui32_t )CONST_VINT32_W(0x02010403, 0x12111413, 0x22212423, 0x32313433);
+  k = (vui128_t) vec_revbh ((vui16_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_revbh i=", (vui128_t)i);
+  print_vint128x ("         k=", k);
+#endif
+  rc += check_vuint128x ("vec_revbh 2:", k, (vui128_t) e);
+
+  ip = (vui32_t*) mem;
+  i = *ip;
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  e = (vui32_t )CONST_VINT32_W(0xf1f0f3f2, 0xe1e0e3e2, 0xd1d0d3d2, 0xc1c0c3c2);
+#else
+  e = (vui32_t)CONST_VINT32_W(0xc2c3c0c1, 0xd2d3d0d1, 0xe2e3e0e1, 0xf2f3f0f1);
+#endif
+  k = (vui128_t) vec_revbh ((vui16_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_revbh i=", (vui128_t)i);
+  print_vint128x ("         k=", k);
+#endif
+  rc += check_vuint128x ("vec_revbh 3:", k, (vui128_t) e);
+
+  return (rc);
+}
+
+int
+test_vec_i16 (void)
+{
+  int rc = 0;
+
+  printf ("\ntest_vec_i16\n");
+#if 1
+  rc += test_revbh ();
+  rc += test_clzh ();
+  rc += test_popcnth();
+#endif
+  return (rc);
+}
+
+

--- a/src/testsuite/arith128_test_i16.h
+++ b/src/testsuite/arith128_test_i16.h
@@ -1,0 +1,28 @@
+/*
+ Copyright (c) [2017] IBM Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ arith128_test_i16.h
+
+ Contributors:
+      IBM Corporation, Steven Munroe
+      Created on: Apr 5, 2018
+ */
+
+#ifndef TESTSUITE_ARITH128_TEST_I16_H_
+#define TESTSUITE_ARITH128_TEST_I16_H_
+
+extern int test_vec_i16 (void);
+
+#endif /* TESTSUITE_ARITH128_TEST_I16_H_ */

--- a/src/testsuite/arith128_test_i32.c
+++ b/src/testsuite/arith128_test_i32.c
@@ -693,7 +693,7 @@ test_vec_i32 (void)
 {
   int rc = 0;
 
-  printf ("\n__FUNCTION__\n");
+  printf ("\n%s\n", __FUNCTION__);
 
   rc += test_revbw ();
   rc += test_clzw ();

--- a/src/testsuite/arith128_test_i32.c
+++ b/src/testsuite/arith128_test_i32.c
@@ -31,7 +31,6 @@
 #include <vec_common_ppc.h>
 #include <vec_int32_ppc.h>
 
-//#include "arith128.h"
 #include <testsuite/arith128_test_i32.h>
 
 int
@@ -87,8 +86,7 @@ test_revbw (void)
 int
 test_popcntw (void)
 {
-  vui32_t i, e;
-  vui32_t j;
+  vui32_t i, e, j;
   int rc = 0;
 
   printf ("\ntest_popcntw Vector Pop Count word\n");
@@ -207,8 +205,7 @@ test_popcntw (void)
 int
 test_clzw (void)
 {
-  vui32_t i, e;
-  vui32_t j;
+  vui32_t i, e, j;
   int rc = 0;
 
   printf ("\ntest_clzw Vector Count Leading Zeros in words\n");
@@ -574,20 +571,13 @@ test_mulouw (void)
 int
 test_muluwm (void)
 {
-  vui32_t i, j;
-  vui32_t k, e;
+  vui32_t i, j, k, e;
   int rc = 0;
 
   printf ("\ntest_muluwm Vector Multiply Unsigned Word Modulo\n");
-#if 0
-  i = (vui32_t )CONST_VINT32_W(1, 2, 3, 4);
-  j = (vui32_t )CONST_VINT32_W(10, 20, 30, 40);
-  e = (vui32_t )CONST_VINT32_W(10, 40, 90, 160);
-#else
   i = (vui32_t ){1, 2, 3, 4};
   j = (vui32_t ){10, 20, 30, 40};
   e = (vui32_t ){10, 40, 90, 160};
-#endif
   k = vec_muluwm(i, j);
 
 #ifdef __DEBUG_PRINT__
@@ -703,7 +693,7 @@ test_vec_i32 (void)
 {
   int rc = 0;
 
-  printf ("\ntest_vec_i32\n");
+  printf ("\n__FUNCTION__\n");
 
   rc += test_revbw ();
   rc += test_clzw ();

--- a/src/testsuite/arith128_test_i32.c
+++ b/src/testsuite/arith128_test_i32.c
@@ -1,0 +1,716 @@
+/*
+ Copyright (c) [2017] IBM Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ arith128_test_i32.c
+
+ Contributors:
+      IBM Corporation, Steven Munroe
+      Created on: Apr 5, 2018
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <fenv.h>
+#include <float.h>
+#include <math.h>
+
+//#define __DEBUG_PRINT__
+#include <testsuite/arith128_print.h>
+#include <vec_common_ppc.h>
+#include <vec_int32_ppc.h>
+
+//#include "arith128.h"
+#include <testsuite/arith128_test_i32.h>
+
+int
+test_revbw (void)
+{
+  vui32_t i, e, *ip;
+  vui128_t k;
+  unsigned char mem[16] __attribute__ ((aligned (16))) = { 0xf0, 0xf1, 0xf2,
+      0xf3, 0xe0, 0xe1, 0xe2, 0xe3, 0xd0, 0xd1, 0xd2, 0xd3, 0xc0, 0xc1, 0xc2,
+      0xc3 };
+  int rc = 0;
+
+  printf ("\ntest_revbw Reverse Bytes in words\n");
+
+  i = (vui32_t )CONST_VINT32_W(0, 1, 2, 3);
+  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x01000000, 0x02000000, 0x03000000);
+  k = (vui128_t) vec_revbw ((vui32_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_revbw i=", (vui128_t)i);
+  print_vint128x ("         k=", k);
+#endif
+  rc += check_vuint128x ("vec_revbw 1:", k, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0x01020304, 0x11121314, 0x21222324, 0x31323334);
+  e = (vui32_t )CONST_VINT32_W(0x04030201, 0x14131211, 0x24232221, 0x34333231);
+  k = (vui128_t) vec_revbw ((vui32_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_revbw i=", (vui128_t)i);
+  print_vint128x ("         k=", k);
+#endif
+  rc += check_vuint128x ("vec_revbw 2:", k, (vui128_t) e);
+
+  ip = (vui32_t*) mem;
+  i = *ip;
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  e = (vui32_t )CONST_VINT32_W(0xf3f2f1f0, 0xe3e2e1e0, 0xd3d2d1d0, 0xc3c2c1c0);
+#else
+  e = (vui32_t)CONST_VINT32_W(0xc0c1c2c3, 0xd0d1d2d3, 0xe0e1e2e3, 0xf0f1f2f3);
+#endif
+  k = (vui128_t) vec_revbw ((vui32_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_revbw i=", (vui128_t)i);
+  print_vint128x ("         k=", k);
+#endif
+  rc += check_vuint128x ("vec_revbw 3:", k, (vui128_t) e);
+
+  return (rc);
+}
+
+int
+test_popcntw (void)
+{
+  vui32_t i, e;
+  vui32_t j;
+  int rc = 0;
+
+  printf ("\ntest_popcntw Vector Pop Count word\n");
+
+  i = (vui32_t)CONST_VINT32_W(0, 1, 2, 4);
+  e = (vui32_t)CONST_VINT32_W(0, 1, 1, 1);
+  j = vec_popcntw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntw({0, 1, 2, 4}) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(8, 16, 32, 64);
+  e = (vui32_t)CONST_VINT32_W(1, 1, 1, 1);
+  j = vec_popcntw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntw({8, 16, 32, 64}) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(128, 256, 512, 1024);
+  e = (vui32_t)CONST_VINT32_W(1, 1, 1, 1);
+  j = vec_popcntw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntw({128, 256, 512, 1024}) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(2048, 4096, 8192, 16384);
+  e = (vui32_t)CONST_VINT32_W(1, 1, 1, 1);
+  j = vec_popcntw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntw({2048, 4096, 8192, 16384}) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(32768, 65536, 131072, 262144);
+  e = (vui32_t)CONST_VINT32_W(1, 1, 1, 1);
+  j = vec_popcntw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntw({32768, 65536, 131072, 262144}) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(134217728, 268435456, 536870912, 1073741824);
+  e = (vui32_t)CONST_VINT32_W(1, 1, 1, 1);
+  j = vec_popcntw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntw({134217728, 268435456, 536870912, 1073741824}) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(-2147483648, -268435456, -16777216, -1048576);
+  e = (vui32_t)CONST_VINT32_W(1, 4, 8, 12);
+  j = vec_popcntw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntw({-2147483648, -268435456, -16777216, -1048576}) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(-2132741936, 521078531, -219024136, 1311448462);
+  e = (vui32_t)CONST_VINT32_W(11, 14, 20, 16);
+  j = vec_popcntw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntw({-2132741936, 521078531, -219024136, 1311448462}) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(-2143281136, 270549120, 540037232, 1081127120);
+  e = (vui32_t)CONST_VINT32_W(4, 4, 8, 10);
+  j = vec_popcntw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntw({-2143281136, 270549120, 540037232, 1081127120}) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(-1177168454, -1789281621, -1700158118, -1044208472);
+  e = (vui32_t)CONST_VINT32_W(20, 18, 16, 12);
+  j = vec_popcntw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntw({-1177168454, -1789281621, -1700158118, -1044208472}) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(-1143095845, -1957965135, -2008800751, 134480385);
+  e = (vui32_t)CONST_VINT32_W(24, 16, 8, 4);
+  j = vec_popcntw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntw({-1143095845, -1957965135, -2008800751, 134480385}) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(-1, -1, -1, -1);
+  e = (vui32_t)CONST_VINT32_W(32, 32, 32, 32);
+  j = vec_popcntw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntw({-1, -1, -1, -1}) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntw:", (vui128_t)j, (vui128_t) e);
+
+  return (rc);
+}
+
+int
+test_clzw (void)
+{
+  vui32_t i, e;
+  vui32_t j;
+  int rc = 0;
+
+  printf ("\ntest_clzw Vector Count Leading Zeros in words\n");
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  e = (vui32_t )CONST_VINT32_W(32, 32, 32, 32);
+  j = vec_clzw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(0) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(-1, 0, -1, 0);
+  e = (vui32_t )CONST_VINT32_W(0, 32, 0, 32);
+  j = vec_clzw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(-1, 0, -1, 0) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0, 1, 2, 4);
+  e = (vui32_t )CONST_VINT32_W(32, 31, 30, 29);
+  j = vec_clzw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(0, 1, 2, 4) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(8, 16, 32, 64);
+  e = (vui32_t )CONST_VINT32_W(28, 27, 26, 25);
+  j = vec_clzw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(8, 16, 32, 64) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(128, 256, 512, 1024);
+  e = (vui32_t )CONST_VINT32_W(24, 23, 22, 21);
+  j = vec_clzw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(128, 256, 512, 1024) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(2048, 4096, 8192, 16384);
+  e = (vui32_t )CONST_VINT32_W(20, 19, 18, 17);
+  j = vec_clzw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(2048, 4096, 8192, 16384) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(32768, 65536, 131072, 262144);
+  e = (vui32_t )CONST_VINT32_W(16, 15, 14, 13);
+  j = vec_clzw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(32768, 65536, 131072, 262144) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(524288, 1048576, 2097152, 4194304);
+  e = (vui32_t )CONST_VINT32_W(12, 11, 10, 9);
+  j = vec_clzw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(524288, 1048576, 2097152, 4194304) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(8388608, 16777216, 33554432, 67108864);
+  e = (vui32_t )CONST_VINT32_W(8, 7, 6, 5);
+  j = vec_clzw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(8388608, 16777216, 33554432, 67108864) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(134217728, 268435456, 536870912, 1073741824);
+  e = (vui32_t )CONST_VINT32_W(4, 3, 2, 1);
+  j = vec_clzw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(134217728, 268435456, 536870912, 1073741824) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(-2147483648, -268435456, -16777216, -1048576);
+  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  j = vec_clzw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(-2147483648, -268435456, -16777216, -1048576) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzw:", (vui128_t)j, (vui128_t) e);
+
+  return (rc);
+}
+
+int
+test_muleuw (void)
+{
+  vui32_t i, j;
+  vui64_t k, e;
+  int rc = 0;
+
+  printf ("\ntest_muleuw Vector Multiply Even Unsigned words\n");
+#if 0
+  i = (vui32_t )CONST_VINT32_W(1, 2, 3, 4);
+  j = (vui32_t )CONST_VINT32_W(10, 20, 30, 40);
+  e = (vui64_t )CONST_VINT64_DW(10, 90);
+#else
+  i = (vui32_t ){1, 2, 3, 4};
+  j = (vui32_t ){10, 20, 30, 40};
+  e = (vui64_t ){10, 90};
+#endif
+  k = vec_muleuw(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muleuw({1, 2, 3, 4}, {10, 20, 30, 40}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muleuw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui32_t ){1, 2, 3, 4};
+  j = (vui32_t ){3, 4, 1, 2};
+  e = (vui64_t ){3, 3};
+  k = vec_muleuw(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muleuw({1, 2, 3, 4}, {3, 4, 1, 2}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muleuw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui32_t ){1, 2, 3, 4};
+  j = (vui32_t ){4, 3, 2, 1};
+  e = (vui64_t ){4, 6};
+  k = vec_muleuw(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muleuw({1, 2, 3, 4}, {4, 3, 2, 1}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muleuw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui32_t ){1, 2, 3, 4};
+  j = (vui32_t ){10, 10, 30, 30};
+  e = (vui64_t ){10, 90};
+  k = vec_muleuw(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muleuw({1, 2, 3, 4}, {10, 10, 30, 30}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muleuw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui32_t ){-1, -1, -1, -1};
+  j = (vui32_t ){-1, -1, -1, -1};
+  e = (vui64_t ){-8589934591, -8589934591};
+  k = vec_muleuw(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muleuw({-1, -1, -1, -1}, {-1, -1, -1, -1}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muleuw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui32_t ){99999999, 99999999, 99999999, 99999999};
+  j = (vui32_t ){99999999, 99999999, 99999999, 99999999};
+  e = (vui64_t ){9999999800000001UL, 9999999800000001UL};
+  k = vec_muleuw(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muleuw({9s, 9s, 9s, 9s}, {9s, 9s, 9s, 9s}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muleuw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui32_t ){88888888, 88888888, 88888888, 88888888};
+  j = (vui32_t ){88888888, 88888888, 88888888, 88888888};
+  e = (vui64_t ){7901234409876544UL, 7901234409876544UL};
+  k = vec_muleuw(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muleuw({8s, 8s, 8s, 8s}, {8s, 8s, 8s, 8s}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muleuw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui32_t ){99999999, 99999999, 99999999, 99999999};
+  j = (vui32_t ){88888888, 88888888, 88888888, 88888888};
+  e = (vui64_t ){8888888711111112UL, 8888888711111112UL};
+  k = vec_muleuw(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muleuw({9s, 9s, 9s, 9s}, {8s, 8s, 8s, 8s}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muleuw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui32_t ){0, 99999999, 0, 99999999};
+  j = (vui32_t ){0, 99999999, 0, 99999999};
+  e = (vui64_t ){0UL, 0UL};
+  k = vec_muleuw(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muleuw({0, 99999999, 0, 99999999}, {0, 99999999, 0, 99999999}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muleuw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui32_t ){0, 9999, 0, 9999};
+  j = (vui32_t ){0, 9999, 0, 9999};
+  e = (vui64_t ){0UL, 0UL};
+  k = vec_muleuw(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muleuw({0, 9999, 0, 9999}, {0, 9999, 0, 9999}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muleuw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui32_t ){0, 196612, 0, 65538};
+  j = (vui32_t ){0, 196612, 0, 65538};
+  e = (vui64_t ){0UL, 0UL};
+  k = vec_muleuw(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muleuw({0, 196612, 0, 65538}, {0, 196612, 0, 65538}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muleuw:", (vui128_t)k, (vui128_t) e);
+
+  return (rc);
+}
+
+//#define __DEBUG_PRINT__ 1
+int
+test_mulouw (void)
+{
+  vui32_t i, j;
+  vui64_t k, e;
+  int rc = 0;
+
+  printf ("\ntest_mulouw Vector Multiply Odd Unsigned words\n");
+#if 0
+  i = (vui32_t )CONST_VINT32_W(1, 2, 3, 4);
+  j = (vui32_t )CONST_VINT32_W(10, 20, 30, 40);
+  e = (vui64_t )CONST_VINT64_DW(40, 160);
+#else
+  i = (vui32_t ){1, 2, 3, 4};
+  j = (vui32_t ){10, 20, 30, 40};
+  e = (vui64_t ){40, 160};
+#endif
+  k = vec_mulouw(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("mulouw({1, 2, 3, 4}, {10, 20, 30, 40}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulouw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui32_t ){1, 2, 3, 4};
+  j = (vui32_t ){3, 4, 1, 2};
+  e = (vui64_t ){8, 8};
+  k = vec_mulouw(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("mulouw({1, 2, 3, 4}, {3, 4, 1, 2}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulouw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui32_t ){1, 2, 3, 4};
+  j = (vui32_t ){4, 3, 2, 1};
+  e = (vui64_t ){6, 4};
+  k = vec_mulouw(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("mulouw({1, 2, 3, 4}, {4, 3, 2, 1}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulouw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui32_t ){1, 2, 3, 4};
+  j = (vui32_t ){10, 10, 30, 30};
+  e = (vui64_t ){20, 120};
+  k = vec_mulouw(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("mulouw({1, 2, 3, 4}, {10, 10, 30, 30}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulouw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui32_t ){-1, -1, -1, -1};
+  j = (vui32_t ){-1, -1, -1, -1};
+  e = (vui64_t ){-8589934591, -8589934591};
+  k = vec_mulouw(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("mulouw({-1, -1, -1, -1}, {-1, -1, -1, -1}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulouw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui32_t ){99999999, 99999999, 99999999, 99999999};
+  j = (vui32_t ){99999999, 99999999, 99999999, 99999999};
+  e = (vui64_t ){9999999800000001UL, 9999999800000001UL};
+  k = vec_mulouw(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("mulouw({9s, 9s, 9s, 9s}, {9s, 9s, 9s, 9s}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulouw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui32_t ){88888888, 88888888, 88888888, 88888888};
+  j = (vui32_t ){88888888, 88888888, 88888888, 88888888};
+  e = (vui64_t ){7901234409876544UL, 7901234409876544UL};
+  k = vec_mulouw(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("mulouw({8s, 8s, 8s, 8s}, {8s, 8s, 8s, 8s}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulouw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui32_t ){99999999, 99999999, 99999999, 99999999};
+  j = (vui32_t ){88888888, 88888888, 88888888, 88888888};
+  e = (vui64_t ){8888888711111112UL, 8888888711111112UL};
+  k = vec_mulouw(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("mulouw({9s, 9s, 9s, 9s}, {8s, 8s, 8s, 8s}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulouw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui32_t ){0, 99999999, 0, 99999999};
+  j = (vui32_t ){0, 99999999, 0, 99999999};
+  e = (vui64_t ){9999999800000001UL, 9999999800000001UL};
+  k = vec_mulouw(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("mulouw({0, 99999999, 0, 99999999}, {0, 99999999, 0, 99999999}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulouw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui32_t ){0, 9999, 0, 9999};
+  j = (vui32_t ){0, 9999, 0, 9999};
+  e = (vui64_t ){99980001UL, 99980001UL};
+  k = vec_mulouw(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("mulouw({0, 9999, 0, 9999}, {0, 9999, 0, 9999}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulouw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui32_t ){0, 196612, 0, 65538};
+  j = (vui32_t ){0, 196612, 0, 65538};
+  e = (vui64_t ){38656278544UL, 4295229444UL};
+  k = vec_mulouw(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("mulouw({0, 196612, 0, 65538}, {0, 196612, 0, 65538}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulouw:", (vui128_t)k, (vui128_t) e);
+
+  return (rc);
+}
+
+//#define __DEBUG_PRINT__ 1
+int
+test_muluwm (void)
+{
+  vui32_t i, j;
+  vui32_t k, e;
+  int rc = 0;
+
+  printf ("\ntest_muluwm Vector Multiply Unsigned Word Modulo\n");
+#if 0
+  i = (vui32_t )CONST_VINT32_W(1, 2, 3, 4);
+  j = (vui32_t )CONST_VINT32_W(10, 20, 30, 40);
+  e = (vui32_t )CONST_VINT32_W(10, 40, 90, 160);
+#else
+  i = (vui32_t ){1, 2, 3, 4};
+  j = (vui32_t ){10, 20, 30, 40};
+  e = (vui32_t ){10, 40, 90, 160};
+#endif
+  k = vec_muluwm(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muluwm({1, 2, 3, 4}, {10, 20, 30, 40}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muluwm:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui32_t ){1, 2, 3, 4};
+  j = (vui32_t ){3, 4, 1, 2};
+  e = (vui32_t ){3, 8, 3, 8};
+  k = vec_muluwm(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muluwm({1, 2, 3, 4}, {3, 4, 1, 2}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muluwm:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui32_t ){1, 2, 3, 4};
+  j = (vui32_t ){4, 3, 2, 1};
+  e = (vui32_t ){4, 6, 6, 4};
+  k = vec_muluwm(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muluwm({1, 2, 3, 4}, {4, 3, 2, 1}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muluwm:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui32_t ){1, 2, 3, 4};
+  j = (vui32_t ){10, 10, 30, 30};
+  e = (vui32_t ){10, 20, 90, 120};
+  k = vec_muluwm(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muluwm({1, 2, 3, 4}, {10, 10, 30, 30}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muluwm:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui32_t ){-1, -1, -1, -1};
+  j = (vui32_t ){-1, -1, -1, -1};
+  e = (vui32_t ){1, 1, 1, 1};
+  k = vec_muluwm(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muluwm({-1, -1, -1, -1}, {-1, -1, -1, -1}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muluwm:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui32_t ){99999999, 99999999, 99999999, 99999999};
+  j = (vui32_t ){99999999, 99999999, 99999999, 99999999};
+  e = (vui32_t ){0x63d53e01, 0x63d53e01, 0x63d53e01, 0x63d53e01};
+  k = vec_muluwm(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muluwm({9s, 9s, 9s, 9s}, {9s, 9s, 9s, 9s}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muluwm:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui32_t ){88888888, 88888888, 88888888, 88888888};
+  j = (vui32_t ){88888888, 88888888, 88888888, 88888888};
+  e = (vui32_t ){0x7e49ac40, 0x7e49ac40, 0x7e49ac40, 0x7e49ac40};
+  k = vec_muluwm(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muluwm({8s, 8s, 8s, 8s}, {8s, 8s, 8s, 8s}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muluwm:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui32_t ){99999999, 99999999, 99999999, 99999999};
+  j = (vui32_t ){88888888, 88888888, 88888888, 88888888};
+  e = (vui32_t ){0xae12e1c8, 0xae12e1c8, 0xae12e1c8, 0xae12e1c8};
+  k = vec_muluwm(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muluwm({9s, 9s, 9s, 9s}, {8s, 8s, 8s, 8s}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muluwm:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui32_t ){0, 99999999, 0, 99999999};
+  j = (vui32_t ){0, 99999999, 0, 99999999};
+  e = (vui32_t ){0, 0x63d53e01, 0, 0x63d53e01};
+  k = vec_muluwm(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muluwm({0, 99999999, 0, 99999999}, {0, 99999999, 0, 99999999}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muluwm:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui32_t ){0, 9999, 0, 9999};
+  j = (vui32_t ){0, 9999, 0, 9999};
+  e = (vui32_t ){0, 99980001, 0, 99980001};
+  k = vec_muluwm(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muluwm({0, 9999, 0, 9999}, {0, 9999, 0, 9999}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muluwm:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui32_t ){0, 196612, 0, 65538};
+  j = (vui32_t ){0, 196612, 0, 65538};
+  e = (vui32_t ){0, 0x00180010, 0, 0x00040004};
+  k = vec_muluwm(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muluwm({0, 196612, 0, 65538}, {0, 196612, 0, 65538}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muluwm:", (vui128_t)k, (vui128_t) e);
+
+  return (rc);
+}
+
+int
+test_vec_i32 (void)
+{
+  int rc = 0;
+
+  printf ("\ntest_vec_i32\n");
+
+  rc += test_revbw ();
+  rc += test_clzw ();
+  rc += test_popcntw();
+  rc += test_muleuw();
+  rc += test_mulouw();
+  rc += test_muluwm();
+
+  return (rc);
+}

--- a/src/testsuite/arith128_test_i32.h
+++ b/src/testsuite/arith128_test_i32.h
@@ -1,0 +1,28 @@
+/*
+ Copyright (c) [2017] IBM Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ arith128_test_i32.h
+
+ Contributors:
+      IBM Corporation, Steven Munroe
+      Created on: Apr 5, 2018
+ */
+
+#ifndef TESTSUITE_ARITH128_TEST_I32_H_
+#define TESTSUITE_ARITH128_TEST_I32_H_
+
+extern int test_vec_i32 (void);
+
+#endif /* TESTSUITE_ARITH128_TEST_I32_H_ */

--- a/src/testsuite/arith128_test_i64.c
+++ b/src/testsuite/arith128_test_i64.c
@@ -1,0 +1,1115 @@
+/*
+ Copyright (c) [2017] IBM Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ arith128_test_i64.c
+
+ Contributors:
+      IBM Corporation, Steven Munroe
+      Created on: Apr 5, 2018
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <fenv.h>
+#include <float.h>
+#include <math.h>
+
+//#define __DEBUG_PRINT__
+#include <testsuite/arith128_print.h>
+#include <vec_common_ppc.h>
+#include <vec_int32_ppc.h>
+#include <vec_int64_ppc.h>
+
+//#include "arith128.h"
+#include <testsuite/arith128_test_i64.h>
+
+//#define __DEBUG_PRINT__ 1
+
+#ifdef __DEBUG_PRINT__
+vui64_t
+db_vec_vsld (vui64_t vra, vui64_t vrb)
+{
+  vui64_t result;
+
+#ifdef _ARCH_PWR8
+  __asm__(
+      "vsld %0,%1,%2;"
+      : "=v" (result)
+      : "v" (vra),
+      "v" (vrb)
+      : );
+#else
+  vui8_t  vsh_h, vsh_l;
+  vui8_t  vr_h, vr_l;
+  vui64_t sel_mask = CONST_VINT128_DW(0, -1LL);
+  vui64_t shft_mask = CONST_VINT128_DW(63, 63);
+  print_v2xint64 ("db_vec_vsld (", vra);
+  print_v2xint64 ("             ", vrb);
+
+  /* constrain the dword shift amounts to 0-63.  */
+  vsh_l = vec_and ((vui8_t)vrb, (vui8_t)shft_mask);
+  /* Isolate the low dword so that bits from the high dword,
+   * do not contaminate the result.  */
+  vr_h = vec_andc ((vui8_t)vra, (vui8_t)sel_mask);
+  vr_l  = vec_and ((vui8_t)vra, (vui8_t)sel_mask);
+  /* The vsr instruction only works correctly if the bit shift
+   * value is splatted to each byte of the vector.  */
+  vsh_h = vec_splat (vsh_l, VEC_BYTE_L_DWH);
+  vsh_l = vec_splat (vsh_l, VEC_BYTE_L_DWL);
+  print_v2xint64 ("      vsh_h (", (vui64_t)vsh_h);
+  print_v2xint64 ("      vsh_l (", (vui64_t)vsh_l);
+//  vsht_splat = vec_splat ((vui8_t) vrb, VEC_BYTE_L);
+  /* Shift the high dword by vsh_h.  */
+  vr_h = vec_vslo (vr_h,  vsh_h);
+  vr_h = vec_vsl  (vr_h, vsh_h);
+  print_v2xint64 ("       vr_h (", (vui64_t)vr_h);
+  /* Shift the low dword by vsh_l.  */
+  vr_l = vec_vslo (vr_l,  vsh_l);
+  vr_l = vec_vsl  (vr_l, vsh_l);
+  print_v2xint64 ("       vr_l (", (vui64_t)vr_l);
+  /* Merge the dwords after shift.  */
+  result = (vui64_t)vec_sel (vr_h, vr_l, (vui8_t)sel_mask);
+#endif
+  return ((vui64_t) result);
+}
+
+vui64_t
+db_vec_vsrd (vui64_t vra, vui64_t vrb)
+{
+  vui64_t result;
+
+#ifdef _ARCH_PWR8
+  __asm__(
+      "vsrd %0,%1,%2;"
+      : "=v" (result)
+      : "v" (vra),
+      "v" (vrb)
+      : );
+#else
+  vui8_t  vsh_h, vsh_l;
+  vui8_t  vr_h, vr_l;
+  vui64_t sel_mask = CONST_VINT128_DW(0, -1LL);
+  vui64_t shft_mask = CONST_VINT128_DW(63, 63);
+  print_v2xint64 ("db_vec_vsrd (", vra);
+  print_v2xint64 ("             ", vrb);
+
+  /* constrain the dword shift amounts to 0-63.  */
+  vsh_l = vec_and ((vui8_t)vrb, (vui8_t)shft_mask);
+  /* Isolate the low dword so that bits from the high dword,
+   * do not contaminate the result.  */
+  vr_l  = vec_and ((vui8_t)vra, (vui8_t)sel_mask);
+  /* The vsr instruction only works correctly if the bit shift
+   * value is splatted to each byte of the vector.  */
+  vsh_h = vec_splat (vsh_l, VEC_BYTE_L_DWH);
+  vsh_l = vec_splat (vsh_l, VEC_BYTE_L_DWL);
+  print_v2xint64 ("      vsh_h (", (vui64_t)vsh_h);
+  print_v2xint64 ("      vsh_l (", (vui64_t)vsh_l);
+//  vsht_splat = vec_splat ((vui8_t) vrb, VEC_BYTE_L);
+  /* Shift the high dword by vsh_h.  */
+  vr_h = vec_vsro ((vui8_t)vra,  vsh_h);
+  vr_h = vec_vsr  (vr_h, vsh_h);
+  print_v2xint64 ("       vr_h (", (vui64_t)vr_h);
+  /* Shift the low dword by vsh_l.  */
+  vr_l = vec_vsro (vr_l,  vsh_l);
+  vr_l = vec_vsr  (vr_l, vsh_l);
+  print_v2xint64 ("       vr_l (", (vui64_t)vr_l);
+  /* Merge the dwords after shift.  */
+  result = (vui64_t)vec_sel (vr_h, vr_l, (vui8_t)sel_mask);
+#endif
+  return ((vui64_t) result);
+}
+
+vi64_t
+db_vec_vsrad (vi64_t vra, vui64_t vrb)
+{
+  vi64_t result;
+
+#ifdef _ARCH_PWR8
+  __asm__(
+      "vsrad %0,%1,%2;"
+      : "=v" (result)
+      : "v" (vra),
+      "v" (brb)
+      : );
+#else
+  vui8_t  vsh_h, vsh_l;
+  vui8_t  vr_h, vr_l;
+  vi32_t exsa;
+  vui32_t shw31 = CONST_VINT128_W (31, 31, 31, 31);
+  vui64_t exsah, exsal;
+//  vui64_t sel_mask = CONST_VINT128_DW(0, -1LL);
+  vui64_t shft_mask = CONST_VINT128_DW(63, 63);
+  print_v2xint64 ("db_vec_vsrad (", (vui64_t)vra);
+  print_v2xint64 ("              ", vrb);
+
+  /* Need to extend each signed long int to __int128. So the unsigned
+   * (128-bit) shift right behave as a arithmetic (64-bit) shift.  */
+  exsa = vec_vsraw ((vi32_t)vra, shw31);
+  exsah = (vui64_t)vec_vmrghw (exsa, exsa);
+  exsal = (vui64_t)vec_vmrglw (exsa, exsa);
+  print_v2xint64 ("      exsah (", (vui64_t)exsah);
+  print_v2xint64 ("      exsal (", (vui64_t)exsal);
+  /* constrain the dword shift amounts to 0-63.  */
+  vsh_l = vec_and ((vui8_t)vrb, (vui8_t)shft_mask);
+  /* Isolate the low dword so that bits from the high dword,
+   * do not contaminate the result.  */
+//  vr_l  = vec_and ((vui8_t)vra, (vui8_t)sel_mask);
+  /* The vsr instruction only works correctly if the bit shift
+   * value is splatted to each byte of the vector.  */
+  vsh_h = vec_splat (vsh_l, VEC_BYTE_L_DWH);
+  vsh_l = vec_splat (vsh_l, VEC_BYTE_L_DWL);
+  print_v2xint64 ("      vsh_h (", (vui64_t)vsh_h);
+  print_v2xint64 ("      vsh_l (", (vui64_t)vsh_l);
+//  vsht_splat = vec_splat ((vui8_t) vrb, VEC_BYTE_L);
+  /* Merge the extended sign with high dword.  */
+  exsah = vec_mrghd (exsah, (vui64_t)vra);
+  print_v2xint64 ("exsd-vra[0] (", (vui64_t)exsah);
+  /* Shift the high dword by vsh_h.  */
+  vr_h = vec_vsro ((vui8_t)exsah,  vsh_h);
+  vr_h = vec_vsr  (vr_h, vsh_h);
+  print_v2xint64 ("       vr_h (", (vui64_t)vr_h);
+  /* Merge the extended sign with high dword.  */
+  exsal = vec_pasted (exsal, (vui64_t)vra);
+  print_v2xint64 ("exsd-vra[1] (", (vui64_t)exsal);
+  /* Shift the low dword by vsh_l.  */
+  vr_l = vec_vsro ((vui8_t)exsal,  vsh_l);
+  vr_l = vec_vsr  (vr_l, vsh_l);
+  print_v2xint64 ("       vr_l (", (vui64_t)vr_l);
+  /* Merge the dwords after shift.  */
+//  result = (vi64_t)vec_sel (vr_h, vr_l, (vui8_t)sel_mask);
+  result = (vi64_t)vec_mrgld ((vui64_t)vr_h, (vui64_t)vr_l);
+#endif
+  return ((vi64_t) result);
+}
+#endif
+
+#ifdef __DEBUG_PRINT__
+#define test_vec_vsld(_i, _j)	db_vec_vsld(_i, _j)
+#else
+#define test_vec_vsld(_i, _j)	vec_vsld(_i, _j)
+#endif
+int
+test_vsld (void)
+{
+  vui64_t i1, i2, e;
+  vui64_t j;
+  int rc = 0;
+
+  printf ("\ntest_vsld Vector shift left doubleword\n");
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 2);
+  i2 = (vui64_t )CONST_VINT64_DW(2, 1);
+  e = (vui64_t )CONST_VINT64_DW(4, 4);
+  j = test_vec_vsld(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vsld   ( ", i1);
+  print_v2xint64 ("        ,", i2);
+  print_v2xint64 ("       )=", j);
+#endif
+  rc += check_vuint128x ("vec_vsld:", (vui128_t)j, (vui128_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(-1, -1);
+  i2 = (vui64_t )CONST_VINT64_DW(33, 31);
+  e = (vui64_t )CONST_VINT64_DW(0xfffffffe00000000, 0xffffffff80000000);
+  j = test_vec_vsld(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vsld   ( ", i1);
+  print_v2xint64 ("        ,", i2);
+  print_v2xint64 ("       )=", j);
+#endif
+  rc += check_vuint128x ("vec_vsld:", (vui128_t)j, (vui128_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(-1, -1);
+  i2 = (vui64_t )CONST_VINT64_DW(63, 60);
+  e = (vui64_t )CONST_VINT64_DW(0x8000000000000000, 0xf000000000000000);
+  j = test_vec_vsld(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vsld   ( ", i1);
+  print_v2xint64 ("        ,", i2);
+  print_v2xint64 ("       )=", j);
+#endif
+  rc += check_vuint128x ("vec_vsld:", (vui128_t)j, (vui128_t) e);
+
+  return (rc);
+}
+
+#ifdef __DEBUG_PRINT__
+#define test_vec_vsrd(_i, _j)	db_vec_vsrd(_i, _j)
+#else
+#define test_vec_vsrd(_i, _j)	vec_vsrd(_i, _j)
+#endif
+int
+test_vsrd (void)
+{
+  vui64_t i1, i2, e;
+  vui64_t j;
+  int rc = 0;
+
+  printf ("\ntest_vsrd Vector shift right doubleword\n");
+
+  i1 = (vui64_t )CONST_VINT64_DW(4, 2);
+  i2 = (vui64_t )CONST_VINT64_DW(2, 1);
+  e = (vui64_t )CONST_VINT64_DW(1, 1);
+  j = test_vec_vsrd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vsrd   ( ", i1);
+  print_v2xint64 ("        ,", i2);
+  print_v2xint64 ("       )=", j);
+#endif
+  rc += check_vuint128x ("vec_vsrd:", (vui128_t)j, (vui128_t) e);
+#if 1
+  i1 = (vui64_t )CONST_VINT64_DW(-1, -1);
+  i2 = (vui64_t )CONST_VINT64_DW(33, 31);
+  e = (vui64_t )CONST_VINT64_DW(0x000000007fffffff, 0x00000001ffffffff);
+  j = test_vec_vsrd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vsrd   ( ", i1);
+  print_v2xint64 ("        ,", i2);
+  print_v2xint64 ("       )=", j);
+#endif
+  rc += check_vuint128x ("vec_vsrd:", (vui128_t)j, (vui128_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(-1, -1);
+  i2 = (vui64_t )CONST_VINT64_DW(63, 60);
+  e = (vui64_t )CONST_VINT64_DW(0x1, 0xf);
+  j = test_vec_vsrd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vsrd   ( ", i1);
+  print_v2xint64 ("        ,", i2);
+  print_v2xint64 ("       )=", j);
+#endif
+  rc += check_vuint128x ("vec_vsrd:", (vui128_t)j, (vui128_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(100000000000, 100000000000);
+  i2 = (vui64_t )CONST_VINT64_DW(33, 31);
+  e = (vui64_t )CONST_VINT64_DW(11, 46);
+  j = test_vec_vsrd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vsrd   ( ", i1);
+  print_v2xint64 ("        ,", i2);
+  print_v2xint64 ("       )=", j);
+#endif
+  rc += check_vuint128x ("vec_vsrd:", (vui128_t)j, (vui128_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(100000000000, 100000000000);
+  i2 = (vui64_t )CONST_VINT64_DW(48, 40);
+  e = (vui64_t )CONST_VINT64_DW(0, 0);
+  j = test_vec_vsrd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vsrd   ( ", i1);
+  print_v2xint64 ("        ,", i2);
+  print_v2xint64 ("       )=", j);
+#endif
+  rc += check_vuint128x ("vec_vsrd:", (vui128_t)j, (vui128_t) e);
+#endif
+  return (rc);
+}
+
+#ifdef __DEBUG_PRINT__
+#define test_vec_vsrad(_i, _j)	db_vec_vsrad(_i, _j)
+#else
+#define test_vec_vsrad(_i, _j)	vec_vsrad(_i, _j)
+#endif
+int
+test_vsrad (void)
+{
+  vi64_t i1, e;
+  vui64_t i2;
+  vi64_t j;
+  int rc = 0;
+
+  printf ("\ntest_vsrd Vector shift right arithmetic doubleword\n");
+
+  i1 = (vi64_t )CONST_VINT64_DW(4, 2);
+  i2 = (vui64_t )CONST_VINT64_DW(2, 1);
+  e = (vi64_t )CONST_VINT64_DW(1, 1);
+  j = test_vec_vsrad(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vsrad  ( ", (vui64_t)i1);
+  print_v2xint64 ("        ,", i2);
+  print_v2xint64 ("       )=", (vui64_t)j);
+#endif
+  rc += check_vuint128x ("vec_vsrad:", (vui128_t)j, (vui128_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-4, -2);
+  i2 = (vui64_t )CONST_VINT64_DW(2, 1);
+  e = (vi64_t )CONST_VINT64_DW(-1, -1);
+  j = test_vec_vsrad(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vsrad  ( ", (vui64_t)i1);
+  print_v2xint64 ("        ,", i2);
+  print_v2xint64 ("       )=", (vui64_t)j);
+#endif
+  rc += check_vuint128x ("vec_vsrad:", (vui128_t)j, (vui128_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000, 0x7fffffffffffffff);
+  i2 = (vui64_t )CONST_VINT64_DW(63, 63);
+  e = (vi64_t )CONST_VINT64_DW(-1, 0);
+  j = test_vec_vsrad(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vsrad  ( ", (vui64_t)i1);
+  print_v2xint64 ("        ,", i2);
+  print_v2xint64 ("       )=", (vui64_t)j);
+#endif
+  rc += check_vuint128x ("vec_vsrad:", (vui128_t)j, (vui128_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x7fffffffffffffff, 0x8000000000000000);
+  i2 = (vui64_t )CONST_VINT64_DW(63, 63);
+  e = (vi64_t )CONST_VINT64_DW(0, -1);
+  j = test_vec_vsrad(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vsrad  ( ", (vui64_t)i1);
+  print_v2xint64 ("        ,", i2);
+  print_v2xint64 ("       )=", (vui64_t)j);
+#endif
+  rc += check_vuint128x ("vec_vsrad:", (vui128_t)j, (vui128_t) e);
+
+  return (rc);
+}
+#undef __DEBUG_PRINT__
+
+int
+test_permdi (void)
+{
+  vui64_t i1, i2, e;
+  vui64_t j;
+  int rc = 0;
+
+  printf ("\ntest_permdi Vector permute doubleword immediate\n");
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 2);
+  i2 = (vui64_t )CONST_VINT64_DW(101, 102);
+  e = (vui64_t )CONST_VINT64_DW(1, 101);
+  j = vec_permdi(i1, i2, 0);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("permdi ( ", i1);
+  print_v2xint64 ("        ,", i2);
+  print_v2xint64 ("     ,0)=", j);
+#endif
+  rc += check_vuint128x ("vec_permdi:", (vui128_t)j, (vui128_t) e);
+
+  e = (vui64_t )CONST_VINT64_DW(1, 102);
+  j = vec_permdi(i1, i2, 1);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("permdi ( ", i1);
+  print_v2xint64 ("        ,", i2);
+  print_v2xint64 ("     ,1)=", j);
+#endif
+  rc += check_vuint128x ("vec_permdi:", (vui128_t)j, (vui128_t) e);
+
+  e = (vui64_t )CONST_VINT64_DW(2, 101);
+  j = vec_permdi(i1, i2, 2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("permdi ( ", i1);
+  print_v2xint64 ("        ,", i2);
+  print_v2xint64 ("     ,2)=", j);
+#endif
+  rc += check_vuint128x ("vec_permdi:", (vui128_t)j, (vui128_t) e);
+
+  e = (vui64_t )CONST_VINT64_DW(2, 102);
+  j = vec_permdi(i1, i2, 3);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("permdi ( ", i1);
+  print_v2xint64 ("        ,", i2);
+  print_v2xint64 ("     ,3)=", j);
+#endif
+  rc += check_vuint128x ("vec_permdi:", (vui128_t)j, (vui128_t) e);
+
+  e = (vui64_t )CONST_VINT64_DW(1, 1);
+  j = vec_spltd(i1, 0);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("spltd  ( ", i1);
+  print_v2xint64 ("     ,0)=", j);
+#endif
+  rc += check_vuint128x ("vec_spltd (x,0):", (vui128_t)j, (vui128_t) e);
+
+  e = (vui64_t )CONST_VINT64_DW(2, 2);
+  j = vec_spltd(i1, 1);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("spltd  ( ", i1);
+  print_v2xint64 ("     ,1)=", j);
+#endif
+  rc += check_vuint128x ("vec_spltd (x,1):", (vui128_t)j, (vui128_t) e);
+
+  e = (vui64_t )CONST_VINT64_DW(2, 1);
+  j = vec_swapd(i1);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("swapd  ( ", i1);
+  print_v2xint64 ("       )=", j);
+#endif
+  rc += check_vuint128x ("vec_swapd (x):", (vui128_t)j, (vui128_t) e);
+
+  e = (vui64_t )CONST_VINT64_DW(1, 101);
+  j = vec_mrghd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("mrghd  ( ", i1);
+  print_v2xint64 ("        ,", i2);
+  print_v2xint64 ("       )=", j);
+#endif
+  rc += check_vuint128x ("vec_mrghd :", (vui128_t)j, (vui128_t) e);
+
+  e = (vui64_t )CONST_VINT64_DW(2, 102);
+  j = vec_mrgld(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("mrgld  ( ", i1);
+  print_v2xint64 ("        ,", i2);
+  print_v2xint64 ("       )=", j);
+#endif
+  rc += check_vuint128x ("vec_mrgld :", (vui128_t)j, (vui128_t) e);
+
+  return (rc);
+}
+
+int
+test_revbd (void)
+{
+  vui32_t i, e, *ip;
+  vui128_t k;
+  unsigned char mem[16] __attribute__ ((aligned (16))) = { 0xf0, 0xf1, 0xf2,
+      0xf3, 0xe0, 0xe1, 0xe2, 0xe3, 0xd0, 0xd1, 0xd2, 0xd3, 0xc0, 0xc1, 0xc2,
+      0xc3 };
+  int rc = 0;
+
+  printf ("\ntest_revbd Reverse Bytes in doublewords\n");
+
+  i = (vui32_t ) { 0, 1, 2, 3 };
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  e = (vui32_t )CONST_VINT32_W(0x01000000, 0x00000000, 0x03000000, 0x02000000);
+#else
+  e = (vui32_t)CONST_VINT32_W(0x02000000, 0x03000000, 0x00000000, 0x01000000);
+#endif
+  k = (vui128_t) vec_revbd ((vui64_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_revbd i=", (vui128_t)i);
+  print_vint128x ("         k=", k);
+#endif
+  rc += check_vuint128x ("vec_revbd 1:", k, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0x01020304, 0x11121314, 0x21222324, 0x31323334);
+  e = (vui32_t )CONST_VINT32_W(0x14131211, 0x04030201, 0x34333231, 0x24232221);
+  k = (vui128_t) vec_revbd ((vui64_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_revbd i=", (vui128_t)i);
+  print_vint128x ("         k=", k);
+#endif
+  rc += check_vuint128x ("vec_revbd 2:", k, (vui128_t) e);
+
+  ip = (vui32_t*) mem;
+  i = *ip;
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  e = (vui32_t )CONST_VINT32_W(0xe3e2e1e0, 0xf3f2f1f0, 0xc3c2c1c0, 0xd3d2d1d0);
+#else
+  e = (vui32_t)CONST_VINT32_W(0xd0d1d2d3, 0xc0c1c2c3, 0xf0f1f2f3, 0xe0e1e2e3);
+#endif
+  k = (vui128_t) vec_revbd ((vui64_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_revbd i=", (vui128_t)i);
+  print_vint128x ("         k=", k);
+#endif
+  rc += check_vuint128x ("vec_revbd 3:", k, (vui128_t) e);
+
+  return (rc);
+}
+
+int
+test_popcntd (void)
+{
+  vui64_t i, e;
+  vui64_t j;
+  int rc = 0;
+
+  printf ("\ntest_popcntd Vector Pop Count doubleword\n");
+
+  i = (vui64_t )CONST_VINT64_DW(0, 0);
+  e = (vui64_t )CONST_VINT64_DW(0, 0);
+  j = vec_popcntd(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntd({0, 0) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntd:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui64_t )CONST_VINT64_DW(0, -1);
+  e = (vui64_t )CONST_VINT64_DW(0, 64);
+  j = vec_popcntd(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntd({0, -1) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntd:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui64_t )CONST_VINT64_DW(-1, 0);
+  e = (vui64_t )CONST_VINT64_DW(64, 0);
+  j = vec_popcntd(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntd({-1, 0) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntd:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui64_t )CONST_VINT64_DW(-1, -1);
+  e = (vui64_t )CONST_VINT64_DW(64, 64);
+  j = vec_popcntd(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntd({-1, -1) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntd:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui64_t )CONST_VINT64_DW(1, 8589934596);
+  e = (vui64_t )CONST_VINT64_DW(1, 2);
+  j = vec_popcntd(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntd({1, 8589934596) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntd:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui64_t )CONST_VINT64_DW(34359738384, 137438953536);
+  e = (vui64_t )CONST_VINT64_DW(2, 2);
+  j = vec_popcntd(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntd({34359738384, 137438953536) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntd:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui64_t )CONST_VINT64_DW(549755814144, 2199023256576);
+  e = (vui64_t )CONST_VINT64_DW(2, 2);
+  j = vec_popcntd(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntd({549755814144, 2199023256576) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntd:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui64_t )CONST_VINT64_DW(8796093026304, 35184372105216);
+  e = (vui64_t )CONST_VINT64_DW(2, 2);
+  j = vec_popcntd(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntd({8796093026304, 35184372105216) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntd:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui64_t )CONST_VINT64_DW(140737488420864, 562949953683456);
+  e = (vui64_t )CONST_VINT64_DW(2, 2);
+  j = vec_popcntd(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntd({140737488420864, 562949953683456) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntd:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui64_t )CONST_VINT64_DW(2251799814733824, 9007199258935296);
+  e = (vui64_t )CONST_VINT64_DW(2, 2);
+  j = vec_popcntd(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntd({2251799814733824, 9007199258935296) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntd:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui64_t )CONST_VINT64_DW(36028797035741184, 144115188142964736);
+  e = (vui64_t )CONST_VINT64_DW(2, 2);
+  j = vec_popcntd(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntd({36028797035741184, 144115188142964736) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntd:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui64_t )CONST_VINT64_DW(576460752571858944, 2305843010287435776);
+  e = (vui64_t )CONST_VINT64_DW(2, 2);
+  j = vec_popcntd(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntd({576460752571858944, 2305843010287435776) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntd:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui64_t )CONST_VINT64_DW(429496725405032703, 429496725405032703);
+  e = (vui64_t )CONST_VINT64_DW(38, 38);
+  j = vec_popcntd(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntd({429496725405032703, 429496725405032703) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntd:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui64_t )CONST_VINT64_DW(381774867026695736, 381774867026695736);
+  e = (vui64_t )CONST_VINT64_DW(24, 24);
+  j = vec_popcntd(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntd({381774867026695736, 381774867026695736) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntd:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui64_t )CONST_VINT64_DW(1000000000, 1000000000);
+  e = (vui64_t )CONST_VINT64_DW(13, 13);
+  j = vec_popcntd(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntd({1000000000, 1000000000) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntd:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui64_t )CONST_VINT64_DW(10000000000, 1000000000);
+  e = (vui64_t )CONST_VINT64_DW(11, 13);
+  j = vec_popcntd(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntd({10000000000, 1000000000) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntd:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui64_t )CONST_VINT64_DW(1000000000, 10000000000);
+  e = (vui64_t )CONST_VINT64_DW(13, 11);
+  j = vec_popcntd(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntd({1000000000, 10000000000) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntd:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui64_t )CONST_VINT64_DW(1000000000000000000, 0);
+  e = (vui64_t )CONST_VINT64_DW(24, 0);
+  j = vec_popcntd(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntd({1000000000000000000, 0) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntd:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui64_t )CONST_VINT64_DW(0, 1000000000000000000);
+  e = (vui64_t )CONST_VINT64_DW(0, 24);
+  j = vec_popcntd(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntd({0, 1000000000000000000) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntd:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui64_t )CONST_VINT64_DW(0, 1000000000000000000);
+  e = (vui64_t )CONST_VINT64_DW(0, 24);
+  j = vec_popcntd(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("popcntd({0, 1000000000000000000) ", (vui128_t)j);
+#endif
+  rc += check_vuint128x ("vec_popcntd:", (vui128_t)j, (vui128_t) e);
+
+  return (rc);
+}
+
+//#undef __DEBUG_PRINT__
+int
+test_clzd (void)
+{
+  vui64_t i, e;
+  vui64_t j;
+  int rc = 0;
+
+  printf ("\ntest_clzd Vector Count Leading Zeros in doublewords\n");
+
+  i = (vui64_t )CONST_VINT64_DW(0, 0);
+  e = (vui64_t )CONST_VINT64_DW(64, 64);
+  j = vec_clzd((vui64_t )i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(0, 0) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzd:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui64_t )CONST_VINT64_DW(-1, -1);
+  e = (vui64_t )CONST_VINT64_DW(0, 0);
+  j = vec_clzd((vui64_t )i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(-1, -1) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzd:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui64_t )CONST_VINT64_DW(0, -1);
+  e = (vui64_t )CONST_VINT64_DW(64, 0);
+  j = vec_clzd((vui64_t )i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(0, -1) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzd:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui64_t )CONST_VINT64_DW(-1, 0);
+  e = (vui64_t )CONST_VINT64_DW(0, 64);
+  j = vec_clzd((vui64_t )i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(-1, 0) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzd:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui64_t )CONST_VINT64_DW(1, 8589934596);
+  e = (vui64_t )CONST_VINT64_DW(63, 30);
+  j = vec_clzd((vui64_t )i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(1, 8589934596) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzd:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui64_t )CONST_VINT64_DW(34359738384, 137438953536);
+  e = (vui64_t )CONST_VINT64_DW(28, 26);
+  j = vec_clzd((vui64_t )i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(34359738384, 137438953536) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzd:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui64_t )CONST_VINT64_DW(549755814144, 2199023256576);
+  e = (vui64_t )CONST_VINT64_DW(24, 22);
+  j = vec_clzd((vui64_t )i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(549755814144, 2199023256576) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzd:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui64_t )CONST_VINT64_DW(8796093026304, 35184372105216);
+  e = (vui64_t )CONST_VINT64_DW(20, 18);
+  j = vec_clzd((vui64_t )i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(8796093026304, 35184372105216) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzd:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui64_t )CONST_VINT64_DW(140737488420864, 562949953683456);
+  e = (vui64_t )CONST_VINT64_DW(16, 14);
+  j = vec_clzd((vui64_t )i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(140737488420864, 562949953683456) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzd:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui64_t )CONST_VINT64_DW(2251799814733824, 9007199258935296);
+  e = (vui64_t )CONST_VINT64_DW(12, 10);
+  j = vec_clzd((vui64_t )i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(2251799814733824, 9007199258935296) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzd:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui64_t )CONST_VINT64_DW(36028797035741184, 144115188142964736);
+  e = (vui64_t )CONST_VINT64_DW(8, 6);
+  j = vec_clzd((vui64_t )i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(36028797035741184, 144115188142964736) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzd:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui64_t )CONST_VINT64_DW(576460752571858944, 2305843010287435776);
+  e = (vui64_t )CONST_VINT64_DW(4, 2);
+  j = vec_clzd((vui64_t )i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(576460752571858944, 2305843010287435776) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzd:", (vui128_t)j, (vui128_t) e);
+
+  return (rc);
+}
+
+int
+test_muleud (void)
+{
+  vui64_t i, j;
+  vui128_t k, e;
+  int rc = 0;
+
+  printf ("\ntest_muleud Vector Multiply Even Unsigned doublewords\n");
+#if 0
+  i = (vui64_t )CONST_VINT32_W(1, 2, 3, 4);
+  j = (vui64_t )CONST_VINT32_W(10, 20, 30, 40);
+  e = (vui128_t )CONST_VINT128_DW128(10, 90);
+#else
+  i = (vui64_t ){1, 2};
+  j = (vui64_t ){101, 102};
+  e = (vui128_t )CONST_VINT128_DW128(0, 101);
+#endif
+  k = vec_muleud(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muleud({1, 2, 3, 4}, {10, 20, 30, 40}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muleud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t ){1000000000, 1000000000};
+  j = (vui64_t ){1000000000, 1000000000};
+  e = (vui128_t )CONST_VINT128_DW128(0, 1000000000000000000UL);
+  k = vec_muleud(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muleud({1000000000, 1000000000}, {1000000000, 1000000000}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muleud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t ){10000000000, 1000000000};
+  j = (vui64_t ){10000000000, 1000000000};
+  e = (vui128_t )CONST_VINT128_DW128(0x5, 0x6bc75e2d63100000UL);
+  k = vec_muleud(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muleud({10000000000, 1000000000}, {10000000000, 1000000000}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muleud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t ){1000000000000000000UL, 0};
+  j = (vui64_t ){1000000000000000000UL, 0};
+  e = (vui128_t )CONST_VINT128_DW128(0x00c097ce7bc90715UL, 0xb34b9f1000000000UL);
+  k = vec_muleud(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muleud({10**18, 0}, {10**18, 0}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muleud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t ){0, 1000000000000000000UL};
+  j = (vui64_t ){0, 1000000000000000000UL};
+  e = (vui128_t )CONST_VINT128_DW128(0x0UL, 0x0UL);
+  k = vec_muleud(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muleud({0, 10**18}, {0, 10**18}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muleud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t ){100000000000UL, 100000000000UL};
+  j = (vui64_t ){100000000000UL, 100000000000UL};
+  e = (vui128_t )CONST_VINT128_DW128(0x021eUL, 0x19e0c9bab2400000UL);
+  k = vec_muleud(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muleud({10**11, 10**11}, {10**11, 10**11}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muleud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t ){0x00000000ffffffffUL, 0x00000000ffffffffUL};
+  j = (vui64_t ){0x00000000ffffffffUL, 0x00000000ffffffffUL};
+  e = (vui128_t )CONST_VINT128_DW128(0x0UL, 0xfffffffe00000001UL);
+  k = vec_muleud(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muleud({2**32-1, 2**32-1}, {2**32-1, 2**32-1}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muleud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t ){0xffffffff00000000UL, 0xffffffff00000000UL};
+  j = (vui64_t ){0xffffffff00000000UL, 0xffffffff00000000UL};
+  e = (vui128_t )CONST_VINT128_DW128(0xfffffffe00000001UL, 0x0UL);
+  k = vec_muleud(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muleud({2**64-2**32 , 2**64-2**32}, {2**64-2**32 , 2**64-2**32}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muleud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t ){0xffffffffffffffffUL, 0x0000000000000000UL};
+  j = (vui64_t ){0xffffffffffffffffUL, 0x0000000000000000UL};
+  e = (vui128_t )CONST_VINT128_DW128(0xfffffffffffffffeUL, 0x0000000000000001UL);
+  k = vec_muleud(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muleud({2**64-1 , 0}, {2**64-1 , 0}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muleud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t ){2000000000000000000UL, 1000000000000000000UL};
+  j = (vui64_t ){1UL, -1UL};
+  e = (vui128_t )CONST_VINT128_DW128(0UL, 2000000000000000000UL);
+  k = vec_muleud(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muleud({2**64-1 , 0}, {2**64-1 , 0}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muleud:", (vui128_t)k, (vui128_t) e);
+
+  return (rc);
+}
+
+int
+test_muloud (void)
+{
+  vui64_t i, j;
+  vui128_t k, e;
+  int rc = 0;
+
+  printf ("\ntest_muloud Vector Multiply Odd Unsigned doublewords\n");
+#if 0
+  i = (vui64_t )CONST_VINT32_W(1, 2, 3, 4);
+  j = (vui64_t )CONST_VINT32_W(10, 20, 30, 40);
+  e = (vui128_t )CONST_VINT128_DW128(10, 90);
+#else
+  i = (vui64_t ){1, 2};
+  j = (vui64_t ){101, 102};
+  e = (vui128_t )CONST_VINT128_DW128(0, 204);
+#endif
+  k = vec_muloud(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muloud({1, 2, 3, 4}, {10, 20, 30, 40}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muloud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t ){1000000000, 1000000000};
+  j = (vui64_t ){1000000000, 1000000000};
+  e = (vui128_t )CONST_VINT128_DW128(0, 1000000000000000000UL);
+  k = vec_muloud(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muloud({1000000000, 1000000000}, {1000000000, 1000000000}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muloud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t ){10000000000, 1000000000};
+  j = (vui64_t ){10000000000, 1000000000};
+  e = (vui128_t )CONST_VINT128_DW128(0x0, 0x0de0b6b3a7640000UL);
+  k = vec_muloud(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muloud({10000000000, 1000000000}, {10000000000, 1000000000}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muloud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t ){1000000000000000000UL, 0};
+  j = (vui64_t ){1000000000000000000UL, 0};
+  e = (vui128_t )CONST_VINT128_DW128(0, 0);
+  k = vec_muloud(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muloud({10**18, 0}, {10**18, 0}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muloud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t ){0, 1000000000000000000UL};
+  j = (vui64_t ){0, 1000000000000000000UL};
+  e = (vui128_t )CONST_VINT128_DW128(0x00c097ce7bc90715UL, 0xb34b9f1000000000UL);
+  k = vec_muloud(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muloud({0, 10**18}, {0, 10**18}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muloud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t ){100000000000UL, 100000000000UL};
+  j = (vui64_t ){100000000000UL, 100000000000UL};
+  e = (vui128_t )CONST_VINT128_DW128(0x021eUL, 0x19e0c9bab2400000UL);
+  k = vec_muloud(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muloud({10**11, 10**11}, {10**11, 10**11}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muloud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t ){0x00000000ffffffffUL, 0x00000000ffffffffUL};
+  j = (vui64_t ){0x00000000ffffffffUL, 0x00000000ffffffffUL};
+  e = (vui128_t )CONST_VINT128_DW128(0x0UL, 0xfffffffe00000001UL);
+  k = vec_muloud(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muloud({2**32-1, 2**32-1}, {2**32-1, 2**32-1}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muloud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t ){0xffffffff00000000UL, 0xffffffff00000000UL};
+  j = (vui64_t ){0xffffffff00000000UL, 0xffffffff00000000UL};
+  e = (vui128_t )CONST_VINT128_DW128(0xfffffffe00000001UL, 0x0UL);
+  k = vec_muloud(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muloud({2**64-2**32 , 2**64-2**32}, {2**64-2**32 , 2**64-2**32}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muloud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t ){ 0x0000000000000000UL, 0xffffffffffffffffUL};
+  j = (vui64_t ){ 0x0000000000000000UL, 0xffffffffffffffffUL};
+  e = (vui128_t )CONST_VINT128_DW128(0xfffffffffffffffeUL, 0x0000000000000001UL);
+  k = vec_muloud(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muloud({2**64-1 , 0}, {2**64-1 , 0}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muloud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t ){2000000000000000000UL, 1000000000000000000UL};
+  j = (vui64_t ){1UL, -1L};
+  e = (vui128_t )CONST_VINT128_DW128(0x0de0b6b3a763ffffUL, -1000000000000000000L);
+  k = vec_muloud(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("muloud({2**64-1 , 0}, {2**64-1 , 0}) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_muloud:", (vui128_t)k, (vui128_t) e);
+
+  return (rc);
+}
+
+int
+test_vec_i64 (void)
+{
+  int rc = 0;
+
+  printf ("\ntest_vec_i64\n");
+
+  rc += test_permdi ();
+  rc += test_revbd ();
+  rc += test_clzd ();
+  rc += test_popcntd();
+  rc += test_vsld ();
+  rc += test_vsrd ();
+  rc += test_vsrad ();
+  rc += test_muleud ();
+  rc += test_muloud ();
+
+  return (rc);
+}

--- a/src/testsuite/arith128_test_i64.c
+++ b/src/testsuite/arith128_test_i64.c
@@ -1099,7 +1099,7 @@ test_vec_i64 (void)
 {
   int rc = 0;
 
-  printf ("\ntest_vec_i64\n");
+  printf ("\n%s\n", __FUNCTION__);
 
   rc += test_permdi ();
   rc += test_revbd ();

--- a/src/testsuite/arith128_test_i64.h
+++ b/src/testsuite/arith128_test_i64.h
@@ -1,0 +1,34 @@
+/*
+ Copyright (c) [2017] IBM Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ arith128_test_i64.h
+
+ Contributors:
+      IBM Corporation, Steven Munroe
+      Created on: Apr 5, 2018
+ */
+
+#ifndef TESTSUITE_ARITH128_TEST_I64_H_
+#define TESTSUITE_ARITH128_TEST_I64_H_
+
+extern int test_vec_i64 (void);
+
+extern int test_vsld (void);
+
+extern int test_vsrd (void);
+
+extern int test_vsrad (void);
+
+#endif /* TESTSUITE_ARITH128_TEST_I64_H_ */


### PR DESCRIPTION
Some of these tests have been where in arith128_test_i128.c and moved
to the file with matching element size. Some test functions where given
more descriptive as part of this.

2018-06-11 Steven Munroe <munroesj52@gmail.com>

        * src/testsuite/arith128_test_bcd.c: New File.
        * src/testsuite/arith128_test_bcd.h: New File.
        * src/testsuite/arith128_test_char.c: New File.
        * src/testsuite/arith128_test_char.h: New file.
        * src/testsuite/arith128_test_i16.c: Mew File.
        * src/testsuite/arith128_test_i16.h: New File.
        * src/testsuite/arith128_test_i32.c: New File.
        * src/testsuite/arith128_test_i32.h: New File.
        * src/testsuite/arith128_test_i64.c: New File.
        * src/testsuite/arith128_test_i64.h: new File.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>