### PR TITLE
Update vec_f64_ppc.h with new functions and prepare to publish.

### DIFF
--- a/doc/pveclib-doxygen-pveclib.doxy
+++ b/doc/pveclib-doxygen-pveclib.doxy
@@ -744,6 +744,7 @@ INPUT                  = $(SRCDIR)/doc/pveclibmaindox.h \
                          $(SRCDIR)/src/vec_bcd_ppc.h \
                          $(SRCDIR)/src/vec_char_ppc.h \
                          $(SRCDIR)/src/vec_f32_ppc.h \
+                         $(SRCDIR)/src/vec_f64_ppc.h \
                          $(SRCDIR)/src/vec_common_ppc.h
 
 # This tag can be used to specify the character encoding of the source files

--- a/src/vec_int64_ppc.h
+++ b/src/vec_int64_ppc.h
@@ -182,7 +182,6 @@ vec_clzd (vui64_t vra)
   r = vec_vclzd (vra);
 #endif
 #else
-  //#warning Implememention pre power8
   vui32_t n, nt, y, x, m;
   vui32_t z = { 0, 0, 0, 0 };
   vui32_t dlwm = { 0, -1, 0, -1 };
@@ -264,7 +263,6 @@ vec_cmpequd (vui64_t a, vui64_t b)
 #ifdef _ARCH_PWR8
 #if __GNUC__ >= 6
   result = (vui64_t)vec_cmpeq(a, b);
-//  result = (vui64_t)vec_cmpeq((__vector bool long long)a, (__vector bool long long)b);
 #else
   __asm__(
       "vcmpequd %0,%1,%2;\n"
@@ -1546,7 +1544,6 @@ vec_popcntd (vui64_t vra)
   r = vec_vpopcntd (vra);
 #endif
 #else
-  //#warning Implememention pre power8
   vui32_t z= { 0,0,0,0};
   vui32_t x;
   x = vec_popcntw ((vui32_t)vra);
@@ -1922,7 +1919,6 @@ vec_vsld (vui64_t vra, vui64_t vrb)
    * value is splatted to each byte of the vector.  */
   vsh_h = vec_splat (vsh_l, VEC_BYTE_L_DWH);
   vsh_l = vec_splat (vsh_l, VEC_BYTE_L_DWL);
-//  vsht_splat = vec_splat ((vui8_t) vrb, VEC_BYTE_L);
   /* Shift the high dword by vsh_h.  */
   vr_h = vec_vslo (vr_h,  vsh_h);
   vr_h = vec_vsl  (vr_h, vsh_h);
@@ -2049,7 +2045,6 @@ vec_vsrd (vui64_t vra, vui64_t vrb)
    * value is splatted to each byte of the vector.  */
   vsh_h = vec_splat (vsh_l, VEC_BYTE_L_DWH);
   vsh_l = vec_splat (vsh_l, VEC_BYTE_L_DWL);
-//  vsht_splat = vec_splat ((vui8_t) vrb, VEC_BYTE_L);
   /* Shift the high dword by vsh_h.  */
   vr_h = vec_vsro ((vui8_t)vra,  vsh_h);
   vr_h = vec_vsr  (vr_h, vsh_h);


### PR DESCRIPTION
This commit is just the f64 header and doxy INPUT. Test cases and
configure.ac/Makefile.am changes will follow in part2/3.

	* src/vec_f64_ppc.h: Add doxygen \file level intro.
	(__f64_bool): Removed. Use vb64_t from <vec_common_ppc.h>.
	(vec_absf64): New Function.
	(vec_all_isinff64, vec_all_isnanf64, vec_all_isnormalf64,
	vec_all_issubnormalf64, vec_all_iszerof64): New Functions.
	(vec_any_isinff64, vec_any_isnanf64, vec_any_isnormalf64,
	vec_any_issubnormalf64, vec_any_iszerof64): New Functions.
	(vec_copysignf64): Update comments.
	(vec_isinff64, vec_isnanf64, vec_isnormalf64,
	vec_issubnormalf64, vec_iszerof64): Update implimentation and
	comments.

	* doc/pveclib-doxygen-pveclib.doxy (INPUT): Add vec_f64_ppc.h
	to the Doxygen INPUT list.

	* src/vec_int64_ppc.h: Remove commented out statements and
	misleading comments.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>