### PR TITLE
Final Makefile and test driver changes to activate vec_f64_ppc.h

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,6 +9,7 @@ libpvec_la_SOURCES = tipowof10.c decpowof2.c
 libvecdummy_la_SOURCES = testsuite/vec_int128_dummy.c \
 	testsuite/vec_int64_dummy.c \
 	testsuite/vec_int32_dummy.c \
+	testsuite/vec_f64_dummy.c \
 	testsuite/vec_f32_dummy.c \
 	testsuite/vec_pwr9_dummy.c \
 	testsuite/vec_bcd_dummy.c \
@@ -32,6 +33,7 @@ pveclib_testincludedir = $(includedir)/testsuite
 # on 'make install'
 pveclibinclude_HEADERS = \
 	vec_common_ppc.h \
+	vec_f64_ppc.h \
 	vec_f32_ppc.h \
 	vec_int128_ppc.h \
 	vec_int64_ppc.h \
@@ -55,8 +57,10 @@ TESTS += pveclib_test
 pveclib_test_SOURCES = \
 	testsuite/pveclib_test.c \
 	testsuite/arith128_print.c \
+	testsuite/vec_perf_f64.c \
 	testsuite/vec_perf_f32.c \
 	testsuite/vec_perf_i128.c \
+	testsuite/arith128_test_f64.c \
 	testsuite/arith128_test_f32.c \
 	testsuite/arith128_test_i128.c \
 	testsuite/arith128_test_i64.c \

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -148,14 +148,17 @@ libvecdummy_la_LIBADD =
 am__dirstamp = $(am__leading_dot)dirstamp
 am_libvecdummy_la_OBJECTS = testsuite/vec_int128_dummy.lo \
 	testsuite/vec_int64_dummy.lo testsuite/vec_int32_dummy.lo \
-	testsuite/vec_f32_dummy.lo testsuite/vec_pwr9_dummy.lo \
-	testsuite/vec_bcd_dummy.lo testsuite/vec_char_dummy.lo
+	testsuite/vec_f64_dummy.lo testsuite/vec_f32_dummy.lo \
+	testsuite/vec_pwr9_dummy.lo testsuite/vec_bcd_dummy.lo \
+	testsuite/vec_char_dummy.lo
 libvecdummy_la_OBJECTS = $(am_libvecdummy_la_OBJECTS)
 am__EXEEXT_1 = pveclib_test$(EXEEXT) vec_dummy$(EXEEXT)
 am_pveclib_test_OBJECTS = testsuite/pveclib_test.$(OBJEXT) \
 	testsuite/arith128_print.$(OBJEXT) \
+	testsuite/vec_perf_f64.$(OBJEXT) \
 	testsuite/vec_perf_f32.$(OBJEXT) \
 	testsuite/vec_perf_i128.$(OBJEXT) \
+	testsuite/arith128_test_f64.$(OBJEXT) \
 	testsuite/arith128_test_f32.$(OBJEXT) \
 	testsuite/arith128_test_i128.$(OBJEXT) \
 	testsuite/arith128_test_i64.$(OBJEXT) \
@@ -427,6 +430,7 @@ CPPFLAGS = @CPPFLAGS@
 CYGPATH_W = @CYGPATH_W@
 DEFS = @DEFS@
 DEPDIR = @DEPDIR@
+DLLTOOL = @DLLTOOL@
 DOXYGEN_PAPER_SIZE = @DOXYGEN_PAPER_SIZE@
 DSYMUTIL = @DSYMUTIL@
 DUMPBIN = @DUMPBIN@
@@ -474,8 +478,10 @@ LIBTOOL = @LIBTOOL@
 LIPO = @LIPO@
 LN_S = @LN_S@
 LTLIBOBJS = @LTLIBOBJS@
+LT_SYS_LIBRARY_PATH = @LT_SYS_LIBRARY_PATH@
 MAINT = @MAINT@
 MAKEINFO = @MAKEINFO@
+MANIFEST_TOOL = @MANIFEST_TOOL@
 MKDIR_P = @MKDIR_P@
 NM = @NM@
 NMEDIT = @NMEDIT@
@@ -501,6 +507,7 @@ abs_builddir = @abs_builddir@
 abs_srcdir = @abs_srcdir@
 abs_top_builddir = @abs_top_builddir@
 abs_top_srcdir = @abs_top_srcdir@
+ac_ct_AR = @ac_ct_AR@
 ac_ct_CC = @ac_ct_CC@
 ac_ct_DUMPBIN = @ac_ct_DUMPBIN@
 am__include = @am__include@
@@ -533,7 +540,6 @@ libdir = @libdir@
 libexecdir = @libexecdir@
 localedir = @localedir@
 localstatedir = @localstatedir@
-lt_ECHO = @lt_ECHO@
 mandir = @mandir@
 mkdir_p = @mkdir_p@
 oldincludedir = @oldincludedir@
@@ -563,6 +569,7 @@ libpvec_la_SOURCES = tipowof10.c decpowof2.c
 libvecdummy_la_SOURCES = testsuite/vec_int128_dummy.c \
 	testsuite/vec_int64_dummy.c \
 	testsuite/vec_int32_dummy.c \
+	testsuite/vec_f64_dummy.c \
 	testsuite/vec_f32_dummy.c \
 	testsuite/vec_pwr9_dummy.c \
 	testsuite/vec_bcd_dummy.c \
@@ -580,6 +587,7 @@ pveclib_testincludedir = $(includedir)/testsuite
 # on 'make install'
 pveclibinclude_HEADERS = \
 	vec_common_ppc.h \
+	vec_f64_ppc.h \
 	vec_f32_ppc.h \
 	vec_int128_ppc.h \
 	vec_int64_ppc.h \
@@ -597,8 +605,10 @@ pveclib_test_la_INCLUDES = \
 pveclib_test_SOURCES = \
 	testsuite/pveclib_test.c \
 	testsuite/arith128_print.c \
+	testsuite/vec_perf_f64.c \
 	testsuite/vec_perf_f32.c \
 	testsuite/vec_perf_i128.c \
+	testsuite/arith128_test_f64.c \
 	testsuite/arith128_test_f32.c \
 	testsuite/arith128_test_i128.c \
 	testsuite/arith128_test_i64.c \
@@ -706,6 +716,8 @@ testsuite/vec_int64_dummy.lo: testsuite/$(am__dirstamp) \
 	testsuite/$(DEPDIR)/$(am__dirstamp)
 testsuite/vec_int32_dummy.lo: testsuite/$(am__dirstamp) \
 	testsuite/$(DEPDIR)/$(am__dirstamp)
+testsuite/vec_f64_dummy.lo: testsuite/$(am__dirstamp) \
+	testsuite/$(DEPDIR)/$(am__dirstamp)
 testsuite/vec_f32_dummy.lo: testsuite/$(am__dirstamp) \
 	testsuite/$(DEPDIR)/$(am__dirstamp)
 testsuite/vec_pwr9_dummy.lo: testsuite/$(am__dirstamp) \
@@ -730,9 +742,13 @@ testsuite/pveclib_test.$(OBJEXT): testsuite/$(am__dirstamp) \
 	testsuite/$(DEPDIR)/$(am__dirstamp)
 testsuite/arith128_print.$(OBJEXT): testsuite/$(am__dirstamp) \
 	testsuite/$(DEPDIR)/$(am__dirstamp)
+testsuite/vec_perf_f64.$(OBJEXT): testsuite/$(am__dirstamp) \
+	testsuite/$(DEPDIR)/$(am__dirstamp)
 testsuite/vec_perf_f32.$(OBJEXT): testsuite/$(am__dirstamp) \
 	testsuite/$(DEPDIR)/$(am__dirstamp)
 testsuite/vec_perf_i128.$(OBJEXT): testsuite/$(am__dirstamp) \
+	testsuite/$(DEPDIR)/$(am__dirstamp)
+testsuite/arith128_test_f64.$(OBJEXT): testsuite/$(am__dirstamp) \
 	testsuite/$(DEPDIR)/$(am__dirstamp)
 testsuite/arith128_test_f32.$(OBJEXT): testsuite/$(am__dirstamp) \
 	testsuite/$(DEPDIR)/$(am__dirstamp)
@@ -773,6 +789,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/arith128_test_bcd.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/arith128_test_char.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/arith128_test_f32.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/arith128_test_f64.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/arith128_test_i128.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/arith128_test_i16.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/arith128_test_i32.Po@am__quote@
@@ -782,10 +799,12 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/vec_char_dummy.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/vec_dummy_main.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/vec_f32_dummy.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/vec_f64_dummy.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/vec_int128_dummy.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/vec_int32_dummy.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/vec_int64_dummy.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/vec_perf_f32.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/vec_perf_f64.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/vec_perf_i128.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/vec_pwr9_dummy.Plo@am__quote@
 

--- a/src/testsuite/pveclib_test.c
+++ b/src/testsuite/pveclib_test.c
@@ -39,6 +39,7 @@
 #include <testsuite/arith128_test_char.h>
 #include <testsuite/arith128_test_bcd.h>
 #include <testsuite/arith128_test_f32.h>
+#include <testsuite/arith128_test_f64.h>
 
 int
 main (void)
@@ -63,6 +64,9 @@ main (void)
 #endif
 #if 1
   rc += test_vec_f32 ();
+#endif
+#if 1
+  rc += test_vec_f64 ();
 #endif
 
   if (rc > 0)


### PR DESCRIPTION
install and make check.

	* src/testsuite/pveclib_test.c:
	Include <testsuite/arith128_test_f64.h>
	(main): Add call to test_vec_f64.

	* src/Makefile.am (libvecdummy_la_SOURCES):
	Add testsuite/vec_f64_dummy.c.
	(pveclibinclude_HEADERS): Add vec_f64_ppc.h.
	(pveclib_test_SOURCES): Add testsuite/vec_perf_f64.c and
	testsuite/arith128_test_f64.c.
	* src/Makefile.in: Automake generated.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>