### PR TITLE
Complete the compare intrinsics for vector long (doubleword integer).

### DIFF
--- a/src/testsuite/arith128_print.c
+++ b/src/testsuite/arith128_print.c
@@ -522,6 +522,54 @@ print_v4b32x (char *prefix, vb32_t boolval)
 }
 
 void
+print_v2f64 (char *prefix, vf64_t val)
+{
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  printf ("%s %16.6f,%16.6f\n", prefix, val[1], val[0]);
+#else
+  printf ("%s %16.6f,%16.6f\n", prefix, val[0], val[1]);
+#endif
+}
+
+void
+print_v2f64x (char *prefix, vf64_t val)
+{
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  printf ("%s %22.13a,%22.13a\n", prefix, val[1], val[0]);
+#else
+  printf ("%s %22.13a,%22.13a\n", prefix, val[0], val[1]);
+#endif
+}
+
+void
+print_v2b64c (char *prefix, vb64_t val)
+{
+  const vui64_t true =  { 'T', 'T' };
+  const vui64_t false = { 'F', 'F' };
+  vui64_t text;
+
+  text = vec_sel (false, true, val);
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  printf ("%s %c,%c\n", prefix, (int)text[1], (int)text[0]);
+#else
+  printf ("%s %c,%c\n", prefix, (int)text[0], (int)text[1]);
+#endif
+}
+
+void
+print_v2b64x (char *prefix, vb64_t boolval)
+{
+  vui64_t val = (vui64_t)boolval;
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  printf ("%s %016lx,%016lx\n", prefix, val[1], val[0]);
+#else
+  printf ("%s %016lx,%016lx\n", prefix, val[0], val[1]);
+#endif
+}
+
+void
 print_v2int64 (char *prefix, vui64_t val128)
 {
   vui64_t val = (vui64_t) val128;
@@ -889,6 +937,74 @@ check_v4f32x_priv (char *prefix, vf32_t val128, vf32_t shouldbe)
       printf ("%s\n", prefix);
       print_v4f32x ("\tshould be: ", shouldbe);
       print_v4f32x ("\t       is: ", val128);
+    }
+
+  return (rc);
+}
+
+int
+check_v2b64c_priv (char *prefix, vb64_t val128, vb64_t shouldbe)
+{
+  int rc = 0;
+
+
+  if (vec_any_ne ((vui32_t) val128, (vui32_t) shouldbe))
+    {
+      rc = 1;
+      printf ("%s\n", prefix);
+      print_v2b64c ("\tshould be: ", shouldbe);
+      print_v2b64c ("\t       is: ", val128);
+    }
+
+  return (rc);
+}
+
+int
+check_v2b64x_priv (char *prefix, vb64_t val128, vb64_t shouldbe)
+{
+  int rc = 0;
+
+
+  if (vec_any_ne ((vui32_t) val128, (vui32_t) shouldbe))
+    {
+      rc = 1;
+      printf ("%s\n", prefix);
+      print_v2b64x ("\tshould be: ", shouldbe);
+      print_v2b64x ("\t       is: ", val128);
+    }
+
+  return (rc);
+}
+
+int
+check_v2f64_priv (char *prefix, vf64_t val128, vf64_t shouldbe)
+{
+  int rc = 0;
+
+
+  if (vec_any_ne ((vui32_t) val128, (vui32_t) shouldbe))
+    {
+      rc = 1;
+      printf ("%s\n", prefix);
+      print_v2f64 ("\tshould be: ", shouldbe);
+      print_v2f64 ("\t       is: ", val128);
+    }
+
+  return (rc);
+}
+
+int
+check_v2f64x_priv (char *prefix, vf64_t val128, vf64_t shouldbe)
+{
+  int rc = 0;
+
+
+  if (vec_any_ne ((vui32_t) val128, (vui32_t) shouldbe))
+    {
+      rc = 1;
+      printf ("%s\n", prefix);
+      print_v2f64x ("\tshould be: ", shouldbe);
+      print_v2f64x ("\t       is: ", val128);
     }
 
   return (rc);

--- a/src/testsuite/arith128_print.h
+++ b/src/testsuite/arith128_print.h
@@ -115,6 +115,18 @@ print_v4b32c (char *prefix, vb32_t val);
 extern void
 print_v4b32x (char *prefix, vb32_t val);
 
+extern void
+print_v2f64 (char *prefix, vf64_t val);
+
+extern void
+print_v2f64x (char *prefix, vf64_t val);
+
+extern void
+print_v2b64c (char *prefix, vb64_t val);
+
+extern void
+print_v2b64x (char *prefix, vb64_t val);
+
 extern int
 check_udiv128_64x (unsigned __int128 numerator, uint64_t divisor,
                    uint64_t exp_q, uint64_t exp_r);
@@ -274,6 +286,18 @@ extern int
 check_v4f32x_priv (char *prefix, vf32_t val128, vf32_t shouldbe);
 
 extern int
+check_v2b64c_priv (char *prefix, vb64_t val128, vb64_t shouldbe);
+
+extern int
+check_v2b64x_priv (char *prefix, vb64_t val128, vb64_t shouldbe);
+
+extern int
+check_v2f64_priv (char *prefix, vf64_t val128, vf64_t shouldbe);
+
+extern int
+check_v2f64x_priv (char *prefix, vf64_t val128, vf64_t shouldbe);
+
+extern int
 check_vuint128_priv (char *prefix, vui128_t val128, vui128_t shouldbe);
 
 extern int
@@ -395,6 +419,58 @@ check_v4f32x (char *prefix, vf32_t val128, vf32_t shouldbe)
   if (vec_any_ne((vui32_t )val128, (vui32_t )shouldbe))
     {
       rc = check_v4f32x_priv (prefix, val128, shouldbe);
+    }
+
+  return (rc);
+
+}
+
+static inline int
+check_v2b64c (char *prefix, vb64_t val128, vb64_t shouldbe)
+{
+  int rc = 0;
+  if (vec_any_ne((vui32_t)val128, (vui32_t)shouldbe))
+    {
+      rc = check_v2b64c_priv (prefix, val128, shouldbe);
+    }
+
+  return (rc);
+
+}
+
+static inline int
+check_v2b64x (char *prefix, vb64_t val128, vb64_t shouldbe)
+{
+  int rc = 0;
+  if (vec_any_ne((vui64_t )val128, (vui64_t )shouldbe))
+    {
+      rc = check_v2b64x_priv (prefix, val128, shouldbe);
+    }
+
+  return (rc);
+
+}
+
+static inline int
+check_v2f64 (char *prefix, vf64_t val128, vf64_t shouldbe)
+{
+  int rc = 0;
+  if (vec_any_ne((vui32_t)val128, (vui32_t)shouldbe))
+    {
+      rc = check_v2f64_priv (prefix, val128, shouldbe);
+    }
+
+  return (rc);
+
+}
+
+static inline int
+check_v2f64x (char *prefix, vf64_t val128, vf64_t shouldbe)
+{
+  int rc = 0;
+  if (vec_any_ne((vui32_t)val128, (vui32_t)shouldbe))
+    {
+      rc = check_v2f64x_priv (prefix, val128, shouldbe);
     }
 
   return (rc);

--- a/src/testsuite/arith128_test_i64.c
+++ b/src/testsuite/arith128_test_i64.c
@@ -1094,6 +1094,8996 @@ test_muloud (void)
   return (rc);
 }
 
+//#define __DEBUG_PRINT__ 1
+int
+test_cmpud (void)
+{
+  vui64_t i1, i2, e;
+  vui64_t j;
+  int rc = 0;
+
+  printf ("\ntest_cmpud Vector Compare Unsigned doubleword\n");
+
+  printf ("test_cmpequd\n");
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+  e = (vui64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpequd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpequd( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpequd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x100000000, 0x200000000);
+  i2 = (vui64_t )CONST_VINT64_DW(0x100000000, 0x200000000);
+  e = (vui64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpequd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpequd( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpequd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(2, 2);
+  e = (vui64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpequd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpequd( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpequd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x100000000, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(2, 2);
+  e = (vui64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpequd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpequd( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpequd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(2, 0x200000000);
+  e = (vui64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpequd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpequd( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpequd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+  e = (vui64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpequd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpequd( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpequd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+  e = (vui64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpequd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpequd( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpequd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 0xffffffff00000000);
+  i2 = (vui64_t )CONST_VINT64_DW(0xffffffff00000000, 0xffffffff00000000);
+  e = (vui64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpequd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpequd( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpequd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+  e = (vui64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpequd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpequd( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpequd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0xffffffff00000000, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0xffffffff00000000, 0xffffffff00000000);
+  e = (vui64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpequd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpequd( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpequd:", (vb64_t)j, (vb64_t) e);
+
+  printf ("test_cmpneud\n");
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+  e = (vui64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpneud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpneud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpneud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x100000000, 0x200000000);
+  i2 = (vui64_t )CONST_VINT64_DW(0x100000000, 0x200000000);
+  e = (vui64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpneud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpneud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpneud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(2, 2);
+  e = (vui64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpneud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpneud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpneud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x100000000, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(2, 2);
+  e = (vui64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpneud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpneud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpneud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(2, 0x200000000);
+  e = (vui64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpneud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpneud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpneud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+  e = (vui64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpneud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpneud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpneud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+  e = (vui64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpneud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpneud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpneud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 0xffffffff00000000);
+  i2 = (vui64_t )CONST_VINT64_DW(0xffffffff00000000, 0xffffffff00000000);
+  e = (vui64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpneud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpneud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpneud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+  e = (vui64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpneud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpneud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpneud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0xffffffff00000000, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0xffffffff00000000, 0xffffffff00000000);
+  e = (vui64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpneud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpneud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpneud:", (vb64_t)j, (vb64_t) e);
+
+  printf ("test_cmpgtud\n");
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+  e = (vui64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpgtud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgtud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpgtud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 0);
+  e = (vui64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpgtud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgtud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpgtud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x100000000);
+  i2 = (vui64_t )CONST_VINT64_DW(0x100000000, 0);
+  e = (vui64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpgtud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgtud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpgtud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 1);
+  e = (vui64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpgtud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgtud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpgtud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x100000000, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x100000000);
+  e = (vui64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpgtud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgtud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpgtud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x100000000, 2);
+  i2 = (vui64_t )CONST_VINT64_DW(2, 0x100000000);
+  e = (vui64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpgtud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgtud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpgtud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 0);
+  e = (vui64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpgtud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgtud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpgtud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x100000000, 0x100000000);
+  i2 = (vui64_t )CONST_VINT64_DW(0x100000000, 0);
+  e = (vui64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpgtud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgtud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpgtud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x100000000, 0x100000000);
+  i2 = (vui64_t )CONST_VINT64_DW(0x100000000, 2);
+  e = (vui64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpgtud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgtud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpgtud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 1);
+  e = (vui64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpgtud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgtud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpgtud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(2, 0x100000000);
+  i2 = (vui64_t )CONST_VINT64_DW(0x100000000, 0x100000000);
+  e = (vui64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpgtud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgtud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpgtud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x100000000);
+  i2 = (vui64_t )CONST_VINT64_DW(0x100000000, 0x100000001);
+  e = (vui64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpgtud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgtud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpgtud:", (vb64_t)j, (vb64_t) e);
+
+  printf ("test_cmpgeud\n");
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+  e = (vui64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpgeud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgeud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpgeud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 0);
+  e = (vui64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpgeud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgeud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpgeud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x100000000);
+  i2 = (vui64_t )CONST_VINT64_DW(0x100000000, 0);
+  e = (vui64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpgeud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgeud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpgeud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 1);
+  e = (vui64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpgeud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgeud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpgeud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x100000000, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x100000000);
+  e = (vui64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpgeud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgeud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpgeud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x100000000, 2);
+  i2 = (vui64_t )CONST_VINT64_DW(2, 0x100000000);
+  e = (vui64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpgeud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgeud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpgeud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 0);
+  e = (vui64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpgeud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgeud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpgeud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x100000000, 0x100000000);
+  i2 = (vui64_t )CONST_VINT64_DW(0x100000000, 0);
+  e = (vui64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpgeud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgeud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpgeud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x100000000, 0x100000000);
+  i2 = (vui64_t )CONST_VINT64_DW(0x100000000, 2);
+  e = (vui64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpgeud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgeud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpgeud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 1);
+  e = (vui64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpgeud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgeud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpgeud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(2, 0x100000000);
+  i2 = (vui64_t )CONST_VINT64_DW(0x100000000, 0x100000000);
+  e = (vui64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpgeud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgeud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpgeud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x100000000);
+  i2 = (vui64_t )CONST_VINT64_DW(0x100000000, 0x100000001);
+  e = (vui64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpgeud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgeud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpgeud:", (vb64_t)j, (vb64_t) e);
+
+  printf ("test_cmpltud\n");
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+  e = (vui64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpltud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpltud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpltud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 0);
+  e = (vui64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpltud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpltud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpltud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x100000000);
+  i2 = (vui64_t )CONST_VINT64_DW(0x100000000, 0);
+  e = (vui64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpltud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpltud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpltud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 1);
+  e = (vui64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpltud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpltud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpltud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x100000000, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x100000000);
+  e = (vui64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpltud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpltud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpltud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x100000000, 2);
+  i2 = (vui64_t )CONST_VINT64_DW(2, 0x100000000);
+  e = (vui64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpltud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpltud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpltud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 0);
+  e = (vui64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpltud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpltud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpltud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x100000000, 0x100000000);
+  i2 = (vui64_t )CONST_VINT64_DW(0x100000000, 0);
+  e = (vui64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpltud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpltud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpltud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x100000000, 0x100000000);
+  i2 = (vui64_t )CONST_VINT64_DW(0x100000000, 2);
+  e = (vui64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpltud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpltud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpltud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 1);
+  e = (vui64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpltud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpltud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpltud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(2, 0x100000000);
+  i2 = (vui64_t )CONST_VINT64_DW(0x100000000, 0x100000000);
+  e = (vui64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpltud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpltud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpltud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x100000000);
+  i2 = (vui64_t )CONST_VINT64_DW(0x100000000, 0x100000001);
+  e = (vui64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpltud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpltud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpltud:", (vb64_t)j, (vb64_t) e);
+
+  printf ("test_cmpleud\n");
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+  e = (vui64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpleud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpleud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpleud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 0);
+  e = (vui64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpleud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpleud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpleud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x100000000);
+  i2 = (vui64_t )CONST_VINT64_DW(0x100000000, 0);
+  e = (vui64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpleud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpleud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpleud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 1);
+  e = (vui64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpleud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpleud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpleud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x100000000, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x100000000);
+  e = (vui64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpleud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpleud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpleud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x100000000, 2);
+  i2 = (vui64_t )CONST_VINT64_DW(2, 0x100000000);
+  e = (vui64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpleud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpleud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpleud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 0);
+  e = (vui64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpleud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpleud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpleud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x100000000, 0x100000000);
+  i2 = (vui64_t )CONST_VINT64_DW(0x100000000, 0);
+  e = (vui64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpleud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpleud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpleud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x100000000, 0x100000000);
+  i2 = (vui64_t )CONST_VINT64_DW(0x100000000, 2);
+  e = (vui64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpleud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpleud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpleud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 1);
+  e = (vui64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpleud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpleud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpleud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(2, 0x100000000);
+  i2 = (vui64_t )CONST_VINT64_DW(0x100000000, 0x100000000);
+  e = (vui64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpleud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpleud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpleud:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x100000000);
+  i2 = (vui64_t )CONST_VINT64_DW(0x100000000, 0x100000001);
+  e = (vui64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpleud(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpleud( ", i1);
+  print_v2xint64 ("         ,", i2);
+  print_v2xint64 ("        )=", j);
+#endif
+  rc += check_v2b64c ("vec_cmpleud:", (vb64_t)j, (vb64_t) e);
+
+  return (rc);
+}
+
+//#define __DEBUG_PRINT__ 1
+int
+test_cmpud_all (void)
+{
+  vui64_t i1, i2;
+#ifdef __DEBUG_PRINT__
+  vui64_t j;
+#endif
+  int rc = 0;
+
+  printf ("\ntest_cmpud_all Vector Compare Unsigned doubleword\n");
+
+  printf ("test_cmp_all_eq\n");
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_eq (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpequd(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_eq( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_eq (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpequd(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_eq( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_eq (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpequd(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_eq( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_eq (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpequd(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_eq( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 0);
+
+  if (vec_cmpud_all_eq (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpequd(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_eq( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 1);
+
+  if (vec_cmpud_all_eq (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpequd(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_eq( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpud_all_eq (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpequd(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_eq( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_eq (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpequd(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_eq( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_eq (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpequd(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_eq( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_eq (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpequd(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_eq( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpud_all_eq (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpequd(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_eq( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpud_all_eq (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpequd(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_eq( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpud_all_eq (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpequd(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_eq( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+
+  if (vec_cmpud_all_eq (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpequd(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_eq( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+
+  if (vec_cmpud_all_eq (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpequd(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_eq( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  printf ("test_cmp_all_ne\n");
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_ne (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpneud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_ne( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_ne (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpneud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_ne( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_ne (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpneud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_ne( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_ne (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpneud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_ne( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 0);
+
+  if (vec_cmpud_all_ne (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpneud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_ne( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 1);
+
+  if (vec_cmpud_all_ne (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpneud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_ne( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpud_all_ne (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpneud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_ne( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_ne (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpneud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_ne( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_ne (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpneud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_ne( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_ne (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpneud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_ne( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpud_all_ne (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpneud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_ne( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpud_all_ne (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpneud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_ne( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpud_all_ne (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpneud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_ne( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+
+  if (vec_cmpud_all_ne (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpneud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_ne( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+
+  if (vec_cmpud_all_ne (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpneud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_ne( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  printf ("test_cmp_all_gt\n");
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_gt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_gt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_gt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_gt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_gt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 0);
+
+  if (vec_cmpud_all_gt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgtud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_gt( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 1);
+
+  if (vec_cmpud_all_gt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgtud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_gt( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpud_all_gt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgtud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_gt( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_gt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_gt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_gt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_gt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpud_all_gt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgtud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_gt( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpud_all_gt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgtud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_gt( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpud_all_gt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgtud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_gt( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+
+  if (vec_cmpud_all_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_gt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+
+  if (vec_cmpud_all_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_gt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpud_all_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_gt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpud_all_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_gt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0x8000000000000001UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpud_all_gt (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgtud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_gt( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  printf ("test_cmp_all_ge\n");
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgeud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_ge( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgeud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_ge( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgeud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_ge( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgeud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_ge( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 0);
+
+  if (vec_cmpud_all_ge (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgeud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_ge( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 1);
+
+  if (vec_cmpud_all_ge (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgeud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_ge( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpud_all_ge (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgeud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_ge( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgeud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_ge( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgeud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_ge( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgeud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_ge( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpud_all_ge (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgeud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_ge( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpud_all_ge (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgeud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_ge( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpud_all_ge (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgeud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_ge( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+
+  if (vec_cmpud_all_ge (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgeud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_ge( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+
+  if (vec_cmpud_all_ge (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgeud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_ge( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpud_all_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgeud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_ge( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpud_all_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgeud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_ge( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0x8000000000000001UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpud_all_ge (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgeud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_ge( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  printf ("test_cmp_all_lt\n");
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_lt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_lt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_lt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_lt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpud_all_lt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_lt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 0);
+
+  if (vec_cmpud_all_lt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_lt( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 1);
+
+  if (vec_cmpud_all_lt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_lt( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpud_all_lt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_lt( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_lt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_lt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_lt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpud_all_lt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_lt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpud_all_lt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_lt( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpud_all_lt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_lt( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpud_all_lt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_lt( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+
+  if (vec_cmpud_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_lt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+
+  if (vec_cmpud_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_lt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpud_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_lt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpud_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_lt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0x8000000000000001UL);
+
+  if (vec_cmpud_all_lt (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_lt( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0x8000000000000001UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpud_all_lt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_lt( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  printf ("test_cmp_all_le\n");
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpleud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_le( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_le (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpleud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_le( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_le (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpleud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_le( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_le (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpleud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_le( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpud_all_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpleud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_le( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 0);
+
+  if (vec_cmpud_all_le (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpleud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_le( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 1);
+
+  if (vec_cmpud_all_le (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpleud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_le( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpud_all_le (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpleud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_le( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_le (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpleud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_le( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_le (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpleud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_le( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_all_le (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpleud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_le( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpud_all_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpleud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_le( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpud_all_le (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpleud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_le( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpud_all_le (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpleud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_le( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpud_all_le (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpleud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_le( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+
+  if (vec_cmpud_all_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpleud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_le( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+
+  if (vec_cmpud_all_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpleud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_le( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpud_all_le (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpleud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_le( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpud_all_le (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpleud(i1, i2);
+      print_v2xint64 ("vec_cmpud_all_le( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0x8000000000000001UL);
+
+  if (vec_cmpud_all_le (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpleud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_le( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0x8000000000000001UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpud_all_le (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpleud(i1, i2);
+    print_v2xint64 ("vec_cmpud_all_le( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  return (rc);
+}
+
+//#define __DEBUG_PRINT__ 1
+int
+test_cmpud_any (void)
+{
+  vui64_t i1, i2;
+#ifdef __DEBUG_PRINT__
+  vui64_t j;
+#endif
+  int rc = 0;
+
+  printf ("\ntest_cmpud_any Vector Compare Unsigned doubleword\n");
+
+  printf ("test_cmp_any_eq\n");
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_eq (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpequd(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_eq( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_eq (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpequd(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_eq( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_eq (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpequd(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_eq( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_eq (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_any_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpequd(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_eq( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 0);
+
+  if (vec_cmpud_any_eq (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_any_eq fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpequd(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_eq( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 1);
+
+  if (vec_cmpud_any_eq (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_any_eq fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpequd(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_eq( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpud_any_eq (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_any_eq fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpequd(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_eq( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_eq (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpequd(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_eq( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_eq (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpequd(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_eq( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_eq (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_any_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpequd(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_eq( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpud_any_eq (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_any_eq fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpequd(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_eq( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpud_any_eq (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_any_eq fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpequd(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_eq( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpud_any_eq (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_any_eq fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpequd(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_eq( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+
+  if (vec_cmpud_any_eq (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpequd(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_eq( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+
+  if (vec_cmpud_any_eq (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpequd(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_eq( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  printf ("test_cmp_any_ne\n");
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_ne (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_any_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpneud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_ne( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_ne (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpneud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_ne( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_ne (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpneud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_ne( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_ne (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpneud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_ne( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 0);
+
+  if (vec_cmpud_any_ne (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_any_ne fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpneud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_ne( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 1);
+
+  if (vec_cmpud_any_ne (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_any_ne fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpneud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_ne( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpud_any_ne (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_any_ne fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpneud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_ne( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_ne (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpneud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_ne( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_ne (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpneud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_ne( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_ne (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpneud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_ne( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpud_any_ne (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_any_ne fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpneud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_ne( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpud_any_ne (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_any_ne fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpneud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_ne( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpud_any_ne (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_any_ne fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpneud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_ne( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+
+  if (vec_cmpud_any_ne (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpneud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_ne( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+
+  if (vec_cmpud_any_ne (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpneud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_ne( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  printf ("test_cmp_any_gt\n");
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_gt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_gt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_gt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_gt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_gt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_gt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_gt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 0);
+
+  if (vec_cmpud_any_gt (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgtud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_gt( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 1);
+
+  if (vec_cmpud_any_gt (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgtud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_gt( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpud_any_gt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgtud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_gt( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_gt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_gt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_gt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_gt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_gt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_gt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpud_any_gt (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgtud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_gt( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpud_any_gt (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgtud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_gt( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpud_any_gt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgtud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_gt( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+
+  if (vec_cmpud_any_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_gt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+
+  if (vec_cmpud_any_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_gt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpud_any_gt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_gt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpud_any_gt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_gt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0x8000000000000001UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpud_any_gt (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgtud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_gt( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  printf ("test_cmp_any_ge\n");
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgeud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_ge( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgeud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_ge( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgeud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_ge( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgeud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_ge( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 0);
+
+  if (vec_cmpud_any_ge (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgeud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_ge( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 1);
+
+  if (vec_cmpud_any_ge (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgeud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_ge( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpud_any_ge (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgeud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_ge( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgeud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_ge( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgeud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_ge( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgeud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_ge( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpud_any_ge (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgeud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_ge( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpud_any_ge (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgeud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_ge( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpud_any_ge (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgeud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_ge( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+
+  if (vec_cmpud_any_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgeud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_ge( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+
+  if (vec_cmpud_any_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgeud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_ge( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpud_any_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgeud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_ge( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpud_any_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgeud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_ge( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0x8000000000000001UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpud_any_ge (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgeud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_ge( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  printf ("test_cmp_any_lt\n");
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_lt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_lt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_lt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_lt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpud_any_lt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_lt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 0);
+
+  if (vec_cmpud_any_lt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_lt( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 1);
+
+  if (vec_cmpud_any_lt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_lt( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpud_any_lt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_lt( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_lt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_lt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_lt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpud_any_lt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_lt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpud_any_lt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_lt( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpud_any_lt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_lt( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpud_any_lt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_lt( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+
+  if (vec_cmpud_any_lt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_lt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+
+  if (vec_cmpud_any_lt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_lt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpud_any_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_lt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpud_any_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_lt( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0x8000000000000001UL);
+
+  if (vec_cmpud_any_lt (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_lt( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0x8000000000000001UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpud_any_lt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_lt( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  printf ("test_cmp_any_le\n");
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpleud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_le( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpleud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_le( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpleud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_le( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_le (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpleud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_le( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpud_any_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpleud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_le( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 0);
+
+  if (vec_cmpud_any_le (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpleud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_le( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 1);
+
+  if (vec_cmpud_any_le (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpleud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_le( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vui64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpud_any_le (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpleud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_le( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpleud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_le( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpleud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_le( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpud_any_le (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpud_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpleud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_le( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpud_any_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpleud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_le( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpud_any_le (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpleud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_le( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpud_any_le (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpleud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_le( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpud_any_le (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpleud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_le( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+
+  if (vec_cmpud_any_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpleud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_le( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+
+  if (vec_cmpud_any_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpleud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_le( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpud_any_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpleud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_le( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpud_any_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpud_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpleud(i1, i2);
+      print_v2xint64 ("vec_cmpud_any_le( ", i1);
+      print_v2xint64 ("                 ,", i2);
+      print_v2xint64 ("                )=", j);
+#endif
+    }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0x8000000000000001UL);
+
+  if (vec_cmpud_any_le (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpud_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpleud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_le( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  }
+
+  i1 = (vui64_t )CONST_VINT64_DW(0x8000000000000001UL, 0x8000000000000001UL);
+  i2 = (vui64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpud_any_le (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpud_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpleud(i1, i2);
+    print_v2xint64 ("vec_cmpud_any_le( ", i1);
+    print_v2xint64 ("                 ,", i2);
+    print_v2xint64 ("                )=", j);
+#endif
+  } else {
+  }
+
+  return (rc);
+}
+//#undef __DEBUG_PRINT__
+//#define __DEBUG_PRINT__ 1
+int
+test_cmpsd (void)
+{
+  vi64_t i1, i2, e;
+  vi64_t j;
+  int rc = 0;
+
+  printf ("\ntest_cmpsd Vector Compare Signed doubleword\n");
+
+  printf ("test_cmpeqsd\n");
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+  e = (vi64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpeqsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpequd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpeqsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+  e = (vi64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpeqsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpequd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpeqsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+  e = (vi64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpeqsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpequd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpeqsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 1);
+  e = (vi64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpeqsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpequd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpeqsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, -1);
+  e = (vi64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpeqsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpequd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpeqsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 1);
+  e = (vi64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpeqsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpequd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpeqsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1,-1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, -1);
+  e = (vi64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpeqsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpequd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpeqsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 1);
+  e = (vi64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpeqsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpequd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpeqsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1,-1);
+  i2 = (vi64_t )CONST_VINT64_DW(-1, -1);
+  e = (vi64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpeqsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpequd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpeqsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 0xffffffff00000000);
+  i2 = (vi64_t )CONST_VINT64_DW(0xffffffff00000000, 0xffffffff00000000);
+  e = (vi64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpeqsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpequd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpeqsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(0xffffffff00000001, 0xffffffff00000000);
+  i2 = (vi64_t )CONST_VINT64_DW(0xffffffff00000000, 0xffffffff00000000);
+  e = (vi64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpeqsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpequd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpeqsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(0xffffffff00000001, 0xffffffffffffffff);
+  i2 = (vi64_t )CONST_VINT64_DW(0xffffffff7fffffff, 0xffffffff00000000);
+  e = (vi64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpeqsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpequd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpeqsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(0xffffffff7fffffff, 0xffffffffffffffff);
+  i2 = (vi64_t )CONST_VINT64_DW(0xffffffff7fffffff, 0xffffffff7fffffff);
+  e = (vi64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpeqsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpequd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpeqsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(0xffffffff7fffffff, 0xffffffff7fffffff);
+  i2 = (vi64_t )CONST_VINT64_DW(0xffffffff7fffffff, 0xffffffffffffffff);
+  e = (vi64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpeqsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpequd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpeqsd:", (vb64_t)j, (vb64_t) e);
+
+  printf ("test_cmpgtsd\n");
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+  e = (vi64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpgtsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgtsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgtsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+  e = (vi64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpgtsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgtsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgtsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+  e = (vi64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpgtsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgtsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgtsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 1);
+  e = (vi64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpgtsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgtsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgtsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, -1);
+  e = (vi64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpgtsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgtsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgtsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 1);
+  e = (vi64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpgtsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgtsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgtsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1,-1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, -1);
+  e = (vi64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpgtsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgtsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgtsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 1);
+  e = (vi64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpgtsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgtsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgtsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1, -1);
+  i2 = (vi64_t )CONST_VINT64_DW(-1, -1);
+  e = (vi64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpgtsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgtsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgtsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1, -1);
+  i2 = (vi64_t )CONST_VINT64_DW(-1, -2);
+  e = (vi64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpgtsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgtsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgtsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1, -1);
+  i2 = (vi64_t )CONST_VINT64_DW(-2, -1);
+  e = (vi64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpgtsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgtsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgtsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 0xffffffff00000000);
+  i2 = (vi64_t )CONST_VINT64_DW(0xffffffff00000000, 0xffffffff00000000);
+  e = (vi64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpgtsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgtsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgtsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(0xffffffff00000001, 0xffffffff00000000);
+  i2 = (vi64_t )CONST_VINT64_DW(0xffffffff00000000, 0xffffffff00000000);
+  e = (vi64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpgtsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgtsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgtsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(0xffffffff00000001, 0xffffffffffffffff);
+  i2 = (vi64_t )CONST_VINT64_DW(0xffffffff7fffffff, 0xffffffff00000000);
+  e = (vi64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpgtsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgtsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgtsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(0xffffffff7fffffff, 0xffffffffffffffff);
+  i2 = (vi64_t )CONST_VINT64_DW(0xffffffff7fffffff, 0xffffffff7fffffff);
+  e = (vi64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpgtsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgtsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgtsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(0xffffffff7fffffff, 0xffffffff7fffffff);
+  i2 = (vi64_t )CONST_VINT64_DW(0xffffffff7fffffff, 0xffffffffffffffff);
+  e = (vi64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpgtsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgtsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgtsd:", (vb64_t)j, (vb64_t) e);
+
+  printf ("test_cmpgesd\n");
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+  e = (vi64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpgesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+  e = (vi64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpgesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+  e = (vi64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpgesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 1);
+  e = (vi64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpgesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, -1);
+  e = (vi64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpgesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 1);
+  e = (vi64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpgesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1,-1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, -1);
+  e = (vi64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpgesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 1);
+  e = (vi64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpgesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1, -1);
+  i2 = (vi64_t )CONST_VINT64_DW(-1, -1);
+  e = (vi64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpgesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1, -1);
+  i2 = (vi64_t )CONST_VINT64_DW(-1, -2);
+  e = (vi64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpgesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1, -1);
+  i2 = (vi64_t )CONST_VINT64_DW(-2, -1);
+  e = (vi64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpgesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 0xffffffff00000000);
+  i2 = (vi64_t )CONST_VINT64_DW(0xffffffff00000000, 0xffffffff00000000);
+  e = (vi64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpgesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(0xffffffff00000001, 0xffffffff00000000);
+  i2 = (vi64_t )CONST_VINT64_DW(0xffffffff00000000, 0xffffffff00000000);
+  e = (vi64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpgesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(0xffffffff00000001, 0xffffffffffffffff);
+  i2 = (vi64_t )CONST_VINT64_DW(0xffffffff7fffffff, 0xffffffff00000000);
+  e = (vi64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpgesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(0xffffffff7fffffff, 0xffffffffffffffff);
+  i2 = (vi64_t )CONST_VINT64_DW(0xffffffff7fffffff, 0xffffffff7fffffff);
+  e = (vi64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpgesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(0xffffffff7fffffff, 0xffffffff7fffffff);
+  i2 = (vi64_t )CONST_VINT64_DW(0xffffffff7fffffff, 0xffffffffffffffff);
+  e = (vi64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpgesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpgesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpgesd:", (vb64_t)j, (vb64_t) e);
+
+  printf ("test_cmpltsd\n");
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+  e = (vi64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpltsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpltsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpltsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+  e = (vi64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpltsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpltsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpltsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+  e = (vi64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpltsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpltsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpltsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 1);
+  e = (vi64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpltsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpltsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpltsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, -1);
+  e = (vi64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpltsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpltsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpltsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 1);
+  e = (vi64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpltsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpltsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpltsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1,-1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, -1);
+  e = (vi64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpltsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpltsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpltsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 1);
+  e = (vi64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpltsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpltsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpltsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1, -1);
+  i2 = (vi64_t )CONST_VINT64_DW(-1, -1);
+  e = (vi64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpltsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpltsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpltsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1, -1);
+  i2 = (vi64_t )CONST_VINT64_DW(-1, -2);
+  e = (vi64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpltsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpltsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpltsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1, -1);
+  i2 = (vi64_t )CONST_VINT64_DW(-2, -1);
+  e = (vi64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpltsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpltsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpltsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 0xffffffff00000000);
+  i2 = (vi64_t )CONST_VINT64_DW(0xffffffff00000000, 0xffffffff00000000);
+  e = (vi64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpltsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpltsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpltsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(0xffffffff00000001, 0xffffffff00000000);
+  i2 = (vi64_t )CONST_VINT64_DW(0xffffffff00000000, 0xffffffff00000000);
+  e = (vi64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpltsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpltsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpltsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(0xffffffff00000001, 0xffffffffffffffff);
+  i2 = (vi64_t )CONST_VINT64_DW(0xffffffff7fffffff, 0xffffffff00000000);
+  e = (vi64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpltsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpltsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpltsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(0xffffffff7fffffff, 0xffffffffffffffff);
+  i2 = (vi64_t )CONST_VINT64_DW(0xffffffff7fffffff, 0xffffffff7fffffff);
+  e = (vi64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpltsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpltsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpltsd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(0xffffffff7fffffff, 0xffffffff7fffffff);
+  i2 = (vi64_t )CONST_VINT64_DW(0xffffffff7fffffff, 0xffffffffffffffff);
+  e = (vi64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpltsd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpltsd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpltsd:", (vb64_t)j, (vb64_t) e);
+
+  printf ("test_cmplesd\n");
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+  e = (vi64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmplesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmplesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmplesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+  e = (vi64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmplesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmplesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmplesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+  e = (vi64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmplesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmplesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmplesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 1);
+  e = (vi64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmplesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmplesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmplesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, -1);
+  e = (vi64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmplesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmplesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmplesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 1);
+  e = (vi64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmplesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmplesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmplesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1,-1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, -1);
+  e = (vi64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmplesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmplesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmplesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 1);
+  e = (vi64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmplesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmplesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmplesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1, -1);
+  i2 = (vi64_t )CONST_VINT64_DW(-1, -1);
+  e = (vi64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmplesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmplesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmplesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1, -1);
+  i2 = (vi64_t )CONST_VINT64_DW(-1, -2);
+  e = (vi64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmplesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmplesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmplesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1, -1);
+  i2 = (vi64_t )CONST_VINT64_DW(-2, -1);
+  e = (vi64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmplesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmplesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmplesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 0xffffffff00000000);
+  i2 = (vi64_t )CONST_VINT64_DW(0xffffffff00000000, 0xffffffff00000000);
+  e = (vi64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmplesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmplesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmplesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(0xffffffff00000001, 0xffffffff00000000);
+  i2 = (vi64_t )CONST_VINT64_DW(0xffffffff00000000, 0xffffffff00000000);
+  e = (vi64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmplesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmplesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmplesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(0xffffffff00000001, 0xffffffffffffffff);
+  i2 = (vi64_t )CONST_VINT64_DW(0xffffffff7fffffff, 0xffffffff00000000);
+  e = (vi64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmplesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmplesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmplesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(0xffffffff7fffffff, 0xffffffffffffffff);
+  i2 = (vi64_t )CONST_VINT64_DW(0xffffffff7fffffff, 0xffffffff7fffffff);
+  e = (vi64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmplesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmplesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmplesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(0xffffffff7fffffff, 0xffffffff7fffffff);
+  i2 = (vi64_t )CONST_VINT64_DW(0xffffffff7fffffff, 0xffffffffffffffff);
+  e = (vi64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmplesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmplesd( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmplesd:", (vb64_t)j, (vb64_t) e);
+
+  printf ("test_cmpnesd\n");
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+  e = (vi64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpnesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpneud( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpnesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+  e = (vi64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpnesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpneud( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpnesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+  e = (vi64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpnesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpneud( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpnesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 1);
+  e = (vi64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpnesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpneud( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpnesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, -1);
+  e = (vi64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpnesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpneud( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpnesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 1);
+  e = (vi64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpnesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpneud( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpnesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1,-1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, -1);
+  e = (vi64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpnesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpneud( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpnesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 1);
+  e = (vi64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpnesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpneud( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpnesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(-1, -1);
+  i2 = (vi64_t )CONST_VINT64_DW(-1, -1);
+  e = (vi64_t )CONST_VINT64_DW(0, 0);
+  j = vec_cmpnesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpneud( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpnesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 0xffffffff00000000);
+  i2 = (vi64_t )CONST_VINT64_DW(0xffffffff00000000, 0xffffffff00000000);
+  e = (vi64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpnesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpneud( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpnesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(0xffffffff00000001, 0xffffffff00000000);
+  i2 = (vi64_t )CONST_VINT64_DW(0xffffffff00000000, 0xffffffff00000000);
+  e = (vi64_t )CONST_VINT64_DW(-1, 0);
+  j = vec_cmpnesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpneud( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpnesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(0xffffffff00000001, 0xffffffffffffffff);
+  i2 = (vi64_t )CONST_VINT64_DW(0xffffffff7fffffff, 0xffffffff00000000);
+  e = (vi64_t )CONST_VINT64_DW(-1, -1);
+  j = vec_cmpnesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpneud( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpnesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(0xffffffff7fffffff, 0xffffffffffffffff);
+  i2 = (vi64_t )CONST_VINT64_DW(0xffffffff7fffffff, 0xffffffff7fffffff);
+  e = (vi64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpnesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpneud( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpnesd:", (vb64_t)j, (vb64_t) e);
+
+  i1 = (vi64_t )CONST_VINT64_DW(0xffffffff7fffffff, 0xffffffff7fffffff);
+  i2 = (vi64_t )CONST_VINT64_DW(0xffffffff7fffffff, 0xffffffffffffffff);
+  e = (vi64_t )CONST_VINT64_DW(0, -1);
+  j = vec_cmpnesd(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vcmpneud( ", (vui64_t)i1);
+  print_v2xint64 ("         ,", (vui64_t)i2);
+  print_v2xint64 ("        )=", (vui64_t)j);
+#endif
+  rc += check_v2b64c ("vec_cmpnesd:", (vb64_t)j, (vb64_t) e);
+
+  return (rc);
+}
+
+//#define __DEBUG_PRINT__ 1
+int
+test_cmpsd_all (void)
+{
+  vi64_t i1, i2;
+#ifdef __DEBUG_PRINT__
+  vi64_t j;
+#endif
+  int rc = 0;
+
+  printf ("\ntest_cmpsd_all Vector Compare Unsigned doubleword\n");
+
+  printf ("test_cmp_all_eq\n");
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_eq (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpeqsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_eq( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_eq (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpeqsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_eq( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_eq (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpeqsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_eq( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_eq (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpeqsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_eq( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 0);
+
+  if (vec_cmpsd_all_eq (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpeqsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_eq( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 1);
+
+  if (vec_cmpsd_all_eq (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpeqsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_eq( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpsd_all_eq (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpeqsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_eq( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_eq (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpeqsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_eq( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_eq (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpeqsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_eq( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_eq (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpeqsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_eq( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpsd_all_eq (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpeqsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_eq( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpsd_all_eq (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpeqsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_eq( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpsd_all_eq (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpeqsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_eq( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+
+  if (vec_cmpsd_all_eq (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpeqsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_eq( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+
+  if (vec_cmpsd_all_eq (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpeqsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_eq( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  printf ("test_cmp_all_ne\n");
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_ne (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpnesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_ne( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_ne (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpnesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_ne( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_ne (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpnesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_ne( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_ne (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpnesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_ne( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 0);
+
+  if (vec_cmpsd_all_ne (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpnesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_ne( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 1);
+
+  if (vec_cmpsd_all_ne (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpnesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_ne( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpsd_all_ne (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpnesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_ne( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_ne (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpnesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_ne( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_ne (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpnesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_ne( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_ne (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpnesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_ne( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpsd_all_ne (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpnesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_ne( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpsd_all_ne (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpnesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_ne( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpsd_all_ne (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpnesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_ne( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+
+  if (vec_cmpsd_all_ne (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpnesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_ne( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+
+  if (vec_cmpsd_all_ne (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpnesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_ne( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  printf ("test_cmp_all_gt\n");
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_gt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_gt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_gt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_gt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_gt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 0);
+
+  if (vec_cmpsd_all_gt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgtsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_gt( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 1);
+
+  if (vec_cmpsd_all_gt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgtsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_gt( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpsd_all_gt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgtsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_gt( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_gt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_gt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_gt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpsd_all_gt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgtsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_gt( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpsd_all_gt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgtsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_gt( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpsd_all_gt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgtsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_gt( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+
+  if (vec_cmpsd_all_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_gt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+
+  if (vec_cmpsd_all_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_gt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpsd_all_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_gt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpsd_all_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_gt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0x8000000000000001UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpsd_all_gt (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgtsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_gt( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  printf ("test_cmp_all_ge\n");
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_ge( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_ge( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_ge( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_ge( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 0);
+
+  if (vec_cmpsd_all_ge (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_ge( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 1);
+
+  if (vec_cmpsd_all_ge (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_ge( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpsd_all_ge (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_ge( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_ge (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_ge( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_ge (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_ge( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_ge (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_ge( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpsd_all_ge (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_ge( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpsd_all_ge (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_ge( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpsd_all_ge (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_ge( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+
+  if (vec_cmpsd_all_ge (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_ge( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+
+  if (vec_cmpsd_all_ge (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_ge( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpsd_all_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_ge( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpsd_all_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_ge( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0x8000000000000001UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpsd_all_ge (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_ge( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  printf ("test_cmp_all_lt\n");
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_lt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_lt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_lt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_lt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpsd_all_lt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_lt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 0);
+
+  if (vec_cmpsd_all_lt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_lt( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 1);
+
+  if (vec_cmpsd_all_lt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_lt( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpsd_all_lt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_lt( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_lt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_lt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_lt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_lt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpsd_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_lt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpsd_all_lt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_lt( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpsd_all_lt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_lt( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpsd_all_lt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_lt( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+
+  if (vec_cmpsd_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_lt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+
+  if (vec_cmpsd_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_lt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpsd_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_lt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpsd_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_lt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0x8000000000000001UL);
+
+  if (vec_cmpsd_all_lt (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_lt( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0x8000000000000001UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpsd_all_lt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_lt( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  printf ("test_cmp_all_le\n");
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmplesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_le( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_le (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmplesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_le( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_le (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmplesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_le( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_le (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmplesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_le( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpsd_all_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmplesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_le( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 0);
+
+  if (vec_cmpsd_all_le (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmplesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_le( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 1);
+
+  if (vec_cmpsd_all_le (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmplesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_le( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpsd_all_le (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmplesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_le( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmplesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_le( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmplesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_le( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_all_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmplesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_le( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpsd_all_le (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmplesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_le( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpsd_all_le (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmplesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_le( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpsd_all_le (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmplesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_le( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpsd_all_le (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmplesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_le( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+
+  if (vec_cmpsd_all_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmplesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_le( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+
+  if (vec_cmpsd_all_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmplesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_le( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpsd_all_le (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmplesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_le( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpsd_all_le (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmplesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_all_le( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0x8000000000000001UL);
+
+  if (vec_cmpsd_all_le (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmplesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_le( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0x8000000000000001UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpsd_all_le (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmplesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_all_le( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  return (rc);
+}
+
+#define __DEBUG_PRINT__ 1
+int
+test_cmpsd_any (void)
+{
+  vi64_t i1, i2;
+#ifdef __DEBUG_PRINT__
+  vi64_t j;
+#endif
+  int rc = 0;
+
+  printf ("\ntest_cmpsd_any Vector Compare Unsigned doubleword\n");
+
+  printf ("test_cmp_any_eq\n");
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_eq (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpeqsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_eq( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_eq (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpeqsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_eq( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_eq (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpeqsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_eq( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_eq (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_any_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpeqsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_eq( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 0);
+
+  if (vec_cmpsd_any_eq (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_any_eq fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpeqsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_eq( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 1);
+
+  if (vec_cmpsd_any_eq (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_any_eq fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpeqsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_eq( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpsd_any_eq (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_any_eq fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpeqsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_eq( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_eq (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpeqsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_eq( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_eq (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpeqsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_eq( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_eq (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_any_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpeqsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_eq( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpsd_any_eq (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_any_eq fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpeqsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_eq( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpsd_any_eq (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_any_eq fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpeqsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_eq( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpsd_any_eq (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_any_eq fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpeqsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_eq( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+
+  if (vec_cmpsd_any_eq (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpeqsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_eq( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+
+  if (vec_cmpsd_any_eq (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpeqsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_eq( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  printf ("test_cmp_any_ne\n");
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_ne (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_any_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpnesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_ne( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_ne (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpnesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_ne( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_ne (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpnesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_ne( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_ne (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpnesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_ne( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 0);
+
+  if (vec_cmpsd_any_ne (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_any_ne fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpnesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_ne( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 1);
+
+  if (vec_cmpsd_any_ne (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_any_ne fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpnesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_ne( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpsd_any_ne (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_any_ne fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpnesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_ne( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_ne (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpnesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_ne( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_ne (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpnesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_ne( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_ne (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpnesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_ne( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpsd_any_ne (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_any_ne fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpnesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_ne( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpsd_any_ne (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_any_ne fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpnesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_ne( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpsd_any_ne (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_any_ne fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpnesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_ne( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+
+  if (vec_cmpsd_any_ne (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpnesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_ne( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+
+  if (vec_cmpsd_any_ne (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpnesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_ne( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  printf ("test_cmp_any_gt\n");
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_gt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_gt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_gt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_gt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_gt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_gt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_gt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 0);
+
+  if (vec_cmpsd_any_gt (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgtsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_gt( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 1);
+
+  if (vec_cmpsd_any_gt (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgtsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_gt( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpsd_any_gt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgtsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_gt( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_gt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_gt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_gt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpsd_any_gt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgtsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_gt( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpsd_any_gt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgtsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_gt( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpsd_any_gt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgtsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_gt( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+
+  if (vec_cmpsd_any_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_gt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+
+  if (vec_cmpsd_any_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_gt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpsd_any_gt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_gt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpsd_any_gt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_gt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0x8000000000000001UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpsd_any_gt (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_any_gt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgtsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_gt( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  printf ("test_cmp_any_ge\n");
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_ge( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_ge( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_ge( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_ge( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 0);
+
+  if (vec_cmpsd_any_ge (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_ge( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 1);
+
+  if (vec_cmpsd_any_ge (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_ge( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpsd_any_ge (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_ge( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_ge( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_ge( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_ge (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_ge( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpsd_any_ge (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_ge( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpsd_any_ge (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_ge( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpsd_any_ge (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_ge( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+
+  if (vec_cmpsd_any_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_ge( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+
+  if (vec_cmpsd_any_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_ge( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpsd_any_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_ge( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpsd_any_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_ge( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0x8000000000000001UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpsd_any_ge (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_any_ge fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpgesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_ge( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  printf ("test_cmp_any_lt\n");
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_lt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_lt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_lt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_lt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpsd_any_lt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_lt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 0);
+
+  if (vec_cmpsd_any_lt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_lt( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 1);
+
+  if (vec_cmpsd_any_lt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_lt( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpsd_any_lt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_lt( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_lt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_lt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_lt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_lt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_lt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_lt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpsd_any_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_lt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpsd_any_lt (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_lt( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpsd_any_lt (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_lt( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpsd_any_lt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_lt( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+
+  if (vec_cmpsd_any_lt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_lt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+
+  if (vec_cmpsd_any_lt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_lt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpsd_any_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_lt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpsd_any_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_lt( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0x8000000000000001UL);
+
+  if (vec_cmpsd_any_lt (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_lt( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0x8000000000000001UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpsd_any_lt (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_any_lt fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmpltsd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_lt( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  printf ("test_cmp_any_le\n");
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmplesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_le( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmplesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_le( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmplesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_le( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_le (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmplesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_le( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpsd_any_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmplesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_le( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 0);
+
+  if (vec_cmpsd_any_le (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmplesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_le( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 1);
+
+  if (vec_cmpsd_any_le (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmplesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_le( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(1, 1);
+  i2 = (vi64_t )CONST_VINT64_DW(1, 1);
+
+  if (vec_cmpsd_any_le (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmplesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_le( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmplesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_le( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmplesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_le( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0);
+
+  if (vec_cmpsd_any_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmplesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_le( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpsd_any_le (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsd_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmplesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_le( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpsd_any_le (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmplesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_le( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpsd_any_le (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmplesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_le( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpsd_any_le (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmplesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_le( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+
+  if (vec_cmpsd_any_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmplesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_le( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+
+  if (vec_cmpsd_any_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmplesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_le( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0);
+
+  if (vec_cmpsd_any_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmplesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_le( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000001UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0, 0x8000000000000000UL);
+
+  if (vec_cmpsd_any_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsd_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmplesd(i1, i2);
+      print_v2xint64 ("vec_cmpsd_any_le( ", (vui64_t)i1);
+      print_v2xint64 ("                 ,", (vui64_t)i2);
+      print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+    }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0x8000000000000001UL);
+
+  if (vec_cmpsd_any_le (i1, i2))
+  {
+  } else {
+    rc += 1;
+    printf ("vec_cmpsd_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmplesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_le( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  }
+
+  i1 = (vi64_t )CONST_VINT64_DW(0x8000000000000001UL, 0x8000000000000001UL);
+  i2 = (vi64_t )CONST_VINT64_DW(0x8000000000000000UL, 0x8000000000000000UL);
+
+  if (vec_cmpsd_any_le (i1, i2))
+  {
+    rc += 1;
+    printf ("vec_cmpsd_any_le fail\n");
+#ifdef __DEBUG_PRINT__
+    j = vec_cmplesd(i1, i2);
+    print_v2xint64 ("vec_cmpsd_any_le( ", (vui64_t)i1);
+    print_v2xint64 ("                 ,", (vui64_t)i2);
+    print_v2xint64 ("                )=", (vui64_t)j);
+#endif
+  } else {
+  }
+
+  return (rc);
+}
+
 int
 test_vec_i64 (void)
 {
@@ -1110,6 +10100,12 @@ test_vec_i64 (void)
   rc += test_vsrad ();
   rc += test_muleud ();
   rc += test_muloud ();
+  rc += test_cmpud ();
+  rc += test_cmpud_all ();
+  rc += test_cmpud_any ();
+  rc += test_cmpsd ();
+  rc += test_cmpsd_all ();
+  rc += test_cmpsd_any ();
 
   return (rc);
 }

--- a/src/testsuite/vec_int64_dummy.c
+++ b/src/testsuite/vec_int64_dummy.c
@@ -131,9 +131,147 @@ test_sradi_64 (vi64_t a)
 }
 
 int
+test_cmpud_all_eq (vui64_t a, vui64_t b)
+{
+  return vec_cmpud_all_eq (a, b);
+}
+
+int
+test_cmpud_all_ge (vui64_t a, vui64_t b)
+{
+  return vec_cmpud_all_ge (a, b);
+}
+
+int
 test_cmpud_all_gt (vui64_t a, vui64_t b)
 {
   return vec_cmpud_all_gt (a, b);
+}
+
+int
+test_cmpud_all_le (vui64_t a, vui64_t b)
+{
+  return vec_cmpud_all_le (a, b);
+}
+
+int
+test_cmpud_all_lt (vui64_t a, vui64_t b)
+{
+  return vec_cmpud_all_lt (a, b);
+}
+
+int
+test_cmpud_all_ne (vui64_t a, vui64_t b)
+{
+  return vec_cmpud_all_ne (a, b);
+}
+
+int
+test_cmpud_any_eq (vui64_t a, vui64_t b)
+{
+  return vec_cmpud_any_eq (a, b);
+}
+
+int
+test_cmpud_any_ge (vui64_t a, vui64_t b)
+{
+  return vec_cmpud_any_ge (a, b);
+}
+
+int
+test_cmpud_any_gt (vui64_t a, vui64_t b)
+{
+  return vec_cmpud_any_gt (a, b);
+}
+
+int
+test_cmpud_any_le (vui64_t a, vui64_t b)
+{
+  return vec_cmpud_any_le (a, b);
+}
+
+int
+test_cmpud_any_lt (vui64_t a, vui64_t b)
+{
+  return vec_cmpud_any_lt (a, b);
+}
+
+int
+test_cmpud_any_ne (vui64_t a, vui64_t b)
+{
+  return vec_cmpud_any_ne (a, b);
+}
+
+int
+test_cmpsd_all_eq (vi64_t a, vi64_t b)
+{
+  return vec_cmpsd_all_eq (a, b);
+}
+
+int
+test_cmpsd_all_ge (vi64_t a, vi64_t b)
+{
+  return vec_cmpsd_all_ge (a, b);
+}
+
+int
+test_cmpsd_all_gt (vi64_t a, vi64_t b)
+{
+  return vec_cmpsd_all_gt (a, b);
+}
+
+int
+test_cmpsd_all_le (vi64_t a, vi64_t b)
+{
+  return vec_cmpsd_all_le (a, b);
+}
+
+int
+test_cmpsd_all_lt (vi64_t a, vi64_t b)
+{
+  return vec_cmpsd_all_lt (a, b);
+}
+
+int
+test_cmpsd_all_ne (vi64_t a, vi64_t b)
+{
+  return vec_cmpsd_all_ne (a, b);
+}
+
+int
+test_cmpsd_any_eq (vi64_t a, vi64_t b)
+{
+  return vec_cmpsd_any_eq (a, b);
+}
+
+int
+test_cmpsd_any_ge (vi64_t a, vi64_t b)
+{
+  return vec_cmpsd_any_ge (a, b);
+}
+
+int
+test_cmpsd_any_gt (vi64_t a, vi64_t b)
+{
+  return vec_cmpsd_any_gt (a, b);
+}
+
+int
+test_cmpsd_any_le (vi64_t a, vi64_t b)
+{
+  return vec_cmpsd_any_le (a, b);
+}
+
+int
+test_cmpsd_any_lt (vi64_t a, vi64_t b)
+{
+  return vec_cmpsd_any_lt (a, b);
+}
+
+int
+test_cmpsd_any_ne (vi64_t a, vi64_t b)
+{
+  return vec_cmpsd_any_ne (a, b);
 }
 
 vui64_t
@@ -143,12 +281,6 @@ test_cmpud_all_gt2 (vui64_t a, vui64_t b, vui64_t c, vui64_t d)
     return c;
   else
     return d;
-}
-
-int
-test_cmpud_all_eq (vui64_t a, vui64_t b)
-{
-  return vec_cmpud_all_eq (a, b);
 }
 
 vui64_t
@@ -173,9 +305,75 @@ test_addudm (vui64_t a, vui64_t b)
 }
 
 vui64_t
+test_cmpequd (vui64_t a, vui64_t b)
+{
+  return vec_cmpequd (a, b);
+}
+
+vui64_t
+test_cmpneud (vui64_t a, vui64_t b)
+{
+  return vec_cmpneud (a, b);
+}
+
+vui64_t
 test_cmpgtud (vui64_t a, vui64_t b)
 {
   return vec_cmpgtud (a, b);
+}
+
+vui64_t
+test_cmpltud (vui64_t a, vui64_t b)
+{
+  return vec_cmpltud (a, b);
+}
+
+vui64_t
+test_cmpgeud (vui64_t a, vui64_t b)
+{
+  return vec_cmpgeud (a, b);
+}
+
+vui64_t
+test_cmpleud (vui64_t a, vui64_t b)
+{
+  return vec_cmpleud (a, b);
+}
+
+vi64_t
+test_cmpeqsd (vi64_t a, vi64_t b)
+{
+  return vec_cmpeqsd (a, b);
+}
+
+vi64_t
+test_cmpnesd (vi64_t a, vi64_t b)
+{
+  return vec_cmpnesd (a, b);
+}
+
+vi64_t
+test_cmpgtsd (vi64_t a, vi64_t b)
+{
+  return vec_cmpgtsd (a, b);
+}
+
+vi64_t
+test_cmpltsd (vi64_t a, vi64_t b)
+{
+  return vec_cmpltsd (a, b);
+}
+
+vi64_t
+test_cmpgesd (vi64_t a, vi64_t b)
+{
+  return vec_cmpgesd (a, b);
+}
+
+vi64_t
+test_cmplesd (vi64_t a, vi64_t b)
+{
+  return vec_cmplesd (a, b);
 }
 
 vui64_t
@@ -255,3 +453,45 @@ __test_swapd (vui64_t __VH)
 {
   return vec_swapd (__VH);
 }
+
+#ifdef _ARCH_PWR8
+/* POWER 64-bit (vector long long) compiler tests.  */
+
+vb64_t
+__test_cmpequd (vui64_t a, vui64_t b)
+{
+  return vec_cmpeq (a, b);
+}
+
+vb64_t
+__test_cmpgtud (vui64_t a, vui64_t b)
+{
+  return vec_cmpgt (a, b);
+}
+
+vb64_t
+__test_cmpltud (vui64_t a, vui64_t b)
+{
+  return vec_cmplt (a, b);
+}
+
+vb64_t
+__test_cmpgeud (vui64_t a, vui64_t b)
+{
+  return vec_cmpge (a, b);
+}
+
+vb64_t
+__test_cmpleud (vui64_t a, vui64_t b)
+{
+  return vec_cmple (a, b);
+}
+
+#ifdef _ARCH_PWR9
+vb64_t
+__test_cmpneud (vui64_t a, vui64_t b)
+{
+  return vec_cmpne (a, b);
+}
+#endif
+#endif

--- a/src/vec_f32_ppc.h
+++ b/src/vec_f32_ppc.h
@@ -74,7 +74,7 @@
  * are not obvious.
  *
  * \section f32_perf_0_0 Performance data.
- * High performance estimates are provided as an aid to function
+ * High level performance estimates are provided as an aid to function
  * selection when evaluating algorithms. For background on how
  * <I>Latency</I> and <I>Throughput</I> are derived see:
  * \ref perf_data

--- a/src/vec_int64_ppc.h
+++ b/src/vec_int64_ppc.h
@@ -26,7 +26,7 @@
 #include <vec_int32_ppc.h>
 
 /*!
- * \file  vec_int64_ppc.h
+ * \file vec_int64_ppc.h
  * \brief Header package containing a collection of 128-bit SIMD
  * operations over 64-bit integer elements.
  *
@@ -52,10 +52,10 @@
  * instructions you can get equivalent function.
  *
  * \note The doubleword integer multiply implementations are included
- * in vec_int128_ppc.h (see also vec_muleud(), vec_muloud(), and
- * vec_msumudm()).  This resolves a circular dependency as 64-bit
- * by 64-bit multiplies require 128-bit addition to produce the full
- * product.
+ * in vec_int128_ppc.h.  This resolves a circular dependency as 64-bit
+ * by 64-bit integer multiplies require 128-bit integer addition to
+ * produce the full product.
+ * \sa vec_adduqm, vec_muleud, vec_muloud, and vec_msumudm
  *
  * Most of these intrinsic (compiler built-in) operations are defined
  * in <altivec.h> and described in the compiler documentation.
@@ -87,7 +87,7 @@
  * a in-line assembler implementation for older compilers that do not
  * provide the build-ins.
  *
- * This header covers operations that are either:
+ * This header covers operations that are any of the following:
  *
  * - Implemented in hardware instructions for later
  * processors and useful to programmers, on slightly older processors,
@@ -101,12 +101,11 @@
  * <altivec.h>, and require multiple instructions or
  * are not obvious.  Examples include the shift immediate operations.
  *
- * \note The Multiply even/odd doubleword operations are
- * currently implemented in <vec_int128_ppc.h> which resolves a
- * dependency on Add Quadword. These functions (vec_msumudm,
- * vec_muleud, vec_muloud) all produce a quadword results and need
- * vec_adduqm to sum partial products on earlier Power platforms.
- * \sa vec_adduqm, vec_muleud, vec_muloud, and vec_msumudm
+ * \section int64_perf_0_0 Performance data.
+ * High level performance estimates are provided as an aid to function
+ * selection when evaluating algorithms. For background on how
+ * <I>Latency</I> and <I>Throughput</I> are derived see:
+ * \ref perf_data
  */
 
 /** \brief Vector Add Unsigned Doubleword Modulo.
@@ -212,7 +211,7 @@ static inline vui64_t vec_cmpneud (vui64_t a, vui64_t b);
  *  Compare each signed long (64-bit) integer and return all '1's,
  *  if a[i] == b[i], otherwise all '0's.
  *
- *  For POWER8 (PowerISA 2.07B) or later use the Vector Compare
+ *  For POWER8 (PowerISA 2.07B) or later, use the Vector Compare
  *  Equal Unsigned DoubleWord (<B>vcmpequd</B>) instruction. Otherwise
  *  use boolean logic using word compares.
  *
@@ -241,7 +240,7 @@ vec_cmpeqsd (vi64_t a, vi64_t b)
  *  Compare each unsigned long (64-bit) integer and return all '1's,
  *  if a[i] == b[i], otherwise all '0's.
  *
- *  For POWER8 (PowerISA 2.07B) or later use the Vector Compare
+ *  For POWER8 (PowerISA 2.07B) or later, use the Vector Compare
  *  Equal Unsigned DoubleWord (<B>vcmpequd</B>) instruction. Otherwise
  *  use boolean logic using word compares.
  *
@@ -320,11 +319,11 @@ static inline
 vi64_t
 vec_cmpgesd (vi64_t a, vi64_t b)
 {
-vi64_t r;
-/* vec_cmpge is implemented as the not of vec_cmplt. And vec_cmplt
-   is implemented as vec_cmpgt with parms reversed.  */
-r = vec_cmpgtsd (b, a);
-return vec_nor (r, r);
+  vi64_t r;
+  /* vec_cmpge is implemented as the not of vec_cmplt. And vec_cmplt
+     is implemented as vec_cmpgt with parms reversed.  */
+  r = vec_cmpgtsd (b, a);
+  return vec_nor (r, r);
 }
 
 /** \brief Vector Compare Greater Than or Equal Unsigned Doubleword.
@@ -736,6 +735,11 @@ vec_cmpsd_all_gt (vi64_t a, vi64_t b)
  *  Compare each signed long (64-bit) integer and return true if all
  *  elements of a <= b.
  *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 4-9   | 2/cycle  |
+ *  |power9   | 3     | 2/cycle  |
+ *
  *  @param a 128-bit vector treated as 2 x 64-bit signed long
  *  integer (dword) elements.
  *  @param b 128-bit vector treated as 2 x 64-bit signed long
@@ -1077,6 +1081,11 @@ vec_cmpud_all_gt (vui64_t a, vui64_t b)
  *  Compare each unsigned long (64-bit) integer and return true if all
  *  elements of a <= b.
  *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 4-9   | 2/cycle  |
+ *  |power9   | 3     | 2/cycle  |
+ *
  *  @param a 128-bit vector treated as 2 x 64-bit unsigned long
  *  integer (dword) elements.
  *  @param b 128-bit vector treated as 2 x 64-bit unsigned long
@@ -1410,10 +1419,16 @@ vec_pasted (vui64_t __VH, vui64_t __VL)
 
 /** \brief Vector Permute Doubleword Immediate.
  *  Combine a doubleword selected from the 1st (vra) vector with
- *  a doubleword selected from the 2nd (vrb) vector. The 2-bit control
- *  operand (ctl) selects which doubleword from the 1st and 2nd
- *  vector operands are transfered to the result vector.
+ *  a doubleword selected from the 2nd (vrb) vector.
  *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   |   2   | 2/cycle  |
+ *  |power9   |   3   | 2/cycle  |
+ *
+ *  The 2-bit control operand (ctl) selects which doubleword from the
+ *  1st and 2nd vector operands are transfered to the result vector.
+ *  Control table:
  *  ctl |  vrt[0:63]  | vrt[64:127]
  *  :-: | :---------: | :----------:
  *   0  |  vra[0:63]  | vrb[0:63]
@@ -1421,10 +1436,6 @@ vec_pasted (vui64_t __VH, vui64_t __VL)
  *   2  | vra[64:127] | vrb[0:63]
  *   3  | vra[64:127] | vrb[64:127]
  *
- *  |processor|Latency|Throughput|
- *  |--------:|:-----:|:---------|
- *  |power8   |   2   | 2/cycle  |
- *  |power9   |   3   | 2/cycle  |
  *
  *  @param vra a 128-bit vector as the source of the
  *  high order doubleword of the result.
@@ -1648,15 +1659,18 @@ vec_sldi (vui64_t vra, const unsigned int shb)
  *  Duplicate the selected doubleword element across the doubleword
  *  elements of the result.
  *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   |   2   | 2/cycle  |
+ *  |power9   |   3   | 2/cycle  |
+ *
+ *  The 1-bit control operand (ctl) selects which (0:1) doubleword
+ *  element, from the vector operand, is replicated to both doublewords
+ *  of the result vector.  Control table:
  *  ctl |  vrt[0:63]  | vrt[64:127]
  *  :-: | :---------: | :----------:
  *   0  |  vra[0:63]  | vra[0:63]
  *   1  | vra[64:127] | vra[64:127]
- *
- *  |processor|Latency|Throughput|
- *  |--------:|:-----:|:---------|
- *  |power8   |   2   | 2/cycle |
- *  |power9   |   3   | 2/cycle  |
  *
  *  @param vra a 128-bit vector.
  *  @param ctl a const integer encoding the source doubleword.


### PR DESCRIPTION
These are needed for the vec_f64_ppc.h vec_is* implementations that
avoid Floating-point exceptions.

	* src/testsuite/arith128_print.c (print_v2f64, print_v2f64x,
	print_v2b64c, print_v2b64x, check_v2b64c_priv,
	check_v2b64x_priv, check_v2f64_priv, check_v2f64x_priv):
	New functions.
	* src/testsuite/arith128_print.h (print_v2f64, print_v2f64x,
	print_v2b64c, print_v2b64x, check_v2b64c_priv,
	check_v2b64x_priv, check_v2f64_priv, check_v2f64x_priv):
	New extern function.
	(check_v2b64c, check_v2b64x, check_v2f64, check_v2f64x):
	New inline function.

	* src/testsuite/arith128_test_i64.c (test_cmpud,
	test_cmpud_all, test_cmpud_any, test_cmpsd, test_cmpsd_all,
	test_cmpsd_any) New function.
	(test_vec_i64): Call test_cmpud, test_cmpud_all,
	test_cmpud_any, test_cmpsd, test_cmpsd_all, test_cmpsd_any.

	* src/testsuite/vec_int64_dummy.c (test_cmpud_all_eq,
	test_cmpud_all_ge, test_cmpud_all_le, test_cmpud_all_lt,
	test_cmpud_all_ne, test_cmpud_any_eq, test_cmpud_any_ge,
	test_cmpud_any_gt, test_cmpud_any_le, test_cmpud_any_lt,
	test_cmpud_any_ne, test_cmpsd_all_eq, test_cmpsd_all_ge,
	test_cmpsd_all_gt, test_cmpsd_all_le, test_cmpsd_all_lt,
	test_cmpsd_all_ne, test_cmpsd_any_eq, test_cmpsd_any_ge,
	test_cmpsd_any_gt, test_cmpsd_any_le, test_cmpsd_any_lt,
	test_cmpsd_any_ne, test_cmpequd, test_cmpneud, test_cmpltud,
	test_cmpgeud, test_cmpleud, test_cmpeqsd, test_cmpnesd,
	test_cmpgtsd, test_cmpltsd, test_cmpgesd, test_cmplesd):
	New functions.
	[_ARCH_PWR8] (__test_cmpequd, __test_cmpgtud, __test_cmpltud,
	__test_cmpgeud, __test_cmpleud): New functions.
	[_ARCH_PWR9] (__test_cmpneud): New function.

	* src/vec_int64_ppc.h: Update Doxygen \file intro.
	Add latency and throughput data for existing functions.
	(vec_cmpeqsd, vec_cmpgesd, vec_cmpgtsd, vec_cmplesd,
	vec_cmpltsd, vec_cmpnesd): New functions.
	(vec_cmpgeud, vec_cmpleud, vec_cmpltud, vec_cmpneud):
	New functions.
	(vec_cmpud_all_ge, vec_cmpud_all_lt, vec_cmpud_all_ne,
	vec_cmpud_any_eq, vec_cmpud_any_ge, vec_cmpud_any_le,
	vec_cmpud_any_lt, vec_cmpud_all_ne): New functions.
	(vec_cmpequd, vec_cmpgtud, vec_cmpleud, vec_cmpud_all_eq,
	vec_cmpud_all_gt, vec_cmpud_all_le, vec_cmpud_any_gt):
	Simplify compiler conditionals. Simplify implimentation.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>