### PR TITLE
Part 2 of vec_int128_ppc.h update. Includes minor comment/doxygen

### DIFF
--- a/src/testsuite/arith128_print.c
+++ b/src/testsuite/arith128_print.c
@@ -631,6 +631,29 @@ print_vint256 (char *prefix, vui128_t val0_128, vui128_t val1_128)
 }
 
 void
+print_vb128c (char *prefix, vb128_t val)
+{
+  const vui64_t true = { 'T', 'T' };
+  const vui64_t false = { 'F', 'F' };
+  vui64_t text;
+
+  text = vec_sel (false, true, (vb64_t) val);
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  printf ("%s %c%c\n", prefix, (int) text[1], (int) text[0]);
+#else
+  printf ("%s %c%c\n", prefix, (int)text[0], (int)text[1]);
+#endif
+}
+
+void
+print_vb128x (char *prefix, vb128_t boolval)
+{
+  vui128_t val = (vui128_t) boolval;
+  print_vint128x (prefix, val);
+}
+
+void
 print_vint384 (char *prefix, vui128_t val0_128, vui128_t val1_128,
                vui128_t val2_128)
 {
@@ -971,6 +994,38 @@ check_v2b64x_priv (char *prefix, vb64_t val128, vb64_t shouldbe)
       printf ("%s\n", prefix);
       print_v2b64x ("\tshould be: ", shouldbe);
       print_v2b64x ("\t       is: ", val128);
+    }
+
+  return (rc);
+}
+
+int
+check_vb128c_priv (char *prefix, vb128_t val128, vb128_t shouldbe)
+{
+  int rc = 0;
+
+  if (vec_any_ne((vui32_t ) val128, (vui32_t ) shouldbe))
+    {
+      rc = 1;
+      printf ("%s\n", prefix);
+      print_vb128c ("\tshould be: ", shouldbe);
+      print_vb128c ("\t       is: ", val128);
+    }
+
+  return (rc);
+}
+
+int
+check_vb128x_priv (char *prefix, vb128_t val128, vb128_t shouldbe)
+{
+  int rc = 0;
+
+  if (vec_any_ne((vui32_t ) val128, (vui32_t ) shouldbe))
+    {
+      rc = 1;
+      printf ("%s\n", prefix);
+      print_vb128x ("\tshould be: ", shouldbe);
+      print_vb128x ("\t       is: ", val128);
     }
 
   return (rc);

--- a/src/testsuite/arith128_print.c
+++ b/src/testsuite/arith128_print.c
@@ -642,7 +642,7 @@ print_vb128c (char *prefix, vb128_t val)
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   printf ("%s %c%c\n", prefix, (int) text[1], (int) text[0]);
 #else
-  printf ("%s %c%c\n", prefix, (int)text[0], (int)text[1]);
+  printf ("%s %c%c\n", prefix, (int) text[0], (int) text[1]);
 #endif
 }
 
@@ -1004,7 +1004,7 @@ check_vb128c_priv (char *prefix, vb128_t val128, vb128_t shouldbe)
 {
   int rc = 0;
 
-  if (vec_any_ne((vui32_t ) val128, (vui32_t ) shouldbe))
+  if (vec_any_ne ((vui32_t) val128, (vui32_t) shouldbe))
     {
       rc = 1;
       printf ("%s\n", prefix);
@@ -1020,7 +1020,7 @@ check_vb128x_priv (char *prefix, vb128_t val128, vb128_t shouldbe)
 {
   int rc = 0;
 
-  if (vec_any_ne((vui32_t ) val128, (vui32_t ) shouldbe))
+  if (vec_any_ne ((vui32_t) val128, (vui32_t) shouldbe))
     {
       rc = 1;
       printf ("%s\n", prefix);

--- a/src/testsuite/arith128_print.h
+++ b/src/testsuite/arith128_print.h
@@ -127,6 +127,12 @@ print_v2b64c (char *prefix, vb64_t val);
 extern void
 print_v2b64x (char *prefix, vb64_t val);
 
+extern void
+print_vb128c (char *prefix, vb128_t boolval);
+
+extern void
+print_vb128x (char *prefix, vb128_t boolval);
+
 extern int
 check_udiv128_64x (unsigned __int128 numerator, uint64_t divisor,
                    uint64_t exp_q, uint64_t exp_r);
@@ -296,6 +302,12 @@ check_v2f64_priv (char *prefix, vf64_t val128, vf64_t shouldbe);
 
 extern int
 check_v2f64x_priv (char *prefix, vf64_t val128, vf64_t shouldbe);
+
+extern int
+check_vb128c_priv (char *prefix, vb128_t val128, vb128_t shouldbe);
+
+extern int
+check_vb128x_priv (char *prefix, vb128_t val128, vb128_t shouldbe);
 
 extern int
 check_vuint128_priv (char *prefix, vui128_t val128, vui128_t shouldbe);
@@ -471,6 +483,32 @@ check_v2f64x (char *prefix, vf64_t val128, vf64_t shouldbe)
   if (vec_any_ne((vui32_t)val128, (vui32_t)shouldbe))
     {
       rc = check_v2f64x_priv (prefix, val128, shouldbe);
+    }
+
+  return (rc);
+
+}
+
+static inline int
+check_vb128c (char *prefix, vb128_t val128, vb128_t shouldbe)
+{
+  int rc = 0;
+  if (vec_any_ne((vui32_t)val128, (vui32_t)shouldbe))
+    {
+      rc = check_vb128c_priv (prefix, val128, shouldbe);
+    }
+
+  return (rc);
+
+}
+
+static inline int
+check_vb128x (char *prefix, vb128_t val128, vb128_t shouldbe)
+{
+  int rc = 0;
+  if (vec_any_ne((vui32_t )val128, (vui32_t )shouldbe))
+    {
+      rc = check_vb128x_priv (prefix, val128, shouldbe);
     }
 
   return (rc);

--- a/src/testsuite/vec_int128_dummy.c
+++ b/src/testsuite/vec_int128_dummy.c
@@ -68,6 +68,188 @@ test_vec_adduqm_cuq (vui128_t *p, vui128_t a, vui128_t b)
 }
 
 vui128_t
+test_vec_subuqm (vui128_t a, vui128_t b)
+{
+  return (vec_subuqm (a, b));
+}
+
+vui128_t
+test_vec_subcuq (vui128_t a, vui128_t b)
+{
+  return (vec_subcuq (a, b));
+}
+
+vui128_t
+test_vec_subeuqm_ecuq (vui128_t *p, vui128_t a, vui128_t b, vui128_t ci)
+{
+  *p = vec_subecuq (a, b, ci);
+  return vec_subeuqm (a, b, ci);
+}
+
+vui128_t
+test_vec_subuqm_cuq (vui128_t *p, vui128_t a, vui128_t b)
+{
+  *p = vec_subcuq (a, b);
+  return vec_subuqm (a, b);
+}
+
+vi128_t
+test_vec_cmpeqsq (vi128_t a, vi128_t b)
+{
+  return (vec_cmpeqsq (a, b));
+}
+
+vi128_t
+test_vec_cmpgesq (vi128_t a, vi128_t b)
+{
+  return (vec_cmpgesq (a, b));
+}
+
+vi128_t
+test_vec_cmpgtsq (vi128_t a, vi128_t b)
+{
+  return (vec_cmpgtsq (a, b));
+}
+
+vi128_t
+test_vec_cmplesq (vi128_t a, vi128_t b)
+{
+  return (vec_cmplesq (a, b));
+}
+
+vi128_t
+test_vec_cmpltsq (vi128_t a, vi128_t b)
+{
+  return (vec_cmpltsq (a, b));
+}
+
+vui128_t
+test_vec_cmpequq (vui128_t a, vui128_t b)
+{
+  return (vec_cmpequq (a, b));
+}
+
+vui128_t
+test_vec_cmpgtuq (vui128_t a, vui128_t b)
+{
+  return (vec_cmpgtuq (a, b));
+}
+
+vui128_t
+test_vec_cmpltuq (vui128_t a, vui128_t b)
+{
+  return (vec_cmpltuq (a, b));
+}
+
+vui128_t
+test_vec_cmpgeuq (vui128_t a, vui128_t b)
+{
+  return (vec_cmpgeuq (a, b));
+}
+
+vui128_t
+test_vec_cmpleuq (vui128_t a, vui128_t b)
+{
+  return (vec_cmpleuq (a, b));
+}
+
+vui128_t
+test_vec_cmpneuq (vui128_t a, vui128_t b)
+{
+  return (vec_cmpneuq (a, b));
+}
+
+int
+test_cmpsq_all_eq (vi128_t a, vi128_t b)
+{
+  return vec_cmpsq_all_eq (a, b);
+}
+
+int
+test_cmpsq_all_ge (vi128_t a, vi128_t b)
+{
+  return vec_cmpsq_all_ge (a, b);
+}
+
+int
+test_cmpsq_all_gt (vi128_t a, vi128_t b)
+{
+  return vec_cmpsq_all_gt (a, b);
+}
+
+int
+test_cmpsq_all_le (vi128_t a, vi128_t b)
+{
+  return vec_cmpsq_all_le (a, b);
+}
+
+int
+test_cmpsq_all_lt (vi128_t a, vi128_t b)
+{
+  return vec_cmpsq_all_lt (a, b);
+}
+
+int
+test_cmpsq_all_ne (vi128_t a, vi128_t b)
+{
+  return vec_cmpsq_all_ne (a, b);
+}
+
+int
+test_cmpuq_all_eq (vui128_t a, vui128_t b)
+{
+  return vec_cmpuq_all_eq (a, b);
+}
+
+int
+test_cmpuq_all_ge (vui128_t a, vui128_t b)
+{
+  return vec_cmpuq_all_ge (a, b);
+}
+
+int
+test_cmpuq_all_gt (vui128_t a, vui128_t b)
+{
+  return vec_cmpuq_all_gt (a, b);
+}
+
+int
+test_cmpuq_all_le (vui128_t a, vui128_t b)
+{
+  return vec_cmpuq_all_le (a, b);
+}
+
+int
+test_cmpuq_all_lt (vui128_t a, vui128_t b)
+{
+  return vec_cmpuq_all_lt (a, b);
+}
+
+int
+test_cmpuq_all_ne (vui128_t a, vui128_t b)
+{
+  return vec_cmpuq_all_ne (a, b);
+}
+
+vui128_t
+test_setb_cyq (vui128_t vcy)
+{
+  return vec_setb_cyq (vcy);
+}
+
+vui128_t
+test_setb_ncq (vui128_t vcy)
+{
+  return vec_setb_ncq (vcy);
+}
+
+vui128_t
+test_setb_sq (vi128_t vcy)
+{
+  return vec_setb_sq (vcy);
+}
+
+vui128_t
 test_vec_mul10uq_cuq (vui128_t *p, vui128_t a)
 {
   *p = vec_mul10cuq (a);
@@ -439,6 +621,110 @@ test_mul4uq (vui128_t *__restrict__ mulu, vui128_t m1h, vui128_t m1l, vui128_t m
   mulu[1] = mplh;
   mulu[2] = mphl;
   mulu[3] = mphh;
+}
+
+/* alternative algorithms tested and not selected due to code size
+   and cycle latency.  */
+vi128_t
+__test_vec_cmpgesq (vi128_t vra, vi128_t vrb)
+{
+#ifdef _ARCH_PWR8
+  vi128_t tand;
+  vui128_t a_b;
+  vui64_t axorb, torc, torc2;
+
+  /* vra >=vrb: (vrb | NOT(vra)) & ((vrb ~ vra) | NOT(vra - vrb)) */
+  a_b = vec_subuqm ((vui128_t)vra, (vui128_t)vrb);
+  axorb = vec_xor ((vui64_t)vra, (vui64_t)vrb);
+  torc = vec_orc (axorb, (vui64_t)a_b);
+  torc2 = vec_orc ((vui64_t)vrb, (vui64_t)vra);
+  tand = (vi128_t)vec_and (torc2, torc);
+  return (vi128_t)vec_setb_sq (tand);
+#else
+  const vui32_t signbit = CONST_VINT128_W (0x80000000, 0, 0, 0);
+  vui32_t _a, _b;
+
+  _a = vec_xor ((vui32_t)vra, signbit);
+  _b = vec_xor ((vui32_t)vrb, signbit);
+  return (vi128_t)vec_cmpgeuq ((vui128_t)_a, (vui128_t)_b);
+#endif
+}
+
+vi128_t
+__test_vec_cmpgtsq (vi128_t vra, vi128_t vrb)
+{
+#ifdef _ARCH_PWR8
+  vi128_t tor;
+  vui128_t b_a;
+  vui64_t aeqvb, tand, tandc;
+
+  /* vra >vrb: (vrb & NOT(vra)) | (NOT(vrb ~ vra) & (vrb - vra)) */
+  b_a = vec_subuqm ((vui128_t)vrb, (vui128_t)vra);
+  /* NOT(a XOR b) == (a EQV b).  */
+  aeqvb = vec_eqv ((vui64_t)vra, (vui64_t)vrb);
+  tand = vec_and (aeqvb, (vui64_t)b_a);
+  tandc = vec_andc ((vui64_t)vrb, (vui64_t)vra);
+  tor = (vi128_t)vec_or (tandc, tand);
+  return (vi128_t)vec_setb_sq (tor);
+#else
+  const vui32_t signbit = CONST_VINT128_W (0x80000000, 0, 0, 0);
+  vui32_t _a, _b;
+
+  _a = vec_xor ((vui32_t)vra, signbit);
+  _b = vec_xor ((vui32_t)vrb, signbit);
+  return (vi128_t)vec_cmpgtuq ((vui128_t)_a, (vui128_t)_b);
+#endif
+}
+
+vi128_t
+__test_vec_cmplesq (vi128_t vra, vi128_t vrb)
+{
+#ifdef _ARCH_PWR8
+  vi128_t tand;
+  vui128_t b_a;
+  vui64_t axorb, torc, torc2;
+
+  /* vra < vrb: (vra | NOT(vrb)) & ((vra ~ vrb) | NOT(vrb - vra)) */
+  b_a = vec_subuqm ((vui128_t)vrb, (vui128_t)vra);
+  axorb = vec_xor ((vui64_t)vra, (vui64_t)vrb);
+  torc = vec_orc (axorb, (vui64_t)b_a);
+  torc2 = vec_orc ((vui64_t)vra, (vui64_t)vrb);
+  tand = (vi128_t)vec_and (torc2, torc);
+  return (vi128_t)vec_setb_sq (tand);
+#else
+  const vui32_t signbit = CONST_VINT128_W (0x80000000, 0, 0, 0);
+  vui32_t _a, _b;
+
+  _a = vec_xor ((vui32_t)vra, signbit);
+  _b = vec_xor ((vui32_t)vrb, signbit);
+  return (vi128_t)vec_cmpleuq ((vui128_t)_a, (vui128_t)_b);
+#endif
+}
+
+vi128_t
+__test_vec_cmpltsq (vi128_t vra, vi128_t vrb)
+{
+#ifdef _ARCH_PWR8
+  vi128_t tor;
+  vui128_t a_b;
+  vui64_t aeqvb, tand, tandc;
+
+  /* vra < vrb: (vra & NOT(vrb)) | (NOT(vra ~ vrb) & (vra - vrb)) */
+  a_b = vec_subuqm ((vui128_t)vra, (vui128_t)vrb);
+  /* NOT(a XOR b) == (a EQV b).  */
+  aeqvb = vec_eqv ((vui64_t)vra, (vui64_t)vrb);
+  tand = vec_and (aeqvb, (vui64_t)a_b);
+  tandc = vec_andc ((vui64_t)vra, (vui64_t)vrb);
+  tor = (vi128_t)vec_or (tandc, tand);
+  return (vi128_t)vec_setb_sq (tor);
+#else
+  const vui32_t signbit = CONST_VINT128_W (0x80000000, 0, 0, 0);
+  vui32_t _a, _b;
+
+  _a = vec_xor ((vui32_t)vra, signbit);
+  _b = vec_xor ((vui32_t)vrb, signbit);
+  return (vi128_t)vec_cmpltuq ((vui128_t)_a, (vui128_t)_b);
+#endif
 }
 
 #ifdef _ARCH_PWR8

--- a/src/testsuite/vec_perf_i128.c
+++ b/src/testsuite/vec_perf_i128.c
@@ -41,6 +41,7 @@ static const vui32_t c_two = CONST_VINT32_W(0, 0, 0, 2);
 static const vui32_t c_nine = CONST_VINT32_W(0, 0, 0, 9);
 static const vui32_t c_ten = CONST_VINT32_W(0, 0, 0, 10);
 
+/* 10^64th as a binary const requiring 256-bits.  */
 static const vui32_t ten_64h =
     CONST_VINT32_W(0x00000000, 0x00184f03, 0xe93ff9f4, 0xdaa797ed);
 static const vui32_t ten_64l =
@@ -194,8 +195,8 @@ timed_muludq (void)
 }
 
 //#define __DEBUG_PRINT__
-/* Older compilers ignore the "no-unroll-loops" pragma and make it
-   hard to isolate each iteration of vec_muludq.  This version
+/* Older (GCC6) compilers ignore the "no-unroll-loops" pragma and make
+   it hard to isolate each iteration of vec_muludq.  This version
    calls __test_muludq from vec_int128_dummy.c as a work around.  */
 extern vui128_t
 __test_muludq (vui128_t *mh, vui128_t a, vui128_t b);
@@ -233,5 +234,3 @@ timed_muludqx (void)
 
   return rc;
 }
-
-

--- a/src/testsuite/vec_perf_i128.c
+++ b/src/testsuite/vec_perf_i128.c
@@ -35,9 +35,16 @@
 #include <testsuite/vec_perf_i128.h>
 
 extern const vui128_t vtipowof10 [];
+static const vui32_t c_zero = CONST_VINT32_W(0, 0, 0, 0);
 static const vui32_t c_one = CONST_VINT32_W(0, 0, 0, 1);
 static const vui32_t c_two = CONST_VINT32_W(0, 0, 0, 2);
+static const vui32_t c_nine = CONST_VINT32_W(0, 0, 0, 9);
 static const vui32_t c_ten = CONST_VINT32_W(0, 0, 0, 10);
+
+static const vui32_t ten_64h =
+    CONST_VINT32_W(0x00000000, 0x00184f03, 0xe93ff9f4, 0xdaa797ed);
+static const vui32_t ten_64l =
+    CONST_VINT32_W(0x6e38ed64, 0xbf6a1f01, 0x00000000, 0x00000000);
 
 
 int timed_mul10uq (void)
@@ -98,6 +105,32 @@ int timed_mul10uq2x (void)
   return rc;
 }
 
+//#define __DEBUG_PRINT__
+int timed_cmul10ecuq (void)
+{
+  vui128_t i, k, j;
+  vui128_t i2, k2, ks;
+  int ii;
+  int rc = 0;
+
+  i = (vui128_t)c_zero;
+  i2 = (vui128_t)c_zero;
+  for (ii = 0; ii < 64; ii++)
+    {
+      k = vec_cmul10ecuq (&j, i, (vui128_t)c_nine);
+      k2 = vec_mul10euq ((vui128_t) i2, j);
+      i = k;
+      i2 = k2;
+    }
+  /* k2|k should be 10^64-1.  */
+  ks = vec_adduqm (k, (vui128_t)c_one);
+  rc += check_vuint128x ("vec_cmul10ecuq:", ks, (vui128_t) ten_64l);
+  rc += check_vuint128x ("vec_mul10euq:", k2, (vui128_t) ten_64h);
+
+  return rc;
+}
+//#undef __DEBUG_PRINT__
+//#define __DEBUG_PRINT__
 int timed_mulluq (void)
 {
   vui128_t i, k;
@@ -114,12 +147,89 @@ int timed_mulluq (void)
       k = vec_mulluq ((vui128_t) i, (vui128_t) c_ten);
 
 #ifdef __DEBUG_PRINT__
-      rc += check_vuint128 ("vec_mul10uq:", k, vtipowof10[ii]);
+      rc += check_vuint128 ("vec_mulluq:", k, vtipowof10[ii]);
       print_vint128 ("x * 10 ", k);
 #endif
       i = k;
     }
   rc += check_vuint128 ("vec_mulluq:", k, vtipowof10[38]);
+
+  return rc;
+}
+
+#pragma GCC optimize ("no-unroll-loops")
+//#define __DEBUG_PRINT__
+int
+timed_muludq (void)
+{
+  vui128_t i, j, k;
+  int ii, iii;
+  int rc = 0;
+
+  i = (vui128_t) c_ten;
+  iii = 2;
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("init i=10", (vui128_t) i);
+#endif
+
+  for (ii = 1; ii < 7; ii++)
+    {
+      k = vec_muludq (&j, (vui128_t) i, (vui128_t) i);
+
+#ifdef __DEBUG_PRINT__
+      if (ii < 6)
+	{
+	  printf ("iii=%d ", iii);
+	  print_vint128 ("10Eiii=", k);
+	  rc += check_vuint128 ("vec_muludq:", k, vtipowof10[iii]);
+	}
+#endif
+      i = k;
+      iii = iii + iii;
+    }
+  rc += check_vuint128x ("vec_muludqx k:", k, (vui128_t) ten_64l);
+  rc += check_vuint128x ("vec_muludqx j:", j, (vui128_t) ten_64h);
+
+  return rc;
+}
+
+//#define __DEBUG_PRINT__
+/* Older compilers ignore the "no-unroll-loops" pragma and make it
+   hard to isolate each iteration of vec_muludq.  This version
+   calls __test_muludq from vec_int128_dummy.c as a work around.  */
+extern vui128_t
+__test_muludq (vui128_t *mh, vui128_t a, vui128_t b);
+
+int
+timed_muludqx (void)
+{
+  vui128_t i, j, k;
+  int ii, iii;
+  int rc = 0;
+
+  i = (vui128_t) c_ten;
+  iii = 2;
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("init i=10", (vui128_t) i);
+#endif
+
+  for (ii = 1; ii < 7; ii++)
+    {
+      k = __test_muludq (&j, (vui128_t) i, (vui128_t) i);
+
+#ifdef __DEBUG_PRINT__
+      if (ii < 6)
+	{
+	  printf ("iii=%d ", iii);
+	  print_vint128 ("10Eiii=", k);
+	  rc += check_vuint128 ("vec_muludq:", k, vtipowof10[iii]);
+	}
+#endif
+      i = k;
+      iii = iii + iii;
+    }
+  rc += check_vuint128x ("vec_muludqx k:", k, (vui128_t) ten_64l);
+  rc += check_vuint128x ("vec_muludqx j:", j, (vui128_t) ten_64h);
 
   return rc;
 }

--- a/src/testsuite/vec_perf_i128.h
+++ b/src/testsuite/vec_perf_i128.h
@@ -25,6 +25,9 @@
 
 extern int timed_mul10uq (void);
 extern int timed_mul10uq2x (void);
+extern int timed_cmul10ecuq (void);
 extern int timed_mulluq (void);
+extern int timed_muludq (void);
+extern int timed_muludqx (void);
 
 #endif /* TESTSUITE_VEC_PERF_I128_H_ */

--- a/src/vec_int128_ppc.h
+++ b/src/vec_int128_ppc.h
@@ -2147,13 +2147,13 @@ vec_muloud (vui64_t a, vui64_t b)
  *
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
- *  |power8   | 56    | 1/cycle  |
+ *  |power8   | 56-64 | 1/cycle  |
  *  |power9   | 33-39 | 1/cycle  |
  *
  *  @param *mulu pointer to upper 128-bits of the product.
  *  @param a 128-bit vector treated a __int128.
  *  @param b 128-bit vector treated a __int128.
- *  @return __int128 (lower 128-bits) a * b.
+ *  @return vector unsigned __int128 (lower 128-bits) of a * b.
  */
 static inline vui128_t
 vec_muludq (vui128_t *mulu, vui128_t a, vui128_t b)
@@ -2441,7 +2441,7 @@ vec_muludq (vui128_t *mulu, vui128_t a, vui128_t b)
  *
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
- *  |power8   | 42    | 1/cycle  |
+ *  |power8   | 42-48 | 1/cycle  |
  *  |power9   | 16-20 | 2/cycle  |
  *
  *  @param a 128-bit vector treated a __int128.


### PR DESCRIPTION
updates and supporting arith128_print changes. Additional int128
specific performance and trace tests. And new dummy examples for
eyeballing the compiler generated code.

	* src/vec_int128_ppc.h: Update doxygen comments.

	* src/testsuite/arith128_print.c (print_vb128c, print_vb128x,
	check_vb128c_priv, check_vb128x_priv): New functions.
	* src/testsuite/arith128_print.h (print_vb128c, print_vb128x
	check_vb128c_priv, check_vb128x_priv): New extern functions.
	(check_vb128c, check_vb128x): New inline functions.

	* src/testsuite/vec_int128_dummy.c (test_vec_subuqm,
	test_vec_subcuq, test_vec_subeuqm_ecuq, test_vec_subuqm_cuq):
	New Functions.
	(test_vec_cmpeqsq, test_vec_cmpgesq, test_vec_cmpgtsq,
	test_vec_cmplesq, test_vec_cmpltsq, test_vec_cmpequq,
	test_vec_cmpgtuq, test_vec_cmpltuq, test_vec_cmpgeuq,
	test_vec_cmpleuq, test_vec_cmpneuq, test_cmpsq_all_eq,
	test_cmpsq_all_ge, test_cmpsq_all_gt, test_cmpsq_all_le,
	test_cmpsq_all_lt, test_cmpsq_all_ne, test_cmpuq_all_eq,
	test_cmpuq_all_ge, test_cmpuq_all_gt, test_cmpuq_all_le,
	test_cmpuq_all_lt, test_cmpuq_all_ne): New functions.
	(test_setb_cyq, test_setb_ncq, test_setb_sq): New functions.
	(__test_vec_cmpgesq, __test_vec_cmpgtsq, __test_vec_cmplesq,
	__test_vec_cmpltsq) New functions.

	* src/testsuite/vec_perf_i128.c (c_zero, c_nine, ten_64h,
	ten_64l): New file scope vector const values.
	(timed_mulluq): Correct check_vuint128 name text.
	(timed_cmul10ecuq, timed_muludq, timed_muludqx)
	New timed functions.
	* src/testsuite/vec_perf_i128.h (timed_cmul10ecuq,
	timed_mulluq, timed_muludq, timed_muludqx): New extern
	functions.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>