### PR TITLE
Part 3 add unit tests for new functions in vec_i128_ppc.h.

### DIFF
--- a/src/testsuite/arith128_test_i128.c
+++ b/src/testsuite/arith128_test_i128.c
@@ -580,7 +580,7 @@ db_vec_addeq (vui32_t *cout, vui32_t a, vui32_t b, vui32_t c)
   vui32_t c2;
   vui32_t z = { 0, 0, 0, 0 };
 
-  co = (vui32_t ) { 0, 0, 0, 1 };
+  co = (vui32_t) { 0, 0, 0, 1 };
 
   printf ("db_vec_addeq\n");
   print_vint128 ("  a = ", (vui128_t)a);
@@ -866,113 +866,113 @@ test_addeq (void)
 
   printf ("\ntest_addeq Vector add extend carry int128\n");
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
-  l = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
+  l = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   k = (vui32_t) vec_addeq ((vui128_t*) &m, (vui128_t) i, (vui128_t) j,
                            (vui128_t) l);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_extend ("extent 2E32-1 + 2E32-1 + c=1", k, m, i, j, l);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000001, 0xffffffff);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000001, 0xffffffff);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
   rc += check_vint256 ("vec_addeq:", (vui128_t) m, (vui128_t) k, (vui128_t) ec,
                        (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
-  j = (vui32_t )
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
+  j = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          __UINT32_MAX__);
-  l = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  l = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
   k = (vui32_t) vec_addeq ((vui128_t*) &m, (vui128_t) i, (vui128_t) j,
                            (vui128_t) l);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_extend ("extend 1 + 2E128-1 + c=0", k, m, i, j, l);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
   rc += check_vint256 ("vec_addeq:", (vui128_t) m, (vui128_t) k, (vui128_t) ec,
                        (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
-  j = (vui32_t )
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
+  j = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          __UINT32_MAX__);
-  l = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  l = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   k = (vui32_t) vec_addeq ((vui128_t*) &m, (vui128_t) i, (vui128_t) j,
                            (vui128_t) l);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_extend ("extend 0 + 2E128-1 + c=1", k, m, i, j, l);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
   rc += check_vint256 ("vec_addeq:", (vui128_t) m, (vui128_t) k, (vui128_t) ec,
                        (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 2);
-  j = (vui32_t )
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 2);
+  j = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          __UINT32_MAX__);
-  l = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  l = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   k = (vui32_t) vec_addeq ((vui128_t*) &m, (vui128_t) i, (vui128_t) j,
                            (vui128_t) l);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_extend ("extend 2 + 2E128-1 + c=1", k, m, i, j, l);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000002);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000002);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
   rc += check_vint256 ("vec_addeq:", (vui128_t) m, (vui128_t) k, (vui128_t) ec,
                        (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 1, 0);
-  j = (vui32_t )
+  i = (vui32_t)CONST_VINT32_W(0, 0, 1, 0);
+  j = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          0);
-  l = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  l = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   k = (vui32_t) vec_addeq ((vui128_t*) &m, (vui128_t) i, (vui128_t) j,
                            (vui128_t) l);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_extend ("extend 2E32 + 2E128-1-2E32-1 + c=1", k, m, i, j, l);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
   rc += check_vint256 ("vec_addeq:", (vui128_t) m, (vui128_t) k, (vui128_t) ec,
                        (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
-  j = (vui32_t )
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
+  j = (vui32_t)
           CONST_VINT32_W(0xfffeffff, __UINT32_MAX__, __UINT32_MAX__,
                          __UINT32_MAX__);
-  l = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  l = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   k = (vui32_t) vec_addeq ((vui128_t*) &m, (vui128_t) i, (vui128_t) j,
                            (vui128_t) l);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_extend ("extend 0 + 2E128-1-2E102 + c=1", k, m, i, j, l);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0xffff0000, 0x00000000, 0x00000000, 0x00000000);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  e = (vui32_t)CONST_VINT32_W(0xffff0000, 0x00000000, 0x00000000, 0x00000000);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
   rc += check_vint256 ("vec_addeq:", (vui128_t) m, (vui128_t) k, (vui128_t) ec,
                        (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
-  j = (vui32_t )
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
+  j = (vui32_t)
           CONST_VINT32_W(0xfffeffff, __UINT32_MAX__, __UINT32_MAX__,
                          __UINT32_MAX__);
-  l = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  l = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   k = (vui32_t) vec_addeq ((vui128_t*) &m, (vui128_t) i, (vui128_t) j,
                            (vui128_t) l);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_extend ("extend 1 + 2E128-1-2E102 + c=1", k, m, i, j, l);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0xffff0000, 0x00000000, 0x00000000, 0x00000001);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  e = (vui32_t)CONST_VINT32_W(0xffff0000, 0x00000000, 0x00000000, 0x00000001);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
   rc += check_vint256 ("vec_addeq:", (vui128_t) m, (vui128_t) k, (vui128_t) ec,
                        (vui128_t) e);
 
@@ -1003,14 +1003,14 @@ test_addq (void)
 
   print_int128_sum ("1 + 2E32-1", c, a, b);
 #endif
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
   k = (vui32_t) vec_adduqm ((vui128_t) i, (vui128_t) j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("1 + 2E32-1", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000001, 0x00000000);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000001, 0x00000000);
   rc += check_vuint128x ("vec_adduqm:", (vui128_t) k, (vui128_t) e);
 
 #ifdef __DEBUG_PRINT__
@@ -1020,14 +1020,14 @@ test_addq (void)
 
   print_int128_sum ("2E32-1 + 2E32-1", c, a, b);
 #endif
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
   k = (vui32_t) vec_adduqm ((vui128_t) i, (vui128_t) j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("2E32-1 + 2E32-1", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000001, 0xfffffffe);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000001, 0xfffffffe);
   rc += check_vuint128x ("vec_adduqm:", (vui128_t) k, (vui128_t) e);
 
 #ifdef __DEBUG_PRINT__
@@ -1037,14 +1037,14 @@ test_addq (void)
 
   print_int128_sum ("1 + 2E64-1", c, a, b);
 #endif
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
-  j = (vui32_t )CONST_VINT32_W(0, 0, __UINT32_MAX__, __UINT32_MAX__);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
+  j = (vui32_t)CONST_VINT32_W(0, 0, __UINT32_MAX__, __UINT32_MAX__);
   k = (vui32_t) vec_adduqm ((vui128_t) i, (vui128_t) j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("1 + 2E64-1", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000001, 0x00000000, 0x00000000);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000001, 0x00000000, 0x00000000);
   rc += check_vuint128x ("vec_adduqm:", (vui128_t) k, (vui128_t) e);
 
 #ifdef __DEBUG_PRINT__
@@ -1056,15 +1056,15 @@ test_addq (void)
 
   print_int128_sum ("1 + 2E96-1", c, a, b);
 #endif
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
-  j = (vui32_t )
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
+  j = (vui32_t)
           CONST_VINT32_W(0, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
   k = (vui32_t) vec_adduqm ((vui128_t) i, (vui128_t) j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("1 + 2E96-1", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000001, 0x00000000, 0x00000000, 0x00000000);
+  e = (vui32_t)CONST_VINT32_W(0x00000001, 0x00000000, 0x00000000, 0x00000000);
   rc += check_vuint128x ("vec_adduqm:", (vui128_t) k, (vui128_t) e);
 
 #ifdef __DEBUG_PRINT__
@@ -1076,8 +1076,8 @@ test_addq (void)
 
   print_int128_sum ("1 + 2E128-1", c, a, b);
 #endif
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
-  j = (vui32_t )
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
+  j = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          __UINT32_MAX__);
   k = (vui32_t) vec_adduqm ((vui128_t) i, (vui128_t) j);
@@ -1087,13 +1087,13 @@ test_addq (void)
   print_vint128x_sum ("1 + 2E128-1", k, i, j);
   print_vint128x     ("  c = ", (vui128_t)l);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
   rc += check_vuint128x ("vec_adduqm:", (vui128_t) k, (vui128_t) e);
   rc += check_vuint128x ("vec_addcuq:", (vui128_t) l, (vui128_t) ec);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 1, 0);
-  j = (vui32_t )
+  i = (vui32_t)CONST_VINT32_W(0, 0, 1, 0);
+  j = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          0);
   k = (vui32_t) vec_adduqm ((vui128_t) i, (vui128_t) j);
@@ -1103,13 +1103,13 @@ test_addq (void)
   print_vint128x_sum ("1 + 2E128-1", k, i, j);
   print_vint128x     ("  c = ", (vui128_t)l);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
   rc += check_vuint128x ("vec_adduqm:", (vui128_t) k, (vui128_t) e);
   rc += check_vuint128x ("vec_addcuq:", (vui128_t) l, (vui128_t) ec);
 
-  i = (vui32_t )CONST_VINT32_W(0, 1, 0, 0);
-  j = (vui32_t )
+  i = (vui32_t)CONST_VINT32_W(0, 1, 0, 0);
+  j = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, 0,
                          0);
   k = (vui32_t) vec_adduqm ((vui128_t) i, (vui128_t) j);
@@ -1119,13 +1119,13 @@ test_addq (void)
   print_vint128x_sum ("1 + 2E128-1", k, i, j);
   print_vint128x     ("  c = ", (vui128_t)l);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
   rc += check_vuint128x ("vec_adduqm:", (vui128_t) k, (vui128_t) e);
   rc += check_vuint128x ("vec_addcuq:", (vui128_t) l, (vui128_t) ec);
 
-  i = (vui32_t )CONST_VINT32_W(1, 0, 0, 0);
-  j = (vui32_t )
+  i = (vui32_t)CONST_VINT32_W(1, 0, 0, 0);
+  j = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, 0, 0,
                          0);
   k = (vui32_t) vec_adduqm ((vui128_t) i, (vui128_t) j);
@@ -1135,13 +1135,13 @@ test_addq (void)
   print_vint128x_sum ("1 + 2E128-1", k, i, j);
   print_vint128x     ("  c = ", (vui128_t)l);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
   rc += check_vuint128x ("vec_adduqm:", (vui128_t) k, (vui128_t) e);
   rc += check_vuint128x ("vec_addcuq:", (vui128_t) l, (vui128_t) ec);
 
-  i = (vui32_t )CONST_VINT32_W(1, 1, 1, 1);
-  j = (vui32_t )
+  i = (vui32_t)CONST_VINT32_W(1, 1, 1, 1);
+  j = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, 0, 0,
                          0);
   k = (vui32_t) vec_adduqm ((vui128_t) i, (vui128_t) j);
@@ -1151,13 +1151,13 @@ test_addq (void)
   print_vint128x_sum ("1 + 2E128-1", k, i, j);
   print_vint128x     ("  c = ", (vui128_t)l);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000001, 0x00000001, 0x00000001);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000001, 0x00000001, 0x00000001);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
   rc += check_vuint128x ("vec_adduqm:", (vui128_t) k, (vui128_t) e);
   rc += check_vuint128x ("vec_addcuq:", (vui128_t) l, (vui128_t) ec);
 
-  i = (vui32_t )CONST_VINT32_W(1, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
-  j = (vui32_t )
+  i = (vui32_t)CONST_VINT32_W(1, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
+  j = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, 0, 0,
                          0);
   k = (vui32_t) vec_adduqm ((vui128_t) i, (vui128_t) j);
@@ -1167,13 +1167,13 @@ test_addq (void)
   print_vint128x_sum ("1 + 2E128-1", k, i, j);
   print_vint128x     ("  c = ", (vui128_t)l);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  e = (vui32_t)CONST_VINT32_W(0, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
   rc += check_vuint128x ("vec_adduqm:", (vui128_t) k, (vui128_t) e);
   rc += check_vuint128x ("vec_addcuq:", (vui128_t) l, (vui128_t) ec);
 
-  i = (vui32_t )CONST_VINT32_W(0, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
-  j = (vui32_t )
+  i = (vui32_t)CONST_VINT32_W(0, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
+  j = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, 0, 0,
                          0);
   k = (vui32_t) vec_adduqm ((vui128_t) i, (vui128_t) j);
@@ -1183,120 +1183,120 @@ test_addq (void)
   print_vint128x_sum ("1 + 2E128-1", k, i, j);
   print_vint128x     ("  c = ", (vui128_t)l);
 #endif
-  e = (vui32_t )CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  e = (vui32_t)CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
   rc += check_vuint128x ("vec_adduqm:", (vui128_t) k, (vui128_t) e);
   rc += check_vuint128x ("vec_addcuq:", (vui128_t) l, (vui128_t) ec);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
-  l = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
+  l = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   k = (vui32_t) vec_addeuqm ((vui128_t) i, (vui128_t) j, (vui128_t) l);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_carry ("1 + 2E32-1 + c=1", k, i, j, l);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000001, 0x00000001);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000001, 0x00000001);
   rc += check_vuint128x ("vec_addeuqm:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
-  l = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
+  l = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   k = (vui32_t) vec_addeuqm ((vui128_t) i, (vui128_t) j, (vui128_t) l);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_carry ("2E32-1 + 2E32-1 + c=1", k, i, j, l);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000001, 0xffffffff);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000001, 0xffffffff);
   rc += check_vuint128x ("vec_addeuqm:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
-  l = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
+  l = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   k = (vui32_t) vec_addecuq ((vui128_t) i, (vui128_t) j, (vui128_t) l);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_carry ("carry 2E32-1 + 2E32-1 + c=1", k, i, j, l);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
   rc += check_vuint128x ("vec_addecuq:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
-  j = (vui32_t )
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
+  j = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          __UINT32_MAX__);
-  l = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  l = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
   k = (vui32_t) vec_addeuqm ((vui128_t) i, (vui128_t) j, (vui128_t) l);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_carry ("1 + 2E128-1 + c=0", k, i, j, l);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
   rc += check_vuint128x ("vec_addeuqm:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
-  j = (vui32_t )
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
+  j = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          __UINT32_MAX__);
-  l = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  l = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
   k = (vui32_t) vec_addecuq ((vui128_t) i, (vui128_t) j, (vui128_t) l);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_carry ("carry 1 + 2E128-1 + c=0", k, i, j, l);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
   rc += check_vuint128x ("vec_addecuq:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
-  j = (vui32_t )
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
+  j = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          __UINT32_MAX__);
-  l = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  l = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   k = (vui32_t) vec_addeuqm ((vui128_t) i, (vui128_t) j, (vui128_t) l);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_carry ("0 + 2E128-1 + c=1", k, i, j, l);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
   rc += check_vuint128x ("vec_addeuqm:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
-  j = (vui32_t )
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
+  j = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          __UINT32_MAX__);
-  l = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  l = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   k = (vui32_t) vec_addecuq ((vui128_t) i, (vui128_t) j, (vui128_t) l);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_carry ("carry 0 + 2E128-1 + c=1", k, i, j, l);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
   rc += check_vuint128x ("vec_addecuq:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
-  j = (vui32_t )
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
+  j = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          __UINT32_MAX__);
-  l = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  l = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   k = (vui32_t) vec_addeuqm ((vui128_t) i, (vui128_t) j, (vui128_t) l);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_carry ("1 + 2E128-1 + c=1", k, i, j, l);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
   rc += check_vuint128x ("vec_addeuqm:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 2);
-  j = (vui32_t )
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 2);
+  j = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          __UINT32_MAX__);
-  l = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  l = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   k = (vui32_t) vec_addecuq ((vui128_t) i, (vui128_t) j, (vui128_t) l);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_carry ("carry 2 + 2E128-1 + c=1", k, i, j, l);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
   rc += check_vuint128x ("vec_addecuq:", (vui128_t) k, (vui128_t) e);
 
   return (rc);
@@ -1313,8 +1313,8 @@ test_mul10uq (void)
 
   printf ("\ntest_mul10uq Vector Multiply by 10 unsigned quadword\n");
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 10);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 10);
   k = vec_mul10uq ((vui128_t) i);
 
 #ifdef __DEBUG_PRINT__
@@ -1323,8 +1323,8 @@ test_mul10uq (void)
 #endif
   rc += check_vuint128 ("vec_mul10uq:", k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 65535);
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 655350);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 65535);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 655350);
   k = vec_mul10uq ((vui128_t) i);
 
 #ifdef __DEBUG_PRINT__
@@ -1333,8 +1333,8 @@ test_mul10uq (void)
 #endif
   rc += check_vuint128 ("vec_mul10uq:", k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 65536);
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 0xa0000U);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 65536);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 0xa0000U);
   k = vec_mul10uq ((vui128_t) i);
 
 #ifdef __DEBUG_PRINT__
@@ -1343,8 +1343,8 @@ test_mul10uq (void)
 #endif
   rc += check_vuint128 ("vec_mul10uq:", k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 65537);
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 0xa000aU);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 65537);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 0xa000aU);
   k = vec_mul10uq ((vui128_t) i);
 
 #ifdef __DEBUG_PRINT__
@@ -1353,8 +1353,8 @@ test_mul10uq (void)
 #endif
   rc += check_vuint128 ("vec_mul10uq:", k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0x00000009U, 0xfffffff6U);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0x00000009U, 0xfffffff6U);
   k = vec_mul10uq ((vui128_t) i);
 
 #ifdef __DEBUG_PRINT__
@@ -1363,8 +1363,8 @@ test_mul10uq (void)
 #endif
   rc += check_vuint128 ("vec_mul10uq:", k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 65535, __UINT32_MAX__);
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0x9ffffU, 0xfffffff6U);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 65535, __UINT32_MAX__);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0x9ffffU, 0xfffffff6U);
   k = vec_mul10uq ((vui128_t) i);
 
 #ifdef __DEBUG_PRINT__
@@ -1373,8 +1373,8 @@ test_mul10uq (void)
 #endif
   rc += check_vuint128 ("vec_mul10uq:", k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, __UINT32_MAX__, __UINT32_MAX__);
-  e = (vui32_t )CONST_VINT32_W(0, 0x00000009U, __UINT32_MAX__, 0xfffffff6U);
+  i = (vui32_t)CONST_VINT32_W(0, 0, __UINT32_MAX__, __UINT32_MAX__);
+  e = (vui32_t)CONST_VINT32_W(0, 0x00000009U, __UINT32_MAX__, 0xfffffff6U);
   k = vec_mul10uq ((vui128_t) i);
 
 #ifdef __DEBUG_PRINT__
@@ -1383,9 +1383,9 @@ test_mul10uq (void)
 #endif
   rc += check_vuint128 ("vec_mul10uq:", k, (vui128_t) e);
 
-  i = (vui32_t )
+  i = (vui32_t)
           CONST_VINT32_W(0, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
-  e = (vui32_t )
+  e = (vui32_t)
           CONST_VINT32_W(0x00000009U, __UINT32_MAX__, __UINT32_MAX__,
                          0xfffffff6U);
   k = vec_mul10uq ((vui128_t) i);
@@ -1396,10 +1396,10 @@ test_mul10uq (void)
 #endif
   rc += check_vuint128 ("vec_mul10uq:", k, (vui128_t) e);
 
-  i = (vui32_t )
+  i = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          __UINT32_MAX__);
-  e = (vui32_t )
+  e = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          0xfffffff6U);
   k = vec_mul10uq ((vui128_t) i);
@@ -1409,7 +1409,7 @@ test_mul10uq (void)
 #endif
   rc += check_vuint128 ("vec_mul10uq:", k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("init i=1", (vui128_t)i);
@@ -1440,13 +1440,13 @@ test_mul10ecuq (void)
   int rc = 0;
 
   printf ("\ntest_mul10ecuq Vector Multiply by 10 unsigned quadword carry/extend\n");
-  i = (vui32_t )
+  i = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          __UINT32_MAX__);
-  e = (vui32_t )
+  e = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          0xfffffff6);
-  ec = (vui32_t )CONST_VINT32_W(0, 0, 0, 9);
+  ec = (vui32_t)CONST_VINT32_W(0, 0, 0, 9);
 
   k = vec_mul10uq ((vui128_t) i);
 #if 1
@@ -1464,11 +1464,11 @@ test_mul10ecuq (void)
 #endif
   rc += check_vint256 ("vec_mul10cuq:", j, k, (vui128_t) ec, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0x19999999, 0x99999999, 0x99999999, 0x99999999);
-  e = (vui32_t )
+  i = (vui32_t)CONST_VINT32_W(0x19999999, 0x99999999, 0x99999999, 0x99999999);
+  e = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          0xfffffffa);
-  ec = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  ec = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
 
   k = vec_mul10uq ((vui128_t) i);
   j = vec_mul10cuq ((vui128_t) i);
@@ -1482,9 +1482,9 @@ test_mul10ecuq (void)
 #endif
   rc += check_vint256 ("vec_mul10cuq 1:", j, k, (vui128_t) ec, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0x19999999, 0x99999999, 0x99999999, 0x9999999a);
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 4);
-  ec = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  i = (vui32_t)CONST_VINT32_W(0x19999999, 0x99999999, 0x99999999, 0x9999999a);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 4);
+  ec = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
 
   k = vec_mul10uq ((vui128_t) i);
   j = vec_mul10cuq ((vui128_t) i);
@@ -1498,13 +1498,13 @@ test_mul10ecuq (void)
 #endif
   rc += check_vint256 ("vec_mul10cuq 2:", j, k, (vui128_t) ec, (vui128_t) e);
 
-  i = (vui32_t )
+  i = (vui32_t)
           CONST_VINT32_W(0x7fffffff, __UINT32_MAX__, __UINT32_MAX__,
                          __UINT32_MAX__);
-  e = (vui32_t )
+  e = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          0xfffffff6);
-  ec = (vui32_t )CONST_VINT32_W(0, 0, 0, 4);
+  ec = (vui32_t)CONST_VINT32_W(0, 0, 0, 4);
 
   k = vec_mul10uq ((vui128_t) i);
   j = vec_mul10cuq ((vui128_t) i);
@@ -1518,11 +1518,11 @@ test_mul10ecuq (void)
 #endif
   rc += check_vint256 ("vec_mul10cuq 3:", j, k, (vui128_t) ec, (vui128_t) e);
 
-  i = (vui32_t )
+  i = (vui32_t)
           CONST_VINT32_W(0x7fffffff, __UINT32_MAX__, __UINT32_MAX__,
                          __UINT32_MAX__);
-  j = (vui128_t) (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
-  e = (vui32_t )
+  j = (vui128_t) (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
+  e = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          0xfffffff6);
   k = vec_mul10euq ((vui128_t) i, j);
@@ -1532,11 +1532,11 @@ test_mul10ecuq (void)
 #endif
   rc += check_vuint128 ("vec_mul10euq 4:", k, (vui128_t) e);
 
-  i = (vui32_t )
+  i = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          __UINT32_MAX__);
-  j = (vui128_t) (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
-  e = (vui32_t )
+  j = (vui128_t) (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
+  e = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          0xfffffff6);
   k = vec_mul10euq ((vui128_t) i, j);
@@ -1545,11 +1545,11 @@ test_mul10ecuq (void)
   print_vint128x("2E128-1*10+e ", k);
 #endif
   rc += check_vuint128 ("vec_mul10euq 5:", k, (vui128_t) e);
-  i = (vui32_t )
+  i = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          __UINT32_MAX__);
-  j = (vui128_t) (vui32_t )CONST_VINT32_W(0, 0, 0, 4);
-  e = (vui32_t )
+  j = (vui128_t) (vui32_t)CONST_VINT32_W(0, 0, 0, 4);
+  e = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          0xfffffffa);
   k = vec_mul10euq ((vui128_t) i, j);
@@ -1560,11 +1560,11 @@ test_mul10ecuq (void)
 #endif
   rc += check_vuint128 ("vec_mul10euq 6:", k, (vui128_t) e);
 
-  i = (vui32_t )
+  i = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          __UINT32_MAX__);
-  j = (vui128_t) (vui32_t )CONST_VINT32_W(0, 0, 0, 9);
-  e = (vui32_t )
+  j = (vui128_t) (vui32_t)CONST_VINT32_W(0, 0, 0, 9);
+  e = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          __UINT32_MAX__);
   k = vec_mul10euq ((vui128_t) i, j);
@@ -1574,14 +1574,14 @@ test_mul10ecuq (void)
 #endif
   rc += check_vuint128 ("vec_mul10euq 7:", k, (vui128_t) e);
 
-  i = (vui32_t )
+  i = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          __UINT32_MAX__);
-  j = (vui128_t) (vui32_t ) { 0, 0, 0, 0 };
-  e = (vui32_t )
+  j = (vui128_t) (vui32_t) { 0, 0, 0, 0 };
+  e = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          0xfffffff6);
-  ec = (vui32_t )CONST_VINT32_W(0, 0, 0, 9);
+  ec = (vui32_t)CONST_VINT32_W(0, 0, 0, 9);
   k = vec_mul10euq ((vui128_t) i, j);
   l = vec_mul10ecuq ((vui128_t) i, j);
 #ifdef __DEBUG_PRINT__
@@ -1592,12 +1592,12 @@ test_mul10ecuq (void)
 #endif
   rc += check_vint256 ("vec_mul10ecuq 8:", l, k, (vui128_t) ec, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0x19999999, 0x99999999, 0x99999999, 0x99999999);
-  j = (vui128_t) (vui32_t ) { 0, 0, 0, 0 };
-  e = (vui32_t )
+  i = (vui32_t)CONST_VINT32_W(0x19999999, 0x99999999, 0x99999999, 0x99999999);
+  j = (vui128_t) (vui32_t) { 0, 0, 0, 0 };
+  e = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          0xfffffffa);
-  ec = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  ec = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
 
   k = vec_mul10euq ((vui128_t) i, j);
   l = vec_mul10ecuq ((vui128_t) i, j);
@@ -1609,12 +1609,12 @@ test_mul10ecuq (void)
 #endif
   rc += check_vint256 ("vec_mul10ecuq 9:", l, k, (vui128_t) ec, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0x19999999, 0x99999999, 0x99999999, 0x99999999);
-  j = (vui128_t) ((vui32_t )CONST_VINT32_W(0, 0, 0, 1));
-  e = (vui32_t )
+  i = (vui32_t)CONST_VINT32_W(0x19999999, 0x99999999, 0x99999999, 0x99999999);
+  j = (vui128_t) ((vui32_t)CONST_VINT32_W(0, 0, 0, 1));
+  e = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          0xfffffffb);
-  ec = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  ec = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
 
   k = vec_mul10euq ((vui128_t) i, j);
   l = vec_mul10ecuq ((vui128_t) i, j);
@@ -1626,10 +1626,10 @@ test_mul10ecuq (void)
 #endif
   rc += check_vint256 ("vec_mul10ecuq 10:", l, k, (vui128_t) ec, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0x19999999, 0x99999999, 0x99999999, 0x99999999);
-  j = (vui128_t) ((vui32_t )CONST_VINT32_W(0, 0, 0, 6));
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
-  ec = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  i = (vui32_t)CONST_VINT32_W(0x19999999, 0x99999999, 0x99999999, 0x99999999);
+  j = (vui128_t) ((vui32_t)CONST_VINT32_W(0, 0, 0, 6));
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
+  ec = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
 
   k = vec_mul10euq ((vui128_t) i, j);
   l = vec_mul10ecuq ((vui128_t) i, j);
@@ -1656,7 +1656,7 @@ test_cmul100 (void)
   int rc = 0;
 
   printf ("\ntest_cmul100 Vector Multiply by 100\n");
-  i = (vui32_t )
+  i = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          __UINT32_MAX__);
   k = vec_cmul100cuq (&j, (vui128_t) i);
@@ -1664,81 +1664,81 @@ test_cmul100 (void)
   print_vint128 ("2E128-1 * 100 ", k);
   print_vint128 ("2E128-1 *100c ", j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffff9c);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000063);
+  e = (vui32_t)CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffff9c);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000063);
   rc += check_vint256 ("vec_cmul100cuq 1:", (vui128_t) j, (vui128_t) k,
                        (vui128_t) ec, (vui128_t) e);
 
-  i = (vui32_t )
+  i = (vui32_t)
           CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
                          __UINT32_MAX__);
-  j = (vui128_t) (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  j = (vui128_t) (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
   k = vec_cmul100ecuq (&l, (vui128_t) i, j);
 #ifdef __DEBUG_PRINT__
   print_vint128 ("2E128-1*100+e ", k);
   print_vint128 ("2E128-1 *100c ", l);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffff9c);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000063);
+  e = (vui32_t)CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffff9c);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000063);
   rc += check_vint256 ("vec_cmul100ecuq 2:", (vui128_t) l, (vui128_t) k,
                        (vui128_t) ec, (vui128_t) e);
 
-  i = (vui32_t ) { __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+  i = (vui32_t) { __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
           __UINT32_MAX__ };
-  j = (vui128_t) (vui32_t )CONST_VINT32_W(0, 0, 0, 4);
+  j = (vui128_t) (vui32_t)CONST_VINT32_W(0, 0, 0, 4);
   k = vec_cmul100ecuq (&l, (vui128_t) i, j);
 #ifdef __DEBUG_PRINT__
   print_vint128 ("2E128-1*100+e ", k);
   print_vint128 ("2E128-1 *100c ", l);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffa0);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000063);
+  e = (vui32_t)CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffa0);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000063);
   rc += check_vint256 ("vec_cmul100ecuq:", (vui128_t) l, (vui128_t) k,
                        (vui128_t) ec, (vui128_t) e);
 
-  i = (vui32_t ) { __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+  i = (vui32_t) { __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
           __UINT32_MAX__ };
-  j = (vui128_t) (vui32_t )CONST_VINT32_W(0, 0, 0, 9);
+  j = (vui128_t) (vui32_t)CONST_VINT32_W(0, 0, 0, 9);
   k = vec_cmul100ecuq (&l, (vui128_t) i, j);
 #ifdef __DEBUG_PRINT__
   print_vint128 ("2E128-1*100+e ", k);
   print_vint128 ("2E128-1 *100c ", l);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffa5);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000063);
+  e = (vui32_t)CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffa5);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000063);
   rc += check_vint256 ("vec_cmul100ecuq 3:", (vui128_t) l, (vui128_t) k,
                        (vui128_t) ec, (vui128_t) e);
 
-  i = (vui32_t ) { __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+  i = (vui32_t) { __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
           __UINT32_MAX__ };
-  j = (vui128_t) (vui32_t )CONST_VINT32_W(0, 0, 0, 10);
+  j = (vui128_t) (vui32_t)CONST_VINT32_W(0, 0, 0, 10);
   k = vec_cmul100ecuq (&l, (vui128_t) i, j);
 #ifdef __DEBUG_PRINT__
   print_vint128 ("2E128-1*100+e ", k);
   print_vint128 ("2E128-1 *100c ", l);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffa6);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000063);
+  e = (vui32_t)CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffa6);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000063);
   rc += check_vint256 ("vec_cmul100ecuq 4:", (vui128_t) l, (vui128_t) k,
                        (vui128_t) ec, (vui128_t) e);
 
-  i = (vui32_t ) { __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+  i = (vui32_t) { __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
           __UINT32_MAX__ };
-  j = (vui128_t) (vui32_t )CONST_VINT32_W(0, 0, 0, 99);
+  j = (vui128_t) (vui32_t)CONST_VINT32_W(0, 0, 0, 99);
   k = vec_cmul100ecuq (&l, (vui128_t) i, j);
 #ifdef __DEBUG_PRINT__
   print_vint128 ("2E128-1*100+e ", k);
   print_vint128 ("2E128-1 *100c ", l);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000063);
+  e = (vui32_t)CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000063);
   rc += check_vint256 ("vec_cmul100ecuq 5:", (vui128_t) l, (vui128_t) k,
                        (vui128_t) ec, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 100);
-  m = (vui128_t) (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
-  e = (vui32_t )CONST_VINT32_W(0x7775a5f1, 0x71951000, 0x00000000, 0x00000000);
-  ec = (vui32_t )CONST_VINT32_W(0x161bcca7, 0x119915b5, 0x0764b4ab, 0xe8652979);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 100);
+  m = (vui128_t) (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
+  e = (vui32_t)CONST_VINT32_W(0x7775a5f1, 0x71951000, 0x00000000, 0x00000000);
+  ec = (vui32_t)CONST_VINT32_W(0x161bcca7, 0x119915b5, 0x0764b4ab, 0xe8652979);
 
   for (ii = 0; ii < 37; ii++)
     {
@@ -1751,10 +1751,10 @@ test_cmul100 (void)
     }
   rc += check_vint256 ("vec_cmul100euq 6:", m, k, (vui128_t) ec, (vui128_t) e);
 
-  n = (vui128_t) (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
-  e = (vui32_t )CONST_VINT32_W (0xd1640000, 0000000000, 0x00000000, 0x00000000);
-  em = (vui32_t )CONST_VINT32_W(0x1db2332b, 0x93f1e94f, 0x637a5429, 0x0fe2a55c);
-  ec = (vui32_t )CONST_VINT32_W(0x067f43fb, 0xe77a37f8, 0xb7309320, 0xc32b3cd3);
+  n = (vui128_t) (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
+  e = (vui32_t)CONST_VINT32_W (0xd1640000, 0000000000, 0x00000000, 0x00000000);
+  em = (vui32_t)CONST_VINT32_W(0x1db2332b, 0x93f1e94f, 0x637a5429, 0x0fe2a55c);
+  ec = (vui32_t)CONST_VINT32_W(0x067f43fb, 0xe77a37f8, 0xb7309320, 0xc32b3cd3);
 
   for (ii = 37; ii < 56; ii++)
     {
@@ -1788,127 +1788,127 @@ test_mulluq (void)
 
   printf ("\ntest_mulluq vector multiply low unsigned quad\n");
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
-  k = (vui32_t) test_vec_mulluq((vui128_t )i, (vui128_t )j);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
+  k = (vui32_t) test_vec_mulluq((vui128_t)i, (vui128_t)j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128_sum ("1 * 1 ", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   rc += check_vuint128 ("vec_mulluq 1:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 100);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 100);
-  k = (vui32_t) test_vec_mulluq((vui128_t )i, (vui128_t )j);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 100);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0, 100);
+  k = (vui32_t) test_vec_mulluq((vui128_t)i, (vui128_t)j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128_sum ("100 * 100 ", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 10000);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 10000);
   rc += check_vuint128 ("vec_mulluq 2:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0x10000);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 0x10000);
-  k = (vui32_t) test_vec_mulluq((vui128_t )i, (vui128_t )j);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 0x10000);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0, 0x10000);
+  k = (vui32_t) test_vec_mulluq((vui128_t)i, (vui128_t)j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("65536 * 65536 ", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0x00000001, 0x00000000);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0x00000001, 0x00000000);
   rc += check_vuint128x ("vec_mulluq 3:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0xffffffff);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 0xffffffff);
-  k = (vui32_t) test_vec_mulluq((vui128_t )i, (vui128_t )j);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 0xffffffff);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0, 0xffffffff);
+  k = (vui32_t) test_vec_mulluq((vui128_t)i, (vui128_t)j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("2**32-1 * 2**32-1 ", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0xfffffffe, 0x00000001);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0xfffffffe, 0x00000001);
   rc += check_vuint128x ("vec_mulluq 4:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0xffff, 0xffffffff);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0xffff, 0xffffffff);
-  k = (vui32_t) test_vec_mulluq((vui128_t )i, (vui128_t )j);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0xffff, 0xffffffff);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0xffff, 0xffffffff);
+  k = (vui32_t) test_vec_mulluq((vui128_t)i, (vui128_t)j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("2**48-1 * 2**48-1 ", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0, 0xffffffff, 0xfffe0000, 0x00000001);
+  e = (vui32_t)CONST_VINT32_W(0, 0xffffffff, 0xfffe0000, 0x00000001);
   rc += check_vuint128x ("vec_mulluq 5:", (vui128_t) k, (vui128_t) e);
 
 #if 1
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0x1, 0x2);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0x3, 0x5);
-  k = (vui32_t) test_vec_mulluq((vui128_t )i, (vui128_t )j);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0x1, 0x2);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0x3, 0x5);
+  k = (vui32_t) test_vec_mulluq((vui128_t)i, (vui128_t)j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("0X100000002 * 0X300000005 ", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0, 0x00000003, 0x0000000b, 0x0000000a);
+  e = (vui32_t)CONST_VINT32_W(0, 0x00000003, 0x0000000b, 0x0000000a);
   rc += check_vuint128x ("vec_mulluq 6:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0xffffffff, 0xffffffff);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0xffffffff, 0xffffffff);
-  k = (vui32_t) test_vec_mulluq((vui128_t )i, (vui128_t )j);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0xffffffff, 0xffffffff);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0xffffffff, 0xffffffff);
+  k = (vui32_t) test_vec_mulluq((vui128_t)i, (vui128_t)j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("2**64-1 * 2**64-1 ", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0xffffffff, 0xfffffffe, 0x00000000, 0x00000001);
+  e = (vui32_t)CONST_VINT32_W(0xffffffff, 0xfffffffe, 0x00000000, 0x00000001);
   rc += check_vuint128x ("vec_mulluq 7:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0xffffffff, 0xffffffff, 0xffffffff);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 0xffffffff);
-  k = (vui32_t) test_vec_mulluq((vui128_t )i, (vui128_t )j);
+  i = (vui32_t)CONST_VINT32_W(0, 0xffffffff, 0xffffffff, 0xffffffff);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0, 0xffffffff);
+  k = (vui32_t) test_vec_mulluq((vui128_t)i, (vui128_t)j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("2**96-1 * 2**32-1 ", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0xfffffffe, 0xffffffff, 0xffffffff, 0x00000001);
+  e = (vui32_t)CONST_VINT32_W(0xfffffffe, 0xffffffff, 0xffffffff, 0x00000001);
   rc += check_vuint128x ("vec_mulluq 8:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0xffffffff);
-  j = (vui32_t )CONST_VINT32_W(0, 0xffffffff, 0xffffffff, 0xffffffff);
-  k = (vui32_t) test_vec_mulluq((vui128_t )i, (vui128_t )j);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 0xffffffff);
+  j = (vui32_t)CONST_VINT32_W(0, 0xffffffff, 0xffffffff, 0xffffffff);
+  k = (vui32_t) test_vec_mulluq((vui128_t)i, (vui128_t)j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("2**32-1 * 2**96-1 ", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0xfffffffe, 0xffffffff, 0xffffffff, 0x00000001);
+  e = (vui32_t)CONST_VINT32_W(0xfffffffe, 0xffffffff, 0xffffffff, 0x00000001);
   rc += check_vuint128x ("vec_mulluq 9:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0xffffffff, 0xffffffff, 0xffffffff);
-  j = (vui32_t )CONST_VINT32_W(0, 0xffffffff, 0xffffffff, 0xffffffff);
-  k = (vui32_t) test_vec_mulluq((vui128_t )i, (vui128_t )j);
+  i = (vui32_t)CONST_VINT32_W(0, 0xffffffff, 0xffffffff, 0xffffffff);
+  j = (vui32_t)CONST_VINT32_W(0, 0xffffffff, 0xffffffff, 0xffffffff);
+  k = (vui32_t) test_vec_mulluq((vui128_t)i, (vui128_t)j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("2**96-1 * 2**96-1 ", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0xfffffffe, 0x00000000, 0x00000000, 0x00000001);
+  e = (vui32_t)CONST_VINT32_W(0xfffffffe, 0x00000000, 0x00000000, 0x00000001);
   rc += check_vuint128x ("vec_mulluq 10:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 100000000);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 100000000);
-  k = (vui32_t) test_vec_mulluq((vui128_t )i, (vui128_t )j);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 100000000);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0, 100000000);
+  k = (vui32_t) test_vec_mulluq((vui128_t)i, (vui128_t)j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128_sum ("10**8 * 10**8 ", k, i, j);
   print_vint128x_sum ("10**8 * 10**8 ", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0x002386f2, 0x6fc10000);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0x002386f2, 0x6fc10000);
   rc += check_vuint128x ("vec_mulluq 11:", (vui128_t) k, (vui128_t) e);
 
   i = k;
   j = k;
-  k = (vui32_t) test_vec_mulluq((vui128_t )i, (vui128_t )j);
+  k = (vui32_t) test_vec_mulluq((vui128_t)i, (vui128_t)j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128_sum ("10**16 * 10**16 ", k, i, j);
   print_vint128x_sum ("10**16 * 10**16 ", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x000004ee, 0x2d6d415b, 0x85acef81, 0x00000000);
+  e = (vui32_t)CONST_VINT32_W(0x000004ee, 0x2d6d415b, 0x85acef81, 0x00000000);
   rc += check_vuint128x ("vec_mulluq 12:", (vui128_t) k, (vui128_t) e);
 #endif
   return (rc);
@@ -2049,63 +2049,63 @@ test_muludq (void)
 
   printf ("\ntest_muludq vector multiply quadword, 256-bit product\n");
 
-  i = (vui32_t )CONST_VINT32_W(0, 0xffffffff, 0xffffffff, 0xffffffff);
-  j = (vui32_t )CONST_VINT32_W(0, 0xffffffff, 0xffffffff, 0xffffffff);
-  k = (vui32_t) test_vec_muludq((vui128_t* )&l, (vui128_t )i, (vui128_t )j);
+  i = (vui32_t)CONST_VINT32_W(0, 0xffffffff, 0xffffffff, 0xffffffff);
+  j = (vui32_t)CONST_VINT32_W(0, 0xffffffff, 0xffffffff, 0xffffffff);
+  k = (vui32_t) test_vec_muludq((vui128_t* )&l, (vui128_t)i, (vui128_t)j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128_prod ("2**96-1 * 2**96-1 ", k, i, j, l);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0xfffffffe, 0x00000000, 0x00000000, 0x00000001);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0xffffffff, 0xffffffff);
+  e = (vui32_t)CONST_VINT32_W(0xfffffffe, 0x00000000, 0x00000000, 0x00000001);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0xffffffff, 0xffffffff);
   rc += check_vint256 ("vec_muludq 1:", (vui128_t) l, (vui128_t) k, (vui128_t) ec,
                        (vui128_t) e);
 #if 1
-  i = (vui32_t )CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
-  j = (vui32_t )CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
-  k = (vui32_t) test_vec_muludq((vui128_t* )&l, (vui128_t )i, (vui128_t )j);
+  i = (vui32_t)CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j = (vui32_t)CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  k = (vui32_t) test_vec_muludq((vui128_t* )&l, (vui128_t)i, (vui128_t)j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128_prod ("2**128-1 * 2**128-1 ", k, i, j, l);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
-  ec = (vui32_t )CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ec = (vui32_t)CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
   rc += check_vint256 ("vec_muludq 2:", (vui128_t) l, (vui128_t) k, (vui128_t) ec,
                        (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 100000000);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 100000000);
-  k = (vui32_t) test_vec_muludq((vui128_t* )&l, (vui128_t )i, (vui128_t )j);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 100000000);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0, 100000000);
+  k = (vui32_t) test_vec_muludq((vui128_t* )&l, (vui128_t)i, (vui128_t)j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128_prod ("10**8 * 10**8 ", k, i, j, l);
 #endif
-  e = (vui32_t )CONST_VINT32_W (0x00000000, 0x00000000, 0x002386f2, 0x6fc10000);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  e = (vui32_t)CONST_VINT32_W (0x00000000, 0x00000000, 0x002386f2, 0x6fc10000);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
   rc += check_vint256 ("vec_muludq 3:", (vui128_t) l, (vui128_t) k, (vui128_t) ec,
                        (vui128_t) e);
 
   i = k;
   j = k;
-  k = (vui32_t) test_vec_muludq((vui128_t* )&l, (vui128_t )i, (vui128_t )j);
+  k = (vui32_t) test_vec_muludq((vui128_t* )&l, (vui128_t)i, (vui128_t)j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128_prod ("10**16 * 10**16 ", k, i, j, l);
 #endif
-  e = (vui32_t )CONST_VINT32_W (0x000004ee, 0x2d6d415b, 0x85acef81, 0x00000000);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  e = (vui32_t)CONST_VINT32_W (0x000004ee, 0x2d6d415b, 0x85acef81, 0x00000000);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
   rc += check_vint256 ("vec_muludq 4:", (vui128_t) l, (vui128_t) k, (vui128_t) ec,
                        (vui128_t) e);
 
   i = k;
   j = k;
-  k = (vui32_t) test_vec_muludq((vui128_t* )&l, (vui128_t )i, (vui128_t )j);
+  k = (vui32_t) test_vec_muludq((vui128_t* )&l, (vui128_t)i, (vui128_t)j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128_prod ("10**32 * 10**32 ", k, i, j, l);
 #endif
-  e = (vui32_t )CONST_VINT32_W (0x6e38ed64, 0xbf6a1f01, 0x00000000, 0x00000000);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00184f03, 0xe93ff9f4, 0xdaa797ed);
+  e = (vui32_t)CONST_VINT32_W (0x6e38ed64, 0xbf6a1f01, 0x00000000, 0x00000000);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00184f03, 0xe93ff9f4, 0xdaa797ed);
   rc += check_vint256 ("vec_muludq 5:", (vui128_t) l, (vui128_t) k, (vui128_t) ec,
                        (vui128_t) e);
 #endif
@@ -2123,81 +2123,81 @@ test_revbq (void)
 
   printf ("\ntest_revbq Reverse Bytes in quadwords\n");
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
-  j = vec_revbq((vui128_t )i);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
+  j = vec_revbq((vui128_t)i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("revbq(0) ", j);
 #endif
   rc += check_vuint128x ("vec_revbq 1:", j, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0xffffffff, 0, 0, 0);
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 0xffffffff);
-  j = vec_revbq((vui128_t )i);
+  i = (vui32_t)CONST_VINT32_W(0xffffffff, 0, 0, 0);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 0xffffffff);
+  j = vec_revbq((vui128_t)i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("revbq(0xffffffff,0,0,0) ", j);
 #endif
   rc += check_vuint128x ("vec_revbq 2:", j, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0xffffffff, 0, 0);
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0xffffffff, 0);
-  j = vec_revbq((vui128_t )i);
+  i = (vui32_t)CONST_VINT32_W(0, 0xffffffff, 0, 0);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0xffffffff, 0);
+  j = vec_revbq((vui128_t)i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("revbq(0,0xffffffff,0,0) ", j);
 #endif
   rc += check_vuint128x ("vec_revbq 3:", j, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0xffffffff);
-  e = (vui32_t )CONST_VINT32_W(0xffffffff, 0, 0, 0);
-  j = vec_revbq((vui128_t )i);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 0xffffffff);
+  e = (vui32_t)CONST_VINT32_W(0xffffffff, 0, 0, 0);
+  j = vec_revbq((vui128_t)i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("revbq(0,0,0,0xffffffff) ", j);
 #endif
   rc += check_vuint128x ("vec_revbq 4:", j, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0xffffffff, 0);
-  e = (vui32_t )CONST_VINT32_W(0, 0xffffffff, 0, 0);
-  j = vec_revbq((vui128_t )i);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0xffffffff, 0);
+  e = (vui32_t)CONST_VINT32_W(0, 0xffffffff, 0, 0);
+  j = vec_revbq((vui128_t)i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("rev(0,0,0xffffffff,0) ", j);
 #endif
   rc += check_vuint128x ("vec_revbq 5:", j, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0xffff, 0);
-  e = (vui32_t )CONST_VINT32_W(0, 0xffff0000, 0, 0);
-  j = vec_revbq((vui128_t )i);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0xffff, 0);
+  e = (vui32_t)CONST_VINT32_W(0, 0xffff0000, 0, 0);
+  j = vec_revbq((vui128_t)i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("revbq(0,0,0xffff,0) ", j);
 #endif
   rc += check_vuint128x ("vec_revbq 6:", j, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0xffffffff, 0, 0xffffffff);
-  e = (vui32_t )CONST_VINT32_W(0xffffffff, 0, 0xffffffff, 0);
-  j = vec_revbq((vui128_t )i);
+  i = (vui32_t)CONST_VINT32_W(0, 0xffffffff, 0, 0xffffffff);
+  e = (vui32_t)CONST_VINT32_W(0xffffffff, 0, 0xffffffff, 0);
+  j = vec_revbq((vui128_t)i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("revbq(0,0xffffffff,0,0xffffffff) ", j);
 #endif
   rc += check_vuint128x ("vec_revbq 7:", j, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0xffff, 0, 0xffffffff);
-  e = (vui32_t )CONST_VINT32_W(0xffffffff, 0, 0xffff0000, 0);
-  j = vec_revbq((vui128_t )i);
+  i = (vui32_t)CONST_VINT32_W(0, 0xffff, 0, 0xffffffff);
+  e = (vui32_t)CONST_VINT32_W(0xffffffff, 0, 0xffff0000, 0);
+  j = vec_revbq((vui128_t)i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("revbq(0,0xffff,0,0xffffffff) ", j);
 #endif
   rc += check_vuint128x ("vec_revbq 8:", j, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0xf, 0, 0xffffffff);
-  e = (vui32_t )CONST_VINT32_W(0xffffffff, 0, 0x0f000000, 0);
-  j = vec_revbq((vui128_t )i);
+  i = (vui32_t)CONST_VINT32_W(0, 0xf, 0, 0xffffffff);
+  e = (vui32_t)CONST_VINT32_W(0xffffffff, 0, 0x0f000000, 0);
+  j = vec_revbq((vui128_t)i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("rev(0,0xf,0,0xffffffff) ", j);
@@ -2288,81 +2288,81 @@ test_clzq (void)
 
   printf ("\ntest_clzq Vector Count Leading Zeros in quadwords\n");
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 128);
-  j = test_vec_clzq((vui128_t )i);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 128);
+  j = test_vec_clzq((vui128_t)i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("clz(0) ", j);
 #endif
   rc += check_vuint128x ("vec_clzq:", j, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0xffffffff, 0, 0, 0);
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
-  j = test_vec_clzq((vui128_t )i);
+  i = (vui32_t)CONST_VINT32_W(0xffffffff, 0, 0, 0);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
+  j = test_vec_clzq((vui128_t)i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("clz(0xffffffff,0,0,0) ", j);
 #endif
   rc += check_vuint128x ("vec_clzq:", j, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0xffffffff, 0, 0);
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 32);
-  j = test_vec_clzq((vui128_t )i);
+  i = (vui32_t)CONST_VINT32_W(0, 0xffffffff, 0, 0);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 32);
+  j = test_vec_clzq((vui128_t)i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("clz(0,0xffffffff,0,0) ", j);
 #endif
   rc += check_vuint128x ("vec_clzq:", j, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0xffffffff);
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 96);
-  j = test_vec_clzq((vui128_t )i);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 0xffffffff);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 96);
+  j = test_vec_clzq((vui128_t)i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("clz(0,0,0,0xffffffff) ", j);
 #endif
   rc += check_vuint128x ("vec_clzq:", j, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0xffffffff, 0);
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 64);
-  j = test_vec_clzq((vui128_t )i);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0xffffffff, 0);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 64);
+  j = test_vec_clzq((vui128_t)i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("clz(0,0,0xffffffff,0) ", j);
 #endif
   rc += check_vuint128x ("vec_clzq:", j, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0xffff, 0);
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 80);
-  j = test_vec_clzq((vui128_t )i);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0xffff, 0);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 80);
+  j = test_vec_clzq((vui128_t)i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("clz(0,0,0xffff,0) ", j);
 #endif
   rc += check_vuint128x ("vec_clzq:", j, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0xffffffff, 0, 0xffffffff);
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 32);
-  j = test_vec_clzq((vui128_t )i);
+  i = (vui32_t)CONST_VINT32_W(0, 0xffffffff, 0, 0xffffffff);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 32);
+  j = test_vec_clzq((vui128_t)i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("clz(0,0xffffffff,0,0xffffffff) ", j);
 #endif
   rc += check_vuint128x ("vec_clzq:", j, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0xffff, 0, 0xffffffff);
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 48);
-  j = test_vec_clzq((vui128_t )i);
+  i = (vui32_t)CONST_VINT32_W(0, 0xffff, 0, 0xffffffff);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 48);
+  j = test_vec_clzq((vui128_t)i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("clz(0,0xffff,0,0xffffffff) ", j);
 #endif
   rc += check_vuint128x ("vec_clzq:", j, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0xf, 0, 0xffffffff);
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 60);
-  j = test_vec_clzq((vui128_t )i);
+  i = (vui32_t)CONST_VINT32_W(0, 0xf, 0, 0xffffffff);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 60);
+  j = test_vec_clzq((vui128_t)i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("clz(0,0xf,0,0xffffffff) ", j);
@@ -4370,94 +4370,94 @@ test_subcuq (void)
 
   printf ("\ntest_subuq Vector subtract & Write Carry unsigned quadword\n");
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
   k = (vui32_t) vec_subcuq ((vui128_t) i, (vui128_t) j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("0 - 0", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   rc += check_vuint128x ("vec_subcuq:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
   k = (vui32_t) vec_subcuq ((vui128_t) i, (vui128_t) j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("1 - 0", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   rc += check_vuint128x ("vec_subcuq:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   k = (vui32_t) vec_subcuq ((vui128_t) i, (vui128_t) j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("0 - 1", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
   rc += check_vuint128x ("vec_subcuq:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   k = (vui32_t) vec_subcuq ((vui128_t) i, (vui128_t) j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("2E32-1 - 1", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   rc += check_vuint128x ("vec_subcuq:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  i = (vui32_t)CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   k = (vui32_t) vec_subcuq ((vui128_t) i, (vui128_t) j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("2E128-1 - 1", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   rc += check_vuint128x ("vec_subcuq:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
-  j = (vui32_t )CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
+  j = (vui32_t)CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
   k = (vui32_t) vec_subcuq ((vui128_t) i, (vui128_t) j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("1 - 2E128-1", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
   rc += check_vuint128x ("vec_subcuq:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
-  j = (vui32_t )CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
+  i = (vui32_t)CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
+  j = (vui32_t)CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
   k = (vui32_t) vec_subcuq ((vui128_t) i, (vui128_t) j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("2E128-1 - 2E128-1", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   rc += check_vuint128x ("vec_subcuq:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__-1);
-  j = (vui32_t )CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
+  i = (vui32_t)CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__-1);
+  j = (vui32_t)CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
   k = (vui32_t) vec_subcuq ((vui128_t) i, (vui128_t) j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("2E128-2 - 2E128-1", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
   rc += check_vuint128x ("vec_subcuq:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
-  j = (vui32_t )CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__-1);
+  i = (vui32_t)CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
+  j = (vui32_t)CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__-1);
   k = (vui32_t) vec_subcuq ((vui128_t) i, (vui128_t) j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("2E128-1 - 2E128-2", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   rc += check_vuint128x ("vec_subcuq:", (vui128_t) k, (vui128_t) e);
 
   return (rc);
@@ -4471,89 +4471,89 @@ test_subecuq (void)
   vui32_t e, ec;
   int rc = 0;
 
-  printf ("\ntest_subeuq Vector subtract extended unsigned quadword modulo\n");
+  printf ("\ntest_subecuq Vector subtract extended/carry unsigned quadword modulo\n");
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
-  k = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
+  k = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
   l = (vui32_t) vec_subeuqm ((vui128_t) i, (vui128_t) j, (vui128_t) k);
   m = (vui32_t) vec_subecuq ((vui128_t) i, (vui128_t) j, (vui128_t) k);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_extend ("extent 0 - 0 + c=0", l, m, i, j, k);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  e = (vui32_t)CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
   rc += check_vint256 ("vec_subeuqm/ecuq:", (vui128_t) m, (vui128_t) l, (vui128_t) ec,
                        (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
-  k = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
+  k = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   l = (vui32_t) vec_subeuqm ((vui128_t) i, (vui128_t) j, (vui128_t) k);
   m = (vui32_t) vec_subecuq ((vui128_t) i, (vui128_t) j, (vui128_t) k);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_extend ("extent 0 - 0 + c=1", l, m, i, j, k);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
   rc += check_vint256 ("vec_subeuqm/ecuq:", (vui128_t) m, (vui128_t) l, (vui128_t) ec,
                        (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
-  k = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
+  k = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
   l = (vui32_t) vec_subeuqm ((vui128_t) i, (vui128_t) j, (vui128_t) k);
   m = (vui32_t) vec_subecuq ((vui128_t) i, (vui128_t) j, (vui128_t) k);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_extend ("extent 1 - 0 + c=0", l, m, i, j, k);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
   rc += check_vint256 ("vec_subeuqm/ecuq:", (vui128_t) m, (vui128_t) l, (vui128_t) ec,
                        (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
-  k = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
+  k = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
   l = (vui32_t) vec_subeuqm ((vui128_t) i, (vui128_t) j, (vui128_t) k);
   m = (vui32_t) vec_subecuq ((vui128_t) i, (vui128_t) j, (vui128_t) k);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_extend ("extent 0 - 1 + c=0", l, m, i, j, k);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  e = (vui32_t)CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
   rc += check_vint256 ("vec_subeuqm/ecuq:", (vui128_t) m, (vui128_t) l, (vui128_t) ec,
                        (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
-  k = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
+  k = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   l = (vui32_t) vec_subeuqm ((vui128_t) i, (vui128_t) j, (vui128_t) k);
   m = (vui32_t) vec_subecuq ((vui128_t) i, (vui128_t) j, (vui128_t) k);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_extend ("extent 1 - 0 + c=1", l, m, i, j, k);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
   rc += check_vint256 ("vec_subeuqm/ecuq:", (vui128_t) m, (vui128_t) l, (vui128_t) ec,
                        (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
-  k = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
+  k = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   l = (vui32_t) vec_subeuqm ((vui128_t) i, (vui128_t) j, (vui128_t) k);
   m = (vui32_t) vec_subecuq ((vui128_t) i, (vui128_t) j, (vui128_t) k);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_extend ("extent 0 - 1 + c=1", l, m, i, j, k);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
-  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  e = (vui32_t)CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  ec = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
   rc += check_vint256 ("vec_subeuqm/ecuq:", (vui128_t) m, (vui128_t) l, (vui128_t) ec,
                        (vui128_t) e);
 
@@ -4584,14 +4584,14 @@ test_subuq (void)
 
   print_int128_sum ("2E32-1 - 1", c, a, b);
 #endif
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   k = (vui32_t) vec_subuqm ((vui128_t) i, (vui128_t) j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("2E32-1 - 1", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0xfffffffe);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0xfffffffe);
   rc += check_vuint128x ("vec_subuqm:", (vui128_t) k, (vui128_t) e);
 
 #ifdef __DEBUG_PRINT__
@@ -4601,14 +4601,14 @@ test_subuq (void)
 
   print_int128_sum ("1 - 2E32-1", c, a, b);
 #endif
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
   k = (vui32_t) vec_subuqm ((vui128_t) i, (vui128_t) j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("1 - 2E32-1", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0x00000002);
+  e = (vui32_t)CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0x00000002);
   rc += check_vuint128x ("vec_subuqm:", (vui128_t) k, (vui128_t) e);
 
 #ifdef __DEBUG_PRINT__
@@ -4618,14 +4618,14 @@ test_subuq (void)
 
   print_int128_sum ("2E64-1 - 1", c, a, b);
 #endif
-  i = (vui32_t )CONST_VINT32_W(0, 0, __UINT32_MAX__, __UINT32_MAX__);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  i = (vui32_t)CONST_VINT32_W(0, 0, __UINT32_MAX__, __UINT32_MAX__);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   k = (vui32_t) vec_subuqm ((vui128_t) i, (vui128_t) j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("2E64-1 - 1", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0xffffffff, 0xfffffffe);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0xffffffff, 0xfffffffe);
   rc += check_vuint128x ("vec_subuqm:", (vui128_t) k, (vui128_t) e);
 
 #ifdef __DEBUG_PRINT__
@@ -4636,44 +4636,44 @@ test_subuq (void)
 
   print_int128_sum ("2E96 - 1", c, a, b);
 #endif
-  i = (vui32_t )CONST_VINT32_W(1, 0, 0, 0);
-  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  i = (vui32_t)CONST_VINT32_W(1, 0, 0, 0);
+  j = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   k = (vui32_t) vec_subuqm ((vui128_t) i, (vui128_t) j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("2E96 - 1", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0xffffffff, 0xffffffff, 0xffffffff);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0xffffffff, 0xffffffff, 0xffffffff);
   rc += check_vuint128x ("vec_subuqm:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
-  j = (vui32_t )CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i = (vui32_t)CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j = (vui32_t)CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
   k = (vui32_t) vec_subuqm ((vui128_t) i, (vui128_t) j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("2E128-1 - 2E128-1", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
   rc += check_vuint128x ("vec_subuqm:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
-  j = (vui32_t )CONST_VINT32_W(0x7fffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i = (vui32_t)CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j = (vui32_t)CONST_VINT32_W(0x7fffffff, 0xffffffff, 0xffffffff, 0xffffffff);
   k = (vui32_t) vec_subuqm ((vui128_t) i, (vui128_t) j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("2E128-1 - 2E127-1", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x80000000, 0x00000000, 0x00000000, 0x00000000);
+  e = (vui32_t)CONST_VINT32_W(0x80000000, 0x00000000, 0x00000000, 0x00000000);
   rc += check_vuint128x ("vec_subuqm:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0x7fffffff, 0xffffffff, 0xffffffff, 0xffffffff);
-  j = (vui32_t )CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i = (vui32_t)CONST_VINT32_W(0x7fffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j = (vui32_t)CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
   k = (vui32_t) vec_subuqm ((vui128_t) i, (vui128_t) j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("2E127-1 - 2E128-1", k, i, j);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x80000000, 0x00000000, 0x00000000, 0x00000000);
+  e = (vui32_t)CONST_VINT32_W(0x80000000, 0x00000000, 0x00000000, 0x00000000);
   rc += check_vuint128x ("vec_subuqm:", (vui128_t) k, (vui128_t) e);
 
   return (rc);
@@ -4689,75 +4689,75 @@ test_setbq (void)
 
   printf ("\ntest_setbq Vector set bool quadword\n");
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
   k = (vui32_t) vec_setb_cyq ((vui128_t) i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x ("vec_setb ", (vui128_t) i);
   print_vint128x ("        =", (vui128_t) k);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
   rc += check_vuint128x ("vec_setb_cyq:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   k = (vui32_t) vec_setb_cyq ((vui128_t) i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x ("vec_setb ", (vui128_t) i);
   print_vint128x ("        =", (vui128_t) k);
 #endif
-  e = (vui32_t )CONST_VINT32_W(-1, -1, -1, -1);
+  e = (vui32_t)CONST_VINT32_W(-1, -1, -1, -1);
   rc += check_vuint128x ("vec_setb_cyq:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
   k = (vui32_t) vec_setb_ncq ((vui128_t) i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x ("vec_setb ", (vui128_t) i);
   print_vint128x ("        =", (vui128_t) k);
 #endif
-  e = (vui32_t )CONST_VINT32_W(-1, -1, -1, -1);
+  e = (vui32_t)CONST_VINT32_W(-1, -1, -1, -1);
   rc += check_vuint128x ("vec_setb_ncq:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 1);
   k = (vui32_t) vec_setb_ncq ((vui128_t) i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x ("vec_setb ", (vui128_t) i);
   print_vint128x ("        =", (vui128_t) k);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
   rc += check_vuint128x ("vec_setb_ncq:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
   k = (vui32_t) vec_setb_sq ((vi128_t) i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x ("vec_setb ", (vui128_t) i);
   print_vint128x ("        =", (vui128_t) k);
 #endif
-  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  e = (vui32_t)CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
   rc += check_vuint128x ("vec_setb_sq:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(0x80000000, 0, 0, 1);
+  i = (vui32_t)CONST_VINT32_W(0x80000000, 0, 0, 1);
   k = (vui32_t) vec_setb_sq ((vi128_t) i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x ("vec_setb ", (vui128_t) i);
   print_vint128x ("        =", (vui128_t) k);
 #endif
-  e = (vui32_t )CONST_VINT32_W(-1, -1, -1, -1);
+  e = (vui32_t)CONST_VINT32_W(-1, -1, -1, -1);
   rc += check_vuint128x ("vec_setb_sq:", (vui128_t) k, (vui128_t) e);
   rc += check_vuint128x ("vec_setb_sq:", (vui128_t) k, (vui128_t) e);
 
-  i = (vui32_t )CONST_VINT32_W(-1, -1, -1, -1);
+  i = (vui32_t)CONST_VINT32_W(-1, -1, -1, -1);
   k = (vui32_t) vec_setb_sq ((vi128_t) i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x ("vec_setb ", (vui128_t) i);
   print_vint128x ("        =", (vui128_t) k);
 #endif
-  e = (vui32_t )CONST_VINT32_W(-1, -1, -1, -1);
+  e = (vui32_t)CONST_VINT32_W(-1, -1, -1, -1);
   rc += check_vuint128x ("vec_setb_sq:", (vui128_t) k, (vui128_t) e);
 
   return (rc);

--- a/src/testsuite/arith128_test_i128.c
+++ b/src/testsuite/arith128_test_i128.c
@@ -4302,18 +4302,18 @@ test_time_i128 (void)
   printf ("\n%s mul10uq  tb delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
 	  delta_sec);
 
-  printf ("\n%s mul10uq2x start, ...\n", __FUNCTION__);
+  printf ("\n%s cmul10ecuq start, ...\n", __FUNCTION__);
   t_start = __builtin_ppc_get_timebase ();
   for (i = 0; i < TIME_10_ITERATION; i++)
     {
-      rc += timed_mul10uq2x ();
+      rc += timed_cmul10ecuq ();
     }
   t_end = __builtin_ppc_get_timebase ();
   t_delta = t_end - t_start;
   delta_sec = TimeDeltaSec (t_delta);
 
-  printf ("\n%s mul10uq2x end", __FUNCTION__);
-  printf ("\n%s mul10uq2x  tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+  printf ("\n%s cmul10ecuq end", __FUNCTION__);
+  printf ("\n%s cmul10ecuq  tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
 	  t_delta, delta_sec);
 
   printf ("\n%s mulluq start, ...\n", __FUNCTION__);
@@ -4329,6 +4329,2840 @@ test_time_i128 (void)
   printf ("\n%s mulluq end", __FUNCTION__);
   printf ("\n%s mulluq  tb delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
 	  delta_sec);
+
+  printf ("\n%s muludq start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIME_10_ITERATION; i++)
+    {
+      rc += timed_muludq ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s muludq end", __FUNCTION__);
+  printf ("\n%s muludq  tb delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
+	  delta_sec);
+
+  printf ("\n%s muludqx start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIME_10_ITERATION; i++)
+    {
+      rc += timed_muludqx ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s muludqx end", __FUNCTION__);
+  printf ("\n%s muludqx  tb delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
+	  delta_sec);
+  return (rc);
+}
+
+//#define __DEBUG_PRINT__ 1
+int
+test_subcuq (void)
+{
+  vui32_t i, j, k;
+  vui32_t e;
+  int rc = 0;
+
+  printf ("\ntest_subuq Vector subtract & Write Carry unsigned quadword\n");
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  k = (vui32_t) vec_subcuq ((vui128_t) i, (vui128_t) j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("0 - 0", k, i, j);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  rc += check_vuint128x ("vec_subcuq:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  k = (vui32_t) vec_subcuq ((vui128_t) i, (vui128_t) j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("1 - 0", k, i, j);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  rc += check_vuint128x ("vec_subcuq:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  k = (vui32_t) vec_subcuq ((vui128_t) i, (vui128_t) j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("0 - 1", k, i, j);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  rc += check_vuint128x ("vec_subcuq:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
+  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  k = (vui32_t) vec_subcuq ((vui128_t) i, (vui128_t) j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("2E32-1 - 1", k, i, j);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  rc += check_vuint128x ("vec_subcuq:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
+  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  k = (vui32_t) vec_subcuq ((vui128_t) i, (vui128_t) j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("2E128-1 - 1", k, i, j);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  rc += check_vuint128x ("vec_subcuq:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  j = (vui32_t )CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
+  k = (vui32_t) vec_subcuq ((vui128_t) i, (vui128_t) j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("1 - 2E128-1", k, i, j);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  rc += check_vuint128x ("vec_subcuq:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
+  j = (vui32_t )CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
+  k = (vui32_t) vec_subcuq ((vui128_t) i, (vui128_t) j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("2E128-1 - 2E128-1", k, i, j);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  rc += check_vuint128x ("vec_subcuq:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__-1);
+  j = (vui32_t )CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
+  k = (vui32_t) vec_subcuq ((vui128_t) i, (vui128_t) j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("2E128-2 - 2E128-1", k, i, j);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  rc += check_vuint128x ("vec_subcuq:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__);
+  j = (vui32_t )CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__-1);
+  k = (vui32_t) vec_subcuq ((vui128_t) i, (vui128_t) j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("2E128-1 - 2E128-2", k, i, j);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  rc += check_vuint128x ("vec_subcuq:", (vui128_t) k, (vui128_t) e);
+
+  return (rc);
+}
+#undef  __DEBUG_PRINT__
+//#define __DEBUG_PRINT__ 1
+int
+test_subecuq (void)
+{
+  vui32_t i, j, k, l, m;
+  vui32_t e, ec;
+  int rc = 0;
+
+  printf ("\ntest_subeuq Vector subtract extended unsigned quadword modulo\n");
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  k = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  l = (vui32_t) vec_subeuqm ((vui128_t) i, (vui128_t) j, (vui128_t) k);
+  m = (vui32_t) vec_subecuq ((vui128_t) i, (vui128_t) j, (vui128_t) k);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_extend ("extent 0 - 0 + c=0", l, m, i, j, k);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint256 ("vec_subeuqm/ecuq:", (vui128_t) m, (vui128_t) l, (vui128_t) ec,
+                       (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  k = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  l = (vui32_t) vec_subeuqm ((vui128_t) i, (vui128_t) j, (vui128_t) k);
+  m = (vui32_t) vec_subecuq ((vui128_t) i, (vui128_t) j, (vui128_t) k);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_extend ("extent 0 - 0 + c=1", l, m, i, j, k);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  rc += check_vint256 ("vec_subeuqm/ecuq:", (vui128_t) m, (vui128_t) l, (vui128_t) ec,
+                       (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  k = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  l = (vui32_t) vec_subeuqm ((vui128_t) i, (vui128_t) j, (vui128_t) k);
+  m = (vui32_t) vec_subecuq ((vui128_t) i, (vui128_t) j, (vui128_t) k);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_extend ("extent 1 - 0 + c=0", l, m, i, j, k);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  rc += check_vint256 ("vec_subeuqm/ecuq:", (vui128_t) m, (vui128_t) l, (vui128_t) ec,
+                       (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  k = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  l = (vui32_t) vec_subeuqm ((vui128_t) i, (vui128_t) j, (vui128_t) k);
+  m = (vui32_t) vec_subecuq ((vui128_t) i, (vui128_t) j, (vui128_t) k);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_extend ("extent 0 - 1 + c=0", l, m, i, j, k);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint256 ("vec_subeuqm/ecuq:", (vui128_t) m, (vui128_t) l, (vui128_t) ec,
+                       (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  k = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  l = (vui32_t) vec_subeuqm ((vui128_t) i, (vui128_t) j, (vui128_t) k);
+  m = (vui32_t) vec_subecuq ((vui128_t) i, (vui128_t) j, (vui128_t) k);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_extend ("extent 1 - 0 + c=1", l, m, i, j, k);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  rc += check_vint256 ("vec_subeuqm/ecuq:", (vui128_t) m, (vui128_t) l, (vui128_t) ec,
+                       (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  k = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  l = (vui32_t) vec_subeuqm ((vui128_t) i, (vui128_t) j, (vui128_t) k);
+  m = (vui32_t) vec_subecuq ((vui128_t) i, (vui128_t) j, (vui128_t) k);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_extend ("extent 0 - 1 + c=1", l, m, i, j, k);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  ec = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint256 ("vec_subeuqm/ecuq:", (vui128_t) m, (vui128_t) l, (vui128_t) ec,
+                       (vui128_t) e);
+
+  return (rc);
+}
+#undef  __DEBUG_PRINT__
+//#define __DEBUG_PRINT__ 1
+int
+test_subuq (void)
+{
+#ifdef __DEBUG_PRINT__
+  unsigned __int128 a, b, c;
+#endif
+  vui32_t i, j, k;
+  vui32_t e;
+  int rc = 0;
+
+  rc += test_subcuq ();
+
+  rc += test_subecuq ();
+
+  printf ("\ntest_subuq Vector subtract unsigned quadword modulo\n");
+
+#ifdef __DEBUG_PRINT__
+  a = __UINT32_MAX__;
+  b = 1UL;
+  c = a - b;
+
+  print_int128_sum ("2E32-1 - 1", c, a, b);
+#endif
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
+  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  k = (vui32_t) vec_subuqm ((vui128_t) i, (vui128_t) j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("2E32-1 - 1", k, i, j);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0xfffffffe);
+  rc += check_vuint128x ("vec_subuqm:", (vui128_t) k, (vui128_t) e);
+
+#ifdef __DEBUG_PRINT__
+  a = 1UL;
+  b = __UINT32_MAX__;
+  c = a - b;
+
+  print_int128_sum ("1 - 2E32-1", c, a, b);
+#endif
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  j = (vui32_t )CONST_VINT32_W(0, 0, 0, __UINT32_MAX__);
+  k = (vui32_t) vec_subuqm ((vui128_t) i, (vui128_t) j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("1 - 2E32-1", k, i, j);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0x00000002);
+  rc += check_vuint128x ("vec_subuqm:", (vui128_t) k, (vui128_t) e);
+
+#ifdef __DEBUG_PRINT__
+  a = __UINT64_MAX__;
+  b = 1UL;
+  c = a - b;
+
+  print_int128_sum ("2E64-1 - 1", c, a, b);
+#endif
+  i = (vui32_t )CONST_VINT32_W(0, 0, __UINT32_MAX__, __UINT32_MAX__);
+  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  k = (vui32_t) vec_subuqm ((vui128_t) i, (vui128_t) j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("2E64-1 - 1", k, i, j);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0xffffffff, 0xfffffffe);
+  rc += check_vuint128x ("vec_subuqm:", (vui128_t) k, (vui128_t) e);
+
+#ifdef __DEBUG_PRINT__
+  a = 1UL;
+  a = a << 96;
+  b = 1UL;
+  c = a - b;
+
+  print_int128_sum ("2E96 - 1", c, a, b);
+#endif
+  i = (vui32_t )CONST_VINT32_W(1, 0, 0, 0);
+  j = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  k = (vui32_t) vec_subuqm ((vui128_t) i, (vui128_t) j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("2E96 - 1", k, i, j);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0x00000000, 0xffffffff, 0xffffffff, 0xffffffff);
+  rc += check_vuint128x ("vec_subuqm:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j = (vui32_t )CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  k = (vui32_t) vec_subuqm ((vui128_t) i, (vui128_t) j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("2E128-1 - 2E128-1", k, i, j);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vuint128x ("vec_subuqm:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j = (vui32_t )CONST_VINT32_W(0x7fffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  k = (vui32_t) vec_subuqm ((vui128_t) i, (vui128_t) j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("2E128-1 - 2E127-1", k, i, j);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0x80000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vuint128x ("vec_subuqm:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0x7fffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j = (vui32_t )CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  k = (vui32_t) vec_subuqm ((vui128_t) i, (vui128_t) j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("2E127-1 - 2E128-1", k, i, j);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0x80000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vuint128x ("vec_subuqm:", (vui128_t) k, (vui128_t) e);
+
+  return (rc);
+}
+#undef  __DEBUG_PRINT__
+//#define __DEBUG_PRINT__ 1
+int
+test_setbq (void)
+{
+  vui32_t i, k;
+  vui32_t e;
+  int rc = 0;
+
+  printf ("\ntest_setbq Vector set bool quadword\n");
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  k = (vui32_t) vec_setb_cyq ((vui128_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_setb ", (vui128_t) i);
+  print_vint128x ("        =", (vui128_t) k);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vuint128x ("vec_setb_cyq:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  k = (vui32_t) vec_setb_cyq ((vui128_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_setb ", (vui128_t) i);
+  print_vint128x ("        =", (vui128_t) k);
+#endif
+  e = (vui32_t )CONST_VINT32_W(-1, -1, -1, -1);
+  rc += check_vuint128x ("vec_setb_cyq:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  k = (vui32_t) vec_setb_ncq ((vui128_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_setb ", (vui128_t) i);
+  print_vint128x ("        =", (vui128_t) k);
+#endif
+  e = (vui32_t )CONST_VINT32_W(-1, -1, -1, -1);
+  rc += check_vuint128x ("vec_setb_ncq:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 1);
+  k = (vui32_t) vec_setb_ncq ((vui128_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_setb ", (vui128_t) i);
+  print_vint128x ("        =", (vui128_t) k);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vuint128x ("vec_setb_ncq:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0, 0, 0, 0);
+  k = (vui32_t) vec_setb_sq ((vi128_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_setb ", (vui128_t) i);
+  print_vint128x ("        =", (vui128_t) k);
+#endif
+  e = (vui32_t )CONST_VINT32_W(0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vuint128x ("vec_setb_sq:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(0x80000000, 0, 0, 1);
+  k = (vui32_t) vec_setb_sq ((vi128_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_setb ", (vui128_t) i);
+  print_vint128x ("        =", (vui128_t) k);
+#endif
+  e = (vui32_t )CONST_VINT32_W(-1, -1, -1, -1);
+  rc += check_vuint128x ("vec_setb_sq:", (vui128_t) k, (vui128_t) e);
+  rc += check_vuint128x ("vec_setb_sq:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t )CONST_VINT32_W(-1, -1, -1, -1);
+  k = (vui32_t) vec_setb_sq ((vi128_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_setb ", (vui128_t) i);
+  print_vint128x ("        =", (vui128_t) k);
+#endif
+  e = (vui32_t )CONST_VINT32_W(-1, -1, -1, -1);
+  rc += check_vuint128x ("vec_setb_sq:", (vui128_t) k, (vui128_t) e);
+
+  return (rc);
+}
+
+//#define __DEBUG_PRINT__ 1
+int
+test_cmpuq (void)
+{
+  vui128_t i1, i2, e;
+  vui128_t j;
+  int rc = 0;
+
+  printf ("\ntest_cmpuq Vector Compare Unsigned Quadword\n");
+
+  printf ("test_cmpequq\n");
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0, 0);
+  e =  CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpequq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpequq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpequq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 1);
+  i2 = CONST_VINT128_DW128(0, 0);
+  e =  CONST_VINT128_DW128(0, 0);
+  j = vec_cmpequq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpequq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpequq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0, 1);
+  e =  CONST_VINT128_DW128(0, 0);
+  j = vec_cmpequq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpequq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpequq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 1);
+  i2 = CONST_VINT128_DW128(0, 1);
+  e =  CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpequq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpequq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpequq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = CONST_VINT128_DW128(0, 0);
+  e =  CONST_VINT128_DW128(0, 0);
+  j = vec_cmpequq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpequq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpequq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  CONST_VINT128_DW128(0, 0);
+  j = vec_cmpequq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpequq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpequq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpequq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpequq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpequq:", (vb128_t)j, (vb128_t) e);
+
+  printf ("test_cmpneuq\n");
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0, 0);
+  e =  CONST_VINT128_DW128(0, 0);
+  j = vec_cmpneuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpneuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpneuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 1);
+  i2 = CONST_VINT128_DW128(0, 0);
+  e =  CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpneuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpneuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpneuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0, 1);
+  e =  CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpneuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpneuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpneuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 1);
+  i2 = CONST_VINT128_DW128(0, 1);
+  e =  CONST_VINT128_DW128(0, 0);
+  j = vec_cmpneuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpneuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpneuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = CONST_VINT128_DW128(0, 0);
+  e =  CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpneuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpneuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpneuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpneuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpneuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpneuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  CONST_VINT128_DW128(0, 0);
+  j = vec_cmpneuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpneuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpneuq:", (vb128_t)j, (vb128_t) e);
+
+  printf ("test_cmpgtuq\n");
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0, 0);
+  e =  CONST_VINT128_DW128(0, 0);
+  j = vec_cmpgtuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpgtuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpgtuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 1);
+  i2 = CONST_VINT128_DW128(0, 0);
+  e =  CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpgtuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpgtuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpgtuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0, 1);
+  e =  CONST_VINT128_DW128(0, 0);
+  j = vec_cmpgtuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpgtuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpgtuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 1);
+  i2 = CONST_VINT128_DW128(0, 1);
+  e =  CONST_VINT128_DW128(0, 0);
+  j = vec_cmpgtuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpgtuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpgtuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = CONST_VINT128_DW128(0, 0);
+  e =  CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpgtuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpgtuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpgtuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  CONST_VINT128_DW128(0, 0);
+  j = vec_cmpgtuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpgtuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpgtuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  CONST_VINT128_DW128(0, 0);
+  j = vec_cmpgtuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpgtuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpgtuq:", (vb128_t)j, (vb128_t) e);
+
+  printf ("test_cmpgeuq\n");
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0, 0);
+  e =  CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpgeuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpgeuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpgeuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 1);
+  i2 = CONST_VINT128_DW128(0, 0);
+  e =  CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpgeuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpgeuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpgeuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0, 1);
+  e =  CONST_VINT128_DW128(0, 0);
+  j = vec_cmpgeuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpgeuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpgeuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 1);
+  i2 = CONST_VINT128_DW128(0, 1);
+  e =  CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpgeuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpgeuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpgeuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = CONST_VINT128_DW128(0, 0);
+  e =  CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpgeuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpgeuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpgeuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  CONST_VINT128_DW128(0, 0);
+  j = vec_cmpgeuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpgeuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpgeuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpgeuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpgeuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpgeuq:", (vb128_t)j, (vb128_t) e);
+
+  printf ("test_cmpltuq\n");
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0, 0);
+  e =  CONST_VINT128_DW128(0, 0);
+  j = vec_cmpltuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpltuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpltuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 1);
+  i2 = CONST_VINT128_DW128(0, 0);
+  e =  CONST_VINT128_DW128(0, 0);
+  j = vec_cmpltuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpltuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpltuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0, 1);
+  e =  CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpltuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpltuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpltuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 1);
+  i2 = CONST_VINT128_DW128(0, 1);
+  e =  CONST_VINT128_DW128(0, 0);
+  j = vec_cmpltuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpltuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpltuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = CONST_VINT128_DW128(0, 0);
+  e =  CONST_VINT128_DW128(0, 0);
+  j = vec_cmpltuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpltuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpltuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpltuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpltuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpltuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  CONST_VINT128_DW128(0, 0);
+  j = vec_cmpltuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpltuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpltuq:", (vb128_t)j, (vb128_t) e);
+
+  printf ("test_cmpleuq\n");
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0, 0);
+  e =  CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpleuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpleuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpleuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 1);
+  i2 = CONST_VINT128_DW128(0, 0);
+  e =  CONST_VINT128_DW128(0, 0);
+  j = vec_cmpleuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpleuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpleuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0, 1);
+  e =  CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpleuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpleuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpleuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 1);
+  i2 = CONST_VINT128_DW128(0, 1);
+  e =  CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpleuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpleuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpleuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = CONST_VINT128_DW128(0, 0);
+  e =  CONST_VINT128_DW128(0, 0);
+  j = vec_cmpleuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpleuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpleuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpleuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpleuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpleuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpleuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpleuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpleuq:", (vb128_t)j, (vb128_t) e);
+
+  return (rc);
+}
+
+//#define __DEBUG_PRINT__ 1
+int
+test_cmpsq (void)
+{
+  vi128_t i1, i2, e;
+  vi128_t j;
+  int rc = 0;
+
+  printf ("\ntest_cmpsq Vector Compare Unsigned Quadword\n");
+
+  printf ("test_cmpeqsq\n");
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpeqsq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpeqsq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpeqsq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
+  j = vec_cmpeqsq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpeqsq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpeqsq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
+  j = vec_cmpeqsq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpeqsq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpeqsq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpeqsq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpeqsq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpeqsq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
+  j = vec_cmpeqsq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpeqsq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpeqsq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
+  j = vec_cmpeqsq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpeqsq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpeqsq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpeqsq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpeqsq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpeqsq:", (vb128_t)j, (vb128_t) e);
+
+  printf ("test_cmpnesq\n");
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
+  j = vec_cmpnesq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpnesq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpnesq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpnesq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpnesq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpnesq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpnesq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpnesq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpnesq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
+  j = vec_cmpnesq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpnesq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpnesq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpnesq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpnesq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpnesq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpnesq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpnesq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpnesq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
+  j = vec_cmpnesq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpnesq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpnesq:", (vb128_t)j, (vb128_t) e);
+
+  printf ("test_cmpgtsq\n");
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
+  j = vec_cmpgtsq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpgtsq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpgtsq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpgtsq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpgtsq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpgtsq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
+  j = vec_cmpgtsq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpgtsq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpgtsq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
+  j = vec_cmpgtsq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpgtsq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpgtsq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
+  j = vec_cmpgtsq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpgtsq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpgtsq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpgtsq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpgtsq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpgtsq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
+  j = vec_cmpgtsq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpgtsq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpgtsq:", (vb128_t)j, (vb128_t) e);
+
+  printf ("test_cmpgesq\n");
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpgesq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpgesq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpgesq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpgesq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpgesq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpgesq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
+  j = vec_cmpgesq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpgesq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpgesq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpgesq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpgesq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpgesq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
+  j = vec_cmpgesq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpgesq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpgesq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpgesq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpgesq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpgesq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpgesq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpgesq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpgesq:", (vb128_t)j, (vb128_t) e);
+
+  printf ("test_cmpltsq\n");
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
+  j = vec_cmpltsq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpltsq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpltsq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
+  j = vec_cmpltsq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpltsq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpltsq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpltsq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpltsq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpltsq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
+  j = vec_cmpltsq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpltsq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpltsq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpltsq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpltsq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpltsq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
+  j = vec_cmpltsq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpltsq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpltsq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
+  j = vec_cmpltsq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpltsq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpltsq:", (vb128_t)j, (vb128_t) e);
+
+  printf ("test_cmplesq\n");
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
+  j = vec_cmplesq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmplesq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmplesq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
+  j = vec_cmplesq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmplesq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmplesq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
+  j = vec_cmplesq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmplesq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmplesq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
+  j = vec_cmplesq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmplesq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmplesq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
+  j = vec_cmplesq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmplesq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmplesq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
+  j = vec_cmplesq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmplesq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmplesq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
+  j = vec_cmplesq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmplesq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmplesq:", (vb128_t)j, (vb128_t) e);
+
+  return (rc);
+}
+
+//#define __DEBUG_PRINT__ 1
+int
+test_cmpuq_all (void)
+{
+  vui128_t i1, i2;
+#ifdef __DEBUG_PRINT__
+  vui128_t j;
+#endif
+  int rc = 0;
+
+  printf ("\ntest_cmpuq_all Vector Compare Unsigned quadword\n");
+
+  printf ("test_cmpuq_all_eq\n");
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0, 0);
+
+  if (vec_cmpuq_all_eq (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpuq_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpequq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_eq( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    }
+
+  i1 = CONST_VINT128_DW128(0, 1);
+  i2 = CONST_VINT128_DW128(0, 0);
+  if (vec_cmpuq_all_eq (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpuq_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpequq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_eq( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0, 1);
+  if (vec_cmpuq_all_eq (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpuq_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpequq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_eq( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = CONST_VINT128_DW128(0, 1);
+  i2 = CONST_VINT128_DW128(0, 1);
+  if (vec_cmpuq_all_eq (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpuq_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpequq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_eq( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    }
+
+  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = CONST_VINT128_DW128(0, 0);
+  if (vec_cmpuq_all_eq (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpuq_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpequq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_eq( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  if (vec_cmpuq_all_eq (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpuq_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpequq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_eq( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  if (vec_cmpuq_all_eq (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpuq_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpequq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_eq( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    }
+
+  printf ("test_cmpuq_all_ne\n");
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0, 0);
+  if (vec_cmpuq_all_ne (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpuq_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpneuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_ne( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = CONST_VINT128_DW128(0, 1);
+  i2 = CONST_VINT128_DW128(0, 0);
+  if (vec_cmpuq_all_ne (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpuq_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpneuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_ne( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    }
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0, 1);
+  if (vec_cmpuq_all_ne (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpuq_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpneuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_ne( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    }
+
+  i1 = CONST_VINT128_DW128(0, 1);
+  i2 = CONST_VINT128_DW128(0, 1);
+  if (vec_cmpuq_all_ne (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpuq_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpneuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_ne( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = CONST_VINT128_DW128(0, 0);
+  if (vec_cmpuq_all_ne (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpuq_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpneuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_ne( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    }
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  if (vec_cmpuq_all_ne (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpuq_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpneuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_ne( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    }
+
+  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  if (vec_cmpuq_all_ne (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpuq_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpneuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_ne( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    } else {
+    }
+
+  printf ("test_cmpuq_all_gt\n");
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0, 0);
+  if (vec_cmpuq_all_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpuq_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_gt( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = CONST_VINT128_DW128(0, 1);
+  i2 = CONST_VINT128_DW128(0, 0);
+  if (vec_cmpuq_all_gt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpuq_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_gt( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    }
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0, 1);
+  if (vec_cmpuq_all_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpuq_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_gt( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = CONST_VINT128_DW128(0, 1);
+  i2 = CONST_VINT128_DW128(0, 1);
+  if (vec_cmpuq_all_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpuq_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_gt( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = CONST_VINT128_DW128(0, 0);
+  if (vec_cmpuq_all_gt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpuq_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_gt( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    }
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  if (vec_cmpuq_all_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpuq_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_gt( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  if (vec_cmpuq_all_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpuq_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_gt( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    } else {
+    }
+
+  printf ("test_cmpuq_all_ge\n");
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0, 0);
+  if (vec_cmpuq_all_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpuq_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgeuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_ge( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    }
+
+  i1 = CONST_VINT128_DW128(0, 1);
+  i2 = CONST_VINT128_DW128(0, 0);
+  if (vec_cmpuq_all_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpuq_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgeuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_ge( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    }
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0, 1);
+  if (vec_cmpuq_all_ge (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpuq_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgeuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_ge( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = CONST_VINT128_DW128(0, 1);
+  i2 = CONST_VINT128_DW128(0, 1);
+  if (vec_cmpuq_all_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpuq_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgeuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_ge( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    }
+
+  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = CONST_VINT128_DW128(0, 0);
+  if (vec_cmpuq_all_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpuq_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgeuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_ge( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    }
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  if (vec_cmpuq_all_ge (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpuq_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgeuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_ge( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  if (vec_cmpuq_all_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpuq_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgeuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_ge( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    }
+
+  printf ("test_cmpuq_all_lt\n");
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0, 0);
+  if (vec_cmpuq_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpuq_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_lt( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = CONST_VINT128_DW128(0, 1);
+  i2 = CONST_VINT128_DW128(0, 0);
+  if (vec_cmpuq_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpuq_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_lt( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0, 1);
+  if (vec_cmpuq_all_lt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpuq_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_lt( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    }
+
+  i1 = CONST_VINT128_DW128(0, 1);
+  i2 = CONST_VINT128_DW128(0, 1);
+  if (vec_cmpuq_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpuq_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_lt( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = CONST_VINT128_DW128(0, 0);
+  if (vec_cmpuq_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpuq_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_lt( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  if (vec_cmpuq_all_lt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpuq_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_lt( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    }
+
+  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  if (vec_cmpuq_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpuq_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_lt( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    } else {
+    }
+
+  printf ("test_cmpuq_all_le\n");
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0, 0);
+  if (vec_cmpuq_all_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpuq_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_le( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    }
+
+  i1 = CONST_VINT128_DW128(0, 1);
+  i2 = CONST_VINT128_DW128(0, 0);
+  if (vec_cmpuq_all_le (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpuq_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_le( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0, 1);
+  if (vec_cmpuq_all_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpuq_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_le( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    }
+
+  i1 = CONST_VINT128_DW128(0, 1);
+  i2 = CONST_VINT128_DW128(0, 1);
+  if (vec_cmpuq_all_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpuq_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_le( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    }
+
+  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = CONST_VINT128_DW128(0, 0);
+  if (vec_cmpuq_all_le (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpuq_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_le( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    } else {
+    }
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  if (vec_cmpuq_all_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpuq_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_le( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    }
+
+  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  if (vec_cmpuq_all_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpuq_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltuq(i1, i2);
+      print_vint128x ("vec_cmpuq_all_le( ", i1);
+      print_vint128x ("                 ,", i2);
+      print_vint128x ("                )=", j);
+#endif
+    }
+
+  return (rc);
+}
+#define __DEBUG_PRINT__ 1
+int
+test_cmpsq_all (void)
+{
+  vi128_t i1, i2;
+#ifdef __DEBUG_PRINT__
+  vi128_t j;
+#endif
+  int rc = 0;
+
+  printf ("\ntest_cmpsq_all Vector Compare Signed quadword\n");
+
+  printf ("test_cmpsq_all_eq\n");
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+
+  if (vec_cmpsq_all_eq (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsq_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpeqsq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_eq( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  if (vec_cmpsq_all_eq (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsq_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpeqsq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_eq( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  if (vec_cmpsq_all_eq (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsq_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpeqsq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_eq( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  if (vec_cmpsq_all_eq (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsq_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpeqsq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_eq( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  if (vec_cmpsq_all_eq (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsq_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpeqsq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_eq( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  if (vec_cmpsq_all_eq (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsq_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpeqsq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_eq( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  if (vec_cmpsq_all_eq (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsq_all_eq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpeqsq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_eq( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    }
+
+  printf ("test_cmpsq_all_ne\n");
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  if (vec_cmpsq_all_ne (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsq_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpnesq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_ne( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  if (vec_cmpsq_all_ne (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsq_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpnesq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_ne( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  if (vec_cmpsq_all_ne (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsq_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpnesq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_ne( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  if (vec_cmpsq_all_ne (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsq_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpnesq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_ne( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  if (vec_cmpsq_all_ne (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsq_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpnesq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_ne( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  if (vec_cmpsq_all_ne (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsq_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpnesq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_ne( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  if (vec_cmpsq_all_ne (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsq_all_ne fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpnesq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_ne( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    } else {
+    }
+
+  printf ("test_cmpsq_all_gt\n");
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  if (vec_cmpsq_all_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsq_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtsq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_gt( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 2);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  if (vec_cmpsq_all_gt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsq_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtsq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_gt( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  if (vec_cmpsq_all_gt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsq_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtsq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_gt( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  if (vec_cmpsq_all_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsq_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtsq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_gt( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  if (vec_cmpsq_all_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsq_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtsq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_gt( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  if (vec_cmpsq_all_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsq_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtsq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_gt( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  if (vec_cmpsq_all_gt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsq_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtsq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_gt( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  if (vec_cmpsq_all_gt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsq_all_gt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgtsq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_gt( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    } else {
+    }
+
+  printf ("test_cmpsq_all_ge\n");
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  if (vec_cmpsq_all_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsq_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgesq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_ge( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 2);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  if (vec_cmpsq_all_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsq_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgesq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_ge( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  if (vec_cmpsq_all_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsq_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgesq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_ge( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  if (vec_cmpsq_all_ge (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsq_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgesq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_ge( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  if (vec_cmpsq_all_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsq_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgesq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_ge( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  if (vec_cmpsq_all_ge (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsq_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgesq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_ge( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  if (vec_cmpsq_all_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsq_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgesq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_ge( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  if (vec_cmpsq_all_ge (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsq_all_ge fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpgesq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_ge( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    }
+
+  printf ("test_cmpsq_all_lt\n");
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  if (vec_cmpsq_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsq_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_lt( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  if (vec_cmpsq_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsq_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_lt( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  if (vec_cmpsq_all_lt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsq_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_lt( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  if (vec_cmpsq_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsq_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_lt( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  if (vec_cmpsq_all_lt (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsq_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_lt( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  if (vec_cmpsq_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsq_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_lt( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  if (vec_cmpsq_all_lt (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsq_all_lt fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_lt( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    } else {
+    }
+
+  printf ("test_cmpsq_all_le\n");
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  if (vec_cmpsq_all_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsq_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_le( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  if (vec_cmpsq_all_le (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsq_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_le( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  if (vec_cmpsq_all_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsq_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_le( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  if (vec_cmpsq_all_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsq_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_le( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  if (vec_cmpsq_all_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsq_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_le( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  if (vec_cmpsq_all_le (i1, i2))
+    {
+      rc += 1;
+      printf ("vec_cmpsq_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_le( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    } else {
+    }
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  if (vec_cmpsq_all_le (i1, i2))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_cmpsq_all_le fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_cmpltsq(i1, i2);
+      print_vint128x ("vec_cmpsq_all_le( ", (vui128_t)i1);
+      print_vint128x ("                 ,", (vui128_t)i2);
+      print_vint128x ("                )=", (vui128_t)j);
+#endif
+    }
+
   return (rc);
 }
 
@@ -4358,6 +7192,13 @@ test_vec_i128 (void)
   rc += test_muludq ();
 
   rc += test_msumudm ();
+
+  rc += test_subuq();
+  rc += test_setbq();
+  rc += test_cmpuq();
+  rc += test_cmpsq();
+  rc += test_cmpuq_all();
+  rc += test_cmpsq_all();
 
   rc += test_time_i128();
 


### PR DESCRIPTION
Completes this update.

	* src/testsuite/arith128_test_i128.c (test_time_i128):
	Change timed loop for mul10uq2x to cmul10ecuq.
	Add timed l;oop for timed_muludq and timed_muludqx.
	(test_subcuq, test_subecuq, test_subuq: New Functions.
	(test_setbq): New function.
	(test_cmpuq, test_cmpsq, test_cmpuq_all, test_cmpsq_all):
	New functions.
	(test_vec_i128): Add calls to test_subuq(), test_setbq(),
	test_cmpuq(), test_cmpsq(), test_cmpuq_all(), and
	test_cmpsq_all().

Signed-off-by: Steven Munroe <munroesj52@gmail.com>