### PR TITLE
Update and refactor the "dummy" files. Dummy files use the pveclib

### DIFF
--- a/src/testsuite/vec_bcd_dummy.c
+++ b/src/testsuite/vec_bcd_dummy.c
@@ -11,7 +11,7 @@
 vui8_t
 test_vec_bcdctb100s (vui8_t a)
 {
-	return (vec_bcdctb100s(a));
+  return (vec_bcdctb100s (a));
 }
 
 vui32_t

--- a/src/testsuite/vec_bcd_dummy.c
+++ b/src/testsuite/vec_bcd_dummy.c
@@ -1,0 +1,39 @@
+/*
+ * vec_bcd_dummy.c
+ *
+ *  Created on: Mar 1, 2018
+ *      Author: sjmunroe
+ */
+
+#include <vec_common_ppc.h>
+#include <vec_bcd_ppc.h>
+
+vui8_t
+test_vec_bcdctb100s (vui8_t a)
+{
+	return (vec_bcdctb100s(a));
+}
+
+vui32_t
+test_vec_bcdadd (vui32_t a, vui32_t b)
+{
+  return vec_bcdadd (a, b);
+}
+
+vui32_t
+test_vec_bcdsub (vui32_t a, vui32_t b)
+{
+  return vec_bcdsub (a, b);
+}
+
+vui32_t
+test_vec_bcdmul (vui32_t a, vui32_t b)
+{
+  return vec_bcdmul (a, b);
+}
+
+vui32_t
+test_vec_bcddiv (vui32_t a, vui32_t b)
+{
+  return vec_bcddiv (a, b);
+}

--- a/src/testsuite/vec_char_dummy.c
+++ b/src/testsuite/vec_char_dummy.c
@@ -1,0 +1,129 @@
+/*
+   vec_char_dummy.c
+  
+    Created on: Jul 31, 2017
+        Author: sjmunroe
+  */
+
+
+#include <stdint.h>
+#include <stdio.h>
+#if 0
+#include <dfp/fenv.h>
+#include <dfp/float.h>
+#include <dfp/math.h>
+#else
+#include <fenv.h>
+#include <float.h>
+#include <math.h>
+#endif
+
+//#define __DEBUG_PRINT__
+
+//#include "dfp_256_ppc.h"
+#include "vec_char_ppc.h"
+
+#if __GNUC__ >= 8
+/* Generic vec_mul not supported for vector char until GCC 8.  */
+vui8_t
+__test_mulubm (vui8_t __A, vui8_t __B)
+{
+  return vec_mul (__A, __B);
+}
+#endif
+
+vui8_t
+__test_absdub (vui8_t __A, vui8_t __B)
+{
+  return vec_absdub (__A, __B);
+}
+
+
+vui8_t
+__test_clzb (vui8_t a)
+{
+  return (vec_clzb (a));
+}
+
+vui8_t
+test_vec_slbi_4 (vui8_t a)
+{
+	return (vec_slbi(a, 4));
+}
+
+vi8_t
+test_vec_srabi_4 (vi8_t a)
+{
+	return (vec_srabi(a, 4));
+}
+
+vui8_t
+test_vec_srbi_4 (vui8_t a)
+{
+	return (vec_srbi(a, 4));
+}
+
+vui8_t
+test_vec_slbi_8 (vui8_t a)
+{
+	return (vec_slbi(a, 8));
+}
+
+vi8_t
+test_vec_srabi_8 (vi8_t a)
+{
+	return (vec_srabi(a, 8));
+}
+
+vui8_t
+test_vec_srbi_8 (vui8_t a)
+{
+	return (vec_srbi(a, 8));
+}
+
+vui8_t
+test_vec_slbi (vui8_t a, const unsigned int shb)
+{
+	return (vec_slbi(a, shb));
+}
+
+vi8_t
+test_vec_srabi (vi8_t a, const unsigned int shb)
+{
+	return (vec_srabi(a, shb));
+}
+
+vui8_t
+test_vec_srbi (vui8_t a, const unsigned int shb)
+{
+	return (vec_srbi(a, shb));
+}
+
+vui8_t
+test_vec_isalnum(vui8_t a)
+{
+	return (vec_isalnum(a));
+}
+vui8_t
+test_vec_isdigit(vui8_t a)
+{
+	return (vec_isdigit(a));
+}
+
+vui8_t
+test_vec_isalnum2(vui8_t a)
+{
+	return (vec_or (vec_isalpha (a), vec_isdigit(a)));
+}
+
+vui8_t
+test_vec_toupper(vui8_t a)
+{
+	return (vec_toupper(a));
+}
+
+vui8_t
+test_vec_tolower(vui8_t a)
+{
+	return (vec_tolower(a));
+}

--- a/src/testsuite/vec_char_dummy.c
+++ b/src/testsuite/vec_char_dummy.c
@@ -7,20 +7,9 @@
 
 
 #include <stdint.h>
-#include <stdio.h>
-#if 0
-#include <dfp/fenv.h>
-#include <dfp/float.h>
-#include <dfp/math.h>
-#else
-#include <fenv.h>
-#include <float.h>
-#include <math.h>
-#endif
 
 //#define __DEBUG_PRINT__
 
-//#include "dfp_256_ppc.h"
 #include "vec_char_ppc.h"
 
 #if __GNUC__ >= 8
@@ -48,82 +37,82 @@ __test_clzb (vui8_t a)
 vui8_t
 test_vec_slbi_4 (vui8_t a)
 {
-	return (vec_slbi(a, 4));
+  return vec_slbi (a, 4);
 }
 
 vi8_t
 test_vec_srabi_4 (vi8_t a)
 {
-	return (vec_srabi(a, 4));
+  return vec_srabi (a, 4);
 }
 
 vui8_t
 test_vec_srbi_4 (vui8_t a)
 {
-	return (vec_srbi(a, 4));
+  return vec_srbi (a, 4);
 }
 
 vui8_t
 test_vec_slbi_8 (vui8_t a)
 {
-	return (vec_slbi(a, 8));
+  return vec_slbi (a, 8);
 }
 
 vi8_t
 test_vec_srabi_8 (vi8_t a)
 {
-	return (vec_srabi(a, 8));
+  return vec_srabi (a, 8);
 }
 
 vui8_t
 test_vec_srbi_8 (vui8_t a)
 {
-	return (vec_srbi(a, 8));
+  return vec_srbi (a, 8);
 }
 
 vui8_t
 test_vec_slbi (vui8_t a, const unsigned int shb)
 {
-	return (vec_slbi(a, shb));
+  return vec_slbi (a, shb);
 }
 
 vi8_t
 test_vec_srabi (vi8_t a, const unsigned int shb)
 {
-	return (vec_srabi(a, shb));
+  return vec_srabi (a, shb);
 }
 
 vui8_t
 test_vec_srbi (vui8_t a, const unsigned int shb)
 {
-	return (vec_srbi(a, shb));
+  return vec_srbi (a, shb);
 }
 
 vui8_t
-test_vec_isalnum(vui8_t a)
+test_vec_isalnum (vui8_t a)
 {
-	return (vec_isalnum(a));
+  return vec_isalnum (a);
 }
 vui8_t
-test_vec_isdigit(vui8_t a)
+test_vec_isdigit (vui8_t a)
 {
-	return (vec_isdigit(a));
-}
-
-vui8_t
-test_vec_isalnum2(vui8_t a)
-{
-	return (vec_or (vec_isalpha (a), vec_isdigit(a)));
+  return vec_isdigit (a);
 }
 
 vui8_t
-test_vec_toupper(vui8_t a)
+test_vec_isalnum2 (vui8_t a)
 {
-	return (vec_toupper(a));
+  return vec_or (vec_isalpha (a), vec_isdigit (a));
 }
 
 vui8_t
-test_vec_tolower(vui8_t a)
+test_vec_toupper (vui8_t a)
 {
-	return (vec_tolower(a));
+  return vec_toupper (a);
+}
+
+vui8_t
+test_vec_tolower (vui8_t a)
+{
+  return vec_tolower (a);
 }

--- a/src/testsuite/vec_dummy_main.c
+++ b/src/testsuite/vec_dummy_main.c
@@ -1,5 +1,5 @@
 /*
- Copyright [2017] IBM Corporation.
+ Copyright (c) [2017] IBM Corporation.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/testsuite/vec_int128_dummy.c
+++ b/src/testsuite/vec_int128_dummy.c
@@ -1,5 +1,5 @@
 /*
- Copyright [2017] IBM Corporation.
+ Copyright (c) [2017] IBM Corporation.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -23,11 +23,33 @@
 #include <vec_int128_ppc.h>
 
 vui128_t
-test_vec_add256 (vui128_t *out, vui128_t a0, vui128_t a1, vui128_t b0, vui128_t b1)
+__test_msumudm (vui64_t a, vui64_t b, vui128_t c)
 {
-  vui128_t c0, c1;
-  out[1] = vec_addcq (&c1, a1, b1);
-  out[0] = vec_addeq (&c0, a0, b0, c1);
+  return vec_msumudm ( a, b, c);
+}
+
+vui128_t
+test_vec_add256_1 (vui128_t *out, vui128_t a0, vui128_t a1, vui128_t b0, vui128_t b1)
+{
+  vui128_t s0, s1, c0, c1;
+  s1 = vec_adduqm (a1, b1);
+  c1 = vec_addcuq (a1, b1);
+  s0 = vec_addeuqm (a0, b0, c1);
+  c0 = vec_addecuq (a0, b0, c1);
+
+  out[1] = s1;
+  out[0] = s0;
+  return (c0);
+}
+vui128_t
+test_vec_add256_2 (vui128_t *out, vui128_t a0, vui128_t a1, vui128_t b0, vui128_t b1)
+{
+  vui128_t s0, s1, c0, c1;
+  s1 = vec_addcq (&c1, a1, b1);
+  s0 = vec_addeq (&c0, a0, b0, c1);
+
+  out[1] = s1;
+  out[0] = s0;
   return (c0);
 }
 
@@ -249,17 +271,27 @@ test_vec_popcntq (vui128_t vra)
 }
 
 vui128_t
-test_cmul10uq (vui128_t *cout, vui128_t a)
+test_cmul10cuq (vui128_t *cout, vui128_t a)
 {
-  *cout = vec_mul10cuq (a);
-  return vec_mul10uq (a);
+  return vec_cmul10cuq (cout, a);
 }
 
 vui128_t
-test_cmul10euq (vui128_t *cout, vui128_t a, vui128_t cin)
+test_cmul10ecuq (vui128_t *cout, vui128_t a, vui128_t cin)
 {
-  *cout = vec_mul10ecuq (a, cin);
-  return vec_mul10euq (a, cin);
+  return vec_cmul10ecuq (cout, a, cin);
+}
+
+vui128_t
+test_cmul100cuq (vui128_t *cout, vui128_t a)
+{
+  return vec_cmul100cuq (cout, a);
+}
+
+vui128_t
+test_cmul100ecuq (vui128_t *cout, vui128_t a, vui128_t cin)
+{
+  return vec_cmul100ecuq (cout, a, cin);
 }
 
 vui128_t
@@ -294,9 +326,9 @@ test_vec_mul10ecuq (vui128_t a, vui128_t cin)
 }
 
 vui128_t
-test_vec_revq (vui128_t a)
+test_vec_revbq (vui128_t a)
 {
-	return vec_revq(a);
+	return vec_revbq(a);
 }
 
 void
@@ -307,12 +339,6 @@ test_vec_load_store (vui128_t *a, vui128_t *b)
     temp = vec_ld (0, (vui64_t *)a);
     vec_st (temp, 0, (vui64_t *)b);
   }
-
-vui64_t
-test_vpaste (vui64_t __VH, vui64_t __VL)
-{
-	return (vec_pasted(__VH, __VL));
-}
 
 vui64_t
 test_vpaste_x (vui64_t __VH, vui64_t __VL)
@@ -354,22 +380,36 @@ test_vec_slq  (vui128_t a, vui128_t sh)
 }
 
 vui128_t
-test_muloud (vui64_t a, vui64_t b)
+__test_muloud (vui64_t a, vui64_t b)
 {
   return (vec_muloud (a, b));
 }
 
 vui128_t
-test_muleud (vui64_t a, vui64_t b)
+__test_muleud (vui64_t a, vui64_t b)
 {
   return (vec_muleud (a, b));
 }
 
 vui128_t
-test_muludq (vui128_t *mulu, vui128_t a, vui128_t b)
+__test_muludq (vui128_t *mulu, vui128_t a, vui128_t b)
 {
   return (vec_muludq (mulu, a, b));
 }
+
+vui128_t
+__test_mulluq (vui128_t a, vui128_t b)
+{
+  return (vec_mulluq (a, b));
+}
+
+#ifdef _ARCH_PWR8
+vui128_t
+test_vec_subq (vui128_t a, vui128_t b)
+{
+  return (vec_sub(a,b));
+}
+#endif
 
 void
 test_mul4uq (vui128_t *__restrict__ mulu, vui128_t m1h, vui128_t m1l, vui128_t m2h, vui128_t m2l)
@@ -395,7 +435,7 @@ test_mul4uq (vui128_t *__restrict__ mulu, vui128_t m1h, vui128_t m1l, vui128_t m
 
 #ifdef _ARCH_PWR8
 vui128_t
-test_clzq (vui128_t vra)
+__test_clzq (vui128_t vra)
 {
 	__vector unsigned long long result, vt1, vt3;
 	__vector unsigned long long vt2;

--- a/src/testsuite/vec_int32_dummy.c
+++ b/src/testsuite/vec_int32_dummy.c
@@ -1,0 +1,173 @@
+/*
+ Copyright (c) [2018] IBM Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ vec_int32_dummy.c
+
+ Contributors:
+      IBM Corporation, Steven Munroe
+      Created on: Mar 29, 2018
+ */
+
+#include <vec_int32_ppc.h>
+
+vui64_t
+__test_muleuw (vui32_t a, vui32_t b)
+{
+  return vec_muleuw (a, b);
+}
+
+vui64_t
+__test_mulouw (vui32_t a, vui32_t b)
+{
+  return vec_mulouw (a, b);
+}
+
+vui32_t
+__test_muluwm (vui32_t a, vui32_t b)
+{
+  return vec_muluwm (a, b);
+}
+
+vui32_t
+test_slwi_1 (vui32_t a)
+{
+  return vec_slwi (a, 1);
+}
+
+vui32_t
+test_slwi_15 (vui32_t a)
+{
+  return vec_slwi (a, 15);
+}
+
+vui32_t
+test_slwi_16 (vui32_t a)
+{
+  return vec_slwi (a, 16);
+}
+
+vui32_t
+test_slwi_31 (vui32_t a)
+{
+  return vec_slwi (a, 31);
+}
+
+vui32_t
+test_slwi_32 (vui32_t a)
+{
+  return vec_slwi (a, 32);
+}
+
+vui32_t
+test_srwi_1 (vui32_t a)
+{
+  return vec_srwi (a, 1);
+}
+
+vui32_t
+test_srwi_15 (vui32_t a)
+{
+  return vec_srwi (a, 15);
+}
+
+vui32_t
+test_srwi_16 (vui32_t a)
+{
+  return vec_srwi (a, 16);
+}
+
+vui32_t
+test_srwi_31 (vui32_t a)
+{
+  return vec_srwi (a, 31);
+}
+
+vui32_t
+test_srwi_32 (vui32_t a)
+{
+  return vec_srwi (a, 32);
+}
+
+vi32_t
+test_srawi_1 (vi32_t a)
+{
+  return vec_srawi (a, 1);
+}
+
+vi32_t
+test_srawi_15 (vi32_t a)
+{
+  return vec_srawi (a, 15);
+}
+
+vi32_t
+test_srawi_16 (vi32_t a)
+{
+  return vec_srawi (a, 16);
+}
+
+vi32_t
+test_srawi_31 (vi32_t a)
+{
+  return vec_srawi (a, 31);
+}
+
+vi32_t
+test_srawi_32 (vi32_t a)
+{
+  return vec_srawi (a, 32);
+}
+
+vui32_t
+test_cmpgtuw (vui32_t a, vui32_t b)
+{
+  return (vui32_t)vec_cmpgt (a, b);
+}
+
+vui32_t
+test_cmpleuw (vui32_t a, vui32_t b)
+{
+  return (vui32_t)vec_cmple (a, b);
+}
+
+int
+test_cmpuw_all_gt (vui32_t a, vui32_t b)
+{
+  return vec_all_gt (a, b);
+}
+
+int
+test_cmpuw_all_le (vui32_t a, vui32_t b)
+{
+  return vec_all_le (a, b);
+}
+
+vui32_t
+__test_popcntw (vui32_t a)
+{
+  return (vec_popcntw (a));
+}
+
+vui32_t
+__test_clzw (vui32_t a)
+{
+  return (vec_clzw (a));
+}
+
+vui32_t
+__test_revbw (vui32_t vra)
+{
+  return vec_revbw (vra);
+}

--- a/src/testsuite/vec_int64_dummy.c
+++ b/src/testsuite/vec_int64_dummy.c
@@ -1,0 +1,258 @@
+/*
+ Copyright (c) [2018] IBM Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ vec_int64_dummy.c
+
+ Contributors:
+      IBM Corporation, Steven Munroe
+      Created on: Mar 29, 2018
+ */
+
+#include <vec_int64_ppc.h>
+
+vui64_t
+__test_vsld (vui64_t a, vui64_t b)
+{
+  return vec_vsld (a, b);
+}
+
+vui64_t
+__test_vsrd (vui64_t a, vui64_t b)
+{
+  return vec_vsrd (a, b);
+}
+
+vi64_t
+__test_vsrad (vi64_t a, vui64_t b)
+{
+  return vec_vsrad (a, b);
+}
+
+vui64_t
+test_sldi_1 (vui64_t a)
+{
+  return vec_sldi (a, 1);
+}
+
+vui64_t
+test_sldi_15 (vui64_t a)
+{
+  return vec_sldi (a, 15);
+}
+
+vui64_t
+test_sldi_16 (vui64_t a)
+{
+  return vec_sldi (a, 16);
+}
+
+vui64_t
+test_sldi_63 (vui64_t a)
+{
+  return vec_sldi (a, 63);
+}
+
+vui64_t
+test_sldi_64 (vui64_t a)
+{
+  return vec_sldi (a, 64);
+}
+
+vui64_t
+test_srdi_1 (vui64_t a)
+{
+  return vec_srdi (a, 1);
+}
+
+vui64_t
+test_srdi_15 (vui64_t a)
+{
+  return vec_srdi (a, 15);
+}
+
+vui64_t
+test_srdi_16 (vui64_t a)
+{
+  return vec_srdi (a, 16);
+}
+
+vui64_t
+test_srdi_63 (vui64_t a)
+{
+  return vec_srdi (a, 63);
+}
+
+vui64_t
+test_srdi_64 (vui64_t a)
+{
+  return vec_srdi (a, 64);
+}
+
+vi64_t
+test_sradi_1 (vi64_t a)
+{
+  return vec_sradi (a, 1);
+}
+
+vi64_t
+test_sradi_15 (vi64_t a)
+{
+  return vec_sradi (a, 15);
+}
+
+vi64_t
+test_sradi_16 (vi64_t a)
+{
+  return vec_sradi (a, 16);
+}
+
+vi64_t
+test_sradi_63 (vi64_t a)
+{
+  return vec_sradi (a, 63);
+}
+
+vi64_t
+test_sradi_64 (vi64_t a)
+{
+  return vec_sradi (a, 64);
+}
+
+
+int
+test_cmpud_all_gt (vui64_t a, vui64_t b)
+{
+  return vec_cmpud_all_gt (a, b);
+}
+
+vui64_t
+test_cmpud_all_gt2 (vui64_t a, vui64_t b, vui64_t c, vui64_t d)
+{
+  if (vec_cmpud_all_gt (a, b))
+    return c;
+  else
+    return d;
+}
+
+int
+test_cmpud_all_eq (vui64_t a, vui64_t b)
+{
+  return vec_cmpud_all_eq (a, b);
+}
+
+vui64_t
+test_cmpud_all_eq2 (vui64_t a, vui64_t b, vui64_t c, vui64_t d)
+{
+  if (vec_cmpud_all_eq (a, b))
+    return c;
+  else
+    return d;
+}
+
+vui64_t
+test_subudm (vui64_t a, vui64_t b)
+{
+  return (vec_subudm (a, b));
+}
+
+vui64_t
+test_addudm (vui64_t a, vui64_t b)
+{
+  return (vec_addudm (a, b));
+}
+
+vui64_t
+test_cmpgtud (vui64_t a, vui64_t b)
+{
+  return (vec_cmpgtud (a, b));
+}
+
+vui64_t
+__test_popcntd (vui64_t a)
+{
+  return (vec_popcntd (a));
+}
+
+vui64_t
+__test_clzd (vui64_t a)
+{
+  return (vec_clzd (a));
+}
+
+vui64_t
+__test_revbd (vui64_t vra)
+{
+  return vec_revbd (vra);
+}
+
+vui64_t
+__test_mrghd (vui64_t __VH, vui64_t __VL)
+{
+	return (vec_mrghd(__VH, __VL));
+}
+
+vui64_t
+__test_mrgld (vui64_t __VH, vui64_t __VL)
+{
+	return (vec_mrgld(__VH, __VL));
+}
+
+vui64_t
+__test_permdi_0 (vui64_t __VH, vui64_t __VL)
+{
+	return (vec_permdi(__VH, __VL, 0));
+}
+
+vui64_t
+__test_permdi_1 (vui64_t __VH, vui64_t __VL)
+{
+	return (vec_permdi(__VH, __VL, 1));
+}
+
+vui64_t
+__test_permdi_2 (vui64_t __VH, vui64_t __VL)
+{
+	return (vec_permdi(__VH, __VL, 2));
+}
+
+vui64_t
+__test_permdi_3 (vui64_t __VH, vui64_t __VL)
+{
+	return (vec_permdi(__VH, __VL, 3));
+}
+
+vui64_t
+__test_vpaste (vui64_t __VH, vui64_t __VL)
+{
+	return (vec_pasted(__VH, __VL));
+}
+
+vui64_t
+__test_spltd_0 (vui64_t __VH)
+{
+	return (vec_spltd(__VH, 0));
+}
+
+vui64_t
+__test_spltd_1 (vui64_t __VH)
+{
+	return (vec_spltd(__VH, 1));
+}
+
+vui64_t
+__test_swapd (vui64_t __VH)
+{
+	return (vec_swapd(__VH));
+}

--- a/src/testsuite/vec_int64_dummy.c
+++ b/src/testsuite/vec_int64_dummy.c
@@ -130,7 +130,6 @@ test_sradi_64 (vi64_t a)
   return vec_sradi (a, 64);
 }
 
-
 int
 test_cmpud_all_gt (vui64_t a, vui64_t b)
 {
@@ -164,31 +163,31 @@ test_cmpud_all_eq2 (vui64_t a, vui64_t b, vui64_t c, vui64_t d)
 vui64_t
 test_subudm (vui64_t a, vui64_t b)
 {
-  return (vec_subudm (a, b));
+  return vec_subudm (a, b);
 }
 
 vui64_t
 test_addudm (vui64_t a, vui64_t b)
 {
-  return (vec_addudm (a, b));
+  return vec_addudm (a, b);
 }
 
 vui64_t
 test_cmpgtud (vui64_t a, vui64_t b)
 {
-  return (vec_cmpgtud (a, b));
+  return vec_cmpgtud (a, b);
 }
 
 vui64_t
 __test_popcntd (vui64_t a)
 {
-  return (vec_popcntd (a));
+  return vec_popcntd (a);
 }
 
 vui64_t
 __test_clzd (vui64_t a)
 {
-  return (vec_clzd (a));
+  return vec_clzd (a);
 }
 
 vui64_t
@@ -200,59 +199,59 @@ __test_revbd (vui64_t vra)
 vui64_t
 __test_mrghd (vui64_t __VH, vui64_t __VL)
 {
-	return (vec_mrghd(__VH, __VL));
+  return vec_mrghd (__VH, __VL);
 }
 
 vui64_t
 __test_mrgld (vui64_t __VH, vui64_t __VL)
 {
-	return (vec_mrgld(__VH, __VL));
+  return vec_mrgld (__VH, __VL);
 }
 
 vui64_t
 __test_permdi_0 (vui64_t __VH, vui64_t __VL)
 {
-	return (vec_permdi(__VH, __VL, 0));
+  return vec_permdi (__VH, __VL, 0);
 }
 
 vui64_t
 __test_permdi_1 (vui64_t __VH, vui64_t __VL)
 {
-	return (vec_permdi(__VH, __VL, 1));
+  return vec_permdi (__VH, __VL, 1);
 }
 
 vui64_t
 __test_permdi_2 (vui64_t __VH, vui64_t __VL)
 {
-	return (vec_permdi(__VH, __VL, 2));
+  return vec_permdi (__VH, __VL, 2);
 }
 
 vui64_t
 __test_permdi_3 (vui64_t __VH, vui64_t __VL)
 {
-	return (vec_permdi(__VH, __VL, 3));
+  return vec_permdi (__VH, __VL, 3);
 }
 
 vui64_t
 __test_vpaste (vui64_t __VH, vui64_t __VL)
 {
-	return (vec_pasted(__VH, __VL));
+  return vec_pasted (__VH, __VL);
 }
 
 vui64_t
 __test_spltd_0 (vui64_t __VH)
 {
-	return (vec_spltd(__VH, 0));
+  return vec_spltd (__VH, 0);
 }
 
 vui64_t
 __test_spltd_1 (vui64_t __VH)
 {
-	return (vec_spltd(__VH, 1));
+  return vec_spltd (__VH, 1);
 }
 
 vui64_t
 __test_swapd (vui64_t __VH)
 {
-	return (vec_swapd(__VH));
+  return vec_swapd (__VH);
 }

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -31,7 +31,7 @@ __test_absdub_PWR9 (vui8_t __A, vui8_t __B)
   return vec_absdub (__A, __B);
 }
 
-vui128_t /*__attribute__ ((__target__ ("cpu=power9")))*/
+vui128_t
 __test_msumudm_PWR9 (vui64_t a, vui64_t b, vui128_t c)
 {
   return vec_msumudm ( a, b, c);
@@ -40,25 +40,25 @@ __test_msumudm_PWR9 (vui64_t a, vui64_t b, vui128_t c)
 vui128_t
 __test_muloud_PWR9 (vui64_t a, vui64_t b)
 {
-  return (vec_muloud (a, b));
+  return vec_muloud (a, b);
 }
 
 vui128_t
 __test_muleud_PWR9 (vui64_t a, vui64_t b)
 {
-  return (vec_muleud (a, b));
+  return vec_muleud (a, b);
 }
 
 vui128_t
 __test_mulluq_PWR9 (vui128_t a, vui128_t b)
 {
-  return (vec_mulluq (a, b));
+  return vec_mulluq (a, b);
 }
 
 vui128_t
 __test_muludq_PWR9 (vui128_t *mulh, vui128_t a, vui128_t b)
 {
-  return (vec_muludq (mulh, a, b));
+  return vec_muludq (mulh, a, b);
 }
 
 vui128_t
@@ -95,49 +95,49 @@ __test_mul10uq_c_PWR9 (vui128_t *p, vui128_t a)
 vui128_t
 __test_mul10uq_PWR9 (vui128_t a)
 {
-	return vec_mul10uq (a);
+  return vec_mul10uq (a);
 }
 
 vui128_t
 __test_mul10euq_PWR9 (vui128_t a, vui128_t cin)
 {
-	return vec_mul10euq (a, cin);
+  return vec_mul10euq (a, cin);
 }
 
 vui128_t
 __test_mul10cuq_PWR9 (vui128_t a)
 {
-	return vec_mul10cuq (a);
+  return vec_mul10cuq (a);
 }
 
 vui128_t
 __test_mul10ecuq_PWR9 (vui128_t a, vui128_t cin)
 {
-	return vec_mul10ecuq (a, cin);
+  return vec_mul10ecuq (a, cin);
 }
 
 vui64_t
 __test_revbd_PWR9 (vui64_t a)
 {
-	return vec_revbd(a);
+  return vec_revbd (a);
 }
 
 vui16_t
 __test_revbh_PWR9 (vui16_t a)
 {
-	return vec_revbh(a);
+  return vec_revbh (a);
 }
 
 vui128_t
 __test_revbq_PWR9 (vui128_t a)
 {
-	return vec_revbq(a);
+  return vec_revbq (a);
 }
 
 vui32_t
 __test_revbw_PWR9 (vui32_t a)
 {
-	return vec_revbw(a);
+  return vec_revbw (a);
 }
 
 void

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -1,0 +1,165 @@
+/*
+ Copyright (c) [2017] IBM Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ vec_pwr9_dummy.c
+
+ Contributors:
+      IBM Corporation, Steven Munroe
+      Created on: April 27, 2018
+ */
+
+//#pragma GCC push target
+#pragma GCC target ("cpu=power9")
+
+#include <vec_int128_ppc.h>
+
+vui8_t
+__test_absdub_PWR9 (vui8_t __A, vui8_t __B)
+{
+  return vec_absdub (__A, __B);
+}
+
+vui128_t /*__attribute__ ((__target__ ("cpu=power9")))*/
+__test_msumudm_PWR9 (vui64_t a, vui64_t b, vui128_t c)
+{
+  return vec_msumudm ( a, b, c);
+}
+
+vui128_t
+__test_muloud_PWR9 (vui64_t a, vui64_t b)
+{
+  return (vec_muloud (a, b));
+}
+
+vui128_t
+__test_muleud_PWR9 (vui64_t a, vui64_t b)
+{
+  return (vec_muleud (a, b));
+}
+
+vui128_t
+__test_mulluq_PWR9 (vui128_t a, vui128_t b)
+{
+  return (vec_mulluq (a, b));
+}
+
+vui128_t
+__test_muludq_PWR9 (vui128_t *mulh, vui128_t a, vui128_t b)
+{
+  return (vec_muludq (mulh, a, b));
+}
+
+vui128_t
+__test_cmul10cuq_PWR9 (vui128_t *cout, vui128_t a)
+{
+  return vec_cmul10cuq (cout, a);
+}
+
+vui128_t
+__test_cmul10ecuq_PWR9 (vui128_t *cout, vui128_t a, vui128_t cin)
+{
+  return vec_cmul10ecuq (cout, a, cin);
+}
+
+vui128_t
+__test_cmul100cuq_PWR9 (vui128_t *cout, vui128_t a)
+{
+  return vec_cmul100cuq (cout, a);
+}
+
+vui128_t
+__test_cmul100ecuq_PWR9 (vui128_t *cout, vui128_t a, vui128_t cin)
+{
+  return vec_cmul100ecuq (cout, a, cin);
+}
+
+vui128_t
+__test_mul10uq_c_PWR9 (vui128_t *p, vui128_t a)
+{
+  *p = vec_mul10uq (a);
+  return vec_mul10uq (a);
+}
+
+vui128_t
+__test_mul10uq_PWR9 (vui128_t a)
+{
+	return vec_mul10uq (a);
+}
+
+vui128_t
+__test_mul10euq_PWR9 (vui128_t a, vui128_t cin)
+{
+	return vec_mul10euq (a, cin);
+}
+
+vui128_t
+__test_mul10cuq_PWR9 (vui128_t a)
+{
+	return vec_mul10cuq (a);
+}
+
+vui128_t
+__test_mul10ecuq_PWR9 (vui128_t a, vui128_t cin)
+{
+	return vec_mul10ecuq (a, cin);
+}
+
+vui64_t
+__test_revbd_PWR9 (vui64_t a)
+{
+	return vec_revbd(a);
+}
+
+vui16_t
+__test_revbh_PWR9 (vui16_t a)
+{
+	return vec_revbh(a);
+}
+
+vui128_t
+__test_revbq_PWR9 (vui128_t a)
+{
+	return vec_revbq(a);
+}
+
+vui32_t
+__test_revbw_PWR9 (vui32_t a)
+{
+	return vec_revbw(a);
+}
+
+void
+test_mul4uq_PWR9 (vui128_t *__restrict__ mulu, vui128_t m1h, vui128_t m1l, vui128_t m2h, vui128_t m2l)
+{
+  vui128_t mc, mp, mq;
+  vui128_t mphh, mphl, mplh, mpll;
+  mpll = vec_muludq (&mplh, m1l, m2l);
+  mp = vec_muludq (&mphl, m1h, m2l);
+  mplh = vec_addcq (&mc, mplh, mp);
+  mphl = vec_addcuq (mphl, mc);
+  mp = vec_muludq (&mc, m2h, m1l);
+  mplh = vec_addcq (&mq, mplh, mp);
+  mphl = vec_addcq (&mc, mphl, mq);
+  mp = vec_muludq (&mphh, m2h, m1h);
+  mplh = vec_addcq (&mc, mplh, mp);
+  mphl = vec_addcuq (mphh, mc);
+
+  mulu[0] = mpll;
+  mulu[1] = mplh;
+  mulu[2] = mphl;
+  mulu[3] = mphh;
+}
+
+//#pragma GCC pop target


### PR DESCRIPTION
headers to generate short sequences of code that can be examined
via opbdump. This used both to evaulate correctness and performance.

2018-06-12 Steven Munroe <munroesj52@gmail.com>

        * src/testsuite/vec_int128_dummy.c (test_vec_add256_1,
        test_vec_add256_2, __test_msumudm, test_vec_cmul10cuq,
        test_vec_cmul100cuq, test_vec_revbq): New Function.
        update copyright.
        * src/testsuite/vec_dummy_main.c: Update copyright.
        * src/testsuite/vec_bcd_dummy.c: New File.
        * src/testsuite/vec_char_dummy.c: New File.
        * src/testsuite/vec_bcd_dummy.c: New File.
        * src/testsuite/vec_int32_dummy.c: New File.
        * src/testsuite/vec_int64_dummy.c: New File.
        * src/testsuite/vec_pwr9_dummy.c: New File.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>