### PR TITLE
Added quadword compares, cleaned up the documentation, for vec_i128_p…

### DIFF
--- a/src/vec_common_ppc.h
+++ b/src/vec_common_ppc.h
@@ -68,6 +68,8 @@ typedef __vector __bool short vb16_t;
 typedef __vector __bool int vb32_t;
 /*! \brief vector of 64-bit bool long long elements. */
 typedef __vector __bool long long vb64_t;
+/*! \brief vector of 128-bit bool __int128 elements. */
+typedef __vector __bool __int128 vb128_t;
 
 /* did not get vector __int128 until GCC4.8.  */
 #if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)

--- a/src/vec_f64_ppc.h
+++ b/src/vec_f64_ppc.h
@@ -386,7 +386,7 @@ vec_all_iszerof64 (vf64_t vf64)
  *  |power8   | 6-20  | 2/cycle  |
  *  |power9   | 5-14  | 2/cycle  |
  *
- *  @param vf32 a vector of __binary32 values.
+ *  @param vf64 a vector of __binary32 values.
  *  @return boolean int, true if any of 2 double values are infinity
  */
 static inline int

--- a/src/vec_int64_ppc.h
+++ b/src/vec_int64_ppc.h
@@ -199,11 +199,13 @@ vec_clzd (vui64_t vra)
   return (r);
 }
 
+///@cond INTERNAL
 static inline vi64_t vec_cmpgtsd (vi64_t a, vi64_t b);
 static inline vui64_t vec_cmpequd (vui64_t a, vui64_t b);
 static inline vui64_t vec_cmpgeud (vui64_t a, vui64_t b);
 static inline vui64_t vec_cmpgtud (vui64_t a, vui64_t b);
 static inline vui64_t vec_cmpneud (vui64_t a, vui64_t b);
+///@endcond
 
 /** \brief Vector Compare Equal Signed Doubleword.
  *


### PR DESCRIPTION
…pc.h.

This part 1, unit and performance tests to follow.

	* src/vec_common_ppc.h (vb128_t): Type defined.
	* src/vec_f64_ppc.h (vec_any_isinff64): Correct doxygent @param.
	* src/vec_int64_ppc.h: Use @cond INTERNAL so doxygen will
	ignore forward referenced function prototypes.

	* src/vec_int128_ppc.h: Update \file description.
	Add processor Latency and Throughput estimates.
	(vec_addcuq, vec_addecuq, vec_addeuqm, vec_adduqm): Reorder for
	alphabetical listing in doxygen.
	Add some function prototypes to resolve forward references so
	functions can be in alphabetical order.
	Use @cond INTERNAL so doxygen will ignore forward referenced
	function prototypes.
	(vec_cmpeqsq, vec_cmpequq, vec_cmpgesq, vec_cmpgeuq,
	vec_cmpgtsq, vec_cmpgtuq, vec_cmplesq, vec_cmpleuq,
	vec_cmpltsq, vec_cmpltuq, vec_cmpnesq, vec_cmpneuq):
	New functions.
	(vec_cmpsq_all_eq, vec_cmpsq_all_ge, vec_cmpsq_all_gt,
	vec_cmpsq_all_le, vec_cmpsq_all_lt, vec_cmpsq_all_ne):
	New functions.
	(vec_cmpuq_all_eq, vec_cmpuq_all_ge, vec_cmpuq_all_gt,
	vec_cmpuq_all_le, vec_cmpuq_all_lt, vec_cmpuq_all_ne):
	New functions.
	Correct test alignement for consistency in doxygen comments.
	(vec_mul10uq): Correct code bugs found in unit test.
	(vec_mul10cuq, vec_mul10ecuq, vec_mul10euq, vec_mul10uq):
	Reorder for alphabetical listing in doxygen.
	(vec_msumudm):
	Reorder for alphabetical listing in doxygen.
	(vec_setb_cyq, vec_setb_ncq, vec_setb_sq): New functions.
	(vec_subcuq, vec_subecuq, vec_subeuqm): New functions.
	(vec_subuqm): Simplify and correct logic.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>