### PR TITLE
Addtional small fixes for -mcpu=power9. After int128 commit.

### DIFF
--- a/src/testsuite/vec_f64_dummy.c
+++ b/src/testsuite/vec_f64_dummy.c
@@ -84,31 +84,31 @@ test_all_f64_zero (vf64_t value)
 	return (vec_all_iszerof64 (value));
 }
 
-__vector bool long
+vb64_t
 test_pred_f64_inf (vf64_t value)
 {
   return (vec_isinff64 (value));
 }
 
-__vector bool long
+vb64_t
 test_pred_f64_nan (vf64_t value)
 {
   return (vec_isnanf64 (value));
 }
 
-__vector bool long
+vb64_t
 test_pred_f64_normal (vf64_t value)
 {
   return (vec_isnormalf64 (value));
 }
 
-__vector bool long
+vb64_t
 test_pred_f64_subnormal (vf64_t value)
 {
   return (vec_issubnormalf64 (value));
 }
 
-__vector bool long
+vb64_t
 test_pred_f64_zero (vf64_t value)
 {
   return (vec_iszerof64 (value));
@@ -255,12 +255,4 @@ __test_cmpledp (vf64_t a, vf64_t b)
 {
   return vec_cmple (a, b);
 }
-
-#ifdef _ARCH_PWR9
-vb64_t
-__test_cmpnedp (vf64_t a, vf64_t b)
-{
-  return vec_cmpne (a, b);
-}
-#endif
 #endif

--- a/src/testsuite/vec_int128_dummy.c
+++ b/src/testsuite/vec_int128_dummy.c
@@ -257,6 +257,15 @@ test_vec_mul10uq_cuq (vui128_t *p, vui128_t a)
 }
 
 vui128_t
+test_vec_cmul10uq_ecuq (vui128_t *p, vui128_t a, vui128_t a2, vui128_t cin)
+{
+  vui128_t k, j;
+  k = vec_cmul10ecuq (&j, a, cin);
+  *p = vec_mul10euq ((vui128_t) a2, j);
+  return k;
+}
+
+vui128_t
 test_vec_addeq (vui128_t *cout, vui128_t a, vui128_t b, vui128_t c)
 {
   return (vec_addeq (cout, a, b, c));

--- a/src/testsuite/vec_int64_dummy.c
+++ b/src/testsuite/vec_int64_dummy.c
@@ -486,12 +486,4 @@ __test_cmpleud (vui64_t a, vui64_t b)
 {
   return vec_cmple (a, b);
 }
-
-#ifdef _ARCH_PWR9
-vb64_t
-__test_cmpneud (vui64_t a, vui64_t b)
-{
-  return vec_cmpne (a, b);
-}
-#endif
 #endif

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -70,6 +70,15 @@ __test_mulhuq_PWR9 (vui128_t a, vui128_t b)
 }
 
 vui128_t
+test_vec_cmul10cuq_256_PWR9 (vui128_t *p, vui128_t a, vui128_t a2, vui128_t cin)
+{
+  vui128_t k, j;
+  k = vec_cmul10ecuq (&j, a, cin);
+  *p = vec_mul10euq ((vui128_t) a2, j);
+  return k;
+}
+
+vui128_t
 __test_cmul10cuq_PWR9 (vui128_t *cout, vui128_t a)
 {
   return vec_cmul10cuq (cout, a);
@@ -147,6 +156,21 @@ __test_revbw_PWR9 (vui32_t a)
 {
   return vec_revbw (a);
 }
+
+#ifdef vec_cmpne
+vb64_t
+__test_cmpnedp_PWR9 (vf64_t a, vf64_t b)
+{
+  return vec_cmpne (a, b);
+}
+
+vb64_t
+__test_cmpneud_PWR9 (vui64_t a, vui64_t b)
+{
+  return vec_cmpne (a, b);
+}
+#endif
+
 
 void
 test_muluq_4x1_PWR9 (vui128_t *__restrict__ mulu, vui128_t m10, vui128_t m11, vui128_t m12, vui128_t m13, vui128_t m2)

--- a/src/vec_f64_ppc.h
+++ b/src/vec_f64_ppc.h
@@ -677,7 +677,7 @@ vec_isnanf64 (vf64_t vf64)
 
 #if _ARCH_PWR9
   /* P9 has a 2 cycle xvabsdp and eliminates a const load. */
-  tmp2 = (vb64_t) vec_abs (vf64);
+  tmp2 = (vui64_t) vec_abs (vf64);
 #else
   const vui64_t signmask = CONST_VINT128_DW(0x8000000000000000UL,
 					    0x8000000000000000UL);
@@ -762,7 +762,7 @@ vec_issubnormalf64 (vf64_t vf64)
 
 #if _ARCH_PWR9
   /* P9 has a 2 cycle xvabsdp and eliminates a const load. */
-  tmp2 = (vui32_t) vec_abs (vf64);
+  tmp2 = (vui64_t) vec_abs (vf64);
 #else
   const vui64_t signmask = CONST_VINT128_DW(0x8000000000000000UL,
 					    0x8000000000000000UL);

--- a/src/vec_int128_ppc.h
+++ b/src/vec_int128_ppc.h
@@ -1329,7 +1329,7 @@ vec_cmul10ecuq (vui128_t *cout, vui128_t a, vui128_t cin)
   __asm__(
       "vmul10ecuq %0,%2,%3;\n"
       "vmul10euq %1,%2,%3;\n"
-      : "=v" (t_carry),
+      : "=&v" (t_carry),
       "=v" (t)
       : "v" (a),
       "v" (cin)
@@ -1392,7 +1392,7 @@ vec_cmul10cuq (vui128_t *cout, vui128_t a)
   __asm__(
       "vmul10cuq %0,%2;\n"
       "vmul10uq %1,%2;\n"
-      : "=v" (t_carry),
+      : "=&v" (t_carry),
       "=v" (t)
       : "v" (a)
       : );
@@ -1507,7 +1507,7 @@ vec_mul10ecuq (vui128_t a, vui128_t cin)
 #ifdef _ARCH_PWR9
   __asm__(
       "vmul10ecuq %0,%1,%2;\n"
-      : "=v" (t_carry)
+      : "=&v" (t_carry)
       : "v" (a),
       "v" (cin)
       : );


### PR DESCRIPTION
Found compile failures under _ARCH_PWR9 conditional due to wrong type.
Found compile failures for GCC6 (AT10) as vec_cmpne is not defined.
Runtime bad results due to early clobbler and reuse of carry VR in
inline __asm.

	* src/testsuite/vec_f64_dummy.c (test_pred_f64_inf,
	test_pred_f64_nan, test_pred_f64_normal,
	test_pred_f64_subnormal, test_pred_f64_zero): Change return
	type to vb64_t from vec_common_ppc.h.
	[_ARCH_PWR9]: Remove __test_cmpnedp.

	* src/testsuite/vec_int128_dummy.c (test_vec_cmul10uq_ecuq):
	New Function.

	* src/testsuite/vec_int64_dummy.c [_ARCH_PWR9]:
	Remove __test_cmpneud.

	* src/testsuite/vec_pwr9_dummy.c (test_vec_cmul10cuq_256_PWR9):
	New Function.
	[vec_cmpne] (__test_cmpnedp_PWR9, __test_cmpneud_PWR9):
	New function.

	* src/vec_f64_ppc.h (vec_isnanf64) [_ARCH_PWR9]: Correct
	vec_abs cast to vui64_t.
	(vec_issubnormalf64) [_ARCH_PWR9]: Correct vec_abs cast to
	vui64_t.

	* src/vec_int128_ppc.h (vec_cmul10ecuq, vec_cmul10cuq,
	vec_mul10ecuq): Add early clobber modifier to __asm parm
	t_carry.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>