### PR TITLE
Adding the float 32-bit stuff with an attempt on performance metrics.

### DIFF
--- a/doc/pveclib-doxygen-pveclib.doxy
+++ b/doc/pveclib-doxygen-pveclib.doxy
@@ -743,6 +743,7 @@ INPUT                  = $(SRCDIR)/doc/pveclibmaindox.h \
                          $(SRCDIR)/src/vec_int16_ppc.h \
                          $(SRCDIR)/src/vec_bcd_ppc.h \
                          $(SRCDIR)/src/vec_char_ppc.h \
+                         $(SRCDIR)/src/vec_f32_ppc.h \
                          $(SRCDIR)/src/vec_common_ppc.h
 
 # This tag can be used to specify the character encoding of the source files

--- a/doc/pveclibmaindox.h
+++ b/doc/pveclibmaindox.h
@@ -80,6 +80,10 @@
 *  https://openpowerfoundation.org/?resource_lib=64-bit-elf-v2-abi-specification-power-architecture
 *  - Using the GNU Compiler Collection (GCC), Free Software Foundation, 1988-2018.
 *  https://gcc.gnu.org/onlinedocs/
+*  - POWER8 Processor User’s Manual for the Single-Chip Module
+*  https://ibm.ent.box.com/s/649rlau0zjcc0yrulqf4cgx5wk3pgbfk
+*  - POWER9 Processor User’s Manual
+*  https://ibm.ent.box.com/s/8uj02ysel62meji4voujw29wwkhsz6a4
 *
 *  \section mainpage_rationale Rationale
 *
@@ -1048,6 +1052,365 @@ s0 = vec_addeq (&c0, a0, b0, c1);
 *  and more consistent vector interface for the PowerISA.
 *  Similarly for implementors of extended arithmetic, cryptographic,
 *  compression/decompression, and pattern matching / search libraries.
+*
+* \section perf_data Performance data.
+*
+* It is useful to provide basic performance data for each pveclib
+* function.  This is challenging as these functions are small and
+* intended to be in-lined within larger functions (algorithms).
+* As such they are subject to both the compilers instruction
+* scheduling and common subexpression optimizations plus the
+* processors super-scalar and out-of-order execution design features.
+*
+* As pveclib functions are normally only a few
+* instructions, the actual timing will depend on the context it
+* is in (the instructions that is depends on for data and instructions
+* that proceed them in the pipelines).
+*
+* The simplest approach is to use the same performance metrics as the
+* Power Processor Users Manuals Performance Profile.
+* This is normally per instruction latency in cycles and
+* throughput in instructions issued per cycle. There may also be
+* additional information for special conditions that may apply.
+*
+* For example the vector float absolute value function.
+* For recent PowerISA implementations this a single
+* (VSX <B>xvabssp</B>) instruction which we can look up in the
+* POWER8 / POWER9 Processor User's Manuals (<B>UM</B>).
+*
+*  |processor|Latency|Throughput|
+*  |--------:|:-----:|:---------|
+*  |power8   | 6-7   | 2/cycle  |
+*  |power9   | 2     | 2/cycle  |
+*
+* The POWER8 UM specifies a latency of
+* <I>"6 cycles to FPU (+1 cycle to other VSU ops"</I>
+* for this class of VSX single precision FPU instructions.
+* So the minimum latency is 6 cycles if the register result is input
+* to another VSX single precision FPU instruction.
+* Otherwise if the result is input to a VSU logical or integer
+* instruction then the latency is 7 cycles.
+* The POWER9 UM shows the pipeline improvement of 2 cycles latency
+* for simple FPU instructions like this.
+* Both processors support dual pipelines for a 2/cycle throughput
+* capability.
+*
+* A more complicated example: \code
+static inline vb32_t
+vec_isnanf32 (vf32_t vf32)
+{
+vui32_t tmp2;
+const vui32_t expmask = CONST_VINT128_W(0x7f800000, 0x7f800000, 0x7f800000,
+					0x7f800000);
+#if _ARCH_PWR9
+// P9 has a 2 cycle xvabssp and eliminates a const load.
+tmp2 = (vui32_t) vec_abs (vf32);
+#else
+const vui32_t signmask = CONST_VINT128_W(0x80000000, 0x80000000, 0x80000000,
+					 0x80000000);
+tmp2 = vec_andc ((vui32_t)vf32, signmask);
+#endif
+return vec_cmpgt (tmp2, expmask);
+}
+* \endcode
+* Here we want to test for <I>Not A Number</I> without triggering any
+* of the associate floating-point exceptions (VXSNAN or VXVC).
+* For this test the sign bit does not effect the result so we need to
+* zero the sign bit before the actual test. The vector abs would work
+* for this, but we know from the example above that this instruction
+* has a high latency as we are definitely passing the result to a
+* non-FPU instruction (vector compare greater than unsigned word).
+*
+* So the code needs to load two constant vectors masks, then vector
+* and-compliment to clear the sign-bit, before comparing each word
+* for greater then infinity. The generated code should look
+* something like this: \code
+      addis   r9,r2,.rodata.cst16+0x10@ha
+      addis   r10,r2,.rodata.cst16+0x20@ha
+      addi    r9,r9,.rodata.cst16+0x10@l
+      addi    r10,r10,.rodata.cst16+0x20@l
+      lvx     v0,0,r10	# load vector const signmask
+      lvx     v12,0,r9	# load vector const expmask
+      xxlandc vs34,vs34,vs32
+      vcmpgtuw v2,v2,v12
+* \endcode
+* So six instructions to load the const masks and two instructions
+* for the actual vec_isnanf32 function. The first six instructions
+* are only needed once for each containing function, can be hoisted
+* out of loops and into the function prologue, can be <I>commoned</I>
+* with the same constant for other pveclib functions, or executed
+* out-of-order and early by the processor.
+*
+* Most of the time, constant setup does not contribute measurably to
+* the over all performance of vec_isnanf32. When it does it is
+* limited by the longest (in cycles latency) of the various
+* independent paths that load constants.  In this case the const load
+* sequence is composed of three pairs of instructions that can issue
+* and execute in parallel. The addis/addi FXU instructions supports
+* throughput of 6/cycle and the lvx load supports 2/cycle.
+* So the two vector constant load sequences can execute
+* in parallel and the latency is same as a single const load.
+*
+* For POWER8 it appears to be (2+2+5=) 9 cycles latency for the const
+* load. While the core vec_isnanf32 function (xxlandc/vcmpgtuw) is a
+* dependent sequence and runs (2+2) 4 cycles latency.
+* Similar analysis for POWER9 where the addis/addi/lvx sequence is
+* still listed as (2+2+5) 9 cycles latency. While the xxlandc/vcmpgtuw
+* sequence increases to (2+3) 5 cycles.
+*
+* The next interesting question is what can we say about throughput
+* (if anything) for this example.  The thought experiment is "what
+* would happen if?";
+* - two or more instances of vec_isnanf32 are used within a single
+* function,
+* - in close proximity in the code,
+* - with independent data as input,
+*
+* could the generated instructions execute in parallel and to what
+* extent. This illustrated by the following (contrived) example:
+* \code
+int
+test512_all_f32_nan (vf32_t val0, vf32_t val1, vf32_t val2, vf32_t val3)
+{
+const vb32_t alltrue = { -1, -1, -1, -1 };
+vb32_t nan0, nan1, nan2, nan3;
+
+nan0 = vec_isnanf32 (val0);
+nan1 = vec_isnanf32 (val1);
+nan2 = vec_isnanf32 (val2);
+nan3 = vec_isnanf32 (val3);
+
+nan0 = vec_and (nan0, nan1);
+nan2 = vec_and (nan2, nan3);
+nan0 = vec_and (nan2, nan0);
+
+return vec_all_eq(nan0, alltrue);
+}
+* \endcode
+* which tests 4 X vector float (16 X float) values and returns true
+* if all 16 floats are NaN. Recent compilers will generates something
+* like the following PowerISA code:
+* \code
+   addis   r9,r2,-2
+   addis   r10,r2,-2
+   vspltisw v13,-1	# load vector const alltrue
+   addi    r9,r9,21184
+   addi    r10,r10,-13760
+   lvx     v0,0,r9	# load vector const signmask
+   lvx     v1,0,r10	# load vector const expmask
+   xxlandc vs35,vs35,vs32
+   xxlandc vs34,vs34,vs32
+   xxlandc vs37,vs37,vs32
+   xxlandc vs36,vs36,vs32
+   vcmpgtuw v3,v3,v1	# nan1 = vec_isnanf32 (val1);
+   vcmpgtuw v2,v2,v1	# nan0 = vec_isnanf32 (val0);
+   vcmpgtuw v5,v5,v1	# nan3 = vec_isnanf32 (val3);
+   vcmpgtuw v4,v4,v1	# nan2 = vec_isnanf32 (val2);
+   xxland  vs35,vs35,vs34	# nan0 = vec_and (nan0, nan1);
+   xxland  vs36,vs37,vs36	# nan2 = vec_and (nan2, nan3);
+   xxland  vs36,vs35,vs36	# nan0 = vec_and (nan2, nan0);
+   vcmpequw. v4,v4,v13	# vec_all_eq(nan0, alltrue);
+...
+* \endcode
+* first the generated code loading the vector constants for signmask,
+* expmask, and alltrue. We see that the code is generated only once
+* for each constant. Then the compiler generate the core vec_isnanf32
+* function four times and interleaves the instructions. This enables
+* parallel pipeline execution where conditions allow. Finally the 16X
+* isnan results are reduced to 8X, then 4X, then to a single
+* condition code.
+*
+* For this exercise we will ignore the constant load as in any
+* realistic usage it will be <I>commoned</I> across several pveclib
+* functions and hoisted out of any loops. The reduction code is not
+* part of the vec_isnanf32 implementation and also ignored.
+* The sequence of 4X xxlandc and 4X vcmpgtuw in the middle it the
+* interesting part.
+*
+* For POWER8 both xxlandc and vcmpgtuw are listed as 2 cycles
+* latency and throughput of 2 per cycle. So we can assume that (only)
+* the first two xxlandc will issue in the same cycle (assuming the
+* input vectors are ready).  The issue of the next two xxlandc
+* instructions will be delay by 1 cycle. The following vcmpgtuw
+* instruction are dependent on the xxlandc results and will not
+* execute until their input vectors are ready. The first two vcmpgtuw
+* instruction will execute 2 cycles (latency) after the first two
+* xxlandc instructions execute. Execution of the second two vcmpgtuw
+* instructions will be delayed 1 cycle due to the issue delay in the
+* second pair of xxlandc instructions.
+*
+* So at least for this example and this set of simplifying assumptions
+* we suggest that the throughput metric for vec_isnanf32 is 2/cycle.
+* For latency metric we offer the range with the latency for the core
+* function (without and constant load overhead) first. Followed by the
+* total latency (the sum of the constant load and core function
+* latency). For the vec_isnanf32 example the metrics are:
+*
+*  |processor|Latency|Throughput|
+*  |--------:|:-----:|:---------|
+*  |power8   | 4-13  | 2/cycle  |
+*  |power9   | 5-14  | 2/cycle  |
+*
+* Looking at a slightly more complicated example where core functions
+* implementation can execute more then one instruction per cycle.
+* Consider:
+* \code
+static inline vb32_t
+vec_isnormalf32 (vf32_t vf32)
+{
+vui32_t tmp, tmp2;
+const vui32_t expmask = CONST_VINT128_W(0x7f800000, 0x7f800000, 0x7f800000,
+					0x7f800000);
+const vui32_t minnorm = CONST_VINT128_W(0x00800000, 0x00800000, 0x00800000,
+					0x00800000);
+#if _ARCH_PWR9
+// P9 has a 2 cycle xvabssp and eliminates a const load.
+tmp2 = (vui32_t) vec_abs (vf32);
+#else
+const vui32_t signmask = CONST_VINT128_W(0x80000000, 0x80000000, 0x80000000,
+					 0x80000000);
+tmp2 = vec_andc ((vui32_t)vf32, signmask);
+#endif
+tmp = vec_and ((vui32_t) vf32, expmask);
+tmp2 = (vui32_t) vec_cmplt (tmp2, minnorm);
+tmp = (vui32_t) vec_cmpeq (tmp, expmask);
+
+return (vb32_t )vec_nor (tmp, tmp2);
+}
+* \endcode
+* which requires two (independent) masking operations (sign and exponent),
+* two (independent) compares that are dependent on the masking operations,
+* and a final <I>not OR</I> operation dependent on the compare results.
+*
+* The generated POWER8 code looks like this: \code
+   addis   r10,r2,-2
+   addis   r8,r2,-2
+   addi    r10,r10,21184
+   addi    r8,r8,-13760
+   addis   r9,r2,-2
+   lvx     v13,0,r8
+   addi    r9,r9,21200
+   lvx     v1,0,r10
+   lvx     v0,0,r9
+   xxland  vs33,vs33,vs34
+   xxlandc vs34,vs45,vs34
+   vcmpgtuw v0,v0,v1
+   vcmpequw v2,v2,v13
+   xxlnor  vs34,vs32,vs34
+* \endcode
+* Note this this sequence needs to load 3 vector constants. In
+* previous examples we have noted that POWER8 lvx supports 2/cycle
+* throughput. But with good scheduling, the 3rd vector constant load,
+* will only add 1 additional cycle to the timing (10 cycles).
+*
+* Once the constant masks are loaded the xxland/xxlandc instructions
+* can execute in parallel. The vcmpgtuw/vcmpequw  can also execute
+* in parallel but are delayed waiting for the results of masking
+* operations. Finally the xxnor is dependent on the data from both
+* compare instructions.
+*
+* For POWER8 the latencies are 2 cycles each, and assuming parallel
+* execution of xxland/xxlandc and vcmpgtuw/vcmpequw we can assume
+* (2+2+2=) 6 cycles minimum latency and another 10 cycles for the
+* constant loads (if needed).
+*
+* While the POWER8 core has ample resources (10 issue ports across
+* 16 execution units), this specific sequence is restricted to the
+* two <I>issue ports and VMX execution units</I> for this class of
+* (simple vector integer and logical) instructions.
+* For vec_isnormalf32 this allows for a lower latency
+* (6 cycles vs the expected 10, over 5 instructions),
+* it also implies that both of the POWER8 cores
+* <I>VMX execution units</I> are busy for 2 out of the 6 cycles.
+*
+* So while the individual instructions have can have a throughput of
+* 2/cycle, vec_isnormalf32 can not.  It is plausible for two
+* executions of vec_isnormalf32 to interleave with a delay of 1 cycle
+* for the second sequence.  To keep the table information simple for
+* now, just say the throughput of vec_isnormalf32 is 1/cycle.
+*
+* After that it gets complicated. For example after the first two
+* instances of vec_isnormalf32 are issued, both
+* <I>VMX execution units</I> are busy for 4 cycles. So either the
+* first instructions of the third vec_isnormalf32 will be delayed
+* until the fifth cycle.  Or the compiler scheduler will interleave
+* instructions across the instances of vec_isnormalf32 and the
+* latencies of individual vec_isnormalf32 results will increase.
+* This is too complicated to put in a simple table.
+*
+* For POWER9 the sequence is slightly different \code
+   addis   r10,r2,-2
+   addis   r9,r2,-2
+   xvabssp vs45,vs34
+   addi    r10,r10,-14016
+   addi    r9,r9,-13920
+   lvx     v1,0,r10
+   lvx     v0,0,r9
+   xxland  vs34,vs34,vs33
+   vcmpgtuw v0,v0,v13
+   vcmpequw v2,v2,v1
+   xxlnor  vs34,vs32,vs34
+* \endcode
+* We use vec_abs (xvabssp) to replace the sigmask and vec_andc
+* and so only need to load two vector constants.
+* So the constant load overhead is reduced to 9 cycles.
+* However the the vector compares are now 3 cycles for (2+3+2=)
+* 7 cycles for the core sequence. The final table for vec_isnormalf32:
+*
+*  |processor|Latency|Throughput|
+*  |--------:|:-----:|:---------|
+*  |power8   | 6-16  | 1/cycle  |
+*  |power9   | 7-16  | 1/cycle  |
+*
+* \subsection  perf_data_sub_1 Additional analysis and tools.
+*
+* The overview above is simplified analysis based on the instruction
+* latency and throughput numbers published in the
+* Processor User's Manuals (see \ref mainpage_ref_docs).
+* These values are <I>best case</I> (input data is ready, SMT1 mode,
+* no cache misses, mispredicted branches, or other hazards) for each
+* instruction in isolation.
+*
+* \note This information is intended as a guide for compiler and
+* application developers wishing to optimize for the platform.
+* Any performance tables provided for pveclib functions are in this
+* spirit.
+*
+* Of course the actual performance is complicated by the overall
+* environment and how the pveclib functions are used. It would be
+* unusual for pveclib functions to be used in isolation. The compiler
+* will in-line pveclib functions and look for sub-expressions it can
+* hoist out of loops or share across pveclib function instances. The
+* The compiler will also model the processor and schedule instructions
+* across the larger containing function. So in actual use the
+* instruction sequences for the examples above are likely to be
+* interleaved with instructions from other pvevlib functions
+* and user written code.
+*
+* Larger functions that use pveclib and even some of the more
+* complicated pveclib functions (like vec_muludq) defy simple
+* analysis. For these cases it is better to use POWER specific
+* analysis tools. To understand the overall pipeline flows and
+* identify hazards the instruction trace driven performance simulator
+* is recommended.
+*
+* The IBM Advance Toolchain includes an updated (POWER enabled)
+* Valgrind tool and instruction trace plug-in (itrace). The itrace
+* tool (--tool=itrace) collects instruction traces for the whole
+* program or specific functions (via --fnname= option).
+*
+* \note The Valgrind package provided by the Linux Distro may not be
+* enabled for the latest POWER processor. Nor will it include the
+* itrace plug-in or the associated vgi2qt conversion tool.
+*
+* Instruction traces are processed by the performance simulator
+* (sim_ppc) models. Performance simulators are specific to each
+* processor generation (POWER7-9) and provides a cycle accurate
+* modeling for instruction trace streams. The results of the model
+* (a pipe file) can viewed via one the interactive display tools
+* (scrollpv, jviewer) or passed to an analysis tool like
+* <B>pipestat</B>.
+*
 *
 **/
 

--- a/doc/pveclibmaindox.h
+++ b/doc/pveclibmaindox.h
@@ -1058,13 +1058,13 @@ s0 = vec_addeq (&c0, a0, b0, c1);
 * It is useful to provide basic performance data for each pveclib
 * function.  This is challenging as these functions are small and
 * intended to be in-lined within larger functions (algorithms).
-* As such they are subject to both the compilers instruction
+* As such they are subject to both the compiler's instruction
 * scheduling and common subexpression optimizations plus the
 * processors super-scalar and out-of-order execution design features.
 *
 * As pveclib functions are normally only a few
 * instructions, the actual timing will depend on the context it
-* is in (the instructions that is depends on for data and instructions
+* is in (the instructions that it depends on for data and instructions
 * that proceed them in the pipelines).
 *
 * The simplest approach is to use the same performance metrics as the
@@ -1394,7 +1394,9 @@ return (vb32_t )vec_nor (tmp, tmp2);
 * identify hazards the instruction trace driven performance simulator
 * is recommended.
 *
-* The IBM Advance Toolchain includes an updated (POWER enabled)
+* The
+* <a href="https://developer.ibm.com/linuxonpower/advance-toolchain/">IBM Advance Toolchain</a>
+* includes an updated (POWER enabled)
 * Valgrind tool and instruction trace plug-in (itrace). The itrace
 * tool (--tool=itrace) collects instruction traces for the whole
 * program or specific functions (via --fnname= option).
@@ -1403,14 +1405,14 @@ return (vb32_t )vec_nor (tmp, tmp2);
 * enabled for the latest POWER processor. Nor will it include the
 * itrace plug-in or the associated vgi2qt conversion tool.
 *
-* Instruction traces are processed by the performance simulator
+* Instruction trace files are processed by the
+* <a href="https://developer.ibm.com/linuxonpower/sdk-packages/">Performance Simulator</a>
 * (sim_ppc) models. Performance simulators are specific to each
 * processor generation (POWER7-9) and provides a cycle accurate
 * modeling for instruction trace streams. The results of the model
 * (a pipe file) can viewed via one the interactive display tools
 * (scrollpv, jviewer) or passed to an analysis tool like
-* <B>pipestat</B>.
-*
+* <a href="https://developer.ibm.com/linuxonpower/sdk-packages/">pipestat</a>.
 *
 **/
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,6 +9,7 @@ libpvec_la_SOURCES = tipowof10.c decpowof2.c
 libvecdummy_la_SOURCES = testsuite/vec_int128_dummy.c \
 	testsuite/vec_int64_dummy.c \
 	testsuite/vec_int32_dummy.c \
+	testsuite/vec_f32_dummy.c \
 	testsuite/vec_pwr9_dummy.c \
 	testsuite/vec_bcd_dummy.c \
 	testsuite/vec_char_dummy.c
@@ -19,6 +20,7 @@ EXTRA_DIST =
 # .libs/libpvec.a and if make is executed in parallel (-jN) the 
 # pveclib_test rule may be run before .libs/libpvec.a is built.
 .libs/libpvec.a: libpvec.la
+.libs/libpvecdummy.a: libpvecdummy.la
 
 # pveclib definitions
 pveclibincludedir = $(includedir)/pveclib
@@ -30,6 +32,7 @@ pveclib_testincludedir = $(includedir)/testsuite
 # on 'make install'
 pveclibinclude_HEADERS = \
 	vec_common_ppc.h \
+	vec_f32_ppc.h \
 	vec_int128_ppc.h \
 	vec_int64_ppc.h \
 	vec_int32_ppc.h \
@@ -52,6 +55,9 @@ TESTS += pveclib_test
 pveclib_test_SOURCES = \
 	testsuite/pveclib_test.c \
 	testsuite/arith128_print.c \
+	testsuite/vec_perf_f32.c \
+	testsuite/vec_perf_i128.c \
+	testsuite/arith128_test_f32.c \
 	testsuite/arith128_test_i128.c \
 	testsuite/arith128_test_i64.c \
 	testsuite/arith128_test_i32.c \
@@ -59,7 +65,7 @@ pveclib_test_SOURCES = \
 	testsuite/arith128_test_char.c \
 	testsuite/arith128_test_bcd.c
 	
-pveclib_test_LDADD = .libs/libpvec.a
+pveclib_test_LDADD = .libs/libpvec.a .libs/libvecdummy.a
 	
 TESTS += vec_dummy
 

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -148,12 +148,15 @@ libvecdummy_la_LIBADD =
 am__dirstamp = $(am__leading_dot)dirstamp
 am_libvecdummy_la_OBJECTS = testsuite/vec_int128_dummy.lo \
 	testsuite/vec_int64_dummy.lo testsuite/vec_int32_dummy.lo \
-	testsuite/vec_pwr9_dummy.lo testsuite/vec_bcd_dummy.lo \
-	testsuite/vec_char_dummy.lo
+	testsuite/vec_f32_dummy.lo testsuite/vec_pwr9_dummy.lo \
+	testsuite/vec_bcd_dummy.lo testsuite/vec_char_dummy.lo
 libvecdummy_la_OBJECTS = $(am_libvecdummy_la_OBJECTS)
 am__EXEEXT_1 = pveclib_test$(EXEEXT) vec_dummy$(EXEEXT)
 am_pveclib_test_OBJECTS = testsuite/pveclib_test.$(OBJEXT) \
 	testsuite/arith128_print.$(OBJEXT) \
+	testsuite/vec_perf_f32.$(OBJEXT) \
+	testsuite/vec_perf_i128.$(OBJEXT) \
+	testsuite/arith128_test_f32.$(OBJEXT) \
 	testsuite/arith128_test_i128.$(OBJEXT) \
 	testsuite/arith128_test_i64.$(OBJEXT) \
 	testsuite/arith128_test_i32.$(OBJEXT) \
@@ -161,7 +164,7 @@ am_pveclib_test_OBJECTS = testsuite/pveclib_test.$(OBJEXT) \
 	testsuite/arith128_test_char.$(OBJEXT) \
 	testsuite/arith128_test_bcd.$(OBJEXT)
 pveclib_test_OBJECTS = $(am_pveclib_test_OBJECTS)
-pveclib_test_DEPENDENCIES = .libs/libpvec.a
+pveclib_test_DEPENDENCIES = .libs/libpvec.a .libs/libvecdummy.a
 am_vec_dummy_OBJECTS = testsuite/vec_dummy_main.$(OBJEXT)
 vec_dummy_OBJECTS = $(am_vec_dummy_OBJECTS)
 vec_dummy_DEPENDENCIES = .libs/libpvec.a libvecdummy.la
@@ -424,7 +427,6 @@ CPPFLAGS = @CPPFLAGS@
 CYGPATH_W = @CYGPATH_W@
 DEFS = @DEFS@
 DEPDIR = @DEPDIR@
-DLLTOOL = @DLLTOOL@
 DOXYGEN_PAPER_SIZE = @DOXYGEN_PAPER_SIZE@
 DSYMUTIL = @DSYMUTIL@
 DUMPBIN = @DUMPBIN@
@@ -472,10 +474,8 @@ LIBTOOL = @LIBTOOL@
 LIPO = @LIPO@
 LN_S = @LN_S@
 LTLIBOBJS = @LTLIBOBJS@
-LT_SYS_LIBRARY_PATH = @LT_SYS_LIBRARY_PATH@
 MAINT = @MAINT@
 MAKEINFO = @MAKEINFO@
-MANIFEST_TOOL = @MANIFEST_TOOL@
 MKDIR_P = @MKDIR_P@
 NM = @NM@
 NMEDIT = @NMEDIT@
@@ -501,7 +501,6 @@ abs_builddir = @abs_builddir@
 abs_srcdir = @abs_srcdir@
 abs_top_builddir = @abs_top_builddir@
 abs_top_srcdir = @abs_top_srcdir@
-ac_ct_AR = @ac_ct_AR@
 ac_ct_CC = @ac_ct_CC@
 ac_ct_DUMPBIN = @ac_ct_DUMPBIN@
 am__include = @am__include@
@@ -534,6 +533,7 @@ libdir = @libdir@
 libexecdir = @libexecdir@
 localedir = @localedir@
 localstatedir = @localstatedir@
+lt_ECHO = @lt_ECHO@
 mandir = @mandir@
 mkdir_p = @mkdir_p@
 oldincludedir = @oldincludedir@
@@ -563,6 +563,7 @@ libpvec_la_SOURCES = tipowof10.c decpowof2.c
 libvecdummy_la_SOURCES = testsuite/vec_int128_dummy.c \
 	testsuite/vec_int64_dummy.c \
 	testsuite/vec_int32_dummy.c \
+	testsuite/vec_f32_dummy.c \
 	testsuite/vec_pwr9_dummy.c \
 	testsuite/vec_bcd_dummy.c \
 	testsuite/vec_char_dummy.c
@@ -579,6 +580,7 @@ pveclib_testincludedir = $(includedir)/testsuite
 # on 'make install'
 pveclibinclude_HEADERS = \
 	vec_common_ppc.h \
+	vec_f32_ppc.h \
 	vec_int128_ppc.h \
 	vec_int64_ppc.h \
 	vec_int32_ppc.h \
@@ -595,6 +597,9 @@ pveclib_test_la_INCLUDES = \
 pveclib_test_SOURCES = \
 	testsuite/pveclib_test.c \
 	testsuite/arith128_print.c \
+	testsuite/vec_perf_f32.c \
+	testsuite/vec_perf_i128.c \
+	testsuite/arith128_test_f32.c \
 	testsuite/arith128_test_i128.c \
 	testsuite/arith128_test_i64.c \
 	testsuite/arith128_test_i32.c \
@@ -602,7 +607,7 @@ pveclib_test_SOURCES = \
 	testsuite/arith128_test_char.c \
 	testsuite/arith128_test_bcd.c
 
-pveclib_test_LDADD = .libs/libpvec.a
+pveclib_test_LDADD = .libs/libpvec.a .libs/libvecdummy.a
 
 #Dummy main to force generation of vec_dummy_* codes
 vec_dummy_SOURCES = testsuite/vec_dummy_main.c 
@@ -701,6 +706,8 @@ testsuite/vec_int64_dummy.lo: testsuite/$(am__dirstamp) \
 	testsuite/$(DEPDIR)/$(am__dirstamp)
 testsuite/vec_int32_dummy.lo: testsuite/$(am__dirstamp) \
 	testsuite/$(DEPDIR)/$(am__dirstamp)
+testsuite/vec_f32_dummy.lo: testsuite/$(am__dirstamp) \
+	testsuite/$(DEPDIR)/$(am__dirstamp)
 testsuite/vec_pwr9_dummy.lo: testsuite/$(am__dirstamp) \
 	testsuite/$(DEPDIR)/$(am__dirstamp)
 testsuite/vec_bcd_dummy.lo: testsuite/$(am__dirstamp) \
@@ -722,6 +729,12 @@ clean-checkPROGRAMS:
 testsuite/pveclib_test.$(OBJEXT): testsuite/$(am__dirstamp) \
 	testsuite/$(DEPDIR)/$(am__dirstamp)
 testsuite/arith128_print.$(OBJEXT): testsuite/$(am__dirstamp) \
+	testsuite/$(DEPDIR)/$(am__dirstamp)
+testsuite/vec_perf_f32.$(OBJEXT): testsuite/$(am__dirstamp) \
+	testsuite/$(DEPDIR)/$(am__dirstamp)
+testsuite/vec_perf_i128.$(OBJEXT): testsuite/$(am__dirstamp) \
+	testsuite/$(DEPDIR)/$(am__dirstamp)
+testsuite/arith128_test_f32.$(OBJEXT): testsuite/$(am__dirstamp) \
 	testsuite/$(DEPDIR)/$(am__dirstamp)
 testsuite/arith128_test_i128.$(OBJEXT): testsuite/$(am__dirstamp) \
 	testsuite/$(DEPDIR)/$(am__dirstamp)
@@ -759,6 +772,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/arith128_print.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/arith128_test_bcd.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/arith128_test_char.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/arith128_test_f32.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/arith128_test_i128.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/arith128_test_i16.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/arith128_test_i32.Po@am__quote@
@@ -767,9 +781,12 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/vec_bcd_dummy.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/vec_char_dummy.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/vec_dummy_main.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/vec_f32_dummy.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/vec_int128_dummy.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/vec_int32_dummy.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/vec_int64_dummy.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/vec_perf_f32.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/vec_perf_i128.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/vec_pwr9_dummy.Plo@am__quote@
 
 .c.o:
@@ -1217,6 +1234,7 @@ uninstall-am: uninstall-libLTLIBRARIES uninstall-pveclibincludeHEADERS
 # .libs/libpvec.a and if make is executed in parallel (-jN) the 
 # pveclib_test rule may be run before .libs/libpvec.a is built.
 .libs/libpvec.a: libpvec.la
+.libs/libpvecdummy.a: libpvecdummy.la
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.

--- a/src/testsuite/arith128_print.c
+++ b/src/testsuite/arith128_print.c
@@ -474,6 +474,54 @@ print_vbool8 (char *prefix, vui8_t val)
 }
 
 void
+print_v4f32 (char *prefix, vf32_t val)
+{
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  printf ("%s %8.3f,%8.3f,%8.3f,%8.3f\n", prefix, val[3], val[2], val[1], val[0]);
+#else
+  printf ("%s %8.3f,%8.3f,%8.3f,%8.3f\n", prefix, val[0], val[1], val[2], val[3]);
+#endif
+}
+
+void
+print_v4f32x (char *prefix, vf32_t val)
+{
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  printf ("%s %16.6a,%16.6a,%16.6a,%16.6a\n", prefix, val[3], val[2], val[1], val[0]);
+#else
+  printf ("%s %16.6a,%16.6a,%16.6a,%16.6a\n", prefix, val[0], val[1], val[2], val[3]);
+#endif
+}
+
+void
+print_v4b32c (char *prefix, vb32_t val)
+{
+  const vui32_t true =  { 'T', 'T', 'T', 'T' };
+  const vui32_t false = { 'F', 'F', 'F', 'F' };
+  vui32_t text;
+
+  text = vec_sel (false, true, val);
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  printf ("%s %c,%c,%c,%c\n", prefix, text[3], text[2], text[1], text[0]);
+#else
+  printf ("%s %c,%c,%c,%c\n", prefix, text[0], text[1], text[2], text[3]);
+#endif
+}
+
+void
+print_v4b32x (char *prefix, vb32_t boolval)
+{
+  vui32_t val = (vui32_t)boolval;
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  printf ("%s %08x,%08x,%08x,%08x\n", prefix, val[3], val[2], val[1], val[0]);
+#else
+  printf ("%s %08x,%08x,%08x,%08x\n", prefix, val[0], val[1], val[2], val[3]);
+#endif
+}
+
+void
 print_v2int64 (char *prefix, vui64_t val128)
 {
   vui64_t val = (vui64_t) val128;
@@ -773,6 +821,74 @@ check_vui8_priv (char *prefix, vui8_t val128, vui8_t shouldbe)
       printf ("%s\n", prefix);
       print_vint8x ("\tshould be: ", shouldbe);
       print_vint8x ("\t       is: ", val128);
+    }
+
+  return (rc);
+}
+
+int
+check_v4b32c_priv (char *prefix, vb32_t val128, vb32_t shouldbe)
+{
+  int rc = 0;
+
+
+  if (vec_any_ne ((vui32_t) val128, (vui32_t) shouldbe))
+    {
+      rc = 1;
+      printf ("%s\n", prefix);
+      print_v4b32c ("\tshould be: ", shouldbe);
+      print_v4b32c ("\t       is: ", val128);
+    }
+
+  return (rc);
+}
+
+int
+check_v4b32x_priv (char *prefix, vb32_t val128, vb32_t shouldbe)
+{
+  int rc = 0;
+
+
+  if (vec_any_ne ((vui32_t) val128, (vui32_t) shouldbe))
+    {
+      rc = 1;
+      printf ("%s\n", prefix);
+      print_v4b32x ("\tshould be: ", shouldbe);
+      print_v4b32x ("\t       is: ", val128);
+    }
+
+  return (rc);
+}
+
+int
+check_v4f32_priv (char *prefix, vf32_t val128, vf32_t shouldbe)
+{
+  int rc = 0;
+
+
+  if (vec_any_ne ((vui32_t) val128, (vui32_t) shouldbe))
+    {
+      rc = 1;
+      printf ("%s\n", prefix);
+      print_v4f32 ("\tshould be: ", shouldbe);
+      print_v4f32 ("\t       is: ", val128);
+    }
+
+  return (rc);
+}
+
+int
+check_v4f32x_priv (char *prefix, vf32_t val128, vf32_t shouldbe)
+{
+  int rc = 0;
+
+
+  if (vec_any_ne ((vui32_t) val128, (vui32_t) shouldbe))
+    {
+      rc = 1;
+      printf ("%s\n", prefix);
+      print_v4f32x ("\tshould be: ", shouldbe);
+      print_v4f32x ("\t       is: ", val128);
     }
 
   return (rc);

--- a/src/testsuite/arith128_print.h
+++ b/src/testsuite/arith128_print.h
@@ -26,6 +26,18 @@
 #include "arith128.h"
 #include "vec_f128_ppc.h"
 
+static inline
+double
+TimeDeltaSec (uint64_t tb_delta)
+{
+	double temp,  result;
+
+	temp = tb_delta;
+	result = temp / 512.e+06;
+
+	return (result);
+}
+
 extern long tcount;
 
 extern void
@@ -90,6 +102,18 @@ print_v2int64 (char *prefix, vui64_t val128);
 
 extern void
 print_v2xint64 (char *prefix, vui64_t val128);
+
+extern void
+print_v4f32 (char *prefix, vf32_t val);
+
+extern void
+print_v4f32x (char *prefix, vf32_t val);
+
+extern void
+print_v4b32c (char *prefix, vb32_t val);
+
+extern void
+print_v4b32x (char *prefix, vb32_t val);
 
 extern int
 check_udiv128_64x (unsigned __int128 numerator, uint64_t divisor,
@@ -210,7 +234,7 @@ static inline int
 check_f128 (char *prefix, __float128 val128, __float128 f128is,
             __float128 shouldbe)
 {
-  VF_128 xfer;
+  __VF_128 xfer;
   __f128_bool boolis, boolshould;
   int rc = 0;
 
@@ -236,6 +260,18 @@ check_int128_priv (char *prefix, __int128 val128, __int128 shouldbe);
 
 extern int
 check_vui8_priv (char *prefix, vui8_t val128, vui8_t shouldbe);
+
+extern int
+check_v4b32c_priv (char *prefix, vb32_t val128, vb32_t shouldbe);
+
+extern int
+check_v4b32x_priv (char *prefix, vb32_t val128, vb32_t shouldbe);
+
+extern int
+check_v4f32_priv (char *prefix, vf32_t val128, vf32_t shouldbe);
+
+extern int
+check_v4f32x_priv (char *prefix, vf32_t val128, vf32_t shouldbe);
 
 extern int
 check_vuint128_priv (char *prefix, vui128_t val128, vui128_t shouldbe);
@@ -311,6 +347,58 @@ check_vui8 (char *prefix, vui8_t val128, vui8_t shouldbe)
     }
 
   return (rc);
+}
+
+static inline int
+check_v4b32c (char *prefix, vb32_t val128, vb32_t shouldbe)
+{
+  int rc = 0;
+  if (vec_any_ne((vui32_t )val128, (vui32_t )shouldbe))
+    {
+      rc = check_v4b32c_priv (prefix, val128, shouldbe);
+    }
+
+  return (rc);
+
+}
+
+static inline int
+check_v4b32x (char *prefix, vb32_t val128, vb32_t shouldbe)
+{
+  int rc = 0;
+  if (vec_any_ne((vui32_t )val128, (vui32_t )shouldbe))
+    {
+      rc = check_v4b32x_priv (prefix, val128, shouldbe);
+    }
+
+  return (rc);
+
+}
+
+static inline int
+check_v4f32 (char *prefix, vf32_t val128, vf32_t shouldbe)
+{
+  int rc = 0;
+  if (vec_any_ne((vui32_t )val128, (vui32_t )shouldbe))
+    {
+      rc = check_v4f32_priv (prefix, val128, shouldbe);
+    }
+
+  return (rc);
+
+}
+
+static inline int
+check_v4f32x (char *prefix, vf32_t val128, vf32_t shouldbe)
+{
+  int rc = 0;
+  if (vec_any_ne((vui32_t )val128, (vui32_t )shouldbe))
+    {
+      rc = check_v4f32x_priv (prefix, val128, shouldbe);
+    }
+
+  return (rc);
+
 }
 
 static inline int

--- a/src/testsuite/arith128_test_bcd.c
+++ b/src/testsuite/arith128_test_bcd.c
@@ -250,7 +250,7 @@ test_cvtbcd2c100 (void)
   vui8_t e;
   int rc = 0;
 
-  printf ("\ntest_48 Vector BCD convert\n");
+  printf ("\n%s Vector BCD convert\n", __FUNCTION__);
 
   i = (vui8_t){0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99};
   e = (vui8_t){99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99};
@@ -311,7 +311,7 @@ test_bcd_addsub (void)
   vui32_t e, ex;
   int rc = 0;
 
-  printf ("\ntest_3 Vector BCD +-\n");
+  printf ("\n%s Vector BCD +-\n", __FUNCTION__);
 
   i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0x0000001c);
   j = (vui32_t )CONST_VINT32_W(0, 0, 0, 0x0000001c);
@@ -380,7 +380,7 @@ test_bcd_addsub (void)
   vui32_t e;
   int rc = 0;
 
-  printf ("\ntest_3 Vector BCD */\n");
+  printf ("\n%s Vector BCD */\n", __FUNCTION__);
 
   i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0x0000001c);
   j = (vui32_t )CONST_VINT32_W(0, 0, 0, 0x9999999c);

--- a/src/testsuite/arith128_test_f32.c
+++ b/src/testsuite/arith128_test_f32.c
@@ -213,7 +213,7 @@ test_float_all_is (void)
   if (vec_all_isnanf32 (i))
     {
       rc += 1;
-      print_v4f32x ("vec_all_isnan fail", i);
+      print_v4f32x ("vec_all_isnan fail 1", i);
     } else {
     }
 
@@ -226,7 +226,7 @@ test_float_all_is (void)
   if (vec_all_isnanf32 (i))
     {
       rc += 1;
-      print_v4f32x ("vec_all_isnan fail", i);
+      print_v4f32x ("vec_all_isnan fail 2", i);
     } else {
     }
 
@@ -236,11 +236,12 @@ test_float_all_is (void)
 #ifdef __DEBUG_PRINT__
   print_v4f32x ("vec_all_isnan i=", i);
 #endif
+
   if (vec_all_isnanf32 (i))
     {
-    } else {
       rc += 1;
-      print_v4f32x ("vec_all_isnan fail", i);
+      print_v4f32x ("vec_all_isnan fail 3", i);
+    } else {
     }
 
   i = (vf32_t) CONST_VINT128_W(__FLOAT_INF, __FLOAT_NINF, __FLOAT_INF,
@@ -252,7 +253,7 @@ test_float_all_is (void)
   if (vec_all_isnanf32 (i))
     {
       rc += 1;
-      print_v4f32x ("vec_all_isnan fail", i);
+      print_v4f32x ("vec_all_isnan fail 4", i);
     } else {
     }
 
@@ -265,8 +266,8 @@ test_float_all_is (void)
   if (vec_all_isnanf32 (i))
     {
     } else {
-	      rc += 1;
-	      print_v4f32x ("vec_all_isnan fail", i);
+      rc += 1;
+      print_v4f32x ("vec_all_isnan fail 5", i);
     }
 
   printf ("\n%s float is all Normal\n", __FUNCTION__);
@@ -722,7 +723,7 @@ test_float_any_is (void)
   if (vec_any_isnormalf32 (i))
     {
       rc += 1;
-      print_v4f32x ("vec_any_isnormal fail", i);
+      print_v4f32x ("vec_any_isnormal fail 1", i);
     } else {
     }
 
@@ -736,7 +737,7 @@ test_float_any_is (void)
     {
     } else {
       rc += 1;
-      print_v4f32x ("vec_any_isnormal fail", i);
+      print_v4f32x ("vec_any_isnormal fail 2", i);
     }
 
   i = (vf32_t) { __FLT_MAX__, __FLT_MIN__, __FLT_EPSILON__,
@@ -749,7 +750,7 @@ test_float_any_is (void)
     {
     } else {
       rc += 1;
-      print_v4f32x ("vec_any_isnormal fail", i);
+      print_v4f32x ("vec_any_isnormal fail 3", i);
     }
 
   i = (vf32_t) { __FLT_DENORM_MIN__, __FLT_DENORM_MIN__, __FLT_DENORM_MIN__,
@@ -761,7 +762,7 @@ test_float_any_is (void)
   if (vec_any_isnormalf32 (i))
     {
       rc += 1;
-      print_v4f32x ("vec_any_isnormal fail", i);
+      print_v4f32x ("vec_any_isnormal fail 4", i);
     } else {
     }
 
@@ -775,7 +776,7 @@ test_float_any_is (void)
     {
     } else {
       rc += 1;
-      print_v4f32x ("vec_any_isnormal fail", i);
+      print_v4f32x ("vec_any_isnormal fail 5", i);
     }
 
   i = (vf32_t) CONST_VINT128_W(__FLOAT_NNAN, 0xff000000, 1,
@@ -788,7 +789,7 @@ test_float_any_is (void)
     {
     } else {
       rc += 1;
-      print_v4f32x ("vec_any_isnormal fail", i);
+      print_v4f32x ("vec_any_isnormal fail 6", i);
     }
 
   i = (vf32_t) CONST_VINT128_W(__FLOAT_INF, __FLOAT_NINF, __FLOAT_INF,
@@ -800,7 +801,7 @@ test_float_any_is (void)
   if (vec_any_isnormalf32 (i))
     {
       rc += 1;
-      print_v4f32x ("vec_any_isnormal fail", i);
+      print_v4f32x ("vec_any_isnormal fail 7", i);
     } else {
     }
 
@@ -813,8 +814,47 @@ test_float_any_is (void)
   if (vec_any_isnormalf32 (i))
     {
       rc += 1;
-      print_v4f32x ("vec_any_isnormal fail", i);
+      print_v4f32x ("vec_any_isnormal fail 8", i);
     } else {
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NAN, __FLOAT_INF, 0x7ffff,
+			       1);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_isnormal i=", i);
+#endif
+  if (vec_any_isnormalf32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_any_isnormal fail 9", i);
+    } else {
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NAN, __FLOAT_INF, 0,
+			       1);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_isnormal i=", i);
+#endif
+  if (vec_any_isnormalf32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_any_isnormal fail 10", i);
+    } else {
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NAN, __FLOAT_INF, 0x00800000,
+			       1);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_isnormal i=", i);
+#endif
+  if (vec_any_isnormalf32 (i))
+    {
+    } else {
+      rc += 1;
+      print_v4f32x ("vec_any_isnormal fail 11", i);
     }
 
   printf ("\n%s float is any Subnormal\n", __FUNCTION__);
@@ -827,7 +867,7 @@ test_float_any_is (void)
   if (vec_any_issubnormalf32 (i))
     {
       rc += 1;
-      print_v4f32x ("vec_any_issubnormal fail", i);
+      print_v4f32x ("vec_any_issubnormal fail 1", i);
     } else {
     }
 
@@ -837,10 +877,11 @@ test_float_any_is (void)
 #ifdef __DEBUG_PRINT__
   print_v4f32x ("vec_any_issubnormal i=", i);
 #endif
+
   if (vec_any_issubnormalf32 (i))
     {
       rc += 1;
-      print_v4f32x ("vec_any_issubnormal fail", i);
+      print_v4f32x ("vec_any_issubnormal fail 2", i);
     } else {
     }
 
@@ -854,7 +895,7 @@ test_float_any_is (void)
     {
     } else {
       rc += 1;
-      print_v4f32x ("vec_any_issubnormal fail", i);
+      print_v4f32x ("vec_any_issubnormal fail 3", i);
     }
 
   i = (vf32_t) CONST_VINT128_W(0x80000001, 0x007fffff, 1,
@@ -867,7 +908,7 @@ test_float_any_is (void)
     {
     } else {
       rc += 1;
-      print_v4f32x ("vec_any_issubnormal fail", i);
+      print_v4f32x ("vec_any_issubnormal fail 4", i);
     }
 
   i = (vf32_t) CONST_VINT128_W(__FLOAT_NNAN, 0xff000000, 1,
@@ -880,7 +921,7 @@ test_float_any_is (void)
     {
     } else {
       rc += 1;
-      print_v4f32x ("vec_any_issubnormal fail", i);
+      print_v4f32x ("vec_any_issubnormal fail 5", i);
     }
 
   i = (vf32_t) CONST_VINT128_W(__FLOAT_INF, __FLOAT_NINF, __FLOAT_INF,
@@ -892,7 +933,7 @@ test_float_any_is (void)
   if (vec_any_issubnormalf32 (i))
     {
       rc += 1;
-      print_v4f32x ("vec_any_issubnormal fail", i);
+      print_v4f32x ("vec_any_issubnormal fail 6", i);
     } else {
     }
 
@@ -905,7 +946,7 @@ test_float_any_is (void)
   if (vec_any_issubnormalf32 (i))
     {
       rc += 1;
-      print_v4f32x ("vec_any_issubnormal fail", i);
+      print_v4f32x ("vec_any_issubnormal fail 7", i);
     } else {
     }
 

--- a/src/testsuite/arith128_test_f32.c
+++ b/src/testsuite/arith128_test_f32.c
@@ -1,0 +1,1588 @@
+/*
+ Copyright (c) [2018] IBM Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ arith128_test_f32.c
+
+ Contributors:
+      IBM Corporation, Steven Munroe
+      Created on: Jul 3, 2018
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <float.h>
+
+#include "arith128.h"
+#include <testsuite/arith128_print.h>
+#include "vec_int32_ppc.h"
+#include "vec_f32_ppc.h"
+#include <testsuite/arith128_test_f32.h>
+#include <testsuite/vec_perf_f32.h>
+
+#define __FLOAT_INF (0x7f800000)
+#define __FLOAT_NINF (0xff800000)
+#define __FLOAT_NAN (0x7f800001)
+#define __FLOAT_NNAN (0xff800001)
+#define __FLOAT_SNAN (0x7fC00001)
+#define __FLOAT_NSNAN (0xffC00001)
+#define __FLOAT_TRUE (0xffffffff)
+#define __FLOAT_NTRUE (0x00000000)
+
+
+#ifdef __DEBUG_PRINT__
+static inline vb32_t
+db_vec_isnormalf32 (vf32_t vf32)
+{
+	vui32_t tmp, tmp2;
+	const vui32_t expmask  = CONST_VINT128_W(0x7f800000, 0x7f800000, 0x7f800000, 0x7f800000);
+	const vui32_t vec_denorm = CONST_VINT128_W(0x00800000, 0x00800000, 0x00800000, 0x00800000);
+	vb32_t result;
+
+	print_v4f32x ("db_vec_isnormalf32:", vf32);
+
+#if _ARCH_PWR7
+	/* Eliminate const load. */
+	tmp2 = (vui32_t)vec_abs (vf32);
+#else
+	const vui32_t signmask = CONST_VINT128_W(0x80000000, 0x80000000, 0x80000000, 0x80000000);
+	tmp2 = vec_andc ((vui32_t)vf32, signmask);
+#endif
+	print_vint128x ("              tmp2=", (vui128_t)tmp2);
+	tmp = vec_and ((vui32_t)vf32, expmask);
+	print_vint128x ("              tmp =", (vui128_t)tmp);
+	tmp2 = (vui32_t)vec_cmplt(tmp2, vec_denorm);
+	print_vint128x ("              tmp2=", (vui128_t)tmp2);
+	tmp = (vui32_t)vec_cmpeq(tmp, expmask);
+	print_vint128x ("              tmp =", (vui128_t)tmp);
+	result = (vb32_t)vec_nor (tmp, tmp2);
+	print_v4b32x   ("            result=", result);
+
+	return (result);
+}
+#endif
+
+int
+test_float_abs (void)
+{
+  vf32_t i, e;
+  vf32_t k;
+  int rc = 0;
+
+  printf ("\n%s float absolute value\n", __FUNCTION__);
+
+  i = (vf32_t) { 0.0, -0.0, 0.0, -0.0 };
+  e = (vf32_t) { 0.0, 0.0, 0.0, 0.0 };
+  k = vec_absf32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_absf32 i=", i);
+  print_v4f32x ("           k=", k);
+#endif
+  rc += check_v4f32x ("vec_absf32 1:", k, e);
+
+  i = (vf32_t) { -(__FLT_MAX__), __FLT_MIN__, __FLT_EPSILON__,
+		  -(__FLT_DENORM_MIN__) };
+  e = (vf32_t) { __FLT_MAX__, __FLT_MIN__, __FLT_EPSILON__,
+		  __FLT_DENORM_MIN__ };
+  k = vec_absf32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_absf32 i=", i);
+  print_v4f32x ("           k=", k);
+#endif
+  rc += check_v4f32x ("vec_absf32 1:", k, e);
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_INF, __FLOAT_NINF, __FLOAT_INF,
+			       __FLOAT_NINF);
+  e = (vf32_t) CONST_VINT128_W(__FLOAT_INF, __FLOAT_INF, __FLOAT_INF,
+			       __FLOAT_INF);
+  k = vec_absf32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_absf32 i=", i);
+  print_v4f32x ("           k=", k);
+#endif
+  rc += check_v4f32x ("vec_absf32 1:", k, e);
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NAN, __FLOAT_NNAN, __FLOAT_SNAN,
+			       __FLOAT_NSNAN);
+  e = (vf32_t) CONST_VINT128_W(__FLOAT_NAN, __FLOAT_NAN, __FLOAT_SNAN,
+			       __FLOAT_SNAN);
+  k = vec_absf32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_absf32 i=", i);
+  print_v4f32x ("           k=", k);
+#endif
+  rc += check_v4f32x ("vec_absf32 1:", k, e);
+
+  return (rc);
+}
+
+int
+test_float_all_is (void)
+{
+  vf32_t i;
+  int rc = 0;
+
+  printf ("\n%s float is all infinity\n", __FUNCTION__);
+
+  i = (vf32_t) { 0.0, -0.0, 0.0, -0.0 };
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_isinf i=", i);
+#endif
+  if (vec_all_isinff32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_all_isinf fail", i);
+    } else {
+    }
+
+  i = (vf32_t) { __FLT_MAX__, __FLT_MIN__, __FLT_EPSILON__,
+		  __FLT_DENORM_MIN__ };
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_isinf i=", i);
+#endif
+  if (vec_all_isinff32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_all_isinf fail", i);
+    } else {
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_INF, __FLOAT_NINF, 0,
+			       __FLOAT_NINF);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_isinf i=", i);
+#endif
+  if (vec_all_isinff32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_all_isinf fail", i);
+    } else {
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_INF, __FLOAT_NINF, __FLOAT_INF,
+			       __FLOAT_NINF);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_isinf i=", i);
+#endif
+  if (vec_all_isinff32 (i))
+    {
+    } else {
+      rc += 1;
+      print_v4f32x ("vec_all_isinf fail", i);
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NAN, __FLOAT_NAN, __FLOAT_SNAN,
+			       __FLOAT_SNAN);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_isinf i=", i);
+#endif
+  if (vec_all_isinff32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_all_isinf fail", i);
+    } else {
+    }
+
+  printf ("\n%s float is all NaN\n", __FUNCTION__);
+
+  i = (vf32_t) { 0.0, -0.0, 0.0, -0.0 };
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_isnan i=", i);
+#endif
+  if (vec_all_isnanf32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_all_isnan fail", i);
+    } else {
+    }
+
+  i = (vf32_t) { __FLT_MAX__, __FLT_MIN__, __FLT_EPSILON__,
+		  __FLT_DENORM_MIN__ };
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_isnan i=", i);
+#endif
+  if (vec_all_isnanf32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_all_isnan fail", i);
+    } else {
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NAN, __FLOAT_NNAN, 0,
+			       __FLOAT_SNAN);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_isnan i=", i);
+#endif
+  if (vec_all_isnanf32 (i))
+    {
+    } else {
+      rc += 1;
+      print_v4f32x ("vec_all_isnan fail", i);
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_INF, __FLOAT_NINF, __FLOAT_INF,
+			       __FLOAT_NINF);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_isnan i=", i);
+#endif
+  if (vec_all_isnanf32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_all_isnan fail", i);
+    } else {
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NAN, __FLOAT_NNAN, __FLOAT_NSNAN,
+			       __FLOAT_SNAN);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_isnan i=", i);
+#endif
+  if (vec_all_isnanf32 (i))
+    {
+    } else {
+	      rc += 1;
+	      print_v4f32x ("vec_all_isnan fail", i);
+    }
+
+  printf ("\n%s float is all Normal\n", __FUNCTION__);
+
+  i = (vf32_t) { 0.0, -0.0, 0.0, -0.0 };
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_isnormal i=", i);
+#endif
+  if (vec_all_isnormalf32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_all_isnormal fail", i);
+    } else {
+    }
+
+  i = (vf32_t) { __FLT_MAX__, __FLT_MIN__, __FLT_EPSILON__,
+		  -0.0 };
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_isnormal i=", i);
+#endif
+  if (vec_all_isnormalf32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_all_isnormal fail", i);
+    } else {
+    }
+
+  i = (vf32_t) { __FLT_MAX__, __FLT_MIN__, __FLT_EPSILON__,
+		  -1.0 };
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_isnormal i=", i);
+#endif
+  if (vec_all_isnormalf32 (i))
+    {
+    } else {
+      rc += 1;
+      print_v4f32x ("vec_all_isnormal fail", i);
+    }
+
+  i = (vf32_t) { __FLT_MAX__, __FLT_MIN__, __FLT_EPSILON__,
+		  __FLT_DENORM_MIN__ };
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_isnormal i=", i);
+#endif
+  if (vec_all_isnormalf32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_all_isnormal fail", i);
+    } else {
+    }
+
+  i = (vf32_t) { __FLT_DENORM_MIN__, __FLT_DENORM_MIN__, __FLT_DENORM_MIN__,
+		  __FLT_DENORM_MIN__ };
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_isnormal i=", i);
+#endif
+  if (vec_all_isnormalf32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_all_isnormal fail", i);
+    } else {
+    }
+
+  i = (vf32_t) CONST_VINT128_W(0, 0xff000000, 1,
+		__FLOAT_INF );
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_isnormal i=", i);
+#endif
+  if (vec_all_isnormalf32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_all_isnormal fail", i);
+    } else {
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NNAN, 0xff000000, 1,
+		0x80000000);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_isnormal i=", i);
+#endif
+  if (vec_all_isnormalf32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_all_isnormal fail", i);
+    } else {
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_INF, __FLOAT_NINF, __FLOAT_INF,
+			       __FLOAT_NINF);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_isnormal i=", i);
+#endif
+  if (vec_all_isnormalf32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_all_isnormal fail", i);
+    } else {
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NAN, __FLOAT_NNAN, __FLOAT_NSNAN,
+			       __FLOAT_SNAN);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_isnormal i=", i);
+#endif
+  if (vec_all_isnormalf32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_all_isnormal fail", i);
+    } else {
+    }
+
+  printf ("\n%s float is all Subnormal\n", __FUNCTION__);
+
+  i = (vf32_t) { 0.0, -0.0, 0.0, -0.0 };
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_issubnormal i=", i);
+#endif
+  if (vec_all_issubnormalf32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_all_issubnormal fail", i);
+    } else {
+    }
+
+  i = (vf32_t) { __FLT_MAX__, __FLT_MIN__, __FLT_EPSILON__,
+		  -0.0 };
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_issubnormal i=", i);
+#endif
+  if (vec_all_issubnormalf32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_all_issubnormal fail", i);
+    } else {
+    }
+
+  i = (vf32_t) { __FLT_MAX__, __FLT_MIN__, __FLT_EPSILON__,
+		  __FLT_DENORM_MIN__ };
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_issubnormal i=", i);
+#endif
+  if (vec_all_issubnormalf32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_all_issubnormal fail", i);
+    } else {
+    }
+
+  i = (vf32_t) CONST_VINT128_W(0x80000001, 0x007fffff, 1,
+			       0x803fffff );
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_issubnormal i=", i);
+#endif
+  if (vec_all_issubnormalf32 (i))
+    {
+    } else {
+      rc += 1;
+      print_v4f32x ("vec_all_issubnormal fail", i);
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NNAN, 0xff000000, 1,
+		0x80000000);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_issubnormal i=", i);
+#endif
+  if (vec_all_issubnormalf32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_all_issubnormal fail", i);
+    } else {
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_INF, __FLOAT_NINF, __FLOAT_INF,
+			       __FLOAT_NINF);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_issubnormal i=", i);
+#endif
+  if (vec_all_issubnormalf32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_all_issubnormal fail", i);
+    } else {
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NAN, __FLOAT_NNAN, __FLOAT_NSNAN,
+			       __FLOAT_SNAN);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_issubnormal i=", i);
+#endif
+  if (vec_all_issubnormalf32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_all_issubnormal fail", i);
+    } else {
+    }
+
+  printf ("\n%s float is all Zero\n", __FUNCTION__);
+
+  i = (vf32_t) { 0.0, -0.0, 0.0, -0.0 };
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_iszero i=", i);
+#endif
+  if (vec_all_iszerof32 (i))
+    {
+    } else {
+      rc += 1;
+      print_v4f32x ("vec_all_iszero fail", i);
+    }
+
+  i = (vf32_t) { __FLT_MAX__, __FLT_MIN__, __FLT_EPSILON__,
+		  -0.0 };
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_iszero i=", i);
+#endif
+  if (vec_all_iszerof32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_all_iszero fail", i);
+    } else {
+    }
+
+  i = (vf32_t) { __FLT_MAX__, __FLT_MIN__, __FLT_EPSILON__,
+		  __FLT_DENORM_MIN__ };
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_iszero i=", i);
+#endif
+  if (vec_all_iszerof32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_all_iszero fail", i);
+    } else {
+    }
+
+  i = (vf32_t) CONST_VINT128_W(0x80000001, 0x007fffff, 1,
+			       0x803fffff );
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_iszero i=", i);
+#endif
+  if (vec_all_iszerof32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_all_iszero fail", i);
+    } else {
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NNAN, 0xff000000, 1,
+		0x80000000);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_iszero i=", i);
+#endif
+  if (vec_all_iszerof32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_all_iszero fail", i);
+    } else {
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_INF, __FLOAT_NINF, __FLOAT_INF,
+			       __FLOAT_NINF);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_iszero i=", i);
+#endif
+  if (vec_all_iszerof32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_all_iszero fail", i);
+    } else {
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NAN, __FLOAT_NNAN, __FLOAT_NSNAN,
+			       __FLOAT_SNAN);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_all_iszero i=", i);
+#endif
+  if (vec_all_iszerof32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_all_iszero fail", i);
+    } else {
+    }
+
+  return (rc);
+}
+
+int
+test_float_any_is (void)
+{
+  vf32_t i;
+  int rc = 0;
+
+  printf ("\n%s float is any infinity\n", __FUNCTION__);
+
+  i = (vf32_t) { 0.0, -0.0, 0.0, -0.0 };
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_isinf i=", i);
+#endif
+  if (vec_any_isinff32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_any_isinf fail", i);
+    } else {
+    }
+
+  i = (vf32_t) { __FLT_MAX__, __FLT_MIN__, __FLT_EPSILON__,
+		  __FLT_DENORM_MIN__ };
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_isinf i=", i);
+#endif
+  if (vec_any_isinff32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_any_isinf fail", i);
+    } else {
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_INF, __FLOAT_NINF, 0,
+			       __FLOAT_NINF);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_isinf i=", i);
+#endif
+  if (vec_any_isinff32 (i))
+    {
+    } else {
+      rc += 1;
+      print_v4f32x ("vec_any_isinf fail", i);
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_INF, __FLOAT_NINF, __FLOAT_INF,
+			       __FLOAT_NINF);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_isinf i=", i);
+#endif
+  if (vec_any_isinff32 (i))
+    {
+    } else {
+      rc += 1;
+      print_v4f32x ("vec_any_isinf fail", i);
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NAN, __FLOAT_NAN, __FLOAT_SNAN,
+			       __FLOAT_SNAN);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_isinf i=", i);
+#endif
+  if (vec_any_isinff32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_any_isinf fail", i);
+    } else {
+    }
+
+  printf ("\n%s float is any NaN\n", __FUNCTION__);
+
+  i = (vf32_t) { 0.0, -0.0, 0.0, -0.0 };
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_isnan i=", i);
+#endif
+  if (vec_any_isnanf32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_any_isnan fail", i);
+    } else {
+    }
+
+  i = (vf32_t) { __FLT_MAX__, __FLT_MIN__, __FLT_EPSILON__,
+		  __FLT_DENORM_MIN__ };
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_isnan i=", i);
+#endif
+  if (vec_any_isnanf32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_any_isnan fail", i);
+    } else {
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NAN, __FLOAT_NNAN, 0,
+			       __FLOAT_SNAN);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_isnan i=", i);
+#endif
+  if (vec_any_isnanf32 (i))
+    {
+    } else {
+      rc += 1;
+      print_v4f32x ("vec_any_isnan fail", i);
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_INF, __FLOAT_NINF, __FLOAT_INF,
+			       __FLOAT_NINF);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_isnan i=", i);
+#endif
+  if (vec_any_isnanf32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_any_isnan fail", i);
+    } else {
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NAN, __FLOAT_NNAN, __FLOAT_NSNAN,
+			       __FLOAT_SNAN);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_isnan i=", i);
+#endif
+  if (vec_any_isnanf32 (i))
+    {
+    } else {
+	      rc += 1;
+	      print_v4f32x ("vec_any_isnan fail", i);
+    }
+
+  printf ("\n%s float is any Normal\n", __FUNCTION__);
+
+  i = (vf32_t) { 0.0, -0.0, 0.0, -0.0 };
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_isnormal i=", i);
+#endif
+  if (vec_any_isnormalf32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_any_isnormal fail", i);
+    } else {
+    }
+
+  i = (vf32_t) { __FLT_MAX__, __FLT_MIN__, __FLT_EPSILON__,
+		  -0.0 };
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_isnormal i=", i);
+#endif
+  if (vec_any_isnormalf32 (i))
+    {
+    } else {
+      rc += 1;
+      print_v4f32x ("vec_any_isnormal fail", i);
+    }
+
+  i = (vf32_t) { __FLT_MAX__, __FLT_MIN__, __FLT_EPSILON__,
+		  __FLT_DENORM_MIN__ };
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_isnormal i=", i);
+#endif
+  if (vec_any_isnormalf32 (i))
+    {
+    } else {
+      rc += 1;
+      print_v4f32x ("vec_any_isnormal fail", i);
+    }
+
+  i = (vf32_t) { __FLT_DENORM_MIN__, __FLT_DENORM_MIN__, __FLT_DENORM_MIN__,
+		  __FLT_DENORM_MIN__ };
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_isnormal i=", i);
+#endif
+  if (vec_any_isnormalf32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_any_isnormal fail", i);
+    } else {
+    }
+
+  i = (vf32_t) CONST_VINT128_W(0, 0xff000000, 1,
+		__FLOAT_INF );
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_isnormal i=", i);
+#endif
+  if (vec_any_isnormalf32 (i))
+    {
+    } else {
+      rc += 1;
+      print_v4f32x ("vec_any_isnormal fail", i);
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NNAN, 0xff000000, 1,
+		0x80000000);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_isnormal i=", i);
+#endif
+  if (vec_any_isnormalf32 (i))
+    {
+    } else {
+      rc += 1;
+      print_v4f32x ("vec_any_isnormal fail", i);
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_INF, __FLOAT_NINF, __FLOAT_INF,
+			       __FLOAT_NINF);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_isnormal i=", i);
+#endif
+  if (vec_any_isnormalf32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_any_isnormal fail", i);
+    } else {
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NAN, __FLOAT_NNAN, __FLOAT_NSNAN,
+			       __FLOAT_SNAN);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_isnormal i=", i);
+#endif
+  if (vec_any_isnormalf32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_any_isnormal fail", i);
+    } else {
+    }
+
+  printf ("\n%s float is any Subnormal\n", __FUNCTION__);
+
+  i = (vf32_t) { 0.0, -0.0, 0.0, -0.0 };
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_issubnormal i=", i);
+#endif
+  if (vec_any_issubnormalf32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_any_issubnormal fail", i);
+    } else {
+    }
+
+  i = (vf32_t) { __FLT_MAX__, __FLT_MIN__, __FLT_EPSILON__,
+		  -0.0 };
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_issubnormal i=", i);
+#endif
+  if (vec_any_issubnormalf32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_any_issubnormal fail", i);
+    } else {
+    }
+
+  i = (vf32_t) { __FLT_MAX__, __FLT_MIN__, __FLT_EPSILON__,
+		  __FLT_DENORM_MIN__ };
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_issubnormal i=", i);
+#endif
+  if (vec_any_issubnormalf32 (i))
+    {
+    } else {
+      rc += 1;
+      print_v4f32x ("vec_any_issubnormal fail", i);
+    }
+
+  i = (vf32_t) CONST_VINT128_W(0x80000001, 0x007fffff, 1,
+			       0x803fffff );
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_issubnormal i=", i);
+#endif
+  if (vec_any_issubnormalf32 (i))
+    {
+    } else {
+      rc += 1;
+      print_v4f32x ("vec_any_issubnormal fail", i);
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NNAN, 0xff000000, 1,
+		0x80000000);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_issubnormal i=", i);
+#endif
+  if (vec_any_issubnormalf32 (i))
+    {
+    } else {
+      rc += 1;
+      print_v4f32x ("vec_any_issubnormal fail", i);
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_INF, __FLOAT_NINF, __FLOAT_INF,
+			       __FLOAT_NINF);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_issubnormal i=", i);
+#endif
+  if (vec_any_issubnormalf32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_any_issubnormal fail", i);
+    } else {
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NAN, __FLOAT_NNAN, __FLOAT_NSNAN,
+			       __FLOAT_SNAN);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_issubnormal i=", i);
+#endif
+  if (vec_any_issubnormalf32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_any_issubnormal fail", i);
+    } else {
+    }
+
+  printf ("\n%s float is any Zero\n", __FUNCTION__);
+
+  i = (vf32_t) { 0.0, -0.0, 0.0, -0.0 };
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_iszero i=", i);
+#endif
+  if (vec_any_iszerof32 (i))
+    {
+    } else {
+      rc += 1;
+      print_v4f32x ("vec_any_iszero fail", i);
+    }
+
+  i = (vf32_t) { __FLT_MAX__, __FLT_MIN__, __FLT_EPSILON__,
+		  -0.0 };
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_iszero i=", i);
+#endif
+  if (vec_any_iszerof32 (i))
+    {
+    } else {
+      rc += 1;
+      print_v4f32x ("vec_any_iszero fail", i);
+    }
+
+  i = (vf32_t) { __FLT_MAX__, __FLT_MIN__, __FLT_EPSILON__,
+		  __FLT_DENORM_MIN__ };
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_iszero i=", i);
+#endif
+  if (vec_any_iszerof32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_any_iszero fail", i);
+    } else {
+    }
+
+  i = (vf32_t) CONST_VINT128_W(0x80000001, 0x007fffff, 1,
+			       0x803fffff );
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_iszero i=", i);
+#endif
+  if (vec_any_iszerof32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_any_iszero fail", i);
+    } else {
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NNAN, 0xff000000, 1,
+		0x80000000);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_iszero i=", i);
+#endif
+  if (vec_any_iszerof32 (i))
+    {
+    } else {
+      rc += 1;
+      print_v4f32x ("vec_any_iszero fail", i);
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_INF, __FLOAT_NINF, __FLOAT_INF,
+			       __FLOAT_NINF);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_iszero i=", i);
+#endif
+  if (vec_any_iszerof32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_any_iszero fail", i);
+    } else {
+    }
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NAN, __FLOAT_NNAN, __FLOAT_NSNAN,
+			       __FLOAT_SNAN);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_any_iszero i=", i);
+#endif
+  if (vec_any_iszerof32 (i))
+    {
+      rc += 1;
+      print_v4f32x ("vec_any_iszero fail", i);
+    } else {
+    }
+
+  return (rc);
+}
+
+int
+test_float_cpsgn (void)
+{
+  vf32_t i, j, e;
+  vf32_t k;
+  int rc = 0;
+
+  printf ("\n%s float Copy Sign\n", __FUNCTION__);
+
+  i = (vf32_t) { 0.0, -0.0, 0.0, -0.0 };
+  j = (vf32_t) {-0.0, 0.0, -0.0, 0.0 };
+  e = (vf32_t) {-0.0, 0.0, -0.0, 0.0 };
+  k = vec_copysignf32 (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_copysignf32 i=", i);
+  print_v4f32x ("                j=", j);
+  print_v4f32x ("                k=", k);
+#endif
+  rc += check_v4f32x ("vec_copysignf32 1:", k, e);
+
+  i = (vf32_t) { __FLT_MAX__, __FLT_MIN__, __FLT_EPSILON__,
+		  __FLT_DENORM_MIN__ };
+  j = (vf32_t) {-0.0, 0.0, -0.0, 0.0 };
+  e = (vf32_t) { -(__FLT_MAX__), __FLT_MIN__, -(__FLT_EPSILON__),
+		  __FLT_DENORM_MIN__ };
+  k = vec_copysignf32 (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_copysignf32 i=", i);
+  print_v4f32x ("                j=", j);
+  print_v4f32x ("                k=", k);
+#endif
+  rc += check_v4f32x ("vec_copysignf32 2:", k, e);
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_INF, __FLOAT_NINF, __FLOAT_INF,
+			       __FLOAT_NINF);
+  j = (vf32_t) CONST_VINT32_W(0.0, -0.0, 0.0, -0.0);
+  e = (vf32_t) CONST_VINT128_W(__FLOAT_INF, __FLOAT_NINF, __FLOAT_INF,
+			       __FLOAT_NINF);
+  k = vec_copysignf32 (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_copysignf32 i=", i);
+  print_v4f32x ("                j=", j);
+  print_v4f32x ("                k=", k);
+#endif
+  rc += check_v4f32x ("vec_copysignf32 3:", k, e);
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NAN, __FLOAT_NNAN, __FLOAT_NSNAN,
+			       __FLOAT_SNAN);
+  j = (vf32_t) {-0.0, 0.0, 0.0, -0.0 };
+  e = (vf32_t) CONST_VINT128_W(__FLOAT_NNAN, __FLOAT_NAN, __FLOAT_SNAN,
+			       __FLOAT_NSNAN);
+  k = vec_copysignf32 (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_copysignf32 i=", i);
+  print_v4f32x ("                j=", j);
+  print_v4f32x ("                k=", k);
+#endif
+  rc += check_v4f32x ("vec_copysignf32 4:", k, e);
+
+  return (rc);
+}
+
+int
+test_float_isinf (void)
+{
+  vf32_t i;
+  vb32_t e, k;
+  int rc = 0;
+
+  printf ("\n%s float isinf\n", __FUNCTION__);
+
+  i = (vf32_t) { 0.0, -0.0, 0.0, -0.0 };
+  e = (vb32_t) CONST_VINT128_W(__FLOAT_NTRUE, __FLOAT_NTRUE, __FLOAT_NTRUE,
+			       __FLOAT_NTRUE);
+  k = vec_isinff32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_isinff32 i=", i);
+  print_v4b32c ("             k=", k);
+  print_v4b32x ("             k=", k);
+#endif
+  rc += check_v4b32c ("vec_isinff32 2:", k, e);
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_INF, __FLOAT_NINF, __FLOAT_INF,
+			       __FLOAT_NINF);
+  e = (vb32_t) CONST_VINT128_W(__FLOAT_TRUE, __FLOAT_TRUE, __FLOAT_TRUE,
+			       __FLOAT_TRUE);
+  k = vec_isinff32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_isinff32 i=", i);
+  print_v4b32c ("             k=", k);
+  print_v4b32x ("             k=", k);
+#endif
+  rc += check_v4b32c ("vec_isinff32 3:", k, e);
+
+  i = (vf32_t) CONST_VINT128_W(0x7f7fffff, 0x00800000, 0x3f800000,
+		0x80000001);
+  e = (vb32_t) CONST_VINT128_W(__FLOAT_NTRUE, __FLOAT_NTRUE, __FLOAT_NTRUE,
+			       __FLOAT_NTRUE);
+  k = vec_isinff32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_isinff32 i=", i);
+  print_v4b32c ("             k=", k);
+  print_v4b32x ("             k=", k);
+#endif
+  rc += check_v4b32c ("vec_isinff32 4:", k, e);
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_INF, 0x00800000, 0x3f800000,
+		0x80000001);
+  e = (vb32_t) CONST_VINT128_W(__FLOAT_TRUE, __FLOAT_NTRUE, __FLOAT_NTRUE,
+			       __FLOAT_NTRUE);
+  k = vec_isinff32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_isinff32 i=", i);
+  print_v4b32c ("             k=", k);
+  print_v4b32x ("             k=", k);
+#endif
+  rc += check_v4b32c ("vec_isinff32 5:", k, e);
+
+  i = (vf32_t) CONST_VINT128_W(0x7f7fffff, __FLOAT_NINF, 0x3f800000,
+		0x80000001);
+  e = (vb32_t) CONST_VINT128_W(__FLOAT_NTRUE, __FLOAT_TRUE, __FLOAT_NTRUE,
+			       __FLOAT_NTRUE);
+  k = vec_isinff32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_isinff32 i=", i);
+  print_v4b32c ("             k=", k);
+  print_v4b32x ("             k=", k);
+#endif
+  rc += check_v4b32c ("vec_isinff32 6:", k, e);
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NINF, 0x00800000, __FLOAT_INF,
+		0x80000001);
+  e = (vb32_t) CONST_VINT128_W(__FLOAT_TRUE, __FLOAT_NTRUE, __FLOAT_TRUE,
+			       __FLOAT_NTRUE);
+  k = vec_isinff32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_isinff32 i=", i);
+  print_v4b32c ("             k=", k);
+  print_v4b32x ("             k=", k);
+#endif
+  rc += check_v4b32c ("vec_isinff32 7:", k, e);
+
+  return (rc);
+}
+
+int
+test_float_isnan (void)
+{
+  vf32_t i;
+  vb32_t e, k;
+  int rc = 0;
+
+  printf ("\n%s float isnan\n", __FUNCTION__);
+
+  i = (vf32_t) { 0.0, -0.0, 0.0, -0.0 };
+  e = (vb32_t) CONST_VINT128_W(__FLOAT_NTRUE, __FLOAT_NTRUE, __FLOAT_NTRUE,
+			       __FLOAT_NTRUE);
+  k = vec_isnanf32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_isnanf32 i=", i);
+  print_v4b32c ("             k=", k);
+  print_v4b32x ("             k=", k);
+#endif
+  rc += check_v4b32c ("vec_isnanf32 2:", k, e);
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NAN, __FLOAT_NNAN, __FLOAT_NSNAN,
+			       __FLOAT_SNAN);
+  e = (vb32_t) CONST_VINT128_W(__FLOAT_TRUE, __FLOAT_TRUE, __FLOAT_TRUE,
+			       __FLOAT_TRUE);
+  k = vec_isnanf32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_isnanf32 i=", i);
+  print_v4b32c ("             k=", k);
+  print_v4b32x ("             k=", k);
+#endif
+  rc += check_v4b32c ("vec_isnanf32 3:", k, e);
+
+  i = (vf32_t) CONST_VINT128_W(0x7f7fffff, 0x00800000, 0x3f800000,
+		0x80000001);
+  e = (vb32_t) CONST_VINT128_W(__FLOAT_NTRUE, __FLOAT_NTRUE, __FLOAT_NTRUE,
+			       __FLOAT_NTRUE);
+  k = vec_isnanf32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_isnanf32 i=", i);
+  print_v4b32c ("             k=", k);
+  print_v4b32x ("             k=", k);
+#endif
+  rc += check_v4b32c ("vec_isnanf32 4:", k, e);
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NAN, 0x00800000, 0x3f800000,
+		0x80000001);
+  e = (vb32_t) CONST_VINT128_W(__FLOAT_TRUE, __FLOAT_NTRUE, __FLOAT_NTRUE,
+			       __FLOAT_NTRUE);
+  k = vec_isnanf32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_isnanf32 i=", i);
+  print_v4b32c ("             k=", k);
+  print_v4b32x ("             k=", k);
+#endif
+  rc += check_v4b32c ("vec_isnanf32 5:", k, e);
+
+  i = (vf32_t) CONST_VINT128_W(0x7f7fffff, __FLOAT_NNAN, 0x3f800000,
+		0x80000001);
+  e = (vb32_t) CONST_VINT128_W(__FLOAT_NTRUE, __FLOAT_TRUE, __FLOAT_NTRUE,
+			       __FLOAT_NTRUE);
+  k = vec_isnanf32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_isnanf32 i=", i);
+  print_v4b32c ("             k=", k);
+  print_v4b32x ("             k=", k);
+#endif
+  rc += check_v4b32c ("vec_isnanf32 6:", k, e);
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_SNAN, 0x00800000, __FLOAT_NNAN,
+		0x80000001);
+  e = (vb32_t) CONST_VINT128_W(__FLOAT_TRUE, __FLOAT_NTRUE, __FLOAT_TRUE,
+			       __FLOAT_NTRUE);
+  k = vec_isnanf32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_isnanf32 i=", i);
+  print_v4b32c ("             k=", k);
+  print_v4b32x ("             k=", k);
+#endif
+  rc += check_v4b32c ("vec_isnanf32 7:", k, e);
+
+  return (rc);
+}
+//#define __DEBUG_PRINT__ 1
+#ifdef __DEBUG_PRINT__
+#define test_vec_isnormalf32(_i)	db_vec_isnormalf32(_i)
+#else
+#define test_vec_isnormalf32(_i)	vec_isnormalf32(_i)
+#endif
+int
+test_float_isnormal (void)
+{
+  vf32_t i;
+  vb32_t e, k;
+  int rc = 0;
+
+  printf ("\n%s float isnormal\n", __FUNCTION__);
+
+  i = (vf32_t) { 0.0, -0.0, 0.0, -0.0 };
+  e = (vb32_t) CONST_VINT128_W(__FLOAT_NTRUE, __FLOAT_NTRUE, __FLOAT_NTRUE,
+			       __FLOAT_NTRUE);
+  k = test_vec_isnormalf32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_isnormalf32 i=", i);
+  print_v4b32c ("             k=", k);
+  print_v4b32x ("             k=", k);
+#endif
+  rc += check_v4b32c ("vec_isnormalf32 2:", k, e);
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NAN, __FLOAT_NNAN, __FLOAT_NSNAN,
+			       __FLOAT_SNAN);
+  e = (vb32_t) CONST_VINT128_W(__FLOAT_NTRUE, __FLOAT_NTRUE, __FLOAT_NTRUE,
+			       __FLOAT_NTRUE);
+  k = test_vec_isnormalf32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_isnormalf32 i=", i);
+  print_v4b32c ("             k=", k);
+  print_v4b32x ("             k=", k);
+#endif
+  rc += check_v4b32c ("vec_isnormalf32 3:", k, e);
+
+  i = (vf32_t) CONST_VINT128_W(0x7f7fffff, 0x00800000, 0x3f800000,
+		0x80000001);
+  e = (vb32_t) CONST_VINT128_W(__FLOAT_TRUE, __FLOAT_TRUE, __FLOAT_TRUE,
+			       __FLOAT_NTRUE);
+  k = test_vec_isnormalf32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_isnormalf32 i=", i);
+  print_v4b32c ("             k=", k);
+  print_v4b32x ("             k=", k);
+#endif
+  rc += check_v4b32c ("vec_isnormalf32 4:", k, e);
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NAN, 0x00800000, 0x3f800000,
+		0x00000001);
+  e = (vb32_t) CONST_VINT128_W(__FLOAT_NTRUE, __FLOAT_TRUE, __FLOAT_TRUE,
+			       __FLOAT_NTRUE);
+  k = test_vec_isnormalf32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_isnormalf32 i=", i);
+  print_v4b32c ("             k=", k);
+  print_v4b32x ("             k=", k);
+#endif
+  rc += check_v4b32c ("vec_isnormalf32 5:", k, e);
+
+  i = (vf32_t) CONST_VINT128_W(0x7f7fffff, __FLOAT_NNAN, 0x3f800000,
+		0x80000001);
+  e = (vb32_t) CONST_VINT128_W(__FLOAT_TRUE, __FLOAT_NTRUE, __FLOAT_TRUE,
+			       __FLOAT_NTRUE);
+  k = test_vec_isnormalf32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_isnormalf32 i=", i);
+  print_v4b32c ("             k=", k);
+  print_v4b32x ("             k=", k);
+#endif
+  rc += check_v4b32c ("vec_isnormalf32 6:", k, e);
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_SNAN, 0x00800000, __FLOAT_NINF,
+		0x80000001);
+  e = (vb32_t) CONST_VINT128_W(__FLOAT_NTRUE, __FLOAT_TRUE, __FLOAT_NTRUE,
+			       __FLOAT_NTRUE);
+  k = test_vec_isnormalf32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_isnormalf32 i=", i);
+  print_v4b32c ("             k=", k);
+  print_v4b32x ("             k=", k);
+#endif
+  rc += check_v4b32c ("vec_isnormalf32 7:", k, e);
+
+  return (rc);
+}
+#undef __DEBUG_PRINT__
+int
+test_float_issubnormal (void)
+{
+  vf32_t i;
+  vb32_t e, k;
+  int rc = 0;
+
+  printf ("\n%s float issubnormal\n", __FUNCTION__);
+
+  i = (vf32_t) { 0.0, -0.0, 0.0, -0.0 };
+  e = (vb32_t) CONST_VINT128_W(__FLOAT_NTRUE, __FLOAT_NTRUE, __FLOAT_NTRUE,
+			       __FLOAT_NTRUE);
+  k = vec_issubnormalf32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_issubnormalf32 i=", i);
+  print_v4b32c ("             k=", k);
+  print_v4b32x ("             k=", k);
+#endif
+  rc += check_v4b32c ("vec_issubnormalf32 2:", k, e);
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NAN, __FLOAT_NNAN, __FLOAT_NSNAN,
+			       __FLOAT_SNAN);
+  e = (vb32_t) CONST_VINT128_W(__FLOAT_NTRUE, __FLOAT_NTRUE, __FLOAT_NTRUE,
+			       __FLOAT_NTRUE);
+  k = vec_issubnormalf32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_issubnormalf32 i=", i);
+  print_v4b32c ("             k=", k);
+  print_v4b32x ("             k=", k);
+#endif
+  rc += check_v4b32c ("vec_issubnormalf32 3:", k, e);
+
+  i = (vf32_t) CONST_VINT128_W(0x7f7fffff, 0x00400000, 0x3f800000,
+		0x80000001);
+  e = (vb32_t) CONST_VINT128_W(__FLOAT_NTRUE, __FLOAT_TRUE, __FLOAT_NTRUE,
+			       __FLOAT_TRUE);
+  k = vec_issubnormalf32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_issubnormalf32 i=", i);
+  print_v4b32c ("             k=", k);
+  print_v4b32x ("             k=", k);
+#endif
+  rc += check_v4b32c ("vec_issubnormalf32 4:", k, e);
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NAN, 0x00800000, 0x3f800000,
+		0x00000001);
+  e = (vb32_t) CONST_VINT128_W(__FLOAT_NTRUE, __FLOAT_NTRUE, __FLOAT_NTRUE,
+			       __FLOAT_TRUE);
+  k = vec_issubnormalf32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_issubnormalf32 i=", i);
+  print_v4b32c ("             k=", k);
+  print_v4b32x ("             k=", k);
+#endif
+  rc += check_v4b32c ("vec_issubnormalf32 5:", k, e);
+
+  i = (vf32_t) CONST_VINT128_W(0x7f7fffff, __FLOAT_NNAN, 0x3f800000,
+		0x80000001);
+  e = (vb32_t) CONST_VINT128_W(__FLOAT_NTRUE, __FLOAT_NTRUE, __FLOAT_NTRUE,
+			       __FLOAT_TRUE);
+  k = vec_issubnormalf32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_issubnormalf32 i=", i);
+  print_v4b32c ("             k=", k);
+  print_v4b32x ("             k=", k);
+#endif
+  rc += check_v4b32c ("vec_issubnormalf32 6:", k, e);
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_SNAN, 0x00800000, __FLOAT_NINF,
+		0x80000001);
+  e = (vb32_t) CONST_VINT128_W(__FLOAT_NTRUE, __FLOAT_NTRUE, __FLOAT_NTRUE,
+			       __FLOAT_TRUE);
+  k = vec_issubnormalf32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_issubnormalf32 i=", i);
+  print_v4b32c ("             k=", k);
+  print_v4b32x ("             k=", k);
+#endif
+  rc += check_v4b32c ("vec_issubnormalf32 7:", k, e);
+
+  return (rc);
+}
+
+int
+test_float_iszero (void)
+{
+  vf32_t i;
+  vb32_t e, k;
+  int rc = 0;
+
+  printf ("\n%s float iszero\n", __FUNCTION__);
+
+  i = (vf32_t) { 0.0, -0.0, 0.0, -0.0 };
+  e = (vb32_t) CONST_VINT128_W(__FLOAT_TRUE, __FLOAT_TRUE, __FLOAT_TRUE,
+			       __FLOAT_TRUE);
+  k = vec_iszerof32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_iszerof32 i=", i);
+  print_v4b32c ("             k=", k);
+  print_v4b32x ("             k=", k);
+#endif
+  rc += check_v4b32c ("vec_iszerof32 2:", k, e);
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NAN, __FLOAT_NNAN, __FLOAT_NINF,
+			       __FLOAT_SNAN);
+  e = (vb32_t) CONST_VINT128_W(__FLOAT_NTRUE, __FLOAT_NTRUE, __FLOAT_NTRUE,
+			       __FLOAT_NTRUE);
+  k = vec_iszerof32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_iszerof32 i=", i);
+  print_v4b32c ("             k=", k);
+  print_v4b32x ("             k=", k);
+#endif
+  rc += check_v4b32c ("vec_iszerof32 3:", k, e);
+
+  i = (vf32_t) CONST_VINT128_W(0x7f7fffff, 0x00400000, 0x3f800000,
+		0x80000000);
+  e = (vb32_t) CONST_VINT128_W(__FLOAT_NTRUE, __FLOAT_NTRUE, __FLOAT_NTRUE,
+			       __FLOAT_TRUE);
+  k = vec_iszerof32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_iszerof32 i=", i);
+  print_v4b32c ("             k=", k);
+  print_v4b32x ("             k=", k);
+#endif
+  rc += check_v4b32c ("vec_iszerof32 4:", k, e);
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_NAN, 0x80000000, 0x3f800000,
+		0x00000001);
+  e = (vb32_t) CONST_VINT128_W(__FLOAT_NTRUE, __FLOAT_TRUE, __FLOAT_NTRUE,
+			       __FLOAT_NTRUE);
+  k = vec_iszerof32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_iszerof32 i=", i);
+  print_v4b32c ("             k=", k);
+  print_v4b32x ("             k=", k);
+#endif
+  rc += check_v4b32c ("vec_iszerof32 5:", k, e);
+
+  i = (vf32_t) CONST_VINT128_W(0x7f7fffff, __FLOAT_NNAN, 0x3f800000,
+		0x80000001);
+  e = (vb32_t) CONST_VINT128_W(__FLOAT_NTRUE, __FLOAT_NTRUE, __FLOAT_NTRUE,
+			       __FLOAT_NTRUE);
+  k = vec_iszerof32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_iszerof32 i=", i);
+  print_v4b32c ("             k=", k);
+  print_v4b32x ("             k=", k);
+#endif
+  rc += check_v4b32c ("vec_iszerof32 6:", k, e);
+
+  i = (vf32_t) CONST_VINT128_W(__FLOAT_SNAN, 0x00800000, __FLOAT_NINF,
+		0x80000001);
+  e = (vb32_t) CONST_VINT128_W(__FLOAT_NTRUE, __FLOAT_NTRUE, __FLOAT_NTRUE,
+			       __FLOAT_NTRUE);
+  k = vec_iszerof32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v4f32x ("vec_iszerof32 i=", i);
+  print_v4b32c ("             k=", k);
+  print_v4b32x ("             k=", k);
+#endif
+  rc += check_v4b32c ("vec_iszerof32 7:", k, e);
+
+  return (rc);
+}
+#define __DEBUG_PRINT__ 1
+#undef __DEBUG_PRINT__
+
+
+#define TIME_10_ITERATION 10
+
+int
+test_time_f32 (void)
+{
+  long i;
+  uint64_t t_start, t_end, t_delta;
+  double delta_sec;
+  int rc = 0;
+
+  printf ("\n%s is_f32 start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIME_10_ITERATION; i++)
+    {
+      rc += timed_is_f32 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s is_f32 end", __FUNCTION__);
+  printf ("\n%s is_f32  tb delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
+	  delta_sec);
+
+  printf ("\n%s fpclassify_f32 start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIME_10_ITERATION; i++)
+    {
+      rc += timed_fpclassify_f32 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s fpclassify_f32 end", __FUNCTION__);
+  printf ("\n%s fpclassify_f32  tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+	  t_delta, delta_sec);
+
+  return (rc);
+}
+
+int
+test_vec_f32 (void)
+{
+  int rc = 0;
+
+  printf ("\n%s\n", __FUNCTION__);
+
+  rc += test_float_abs ();
+  rc += test_float_all_is ();
+  rc += test_float_any_is ();
+  rc += test_float_cpsgn ();
+  rc += test_float_isinf ();
+  rc += test_float_isnan ();
+  rc += test_float_isnormal ();
+  rc += test_float_issubnormal ();
+  rc += test_float_iszero ();
+
+  rc += test_time_f32 ();
+
+  return (rc);
+}
+

--- a/src/testsuite/arith128_test_f32.h
+++ b/src/testsuite/arith128_test_f32.h
@@ -1,0 +1,29 @@
+/*
+ Copyright (c) [2018] IBM Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ arith128_test_f32.h
+
+ Contributors:
+      IBM Corporation, Steven Munroe
+      Created on: Jul 3, 2018
+ */
+
+#ifndef TESTSUITE_ARITH128_TEST_F32_H_
+#define TESTSUITE_ARITH128_TEST_F32_H_
+
+extern int
+test_vec_f32 (void);
+
+#endif /* TESTSUITE_ARITH128_TEST_F32_H_ */

--- a/src/testsuite/arith128_test_i128.c
+++ b/src/testsuite/arith128_test_i128.c
@@ -44,6 +44,7 @@
 #include <testsuite/arith128_print.h>
 
 #include <testsuite/arith128_test_i128.h>
+#include <testsuite/vec_perf_i128.h>
 
 extern const vui128_t vtipowof10 [];
 
@@ -1425,7 +1426,7 @@ test_mul10uq (void)
     }
 
   if (rc)
-    printf ("\ntest_4 Vector Multiply by 10 %d errors\n", rc);
+    printf ("\n%s Vector Multiply by 10 %d errors\n", __FUNCTION__, rc);
 
   return (rc);
 }
@@ -4277,6 +4278,60 @@ test_vslq (void)
   return (rc);
 }
 
+#define TIME_10_ITERATION 10
+
+int
+test_time_i128 (void)
+{
+  long i;
+  uint64_t t_start, t_end, t_delta;
+  double delta_sec;
+  int rc = 0;
+
+  printf ("\n%s mul10uq start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIME_10_ITERATION; i++)
+    {
+      rc += timed_mul10uq ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s mul10uq end", __FUNCTION__);
+  printf ("\n%s mul10uq  tb delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
+	  delta_sec);
+
+  printf ("\n%s mul10uq2x start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIME_10_ITERATION; i++)
+    {
+      rc += timed_mul10uq2x ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s mul10uq2x end", __FUNCTION__);
+  printf ("\n%s mul10uq2x  tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+	  t_delta, delta_sec);
+
+  printf ("\n%s mulluq start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIME_10_ITERATION; i++)
+    {
+      rc += timed_mulluq ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s mulluq end", __FUNCTION__);
+  printf ("\n%s mulluq  tb delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
+	  delta_sec);
+  return (rc);
+}
+
 int
 test_vec_i128 (void)
 {
@@ -4303,6 +4358,8 @@ test_vec_i128 (void)
   rc += test_muludq ();
 
   rc += test_msumudm ();
+
+  rc += test_time_i128();
 
   return (rc);
 }

--- a/src/testsuite/pveclib_test.c
+++ b/src/testsuite/pveclib_test.c
@@ -38,6 +38,7 @@
 #include <testsuite/arith128_test_i16.h>
 #include <testsuite/arith128_test_char.h>
 #include <testsuite/arith128_test_bcd.h>
+#include <testsuite/arith128_test_f32.h>
 
 int
 main (void)
@@ -59,6 +60,9 @@ main (void)
 #endif
 #if 1
   rc += test_vec_i128 ();
+#endif
+#if 1
+  rc += test_vec_f32 ();
 #endif
 
   if (rc > 0)

--- a/src/testsuite/vec_f32_dummy.c
+++ b/src/testsuite/vec_f32_dummy.c
@@ -1,10 +1,24 @@
 /*
-   vec_f32_dummy.c
-  
-    Created on: Jul 31, 2017
-        Author: sjmunroe
-  */
+ Copyright (c) [2017-18] IBM Corporation.
 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ vec_int32_dummy.c
+
+ Contributors:
+      IBM Corporation, Steven Munroe
+      Created on: Jul 31, 2017
+ */
 
 #include <stdint.h>
 #include <stdio.h>
@@ -13,8 +27,6 @@
 #include <math.h>
 
 //#define __DEBUG_PRINT__
-
-//#include "arith128.h"
 #include "vec_f32_ppc.h"
 
 vf32_t

--- a/src/testsuite/vec_f32_dummy.c
+++ b/src/testsuite/vec_f32_dummy.c
@@ -1,0 +1,269 @@
+/*
+   vec_f32_dummy.c
+  
+    Created on: Jul 31, 2017
+        Author: sjmunroe
+  */
+
+
+#include <stdint.h>
+#include <stdio.h>
+#include <fenv.h>
+#include <float.h>
+#include <math.h>
+
+//#define __DEBUG_PRINT__
+
+//#include "arith128.h"
+#include "vec_f32_ppc.h"
+
+vf32_t
+test_vec_f32_abs (vf32_t value)
+{
+  return (vec_absf32 (value));
+}
+
+vf32_t
+test_f32_zero_demorm (vf32_t value)
+{
+  vf32_t result = value;
+  vui32_t mask;
+  vf32_t fzero = {0.0, 0.0, 0.0, 0.0};
+
+  mask = (vui32_t)vec_issubnormalf32 (value);
+  if (vec_any_issubnormalf32 (value))
+    {
+      result = vec_sel (value, fzero, mask);
+    }
+
+  return result;
+}
+
+vui32_t
+test_fpclassify_f32 (vf32_t value)
+{
+  const vui32_t VFP_NAN =
+    { FP_NAN, FP_NAN, FP_NAN, FP_NAN };
+  const vui32_t VFP_INFINITE =
+    { FP_INFINITE, FP_INFINITE,
+    FP_INFINITE, FP_INFINITE };
+  const vui32_t VFP_ZERO =
+    { FP_ZERO, FP_ZERO, FP_ZERO, FP_ZERO };
+  const vui32_t VFP_SUBNORMAL =
+    { FP_SUBNORMAL, FP_SUBNORMAL,
+    FP_SUBNORMAL, FP_SUBNORMAL };
+  const vui32_t VFP_NORMAL =
+    { FP_NORMAL, FP_NORMAL, FP_NORMAL,
+    FP_NORMAL };
+  /* FP_NAN should be 0.  */
+  vui32_t result = VFP_NAN;
+  vui32_t mask;
+
+  mask = (vui32_t)vec_isinff32 (value);
+  result = vec_sel (result, VFP_INFINITE, mask);
+  mask = (vui32_t)vec_iszerof32 (value);
+  result = vec_sel (result, VFP_ZERO, mask);
+  mask = (vui32_t)vec_issubnormalf32 (value);
+  result = vec_sel (result, VFP_SUBNORMAL, mask);
+  mask = (vui32_t)vec_isnormalf32 (value);
+  result = vec_sel (result, VFP_NORMAL, mask);
+
+  return result;
+}
+
+int
+test512_any_f32_subnorm (vf32_t val0, vf32_t val1, vf32_t val2, vf32_t val3)
+{
+  const vb32_t alltrue = {-1,-1,-1,-1};
+  vb32_t sub0, sub1, sub2, sub3;
+
+  sub0 = vec_issubnormalf32(val0);
+  sub1 = vec_issubnormalf32(val1);
+  sub2 = vec_issubnormalf32(val2);
+  sub3 = vec_issubnormalf32(val3);
+
+  sub0 = vec_or (sub0, sub1);
+  sub2 = vec_or (sub2, sub3);
+  sub0 = vec_or (sub2, sub0);
+
+  return vec_any_eq (sub0, alltrue);
+}
+
+int
+test512_all_f32_nan (vf32_t val0, vf32_t val1, vf32_t val2, vf32_t val3)
+{
+  const vb32_t alltrue = { -1, -1, -1, -1 };
+  vb32_t nan0, nan1, nan2, nan3;
+
+  nan0 = vec_isnanf32 (val0);
+  nan1 = vec_isnanf32 (val1);
+  nan2 = vec_isnanf32 (val2);
+  nan3 = vec_isnanf32 (val3);
+
+  nan0 = vec_and (nan0, nan1);
+  nan2 = vec_and (nan2, nan3);
+  nan0 = vec_and (nan2, nan0);
+
+  return vec_all_eq(nan0, alltrue);
+}
+
+int
+test_all_f32_inf (vf32_t value)
+{
+  return (vec_all_isinff32 (value));
+}
+
+int
+test_any_f32_inf (vf32_t value)
+{
+	return (vec_any_isinff32 (value));
+}
+
+__vector bool int
+test_pred_f32_inf (vf32_t value)
+{
+	return (vec_isinff32 (value));
+}
+
+int
+test_all_f32_nan (vf32_t value)
+{
+	return (vec_all_isnanf32 (value));
+}
+
+int
+test_any_f32_nan (vf32_t value)
+{
+	return (vec_any_isnanf32 (value));
+}
+
+__vector bool int
+test_pred_f32_nan (vf32_t value)
+{
+	return (vec_isnanf32 (value));
+}
+
+int
+test_all_f32_norm (vf32_t value)
+{
+	return (vec_all_isnormalf32 (value));
+}
+
+int
+test_any_f32_norm (vf32_t value)
+{
+	return (vec_any_isnormalf32 (value));
+}
+
+__vector bool int
+test_pred_f32_normal (vf32_t value)
+{
+	return (vec_isnormalf32 (value));
+}
+
+int
+test_all_f32_subnorm (vf32_t value)
+{
+	return (vec_all_issubnormalf32 (value));
+}
+
+int
+test_any_f32_subnorm (vf32_t value)
+{
+	return (vec_any_issubnormalf32 (value));
+}
+
+__vector bool int
+test_pred_f32_subnormal (vf32_t value)
+{
+	return (vec_issubnormalf32 (value));
+}
+
+int
+test_all_f32_zero (vf32_t value)
+{
+	return (vec_all_iszerof32 (value));
+}
+
+int
+test_any_f32_zero (vf32_t value)
+{
+	return (vec_any_iszerof32 (value));
+}
+
+__vector bool int
+test_pred_f32_zero (vf32_t value)
+{
+	return (vec_iszerof32 (value));
+}
+/* Compiler generation tests.  */
+#ifdef vec_float
+vf32_t
+test_vec_float_int (vi32_t __A)
+  {
+    return vec_float (__A);
+  }
+
+vf32_t
+test_vec_float_uint (vui32_t __A)
+  {
+    return vec_float (__A);
+  }
+#endif
+#ifdef vec_float2
+vf32_t
+test_vec_float2_long (vi64_t __A, vi64_t __B)
+  {
+    return vec_float2 (__A, __B);
+  }
+
+vf32_t
+test_vec_float2_ulong (vui64_t __A, vui64_t __B)
+  {
+    return vec_float2 (__A, __B);
+  }
+
+vf32_t
+test_vec_float2_double (vf64_t __A, vf64_t __B)
+  {
+    return vec_float2 (__A, __B);
+  }
+#endif
+#ifdef vec_floate
+vf32_t
+test_vec_floate_long (vi64_t __A)
+  {
+    return vec_floate (__A);
+  }
+
+vf32_t
+test_vec_floate_ulong (vui64_t __A)
+  {
+    return vec_floate (__A);
+  }
+
+vf32_t
+test_vec_floate_double (vf64_t __A)
+  {
+    return vec_floate (__A);
+  }
+#endif
+#ifdef vec_floato
+vf32_t
+test_vec_floato_long (vi64_t __A)
+  {
+    return vec_floato (__A);
+  }
+
+vf32_t
+test_vec_floato_ulong (vui64_t __A)
+  {
+    return vec_floato (__A);
+  }
+
+vf32_t
+test_vec_floato_double (vf64_t __A)
+  {
+    return vec_floato (__A);
+  }
+#endif

--- a/src/testsuite/vec_f32_dummy.c
+++ b/src/testsuite/vec_f32_dummy.c
@@ -90,6 +90,15 @@ test512_any_f32_subnorm (vf32_t val0, vf32_t val1, vf32_t val2, vf32_t val3)
 }
 
 int
+test512_any_f32_subnorm2 (vf32_t val0, vf32_t val1, vf32_t val2, vf32_t val3)
+{
+  return vec_any_issubnormalf32 (val0)
+      || vec_any_issubnormalf32 (val1)
+      || vec_any_issubnormalf32 (val2)
+      || vec_any_issubnormalf32 (val3);
+}
+
+int
 test512_all_f32_nan (vf32_t val0, vf32_t val1, vf32_t val2, vf32_t val3)
 {
   const vb32_t alltrue = { -1, -1, -1, -1 };

--- a/src/testsuite/vec_int128_dummy.c
+++ b/src/testsuite/vec_int128_dummy.c
@@ -403,6 +403,14 @@ __test_mulluq (vui128_t a, vui128_t b)
   return (vec_mulluq (a, b));
 }
 
+vui128_t
+__test_mulhuq (vui128_t a, vui128_t b)
+{
+  vui128_t mq, r;
+  r = vec_muludq (&mq, a, b);
+  return mq;
+}
+
 #ifdef _ARCH_PWR8
 vui128_t
 test_vec_subq (vui128_t a, vui128_t b)

--- a/src/testsuite/vec_perf_f32.c
+++ b/src/testsuite/vec_perf_f32.c
@@ -41,8 +41,8 @@
 #include <testsuite/vec_perf_f32.h>
 
 #define N 10
-const vf32_t data0 = { __FLT_MAX__, __FLT_MIN__, __FLT_EPSILON__,
-	  __FLT_DENORM_MIN__ };
+static const vf32_t data0 =
+  { __FLT_MAX__, __FLT_MIN__, __FLT_EPSILON__, __FLT_DENORM_MIN__ };
 
 extern __vector bool int
 test_pred_f32_inf (vf32_t value);
@@ -60,7 +60,6 @@ test_fpclassify_f32 (vf32_t value);
 int timed_is_f32 (void)
 {
   vb32_t accum = {0,0,0,0};
-  vb32_t result;
   int i;
 
   for (i=0; i<N; i++)
@@ -77,7 +76,6 @@ int timed_is_f32 (void)
 int timed_fpclassify_f32 (void)
 {
   vb32_t accum = {0,0,0,0};
-  vb32_t result;
   int i;
 
   for (i=0; i<N; i++)

--- a/src/testsuite/vec_perf_f32.c
+++ b/src/testsuite/vec_perf_f32.c
@@ -1,0 +1,88 @@
+/*
+ * vec_perf_f32.c
+ *
+ *  Created on: Jul 4, 2018
+ *      Author: sjmunroe
+ */
+/*
+ Copyright (c) [2018] IBM Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ vec_perf_i128.c
+
+ Contributors:
+      IBM Corporation, Steven Munroe
+      Created on: Jun 21, 2018
+ */
+
+
+#include <stdint.h>
+#include <stdio.h>
+#include <fenv.h>
+#include <float.h>
+#include <math.h>
+
+//#define __DEBUG_PRINT__
+#include <vec_f32_ppc.h>
+
+//#include "arith128.h"
+#include <testsuite/arith128_print.h>
+#include <testsuite/vec_perf_f32.h>
+
+#define N 10
+const vf32_t data0 = { __FLT_MAX__, __FLT_MIN__, __FLT_EPSILON__,
+	  __FLT_DENORM_MIN__ };
+
+extern __vector bool int
+test_pred_f32_inf (vf32_t value);
+extern __vector bool int
+test_pred_f32_nan (vf32_t value);
+extern __vector bool int
+test_pred_f32_normal (vf32_t value);
+extern __vector bool int
+test_pred_f32_subnormal (vf32_t value);
+extern __vector bool int
+test_pred_f32_zero (vf32_t value);
+extern vui32_t
+test_fpclassify_f32 (vf32_t value);
+
+int timed_is_f32 (void)
+{
+  vb32_t accum = {0,0,0,0};
+  vb32_t result;
+  int i;
+
+  for (i=0; i<N; i++)
+    {
+      accum |= test_pred_f32_inf (data0);
+      accum |= test_pred_f32_nan (data0);
+      accum |= test_pred_f32_normal (data0);
+      accum |= test_pred_f32_subnormal (data0);
+      accum |= test_pred_f32_zero (data0);
+    }
+   return 0;
+}
+
+int timed_fpclassify_f32 (void)
+{
+  vb32_t accum = {0,0,0,0};
+  vb32_t result;
+  int i;
+
+  for (i=0; i<N; i++)
+    {
+      accum |= test_fpclassify_f32 (data0);
+    }
+   return 0;
+}

--- a/src/testsuite/vec_perf_f32.h
+++ b/src/testsuite/vec_perf_f32.h
@@ -1,0 +1,29 @@
+/*
+ Copyright (c) [2018] IBM Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ vec_perf_i128.h
+
+ Contributors:
+      IBM Corporation, Steven Munroe
+      Created on: Jul 4, 2018
+ */
+
+#ifndef TESTSUITE_VEC_PERF_F32_H_
+#define TESTSUITE_VEC_PERF_F32_H_
+
+extern int timed_is_f32 (void);
+extern int timed_fpclassify_f32 (void);
+
+#endif /* TESTSUITE_VEC_PERF_F32_H_ */

--- a/src/testsuite/vec_perf_i128.c
+++ b/src/testsuite/vec_perf_i128.c
@@ -1,0 +1,127 @@
+/*
+ Copyright (c) [2018] IBM Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ vec_perf_i128.c
+
+ Contributors:
+      IBM Corporation, Steven Munroe
+      Created on: Jun 21, 2018
+ */
+
+
+#include <stdint.h>
+#include <stdio.h>
+#include <fenv.h>
+#include <float.h>
+#include <math.h>
+
+//#define __DEBUG_PRINT__
+#include <vec_int128_ppc.h>
+
+//#include "arith128.h"
+#include <testsuite/arith128_print.h>
+#include <testsuite/vec_perf_i128.h>
+
+extern const vui128_t vtipowof10 [];
+static const vui32_t c_one = CONST_VINT32_W(0, 0, 0, 1);
+static const vui32_t c_two = CONST_VINT32_W(0, 0, 0, 2);
+static const vui32_t c_ten = CONST_VINT32_W(0, 0, 0, 10);
+
+
+int timed_mul10uq (void)
+{
+  vui128_t i, k;
+  int ii;
+  int rc = 0;
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("init i=1", (vui128_t)i);
+#endif
+
+  i = (vui128_t)c_one;
+  for (ii = 1; ii < 39; ii++)
+    {
+      k = vec_mul10uq ((vui128_t) i);
+
+#ifdef __DEBUG_PRINT__
+      rc += check_vuint128 ("vec_mul10uq:", k, vtipowof10[ii]);
+      print_vint128 ("x * 10 ", k);
+#endif
+      i = k;
+    }
+  rc += check_vuint128 ("vec_mul10uq:", k, vtipowof10[38]);
+
+  return rc;
+}
+
+int timed_mul10uq2x (void)
+{
+  vui128_t i, k;
+  vui128_t i2, k2, ks;
+  int ii;
+  int rc = 0;
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("init i=1", (vui128_t)i);
+#endif
+
+  i = (vui128_t)c_one;
+  i2 = (vui128_t)c_two;
+  for (ii = 1; ii < 39; ii++)
+    {
+      k = vec_mul10uq ((vui128_t) i);
+      k2 = vec_mul10uq ((vui128_t) i2);
+
+#ifdef __DEBUG_PRINT__
+      rc += check_vuint128 ("vec_mul10uq:", k, vtipowof10[ii]);
+      print_vint128 ("x * 10 ", k);
+#endif
+      i = k;
+      i2 = k2;
+    }
+  rc += check_vuint128 ("vec_mul10uq:", k, vtipowof10[38]);
+  ks = vec_adduqm (k,k);
+  rc += check_vuint128 ("vec_mul10uq2x:", k2, ks);
+
+  return rc;
+}
+
+int timed_mulluq (void)
+{
+  vui128_t i, k;
+  int ii;
+  int rc = 0;
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("init i=1", (vui128_t)i);
+#endif
+
+  i = (vui128_t)c_one;
+  for (ii = 1; ii < 39; ii++)
+    {
+      k = vec_mulluq ((vui128_t) i, (vui128_t) c_ten);
+
+#ifdef __DEBUG_PRINT__
+      rc += check_vuint128 ("vec_mul10uq:", k, vtipowof10[ii]);
+      print_vint128 ("x * 10 ", k);
+#endif
+      i = k;
+    }
+  rc += check_vuint128 ("vec_mulluq:", k, vtipowof10[38]);
+
+  return rc;
+}
+
+

--- a/src/testsuite/vec_perf_i128.h
+++ b/src/testsuite/vec_perf_i128.h
@@ -1,0 +1,30 @@
+/*
+ Copyright (c) [2018] IBM Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ vec_perf_i128.h
+
+ Contributors:
+      IBM Corporation, Steven Munroe
+      Created on: Jun 21, 2018
+ */
+
+#ifndef TESTSUITE_VEC_PERF_I128_H_
+#define TESTSUITE_VEC_PERF_I128_H_
+
+extern int timed_mul10uq (void);
+extern int timed_mul10uq2x (void);
+extern int timed_mulluq (void);
+
+#endif /* TESTSUITE_VEC_PERF_I128_H_ */

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -62,6 +62,14 @@ __test_muludq_PWR9 (vui128_t *mulh, vui128_t a, vui128_t b)
 }
 
 vui128_t
+__test_mulhuq_PWR9 (vui128_t a, vui128_t b)
+{
+  vui128_t mq, r;
+  r = vec_muludq (&mq, a, b);
+  return mq;
+}
+
+vui128_t
 __test_cmul10cuq_PWR9 (vui128_t *cout, vui128_t a)
 {
   return vec_cmul10cuq (cout, a);
@@ -138,6 +146,26 @@ vui32_t
 __test_revbw_PWR9 (vui32_t a)
 {
   return vec_revbw (a);
+}
+
+void
+test_muluq_4x1_PWR9 (vui128_t *__restrict__ mulu, vui128_t m10, vui128_t m11, vui128_t m12, vui128_t m13, vui128_t m2)
+{
+  vui128_t mq2, mq1, mq0, mq, mc;
+  vui128_t mpx0, mpx1, mpx2, mpx3;
+  mpx3 = vec_muludq (&mq2, m13, m2);
+  mpx2 = vec_muludq (&mq1, m12, m2);
+  mpx2 = vec_addcq (&mc, mpx2, mq2);
+  mpx1 = vec_muludq (&mq0, m11, m2);
+  mpx1 = vec_addeq (&mc, mpx1, mq1, mc);
+  mpx0 = vec_muludq (&mq, m10, m2);
+  mpx0 = vec_addeq (&mc, mpx0, mq0, mc);
+  mq   = vec_adduqm (mc, mq);
+
+  mulu[0] = mpx0;
+  mulu[1] = mpx1;
+  mulu[2] = mpx2;
+  mulu[3] = mpx3;
 }
 
 void

--- a/src/vec_common_ppc.h
+++ b/src/vec_common_ppc.h
@@ -60,6 +60,15 @@ typedef __vector float vf32_t;
 /*! \brief vector of 64-bit double elements. */
 typedef __vector double vf64_t;
 
+/*! \brief vector of 8-bit bool char elements. */
+typedef __vector __bool char vb8_t;
+/*! \brief vector of 16-bit bool short elements. */
+typedef __vector __bool short vb16_t;
+/*! \brief vector of 32-bit bool int elements. */
+typedef __vector __bool int vb32_t;
+/*! \brief vector of 64-bit bool long long elements. */
+typedef __vector __bool long long vb64_t;
+
 /* did not get vector __int128 until GCC4.8.  */
 #if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
 typedef __vector __int128 vi128_t;

--- a/src/vec_f128_ppc.h
+++ b/src/vec_f128_ppc.h
@@ -52,12 +52,12 @@ typedef union
        __f128_bool vbool1;
        __i128_bool vbool2;
        __binary128 vf1;
-     } VF_128;
+     } __VF_128;
 
 static inline vui16_t
 vec_xfer_bin128_2_vui16t (__binary128 f128)
 {
-	VF_128 vunion;
+	__VF_128 vunion;
 
 	vunion.vf1 = f128;
 
@@ -67,7 +67,7 @@ vec_xfer_bin128_2_vui16t (__binary128 f128)
 static inline vui32_t
 vec_xfer_bin128_2_vui32t (__binary128 f128)
 {
-	VF_128 vunion;
+	__VF_128 vunion;
 
 	vunion.vf1 = f128;
 
@@ -77,7 +77,7 @@ vec_xfer_bin128_2_vui32t (__binary128 f128)
 static inline vui64_t
 vec_xfer_bin128_2_vui64t (__binary128 f128)
 {
-	VF_128 vunion;
+	__VF_128 vunion;
 
 	vunion.vf1 = f128;
 
@@ -87,7 +87,7 @@ vec_xfer_bin128_2_vui64t (__binary128 f128)
 static inline __binary128
 vec_xfer_vui16t_2_bin128 (vui16_t f128)
 {
-	VF_128 vunion;
+	__VF_128 vunion;
 
 	vunion.vx8 = f128;
 
@@ -97,7 +97,7 @@ vec_xfer_vui16t_2_bin128 (vui16_t f128)
 static inline __binary128
 vec_xfer_vui32t_2_bin128 (vui32_t f128)
 {
-	VF_128 vunion;
+	__VF_128 vunion;
 
 	vunion.vx4 = f128;
 
@@ -107,7 +107,7 @@ vec_xfer_vui32t_2_bin128 (vui32_t f128)
 static inline __binary128
 vec_xfer_vui64t_2_bin128 (vui64_t f128)
 {
-	VF_128 vunion;
+	__VF_128 vunion;
 
 	vunion.vx2 = f128;
 

--- a/src/vec_f32_ppc.h
+++ b/src/vec_f32_ppc.h
@@ -19,43 +19,722 @@
       IBM Corporation, Steven Munroe
       Created on: Apr 13, 2016
  */
-/*
- * vec_f32_ppc.h
- *
- *  Created on: Apr 13, 2016
- *      Author: sjmunroe
- */
 
 #ifndef VEC_F32_PPC_H_
 #define VEC_F32_PPC_H_
 
-/* define vf32_t etc.  */
+#include <vec_common_ppc.h>
+/*!
+ * \file  vec_f32_ppc.h
+ * \brief Header package containing a collection of 128-bit SIMD
+ * operations over 32-bit floating point elements.
+ *
+ * Most vector float (32-bit float) operations are implemented
+ * with PowerISA VMX instructions either defined by the original VMX
+ * (AKA Altivec) or added to later versions of the PowerISA.
+ * POWER8 added the Vector Scalar Extended (VSX) with access to
+ * additional vector (64) registers and operations.
+ * Most of these intrinsic (compiler built-ins) operations are defined
+ * in <altivec.h> and described in the compiler documentation.
+ *
+ * \note The compiler disables associated <altivec.h> built-ins if the
+ * <B>mcpu</B> target does not enable the specific instruction.
+ * For example if you compile with <B>-mcpu=power7</B>, some of the
+ * wordwise pack, unpack and merge operations useful for conversions
+ * are not defined and the equivalent vec_perm and permute control
+ * must be used instead. This header will provide the appropriate
+ * substitutions, will generate the minimum code, appropriate for the
+ * target, and produce correct results.
+ *
+ * Most of these operations are implemented in a single instruction
+ * on newer (POWER8/POWER9) processors.
+ * This header serves to fill in functional gaps for older
+ * (POWER7, POWER8) processors and provides a in-line assembler
+ * implementation for older compilers that do not
+ * provide the build-ins.
+ *
+ * This header covers operations that are either:
+ *
+ * - Implemented in hardware instructions for later
+ * processors and useful to programmers, on slightly older processors,
+ * even if the equivalent function requires more instructions.
+ * Examples include the multiply even/odd/modulo word operations.
+ * - Defined in the OpenPOWER ABI but <I>not</I> yet defined in
+ * <altivec.n> provided by available compilers in common use.
+ * Examples include vector float even/odd.
+ * - Provide special vector float tests for special conditions
+ * without generating extraneous floating-point exceptions.
+ * This is important for implementing vectorized forms of ISO C99 Math
+ * functions.
+ * - Commonly used operations, not covered by the ABI or
+ * <altivec.h>, and require multiple instructions or
+ * are not obvious.
+ * See example above.
+ *
+ * \section f32_sub_0_0_1 Performance data.
+ * It is useful to provide basic performance data for each pveclib
+ * function.  This is challenging as these functions are small and
+ * intended to be in-lined within larger functions (algorithms).
+ * As such they are subject to both the compilers instruction
+ * scheduling and common subexpression optimizations plus the
+ * processors super-scalar and out-of-order execution design features.
+ *
+ * As pveclib functions are normally only a few
+ * instructions, the actual timing will depend on the context it
+ * is in (the instructions that is depends on for data and instructions
+ * that proceed them in the pipelines).
+ *
+ * The simplest approach is to use the same performance metrics as the
+ * Power Processor Users Manuals Performance Profile.
+ * This is normally per instruction latency in cycles and
+ * throughput in instructions issued per cycle. There may also be
+ * additional information for special conditions that may apply.
+ *
+ * For example the vector float absolute value function.
+ * For recent PowerISA implementations this a single
+ * (VSX <B>xvabssp</B>) instruction which we can look up in the
+ * POWER8 / POWER9 Processor User's Manuals (<B>UM</B>).
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 6-7   | 2/cycle  |
+ *  |power9   | 2     | 2/cycle  |
+ *
+ * The POWER8 UM specifies a latency of
+ * <I>"6 cycles to FPU (+1 cycle to other VSU ops"</I>
+ * for this class of VSX single precision FPU instructions.
+ * So the minimum latency is 6 cycles if the register result is input
+ * to another VSX single precision FPU instruction.
+ * Otherwise if the result is input to a VSU logical or integer
+ * instruction then the latency is 7 cycles.
+ * The POWER9 UM shows the pipeline improvement of 2 cycles latency
+ * for simple FPU instructions like this.
+ * Both processors support dual pipelines for a 2/cycle throughput
+ * capability.
+ *
+ * A more complicated example: \code
+static inline vb32_t
+vec_isnanf32 (vf32_t vf32)
+{
+  vui32_t tmp2;
+  const vui32_t expmask = CONST_VINT128_W(0x7f800000, 0x7f800000, 0x7f800000,
+					  0x7f800000);
+#if _ARCH_PWR9
+  // P9 has a 2 cycle xvabssp and eliminates a const load.
+  tmp2 = (vui32_t) vec_abs (vf32);
+#else
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0x80000000, 0x80000000,
+					   0x80000000);
+  tmp2 = vec_andc ((vui32_t)vf32, signmask);
+#endif
+  return vec_cmpgt (tmp2, expmask);
+}
+ * \endcode
+ * Here we want to test for <I>Not A Number</I> without triggering any
+ * of the associate floating-point exceptions (VXSNAN or VXVC).
+ * For this test the sign bit does not effect the result so we need to
+ * zero the sign bit before the actual test. The vector abs would work
+ * for this, but we know from the example above that this instruction
+ * has a high latency as we are definitely passing the result to a
+ * non-FPU instruction (vector compare greater than unsigned word).
+ *
+ * So the code needs to load two constant vectors masks, then vector
+ * and-compliment to clear the sign-bit, before comparing each word
+ * for greater then infinity. The generated code should look
+ * something like this: \code
+ 	addis   r9,r2,.rodata.cst16+0x10@ha
+ 	addis   r10,r2,.rodata.cst16+0x20@ha
+ 	addi    r9,r9,.rodata.cst16+0x10@l
+ 	addi    r10,r10,.rodata.cst16+0x20@l
+ 	lvx     v0,0,r10	# load vector const signmask
+ 	lvx     v12,0,r9	# load vector const expmask
+ 	xxlandc vs34,vs34,vs32
+ 	vcmpgtuw v2,v2,v12
+ * \endcode
+ * So six instructions to load the const masks and two instructions
+ * for the actual vec_isnanf32 function. The first six instructions
+ * are only needed once for each containing function, can be hoisted
+ * out of loops and into the function prologue, can be <I>commoned</I>
+ * with the same constant for other pveclib functions, or executed
+ * out-of-order and early by the processor.
+ *
+ * Most of the time, constant setup does not contribute measurably to
+ * the over all performance of vec_isnanf32. When it does it is
+ * limited by the longest (in cycles latency) of the various
+ * independent paths that load constants.  In this case the const load
+ * sequence is composed of three pairs of instructions that can issue
+ * and execute in parallel. The addis/addi FXU instructions supports
+ * throughput of 6/cycle and the lvx load supports 2/cycle.
+ * So the two vector constant load sequences can execute
+ * in parallel and the latency is same as a single const load.
+ *
+ * For POWER8 it appears to be (2+2+5=) 9 cycles latency for the const
+ * load. While the core vec_isnanf32 function (xxlandc/vcmpgtuw) is a
+ * dependent sequence and runs (2+2) 4 cycles latency.
+ * Similar analysis for POWER9 where the addis/addi/lvx sequence is
+ * still listed as (2+2+5) 9 cycles latency. While the xxlandc/vcmpgtuw
+ * sequence increases to (2+3) 5 cycles.
+ *
+ * The next interesting question is what can we say about throughput
+ * (if anything) for this example.  The thought experiment is "what
+ * would happen if?";
+ * - two or more instances of vec_isnanf32 are used within a single
+ * function,
+ * - in close proximity in the code,
+ * - with independent data as input,
+ *
+ * could the generated instructions execute in parallel and to what
+ * extent. This illustrated by the following (contrived) example:
+ * \code
+int
+test512_all_f32_nan (vf32_t val0, vf32_t val1, vf32_t val2, vf32_t val3)
+{
+  const vb32_t alltrue = { -1, -1, -1, -1 };
+  vb32_t nan0, nan1, nan2, nan3;
+
+  nan0 = vec_isnanf32 (val0);
+  nan1 = vec_isnanf32 (val1);
+  nan2 = vec_isnanf32 (val2);
+  nan3 = vec_isnanf32 (val3);
+
+  nan0 = vec_and (nan0, nan1);
+  nan2 = vec_and (nan2, nan3);
+  nan0 = vec_and (nan2, nan0);
+
+  return vec_all_eq(nan0, alltrue);
+}
+ * \endcode
+ * which tests 4 X vector float (16 X float) values and returns true
+ * if all 16 floats are NaN. Recent compilers will generates something
+ * like the following PowerISA code:
+ * \code
+     addis   r9,r2,-2
+     addis   r10,r2,-2
+     vspltisw v13,-1	# load vector const alltrue
+     addi    r9,r9,21184
+     addi    r10,r10,-13760
+     lvx     v0,0,r9	# load vector const signmask
+     lvx     v1,0,r10	# load vector const expmask
+     xxlandc vs35,vs35,vs32
+     xxlandc vs34,vs34,vs32
+     xxlandc vs37,vs37,vs32
+     xxlandc vs36,vs36,vs32
+     vcmpgtuw v3,v3,v1	# nan1 = vec_isnanf32 (val1);
+     vcmpgtuw v2,v2,v1	# nan0 = vec_isnanf32 (val0);
+     vcmpgtuw v5,v5,v1	# nan3 = vec_isnanf32 (val3);
+     vcmpgtuw v4,v4,v1	# nan2 = vec_isnanf32 (val2);
+     xxland  vs35,vs35,vs34	# nan0 = vec_and (nan0, nan1);
+     xxland  vs36,vs37,vs36	# nan2 = vec_and (nan2, nan3);
+     xxland  vs36,vs35,vs36	# nan0 = vec_and (nan2, nan0);
+     vcmpequw. v4,v4,v13	# vec_all_eq(nan0, alltrue);
+...
+ * \endcode
+ * first the generated code loading the vector constants for signmask,
+ * expmask, and alltrue. We see that the code is generated only once
+ * for each constant. Then the compiler generate the core vec_isnanf32
+ * function four times and interleaves the instructions. This enables
+ * parallel pipeline execution where conditions allow. Finally the 16X
+ * isnan results are reduced to 8X, then 4X, then to a single
+ * condition code.
+ *
+ * For this exercise we will ignore the constant load as in any
+ * realistic usage it will be <I>commoned</I> across several pveclib
+ * functions and hoisted out of any loops. The reduction code is not
+ * part of the vec_isnanf32 implementation and also ignored.
+ * The sequence of 4X xxlandc and 4X vcmpgtuw in the middle it the
+ * interesting part.
+ *
+ * For POWER8 both xxlandc and vcmpgtuw are listed as 2 cycles
+ * latency and throughput of 2 per cycle. So we can assume that (only)
+ * the first two xxlandc will issue in the same cycle (assuming the
+ * input vectors are ready).  The issue of the next two xxlandc
+ * instructions will be delay by 1 cycle. The following vcmpgtuw
+ * instruction are dependent on the xxlandc results and will not
+ * execute until their input vectors are ready. The first two vcmpgtuw
+ * instruction will execute 2 cycles (latency) after the first two
+ * xxlandc instructions execute. Execution of the second two vcmpgtuw
+ * instructions will be delayed 1 cycle due to the issue delay in the
+ * second pair of xxlandc instructions.
+ *
+ * So at least for this example and this set of simplifying assumptions
+ * we suggest that the throughput metric for vec_isnanf32 is 2/cycle.
+ * For latency metric we offer the range with the latency for the core
+ * function (without and constant load overhead) first. Followed by the
+ * total latency (the sum of the constant load and core function
+ * latency). For the vec_isnanf32 example the metrics are:
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 4-13  | 2/cycle  |
+ *  |power9   | 5-14  | 2/cycle  |
+ *
+ */
+
 #include <vec_common_ppc.h>
 
+/*! \brief typedef __vbinary32 to vector of float elements. */
 typedef vf32_t __vbinary32;
 
-typedef __vector __bool int __f32_bool;
-
-/** \brief Copy the sign bit from vf32y merged with magnitude from
- * vf32x and return the resulting vector float values.
+/** \brief Vector float absolute value.
  *
- *	@param vf32x vector float values containing the magnitudes.
- *	@param vf32y vector float values containing the sign bits.
- *	@return vector float values with magnitude from vf32x and the
- *	sign of vf32y.
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 6-7   | 2/cycle  |
+ *  |power9   | 2     | 2/cycle  |
+ *
+ *  @param vf32x vector float values containing the magnitudes.
+ *  @return vector float absolute values of vf32x.
  */
 static inline vf32_t
-vec_copysignf32 (vf32_t vf32x , vf32_t vf32y)
+vec_absf32 (vf32_t vf32x)
 {
 #if _ARCH_PWR7
-	return (vec_cpsgn (vf32x, vf32y));
+  /* Requires VSX but eliminates a const load. */
+  return vec_abs (vf32x);
 #else
-	const vui32_t signmask  = CONST_VINT128_W(0x80000000, 0x80000000,
-											0x80000000, 0x80000000);
-	vf32_t result;
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0x80000000,
+      0x80000000, 0x80000000);
+  return (vf32_t)vec_andc ((vui32_t)vf32x, signmask);
+#endif
+}
 
-	result  = (vf32_t)vec_sel ((vui32_t)vf32x, (vui32_t)vf32y, signmask);
-	return (result);
+/** \brief Return true if all 4x32-bit vector float values
+ *  are infinity.
+ *
+ *  A IEEE Binary32 infinity has a exponent of 0x7f8 and significand
+ *  of all zeros.
+ *
+ *  \note This function will not raise VXSNAN or VXVC (FE_INVALID)
+ *  exceptions. A normal float compare can.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 4-15  | 2/cycle  |
+ *  |power9   | 6     | 2/cycle  |
+ *
+ *  @param vf32 a vector of __binary32 values.
+ *  @return boolean int, true if all 4 float values are infinity
+ */
+static inline int
+vec_all_isinff32 (vf32_t vf32)
+{
+  vui32_t tmp;
+  const vui32_t expmask = CONST_VINT128_W(0x7f800000, 0x7f800000, 0x7f800000,
+					  0x7f800000);
+  int result;
+
+#if _ARCH_PWR9
+  /* P9 has a 2 cycle xvabssp and eliminates a const load. */
+  tmp = (vui32_t) vec_abs (vf32);
+#else
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0x80000000, 0x80000000,
+					   0x80000000);
+  tmp = vec_andc ((vui32_t)vf32, signmask);
+#endif
+  result = vec_all_eq(tmp, expmask);
+
+  return (result);
+}
+
+/** \brief Return true if all of 4x32-bit vector float
+ *  values are NaN.
+ *
+ *  A IEEE Binary32 NaN value has an exponent between 0x7f8 and
+ *  the significand is nonzero.
+ *  The sign bit is ignored.
+ *
+ *  \note This function will not raise VXSNAN or VXVC (FE_INVALID)
+ *  exceptions. A normal float compare can.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 4-15  | 2/cycle  |
+ *  |power9   | 6     | 2/cycle  |
+ *
+ *  @param vf32 a vector of __binary32 values.
+ *  @return a boolean int, true if all of 4 vector float values are
+ *  NaN.
+ */
+static inline int
+vec_all_isnanf32 (vf32_t vf32)
+{
+  vui32_t tmp2;
+  const vui32_t expmask = CONST_VINT128_W(0x7f800000, 0x7f800000, 0x7f800000,
+					  0x7f800000);
+  int result;
+
+#if _ARCH_PWR9
+  /* P9 has a 2 cycle xvabssp and eliminates a const load. */
+  tmp2 = (vui32_t) vec_abs (vf32);
+#else
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0x80000000, 0x80000000,
+					   0x80000000);
+  tmp2 = vec_andc ((vui32_t)vf32, signmask);
+#endif
+  result = vec_all_gt(tmp2, expmask);
+
+  return (result);
+}
+
+/** \brief Return true if all of 4x32-bit vector float
+ *  values are normal (Not NaN, Inf, denormal, or zero).
+ *
+ *  A IEEE Binary32 normal value has an exponent between 0x008 and
+ *  0x7f (a 0x7f8 indicates NaN or Inf).  The significand can be
+ *  any value (expect 0 if the exponent is zero).
+ *  The sign bit is ignored.
+ *
+ *  \note This function will not raise VXSNAN or VXVC (FE_INVALID)
+ *  exceptions. A normal float compare can.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 11-18 | 1/cycle  |
+ *  |power9   | 14    | 1/cycle  |
+ *
+ *  @param vf32 a vector of __binary32 values.
+ *  @return a boolean int, true if all of 4 vector float values are
+ *  normal.
+ */
+static inline int
+vec_all_isnormalf32 (vf32_t vf32)
+{
+  vui32_t tmp, tmp2;
+  const vui32_t expmask = CONST_VINT128_W(0x7f800000, 0x7f800000, 0x7f800000,
+					  0x7f800000);
+  const vui32_t minnorm = CONST_VINT128_W(0x00800000, 0x00800000, 0x00800000,
+					  0x00800000);
+  const vui32_t vec_zero = CONST_VINT128_W(0, 0, 0, 0);
+  vb32_t vnorm;
+  int result;
+
+#if _ARCH_PWR9
+  /* P9 has a 2 cycle xvabssp and eliminates a const load. */
+  tmp2 = (vui32_t) vec_abs (vf32);
+#else
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0x80000000, 0x80000000, 0x80000000);
+  tmp2 = vec_andc ((vui32_t)vf32, signmask);
+#endif
+  tmp = vec_and ((vui32_t) vf32, expmask);
+  tmp2 = (vui32_t) vec_cmplt(tmp2, minnorm);
+  tmp = (vui32_t) vec_cmpeq (tmp, expmask);
+  vnorm = (vb32_t ) vec_nor (tmp, tmp2);
+
+  result = vec_all_gt(vnorm, vec_zero);
+
+  return (result);
+}
+
+/** \brief Return true if all of 4x32-bit vector float
+ *  values is subnormal (denormal).
+ *
+ *  A IEEE Binary32 subnormal has an exponent of 0x000 and a
+ *  nonzero significand.
+ *  The sign bit is ignored.
+ *
+ *  \note This function will not raise VXSNAN or VXVC (FE_INVALID)
+ *  exceptions. A normal float compare can.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 10-18 | 1/cycle  |
+ *  |power9   | 14    | 1/cycle  |
+ *
+ *  @param vf32 a vector of __binary32 values.
+ *  @return a boolean int, true if all of 4 vector float values are
+ *  subnormal.
+ */
+static inline int
+vec_all_issubnormalf32 (vf32_t vf32)
+{
+  vui32_t tmp, tmpz, tmp2;
+  const vui32_t explow = CONST_VINT128_W(0x00800000, 0x00800000, 0x00800000,
+					 0x00800000);
+  const vui32_t vec_zero = CONST_VINT128_W(0, 0, 0, 0);
+  vb32_t vsubnorm;
+  int result;
+
+#if _ARCH_PWR9
+  /* P9 has a 2 cycle xvabssp and eliminates a const load. */
+  tmp2 = (vui32_t) vec_abs (vf32);
+#else
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0x80000000, 0x80000000,
+					   0x80000000);
+  tmp2 = vec_andc ((vui32_t)vf32, signmask);
+#endif
+  tmp = (vui32_t) vec_cmplt(tmp2, explow);
+  tmpz = (vui32_t) vec_cmpeq (tmp2, vec_zero);
+  vsubnorm = (vb32_t ) vec_andc (tmp, tmpz);
+  result = vec_all_ne(vsubnorm, vec_zero);
+
+  return (result);
+}
+
+/** \brief Return true if all of 4x32-bit vector float
+ *  values are +-0.0.
+ *
+ *  A IEEE Binary32 zero has an exponent of 0x000 and a
+ *  zero significand.
+ *  The sign bit is ignored.
+ *
+ *  \note This function will not raise VXSNAN or VXVC (FE_INVALID)
+ *  exceptions. A normal float compare can.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 6-12  | 2/cycle  |
+ *  |power9   | 5     | 2/cycle  |
+ *
+ *  @param vf32 a vector of __binary32 values.
+ *  @return a boolean int, true if all of 4 vector float values are
+ *  +/- zero.
+ */
+static inline int
+vec_all_iszerof32 (vf32_t vf32)
+{
+  vui32_t tmp2;
+  const vui32_t vec_zero = CONST_VINT128_W(0, 0, 0, 0);
+  int result;
+
+#if _ARCH_PWR9
+  /* P9 has a 2 cycle xvabssp and eliminates a const load. */
+  tmp2 = (vui32_t) vec_abs (vf32);
+#else
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0x80000000, 0x80000000,
+					   0x80000000);
+  tmp2 = vec_andc ((vui32_t)vf32, signmask);
+#endif
+  result = vec_all_eq(tmp2, vec_zero);
+
+  return (result);
+}
+
+/** \brief Return true if any 4x32-bit vector float values
+ *  are infinity.
+ *
+ *  A IEEE Binary32 infinity has a exponent of 0x7f8 and significand
+ *  of all zeros.
+ *
+ *  \note This function will not raise VXSNAN or VXVC (FE_INVALID)
+ *  exceptions. A normal float compare can.
+ *
+ *  @param vf32 a vector of __binary32 values.
+ *  @return boolean int, true if any of 4 float values are infinity
+ */
+
+static inline int
+vec_any_isinff32 (vf32_t vf32)
+{
+  vui32_t tmp;
+  const vui32_t expmask = CONST_VINT128_W(0x7f800000, 0x7f800000, 0x7f800000,
+					  0x7f800000);
+  int result;
+
+#if _ARCH_PWR9
+  /* P9 has a 2 cycle xvabssp and eliminates a const load. */
+  tmp = (vui32_t) vec_abs (vf32);
+#else
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0x80000000, 0x80000000,
+					   0x80000000);
+  tmp = vec_andc ((vui32_t)vf32, signmask);
+#endif
+  result = vec_any_eq(tmp, expmask);
+
+  return (result);
+}
+
+/** \brief Return true if any of 4x32-bit vector float
+ *  values are NaN.
+ *
+ *  A IEEE Binary32 NaN value has an exponent between 0x7f8 and
+ *  the significand is nonzero.
+ *  The sign bit is ignored.
+ *
+ *  \note This function will not raise VXSNAN or VXVC (FE_INVALID)
+ *  exceptions. A normal float compare can.
+ *
+ *  @param vf32 a vector of __binary32 values.
+ *  @return a boolean int, true if aany of 4 vector float values are
+ *  NaN.
+ */
+static inline int
+vec_any_isnanf32 (vf32_t vf32)
+{
+  vui32_t tmp2;
+  const vui32_t expmask = CONST_VINT128_W(0x7f800000, 0x7f800000, 0x7f800000,
+					  0x7f800000);
+  int result;
+
+#if _ARCH_PWR9
+  /* P9 has a 2 cycle xvabssp and eliminates a const load. */
+  tmp2 = (vui32_t) vec_abs (vf32);
+#else
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0x80000000, 0x80000000,
+					   0x80000000);
+  tmp2 = vec_andc ((vui32_t)vf32, signmask);
+#endif
+  result = vec_any_gt(tmp2, expmask);
+
+  return (result);
+}
+
+/** \brief Return true if any of 4x32-bit vector float
+ *  values are normal (Not NaN, Inf, denormal, or zero).
+ *
+ *  A IEEE Binary32 normal value has an exponent between 0x008 and
+ *  0x7f (a 0x7f8 indicates NaN or Inf).  The significand can be
+ *  any value (expect 0 if the exponent is zero).
+ *  The sign bit is ignored.
+ *
+ *  \note This function will not raise VXSNAN or VXVC (FE_INVALID)
+ *  exceptions. A normal float compare can.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 11-18 | 1/cycle  |
+ *  |power9   | 14    | 1/cycle  |
+ *
+ *  @param vf32 a vector of __binary32 values.
+ *  @return a boolean int, true if any of 4 vector float values are
+ *  normal.
+ */
+static inline int
+vec_any_isnormalf32 (vf32_t vf32)
+{
+  vui32_t tmp, tmp2;
+  const vui32_t expmask = CONST_VINT128_W(0x7f800000, 0x7f800000, 0x7f800000,
+					  0x7f800000);
+  const vui32_t minnorm = CONST_VINT128_W(0x00800000, 0x00800000, 0x00800000,
+					  0x00800000);
+  const vui32_t vec_zero = CONST_VINT128_W(0, 0, 0, 0);
+  vb32_t vnorm;
+  int result;
+
+#if _ARCH_PWR9
+  /* P9 has a 2 cycle xvabssp and eliminates a const load. */
+  tmp2 = (vui32_t) vec_abs (vf32);
+#else
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0x80000000, 0x80000000, 0x80000000);
+  tmp2 = vec_andc ((vui32_t)vf32, signmask);
+#endif
+  tmp = vec_and ((vui32_t) vf32, expmask);
+  tmp2 = (vui32_t) vec_cmplt(tmp2, minnorm);
+  tmp = (vui32_t) vec_cmpeq (tmp, expmask);
+  vnorm = (vb32_t ) vec_nor (tmp, tmp2);
+
+  result = vec_any_gt(vnorm, vec_zero);
+
+  return (result);
+}
+
+/** \brief Return true if any of 4x32-bit vector float
+ *  values is subnormal (denormal).
+ *
+ *  A IEEE Binary32 subnormal has an exponent of 0x000 and a
+ *  nonzero significand.
+ *  The sign bit is ignored.
+ *
+ *  \note This function will not raise VXSNAN or VXVC (FE_INVALID)
+ *  exceptions. A normal float compare can.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 10-18 | 1/cycle  |
+ *  |power9   | 14    | 1/cycle  |
+ *
+ *  @param vf32 a vector of __binary32 values.
+ *  @return if any of 4 vector float values are subnormal.
+ */
+static inline int
+vec_any_issubnormalf32 (vf32_t vf32)
+{
+  vui32_t tmp, tmpz, tmp2;
+  const vui32_t explow = CONST_VINT128_W(0x00800000, 0x00800000, 0x00800000,
+					 0x00800000);
+  const vui32_t vec_zero = CONST_VINT128_W(0, 0, 0, 0);
+  vb32_t vsubnorm;
+  int result;
+
+#if _ARCH_PWR9
+  /* P9 has a 2 cycle xvabssp and eliminates a const load. */
+  tmp2 = (vui32_t) vec_abs (vf32);
+#else
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0x80000000, 0x80000000,
+					   0x80000000);
+  tmp2 = vec_andc ((vui32_t)vf32, signmask);
+#endif
+  tmp = (vui32_t) vec_cmplt(tmp2, explow);
+  tmpz = (vui32_t) vec_cmpeq (tmp2, vec_zero);
+  vsubnorm = (vb32_t ) vec_andc (tmp, tmpz);
+  result = vec_any_ne(vsubnorm, vec_zero);
+
+  return (result);
+}
+
+/** \brief Return true if any of 4x32-bit vector float
+ *  values are +-0.0.
+ *
+ *  A IEEE Binary32 zero has an exponent of 0x000 and a
+ *  zero significand.
+ *  The sign bit is ignored.
+ *
+ *  \note This function will not raise VXSNAN or VXVC (FE_INVALID)
+ *  exceptions. A normal float compare can.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 6-12  | 2/cycle  |
+ *  |power9   | 5     | 2/cycle  |
+ *
+ *  @param vf32 a vector of __binary32 values.
+ *  @return a boolean int, true if aany of 4 vector float values are
+ *  +/- zero.
+ */
+static inline int
+vec_any_iszerof32 (vf32_t vf32)
+{
+  vui32_t tmp2;
+  const vui32_t vec_zero = CONST_VINT128_W(0, 0, 0, 0);
+  int result;
+
+#if _ARCH_PWR9
+  /* P9 has a 2 cycle xvabssp and eliminates a const load. */
+  tmp2 = (vui32_t) vec_abs (vf32);
+#else
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0x80000000, 0x80000000,
+					   0x80000000);
+  tmp2 = vec_andc ((vui32_t)vf32, signmask);
+#endif
+  result = vec_any_eq(tmp2, vec_zero);
+
+  return (result);
+}
+
+/** \brief Copy the sign bit from vf32y merged with magnitude from
+ *  vf32x and return the resulting vector float values.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 6-7   | 2/cycle  |
+ *  |power9   | 2     | 2/cycle  |
+ *
+ *  @param vf32x vector float values containing the magnitudes.
+ *  @param vf32y vector float values containing the sign bits.
+ *  @return vector float values with magnitude from vf32x and the
+ *  sign of vf32y.
+ */
+static inline vf32_t
+vec_copysignf32 (vf32_t vf32x, vf32_t vf32y)
+{
+#if _ARCH_PWR7
+  return (vec_cpsgn (vf32x, vf32y));
+#else
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0x80000000,
+      0x80000000, 0x80000000);
+  vf32_t result;
+
+  result = (vf32_t)vec_sel ((vui32_t)vf32x, (vui32_t)vf32y, signmask);
+  return (result);
 #endif
 }
 
@@ -65,26 +744,74 @@ vec_copysignf32 (vf32_t vf32x , vf32_t vf32y)
  *  A IEEE Binary32 infinity has a exponent of 0x7f8 and significand
  *  of all zeros.
  *
- *	@param vf32 a vector of __binary32 values.
- *	@return a vector boolean int, each containing all 0s or 1s.
+ *  \note This function will not raise VXSNAN or VXVC (FE_INVALID)
+ *  exceptions. A normal float compare can.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 4-15  | 2/cycle  |
+ *  |power9   | 6     | 2/cycle  |
+ *
+ *  @param vf32 a vector of __binary32 values.
+ *  @return a vector boolean int, each containing all 0s(false)
+ *  or 1s(true).
  */
-static inline __f32_bool
+static inline vb32_t
 vec_isinff32 (vf32_t vf32)
 {
-	vui32_t tmp;
-	const vui32_t expmask  = CONST_VINT128_W(0x7f800000, 0x7f800000, 0x7f800000, 0x7f800000);
-	__f32_bool result;
+  vui32_t tmp;
+  const vui32_t expmask = CONST_VINT128_W(0x7f800000, 0x7f800000, 0x7f800000,
+					  0x7f800000);
+  vb32_t result;
 
-#if _ARCH_PWR7
-	/* Eliminate const load. */
-	tmp = (vui32_t)vec_abs (vf32);
+#if _ARCH_PWR9
+  /* P9 has a 2 cycle xvabssp and eliminates a const load. */
+  tmp = (vui32_t) vec_abs (vf32);
 #else
-	const vui32_t signmask = CONST_VINT128_W(0x80000000, 0x80000000, 0x80000000, 0x80000000);
-	tmp = vec_andc ((vui32_t)vf32, signmask);
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0x80000000, 0x80000000,
+					   0x80000000);
+  tmp = vec_andc ((vui32_t)vf32, signmask);
 #endif
-	result = vec_cmpeq (tmp, expmask);
+  result = vec_cmpeq (tmp, expmask);
 
-	return (result);
+  return (result);
+}
+
+/** \brief Return 4x32-bit vector boolean true values, for each float
+ *  NaN value.
+ *
+ *  A IEEE Binary32 NaN value has an exponent between 0x7f8 and
+ *  the significand is nonzero.
+ *  The sign bit is ignored.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 4-13  | 2/cycle  |
+ *  |power9   | 5-14  | 2/cycle  |
+ *
+ *  @param vf32 a vector of __binary32 values.
+ *  @return a vector boolean int, each containing all 0s(false)
+ *  or 1s(true).
+ */
+static inline vb32_t
+vec_isnanf32 (vf32_t vf32)
+{
+  vui32_t tmp2;
+  const vui32_t expmask = CONST_VINT128_W(0x7f800000, 0x7f800000, 0x7f800000,
+					  0x7f800000);
+  vb32_t result;
+
+#if _ARCH_PWR9
+  /* P9 has a 2 cycle xvabssp and eliminates a const load. */
+  tmp2 = (vui32_t) vec_abs (vf32);
+#else
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0x80000000, 0x80000000,
+					   0x80000000);
+  tmp2 = vec_andc ((vui32_t)vf32, signmask);
+#endif
+  result = vec_cmpgt (tmp2, expmask);
+
+  return (result);
 }
 
 /** \brief Return 4x32-bit vector boolean true values, for each float
@@ -95,30 +822,123 @@ vec_isinff32 (vf32_t vf32)
  *  any value (expect 0 if the exponent is zero).
  *  The sign bit is ignored.
  *
- *	@param vf32 a vector of __binary32 values.
- *	@return a vector boolean int, each containing all 0s or 1s..
+ *  \note This function will not raise VXSNAN or VXVC (FE_INVALID)
+ *  exceptions. A normal float compare can.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 9-16  | 1/cycle  |
+ *  |power9   | 14    | 1/cycle  |
+ *
+ *  @param vf32 a vector of __binary32 values.
+ *  @return a vector boolean int, each containing all 0s(false)
+ *  or 1s(true).
  */
-static inline __f32_bool
+static inline vb32_t
 vec_isnormalf32 (vf32_t vf32)
 {
-	vui32_t tmp, tmp2;
-	const vui32_t expmask  = CONST_VINT128_W(0x7f800000, 0x7f800000, 0x7f800000, 0x7f800000);
-	const vui32_t vec_zero = CONST_VINT128_W(0, 0, 0, 0);
-	__f32_bool result;
+  vui32_t tmp, tmp2;
+  const vui32_t expmask = CONST_VINT128_W(0x7f800000, 0x7f800000, 0x7f800000,
+					  0x7f800000);
+  const vui32_t minnorm = CONST_VINT128_W(0x00800000, 0x00800000, 0x00800000,
+					  0x00800000);
+  vb32_t result;
 
-#if _ARCH_PWR7
-	/* Eliminate const load. */
-	tmp2 = (vui32_t)vec_abs (vf32);
+#if _ARCH_PWR9
+  /* P9 has a 2 cycle xvabssp and eliminates a const load. */
+  tmp2 = (vui32_t) vec_abs (vf32);
 #else
-	const vui32_t signmask = CONST_VINT128_W(0x80000000, 0x80000000, 0x80000000, 0x80000000);
-	tmp2 = vec_andc ((vui32_t)vf32, signmask);
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0x80000000, 0x80000000, 0x80000000);
+  tmp2 = vec_andc ((vui32_t)vf32, signmask);
 #endif
-	tmp = vec_and ((vui32_t)vf32, expmask);
-	tmp2 = (vui32_t)vec_cmpeq(tmp2, vec_zero);
-	tmp = (vui32_t)vec_cmpeq(tmp, expmask);
-	result = (__f32_bool)vec_nor (tmp, tmp2);
+  tmp = vec_and ((vui32_t) vf32, expmask);
+  tmp2 = (vui32_t) vec_cmplt (tmp2, minnorm);
+  tmp = (vui32_t) vec_cmpeq (tmp, expmask);
+  result = (vb32_t ) vec_nor (tmp, tmp2);
 
-	return (result);
+  return (result);
+}
+
+/** \brief Return 4x32-bit vector boolean true values, for each float
+ *  value that is subnormal (denormal).
+ *
+ *  A IEEE Binary32 subnormal has an exponent of 0x000 and a
+ *  nonzero significand.
+ *  The sign bit is ignored.
+ *
+ *  \note This function will not raise VXSNAN or VXVC (FE_INVALID)
+ *  exceptions. A normal float compare can.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 8-16  | 2/cycle  |
+ *  |power9   | 14    | 2/cycle  |
+ *
+ *  @param vf32 a vector of __binary32 values.
+ *  @return a vector boolean int, each containing all 0s(false)
+ *  or 1s(true).
+ */
+static inline vb32_t
+vec_issubnormalf32 (vf32_t vf32)
+{
+  vui32_t tmp, tmpz, tmp2;
+  const vui32_t explow = CONST_VINT128_W(0x00800000, 0x00800000, 0x00800000,
+					 0x00800000);
+  const vui32_t vec_zero = CONST_VINT128_W(0, 0, 0, 0);
+  vb32_t result;
+
+#if _ARCH_PWR9
+  /* P9 has a 2 cycle xvabssp and eliminates a const load. */
+  tmp2 = (vui32_t) vec_abs (vf32);
+#else
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0x80000000, 0x80000000,
+					   0x80000000);
+  tmp2 = vec_andc ((vui32_t)vf32, signmask);
+#endif
+  tmp = (vui32_t) vec_cmplt(tmp2, explow);
+  tmpz = (vui32_t) vec_cmpeq (tmp2, vec_zero);
+  result = (vb32_t ) vec_andc (tmp, tmpz);
+
+  return (result);
+}
+
+/** \brief Return 4x32-bit vector boolean true values, for each float
+ *  value that is +-0.0.
+ *
+ *  A IEEE Binary32 zero has an exponent of 0x000 and a
+ *  zero significand.
+ *  The sign bit is ignored.
+ *
+ *  \note This function will not raise VXSNAN or VXVC (FE_INVALID)
+ *  exceptions. A normal float compare can.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 6-12  | 2/cycle  |
+ *  |power9   | 5     | 2/cycle  |
+ *
+ *  @param vf32 a vector of __binary32 values.
+ *  @return a vector boolean int, each containing all 0s(false)
+ *  or 1s(true).
+ */
+static inline vb32_t
+vec_iszerof32 (vf32_t vf32)
+{
+  vui32_t tmp2;
+  const vui32_t vec_zero = CONST_VINT128_W(0, 0, 0, 0);
+  vb32_t result;
+
+#if _ARCH_PWR9
+  /* P9 has a 2 cycle xvabssp and eliminates a const load. */
+  tmp2 = (vui32_t) vec_abs (vf32);
+#else
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0x80000000, 0x80000000,
+					   0x80000000);
+  tmp2 = vec_andc ((vui32_t)vf32, signmask);
+#endif
+  result = vec_cmpeq (tmp2, vec_zero);
+
+  return (result);
 }
 
 #endif /* VEC_F32_PPC_H_ */

--- a/src/vec_f32_ppc.h
+++ b/src/vec_f32_ppc.h
@@ -71,203 +71,11 @@
  * are not obvious.
  * See example above.
  *
- * \section f32_sub_0_0_1 Performance data.
- * It is useful to provide basic performance data for each pveclib
- * function.  This is challenging as these functions are small and
- * intended to be in-lined within larger functions (algorithms).
- * As such they are subject to both the compilers instruction
- * scheduling and common subexpression optimizations plus the
- * processors super-scalar and out-of-order execution design features.
- *
- * As pveclib functions are normally only a few
- * instructions, the actual timing will depend on the context it
- * is in (the instructions that is depends on for data and instructions
- * that proceed them in the pipelines).
- *
- * The simplest approach is to use the same performance metrics as the
- * Power Processor Users Manuals Performance Profile.
- * This is normally per instruction latency in cycles and
- * throughput in instructions issued per cycle. There may also be
- * additional information for special conditions that may apply.
- *
- * For example the vector float absolute value function.
- * For recent PowerISA implementations this a single
- * (VSX <B>xvabssp</B>) instruction which we can look up in the
- * POWER8 / POWER9 Processor User's Manuals (<B>UM</B>).
- *
- *  |processor|Latency|Throughput|
- *  |--------:|:-----:|:---------|
- *  |power8   | 6-7   | 2/cycle  |
- *  |power9   | 2     | 2/cycle  |
- *
- * The POWER8 UM specifies a latency of
- * <I>"6 cycles to FPU (+1 cycle to other VSU ops"</I>
- * for this class of VSX single precision FPU instructions.
- * So the minimum latency is 6 cycles if the register result is input
- * to another VSX single precision FPU instruction.
- * Otherwise if the result is input to a VSU logical or integer
- * instruction then the latency is 7 cycles.
- * The POWER9 UM shows the pipeline improvement of 2 cycles latency
- * for simple FPU instructions like this.
- * Both processors support dual pipelines for a 2/cycle throughput
- * capability.
- *
- * A more complicated example: \code
-static inline vb32_t
-vec_isnanf32 (vf32_t vf32)
-{
-  vui32_t tmp2;
-  const vui32_t expmask = CONST_VINT128_W(0x7f800000, 0x7f800000, 0x7f800000,
-					  0x7f800000);
-#if _ARCH_PWR9
-  // P9 has a 2 cycle xvabssp and eliminates a const load.
-  tmp2 = (vui32_t) vec_abs (vf32);
-#else
-  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0x80000000, 0x80000000,
-					   0x80000000);
-  tmp2 = vec_andc ((vui32_t)vf32, signmask);
-#endif
-  return vec_cmpgt (tmp2, expmask);
-}
- * \endcode
- * Here we want to test for <I>Not A Number</I> without triggering any
- * of the associate floating-point exceptions (VXSNAN or VXVC).
- * For this test the sign bit does not effect the result so we need to
- * zero the sign bit before the actual test. The vector abs would work
- * for this, but we know from the example above that this instruction
- * has a high latency as we are definitely passing the result to a
- * non-FPU instruction (vector compare greater than unsigned word).
- *
- * So the code needs to load two constant vectors masks, then vector
- * and-compliment to clear the sign-bit, before comparing each word
- * for greater then infinity. The generated code should look
- * something like this: \code
- 	addis   r9,r2,.rodata.cst16+0x10@ha
- 	addis   r10,r2,.rodata.cst16+0x20@ha
- 	addi    r9,r9,.rodata.cst16+0x10@l
- 	addi    r10,r10,.rodata.cst16+0x20@l
- 	lvx     v0,0,r10	# load vector const signmask
- 	lvx     v12,0,r9	# load vector const expmask
- 	xxlandc vs34,vs34,vs32
- 	vcmpgtuw v2,v2,v12
- * \endcode
- * So six instructions to load the const masks and two instructions
- * for the actual vec_isnanf32 function. The first six instructions
- * are only needed once for each containing function, can be hoisted
- * out of loops and into the function prologue, can be <I>commoned</I>
- * with the same constant for other pveclib functions, or executed
- * out-of-order and early by the processor.
- *
- * Most of the time, constant setup does not contribute measurably to
- * the over all performance of vec_isnanf32. When it does it is
- * limited by the longest (in cycles latency) of the various
- * independent paths that load constants.  In this case the const load
- * sequence is composed of three pairs of instructions that can issue
- * and execute in parallel. The addis/addi FXU instructions supports
- * throughput of 6/cycle and the lvx load supports 2/cycle.
- * So the two vector constant load sequences can execute
- * in parallel and the latency is same as a single const load.
- *
- * For POWER8 it appears to be (2+2+5=) 9 cycles latency for the const
- * load. While the core vec_isnanf32 function (xxlandc/vcmpgtuw) is a
- * dependent sequence and runs (2+2) 4 cycles latency.
- * Similar analysis for POWER9 where the addis/addi/lvx sequence is
- * still listed as (2+2+5) 9 cycles latency. While the xxlandc/vcmpgtuw
- * sequence increases to (2+3) 5 cycles.
- *
- * The next interesting question is what can we say about throughput
- * (if anything) for this example.  The thought experiment is "what
- * would happen if?";
- * - two or more instances of vec_isnanf32 are used within a single
- * function,
- * - in close proximity in the code,
- * - with independent data as input,
- *
- * could the generated instructions execute in parallel and to what
- * extent. This illustrated by the following (contrived) example:
- * \code
-int
-test512_all_f32_nan (vf32_t val0, vf32_t val1, vf32_t val2, vf32_t val3)
-{
-  const vb32_t alltrue = { -1, -1, -1, -1 };
-  vb32_t nan0, nan1, nan2, nan3;
-
-  nan0 = vec_isnanf32 (val0);
-  nan1 = vec_isnanf32 (val1);
-  nan2 = vec_isnanf32 (val2);
-  nan3 = vec_isnanf32 (val3);
-
-  nan0 = vec_and (nan0, nan1);
-  nan2 = vec_and (nan2, nan3);
-  nan0 = vec_and (nan2, nan0);
-
-  return vec_all_eq(nan0, alltrue);
-}
- * \endcode
- * which tests 4 X vector float (16 X float) values and returns true
- * if all 16 floats are NaN. Recent compilers will generates something
- * like the following PowerISA code:
- * \code
-     addis   r9,r2,-2
-     addis   r10,r2,-2
-     vspltisw v13,-1	# load vector const alltrue
-     addi    r9,r9,21184
-     addi    r10,r10,-13760
-     lvx     v0,0,r9	# load vector const signmask
-     lvx     v1,0,r10	# load vector const expmask
-     xxlandc vs35,vs35,vs32
-     xxlandc vs34,vs34,vs32
-     xxlandc vs37,vs37,vs32
-     xxlandc vs36,vs36,vs32
-     vcmpgtuw v3,v3,v1	# nan1 = vec_isnanf32 (val1);
-     vcmpgtuw v2,v2,v1	# nan0 = vec_isnanf32 (val0);
-     vcmpgtuw v5,v5,v1	# nan3 = vec_isnanf32 (val3);
-     vcmpgtuw v4,v4,v1	# nan2 = vec_isnanf32 (val2);
-     xxland  vs35,vs35,vs34	# nan0 = vec_and (nan0, nan1);
-     xxland  vs36,vs37,vs36	# nan2 = vec_and (nan2, nan3);
-     xxland  vs36,vs35,vs36	# nan0 = vec_and (nan2, nan0);
-     vcmpequw. v4,v4,v13	# vec_all_eq(nan0, alltrue);
-...
- * \endcode
- * first the generated code loading the vector constants for signmask,
- * expmask, and alltrue. We see that the code is generated only once
- * for each constant. Then the compiler generate the core vec_isnanf32
- * function four times and interleaves the instructions. This enables
- * parallel pipeline execution where conditions allow. Finally the 16X
- * isnan results are reduced to 8X, then 4X, then to a single
- * condition code.
- *
- * For this exercise we will ignore the constant load as in any
- * realistic usage it will be <I>commoned</I> across several pveclib
- * functions and hoisted out of any loops. The reduction code is not
- * part of the vec_isnanf32 implementation and also ignored.
- * The sequence of 4X xxlandc and 4X vcmpgtuw in the middle it the
- * interesting part.
- *
- * For POWER8 both xxlandc and vcmpgtuw are listed as 2 cycles
- * latency and throughput of 2 per cycle. So we can assume that (only)
- * the first two xxlandc will issue in the same cycle (assuming the
- * input vectors are ready).  The issue of the next two xxlandc
- * instructions will be delay by 1 cycle. The following vcmpgtuw
- * instruction are dependent on the xxlandc results and will not
- * execute until their input vectors are ready. The first two vcmpgtuw
- * instruction will execute 2 cycles (latency) after the first two
- * xxlandc instructions execute. Execution of the second two vcmpgtuw
- * instructions will be delayed 1 cycle due to the issue delay in the
- * second pair of xxlandc instructions.
- *
- * So at least for this example and this set of simplifying assumptions
- * we suggest that the throughput metric for vec_isnanf32 is 2/cycle.
- * For latency metric we offer the range with the latency for the core
- * function (without and constant load overhead) first. Followed by the
- * total latency (the sum of the constant load and core function
- * latency). For the vec_isnanf32 example the metrics are:
- *
- *  |processor|Latency|Throughput|
- *  |--------:|:-----:|:---------|
- *  |power8   | 4-13  | 2/cycle  |
- *  |power9   | 5-14  | 2/cycle  |
- *
+ * \section f32_perf_0_0 Performance data.
+ * High performance estimates are provided a s an aid to function
+ * selection when evaluating algorithms. For background on how
+ * <I>Latency</I> and <I>Throughput</I> are derived see:
+ * \ref perf_data
  */
 
 #include <vec_common_ppc.h>
@@ -309,8 +117,8 @@ vec_absf32 (vf32_t vf32x)
  *
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
- *  |power8   | 4-15  | 2/cycle  |
- *  |power9   | 6     | 2/cycle  |
+ *  |power8   | 6-20  | 2/cycle  |
+ *  |power9   | 5-14  | 2/cycle  |
  *
  *  @param vf32 a vector of __binary32 values.
  *  @return boolean int, true if all 4 float values are infinity
@@ -348,8 +156,8 @@ vec_all_isinff32 (vf32_t vf32)
  *
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
- *  |power8   | 4-15  | 2/cycle  |
- *  |power9   | 6     | 2/cycle  |
+ *  |power8   | 6-20  | 2/cycle  |
+ *  |power9   | 5-14  | 2/cycle  |
  *
  *  @param vf32 a vector of __binary32 values.
  *  @return a boolean int, true if all of 4 vector float values are
@@ -389,8 +197,8 @@ vec_all_isnanf32 (vf32_t vf32)
  *
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
- *  |power8   | 11-18 | 1/cycle  |
- *  |power9   | 14    | 1/cycle  |
+ *  |power8   | 10-28 | 1/cycle  |
+ *  |power9   | 8-16  | 1/cycle  |
  *
  *  @param vf32 a vector of __binary32 values.
  *  @return a boolean int, true if all of 4 vector float values are
@@ -405,7 +213,6 @@ vec_all_isnormalf32 (vf32_t vf32)
   const vui32_t minnorm = CONST_VINT128_W(0x00800000, 0x00800000, 0x00800000,
 					  0x00800000);
   const vui32_t vec_zero = CONST_VINT128_W(0, 0, 0, 0);
-  vb32_t vnorm;
   int result;
 
 #if _ARCH_PWR9
@@ -416,11 +223,7 @@ vec_all_isnormalf32 (vf32_t vf32)
   tmp2 = vec_andc ((vui32_t)vf32, signmask);
 #endif
   tmp = vec_and ((vui32_t) vf32, expmask);
-  tmp2 = (vui32_t) vec_cmplt(tmp2, minnorm);
-  tmp = (vui32_t) vec_cmpeq (tmp, expmask);
-  vnorm = (vb32_t ) vec_nor (tmp, tmp2);
-
-  result = vec_all_gt(vnorm, vec_zero);
+  result = vec_all_ge (tmp2, minnorm) && vec_all_ne (tmp, expmask);
 
   return (result);
 }
@@ -437,8 +240,8 @@ vec_all_isnormalf32 (vf32_t vf32)
  *
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
- *  |power8   | 10-18 | 1/cycle  |
- *  |power9   | 14    | 1/cycle  |
+ *  |power8   | 10-30 | 1/cycle  |
+ *  |power9   | 10-19 | 1/cycle  |
  *
  *  @param vf32 a vector of __binary32 values.
  *  @return a boolean int, true if all of 4 vector float values are
@@ -451,7 +254,6 @@ vec_all_issubnormalf32 (vf32_t vf32)
   const vui32_t explow = CONST_VINT128_W(0x00800000, 0x00800000, 0x00800000,
 					 0x00800000);
   const vui32_t vec_zero = CONST_VINT128_W(0, 0, 0, 0);
-  vb32_t vsubnorm;
   int result;
 
 #if _ARCH_PWR9
@@ -462,10 +264,7 @@ vec_all_issubnormalf32 (vf32_t vf32)
 					   0x80000000);
   tmp2 = vec_andc ((vui32_t)vf32, signmask);
 #endif
-  tmp = (vui32_t) vec_cmplt(tmp2, explow);
-  tmpz = (vui32_t) vec_cmpeq (tmp2, vec_zero);
-  vsubnorm = (vb32_t ) vec_andc (tmp, tmpz);
-  result = vec_all_ne(vsubnorm, vec_zero);
+  result = vec_all_lt (tmp2, explow) && vec_all_ne (tmp2, vec_zero);
 
   return (result);
 }
@@ -482,7 +281,7 @@ vec_all_issubnormalf32 (vf32_t vf32)
  *
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
- *  |power8   | 6-12  | 2/cycle  |
+ *  |power8   | 6-20  | 2/cycle  |
  *  |power9   | 5     | 2/cycle  |
  *
  *  @param vf32 a vector of __binary32 values.
@@ -518,6 +317,11 @@ vec_all_iszerof32 (vf32_t vf32)
  *  \note This function will not raise VXSNAN or VXVC (FE_INVALID)
  *  exceptions. A normal float compare can.
  *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 6-20  | 2/cycle  |
+ *  |power9   | 5-14  | 2/cycle  |
+ *
  *  @param vf32 a vector of __binary32 values.
  *  @return boolean int, true if any of 4 float values are infinity
  */
@@ -552,6 +356,11 @@ vec_any_isinff32 (vf32_t vf32)
  *
  *  \note This function will not raise VXSNAN or VXVC (FE_INVALID)
  *  exceptions. A normal float compare can.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 6-20  | 2/cycle  |
+ *  |power9   | 5-14  | 2/cycle  |
  *
  *  @param vf32 a vector of __binary32 values.
  *  @return a boolean int, true if aany of 4 vector float values are
@@ -591,8 +400,8 @@ vec_any_isnanf32 (vf32_t vf32)
  *
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
- *  |power8   | 11-18 | 1/cycle  |
- *  |power9   | 14    | 1/cycle  |
+ *  |power8   | 10-25 | 1/cycle  |
+ *  |power9   | 10-19 | 1/cycle  |
  *
  *  @param vf32 a vector of __binary32 values.
  *  @return a boolean int, true if any of 4 vector float values are
@@ -683,7 +492,7 @@ vec_any_issubnormalf32 (vf32_t vf32)
  *
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
- *  |power8   | 6-12  | 2/cycle  |
+ *  |power8   | 6-20  | 2/cycle  |
  *  |power9   | 5     | 2/cycle  |
  *
  *  @param vf32 a vector of __binary32 values.
@@ -749,8 +558,8 @@ vec_copysignf32 (vf32_t vf32x, vf32_t vf32y)
  *
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
- *  |power8   | 4-15  | 2/cycle  |
- *  |power9   | 6     | 2/cycle  |
+ *  |power8   | 4-13  | 2/cycle  |
+ *  |power9   | 5-14  | 2/cycle  |
  *
  *  @param vf32 a vector of __binary32 values.
  *  @return a vector boolean int, each containing all 0s(false)
@@ -827,8 +636,8 @@ vec_isnanf32 (vf32_t vf32)
  *
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
- *  |power8   | 9-16  | 1/cycle  |
- *  |power9   | 14    | 1/cycle  |
+ *  |power8   | 6-16  | 1/cycle  |
+ *  |power9   | 7-16  | 1/cycle  |
  *
  *  @param vf32 a vector of __binary32 values.
  *  @return a vector boolean int, each containing all 0s(false)
@@ -848,7 +657,8 @@ vec_isnormalf32 (vf32_t vf32)
   /* P9 has a 2 cycle xvabssp and eliminates a const load. */
   tmp2 = (vui32_t) vec_abs (vf32);
 #else
-  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0x80000000, 0x80000000, 0x80000000);
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0x80000000, 0x80000000,
+					   0x80000000);
   tmp2 = vec_andc ((vui32_t)vf32, signmask);
 #endif
   tmp = vec_and ((vui32_t) vf32, expmask);
@@ -871,8 +681,8 @@ vec_isnormalf32 (vf32_t vf32)
  *
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
- *  |power8   | 8-16  | 2/cycle  |
- *  |power9   | 14    | 2/cycle  |
+ *  |power8   | 6-16  | 1/cycle  |
+ *  |power9   | 7-16  | 1/cycle  |
  *
  *  @param vf32 a vector of __binary32 values.
  *  @return a vector boolean int, each containing all 0s(false)
@@ -914,7 +724,7 @@ vec_issubnormalf32 (vf32_t vf32)
  *
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
- *  |power8   | 6-12  | 2/cycle  |
+ *  |power8   | 4-13  | 2/cycle  |
  *  |power9   | 5     | 2/cycle  |
  *
  *  @param vf32 a vector of __binary32 values.


### PR DESCRIPTION
	* doc/pveclib-doxygen-pveclib.doxy: Add vec_f32_ppc.h.

	* src/Makefile.am: Add .libs/libpvecdummy.a ref.
	* src/Makefile.am (libpvec_la_SOURCES): Add
	testsuite/vec_f32_dummy.c.
	* src/Makefile.am (pveclibinclude_HEADERS): Add vec_f32_ppc.h.
	* src/Makefile.am (pveclib_test_SOURCES): Add
	testsuite/vec_perf_f32.c, testsuite/vec_perf_i128.c,
	testsuite/arith128_test_f32.c
	* src/Makefile.am (pveclib_test_LDADD): Add .libs/libvecdummy.a
	* src/Makefile.in: Regenerate.

	* src/testsuite/arith128_print.c (print_vbool8, print_v4f32,
	print_v4f32x, print_v4b32c, print_v4b32x, check_v4b32c_priv,
	check_v4b32x_priv, check_v4f32_priv, check_v4f32x_priv):
	New functions.
	* src/testsuite/arith128_print.h (__VF_128 xfer): Rename.
	* src/testsuite/arith128_print.h (TimeDeltaSec): New functions.
	* src/testsuite/arith128_print.h (print_v4f32, print_v4f32x,
	print_v4b32c, print_v4b32x): New functions.
	* src/testsuite/arith128_print.h (check_v4b32c,  check_v4b32x,
	check_v4f32, check_v4f32x): New functions.

	* src/testsuite/arith128_test_bcd.c (test_bcd_addsub): Use
	__FUNCTION__ in status printf.

	* src/testsuite/arith128_test_f32.c: New File
	* src/testsuite/arith128_test_f32.h: New File.
	* src/testsuite/vec_f32_dummy.c: New File.

	* src/testsuite/arith128_test_i128.c (test_time_i128):
	New Function.
	* src/testsuite/arith128_test_i128.c (test_vec_i128):
	Call test_time_i128.

	*src/testsuite/pveclib_test.c (main): Call test_vec_f32.

	* src/testsuite/vec_int128_dummy.c (__test_mulhuq):
	New Function.
	* src/testsuite/vec_pwr9_dummy.c (__test_mulhuq_PWR9,
	__test_cmul10cuq_PWR9, test_muluq_4x1_PWR9) New Functions.

	* src/vec_common_ppc.h (vb8_t, vb16_t, vb32_t, vb64_t:
	Add vector bool typedefs.
	* src/vec_f128_ppc.h (__VF_128): Rename.
	* src/vec_f32_ppc.h: Add Doxygen overview.
	* src/vec_f32_ppc.h (vec_absf32, vec_all_isinff32,
	vec_all_isnanf32, vec_all_isnormalf32, vec_all_issubnormalf32,
	vec_all_iszerof32, vec_any_isinff32, vec_any_isnanf32,
	vec_any_isnormalf32, vec_any_issubnormalf32, vec_any_iszerof32,
	vec_issubnormalf32, vec_iszerof32): New Functions.
	(vec_copysignf32, vec_isinff32, vec_isnanf32, vec_isnormalf32):
	reformate.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>