### PR TITLE
Per discussion in issue #29, this patch changes vec_int64_ppc.h

### DIFF
--- a/src/testsuite/arith128_test_i64.c
+++ b/src/testsuite/arith128_test_i64.c
@@ -1099,7 +1099,7 @@ int
 test_cmpud (void)
 {
   vui64_t i1, i2, e;
-  vui64_t j;
+  vb64_t j;
   int rc = 0;
 
   printf ("\ntest_cmpud Vector Compare Unsigned doubleword\n");
@@ -1941,7 +1941,7 @@ test_cmpud_all (void)
 {
   vui64_t i1, i2;
 #ifdef __DEBUG_PRINT__
-  vui64_t j;
+  vb64_t j;
 #endif
   int rc = 0;
 
@@ -3696,7 +3696,7 @@ test_cmpud_any (void)
 {
   vui64_t i1, i2;
 #ifdef __DEBUG_PRINT__
-  vui64_t j;
+  vb64_t j;
 #endif
   int rc = 0;
 
@@ -5450,7 +5450,7 @@ int
 test_cmpsd (void)
 {
   vi64_t i1, i2, e;
-  vi64_t j;
+  vb64_t j;
   int rc = 0;
 
   printf ("\ntest_cmpsd Vector Compare Signed doubleword\n");
@@ -6580,7 +6580,7 @@ test_cmpsd_all (void)
 {
   vi64_t i1, i2;
 #ifdef __DEBUG_PRINT__
-  vi64_t j;
+  vb64_t j;
 #endif
   int rc = 0;
 
@@ -8335,7 +8335,7 @@ test_cmpsd_any (void)
 {
   vi64_t i1, i2;
 #ifdef __DEBUG_PRINT__
-  vi64_t j;
+  vb64_t j;
 #endif
   int rc = 0;
 

--- a/src/testsuite/vec_int64_dummy.c
+++ b/src/testsuite/vec_int64_dummy.c
@@ -304,73 +304,73 @@ test_addudm (vui64_t a, vui64_t b)
   return vec_addudm (a, b);
 }
 
-vui64_t
+vb64_t
 test_cmpequd (vui64_t a, vui64_t b)
 {
   return vec_cmpequd (a, b);
 }
 
-vui64_t
+vb64_t
 test_cmpneud (vui64_t a, vui64_t b)
 {
   return vec_cmpneud (a, b);
 }
 
-vui64_t
+vb64_t
 test_cmpgtud (vui64_t a, vui64_t b)
 {
   return vec_cmpgtud (a, b);
 }
 
-vui64_t
+vb64_t
 test_cmpltud (vui64_t a, vui64_t b)
 {
   return vec_cmpltud (a, b);
 }
 
-vui64_t
+vb64_t
 test_cmpgeud (vui64_t a, vui64_t b)
 {
   return vec_cmpgeud (a, b);
 }
 
-vui64_t
+vb64_t
 test_cmpleud (vui64_t a, vui64_t b)
 {
   return vec_cmpleud (a, b);
 }
 
-vi64_t
+vb64_t
 test_cmpeqsd (vi64_t a, vi64_t b)
 {
   return vec_cmpeqsd (a, b);
 }
 
-vi64_t
+vb64_t
 test_cmpnesd (vi64_t a, vi64_t b)
 {
   return vec_cmpnesd (a, b);
 }
 
-vi64_t
+vb64_t
 test_cmpgtsd (vi64_t a, vi64_t b)
 {
   return vec_cmpgtsd (a, b);
 }
 
-vi64_t
+vb64_t
 test_cmpltsd (vi64_t a, vi64_t b)
 {
   return vec_cmpltsd (a, b);
 }
 
-vi64_t
+vb64_t
 test_cmpgesd (vi64_t a, vi64_t b)
 {
   return vec_cmpgesd (a, b);
 }
 
-vi64_t
+vb64_t
 test_cmplesd (vi64_t a, vi64_t b)
 {
   return vec_cmplesd (a, b);

--- a/src/vec_int64_ppc.h
+++ b/src/vec_int64_ppc.h
@@ -200,11 +200,11 @@ vec_clzd (vui64_t vra)
 }
 
 ///@cond INTERNAL
-static inline vi64_t vec_cmpgtsd (vi64_t a, vi64_t b);
-static inline vui64_t vec_cmpequd (vui64_t a, vui64_t b);
-static inline vui64_t vec_cmpgeud (vui64_t a, vui64_t b);
-static inline vui64_t vec_cmpgtud (vui64_t a, vui64_t b);
-static inline vui64_t vec_cmpneud (vui64_t a, vui64_t b);
+static inline vb64_t vec_cmpgtsd (vi64_t a, vi64_t b);
+static inline vb64_t vec_cmpequd (vui64_t a, vui64_t b);
+static inline vb64_t vec_cmpgeud (vui64_t a, vui64_t b);
+static inline vb64_t vec_cmpgtud (vui64_t a, vui64_t b);
+static inline vb64_t vec_cmpneud (vui64_t a, vui64_t b);
 ///@endcond
 
 /** \brief Vector Compare Equal Signed Doubleword.
@@ -229,11 +229,11 @@ static inline vui64_t vec_cmpneud (vui64_t a, vui64_t b);
  *  equal result for each element.
  */
 static inline
-vi64_t
+vb64_t
 vec_cmpeqsd (vi64_t a, vi64_t b)
 {
   /* vcmpequd works for both signed and unsigned compares.  */
-  return (vi64_t)vec_cmpequd ((vui64_t) a, (vui64_t) b);
+  return vec_cmpequd ((vui64_t) a, (vui64_t) b);
 }
 
 /** \brief Vector Compare Equal Unsigned Doubleword.
@@ -258,13 +258,13 @@ vec_cmpeqsd (vi64_t a, vi64_t b)
  *  equal result for each element.
  */
 static inline
-vui64_t
+vb64_t
 vec_cmpequd (vui64_t a, vui64_t b)
 {
-  vui64_t result;
+  vb64_t result;
 #ifdef _ARCH_PWR8
 #if __GNUC__ >= 6
-  result = (vui64_t)vec_cmpeq(a, b);
+  result = vec_cmpeq(a, b);
 #else
   __asm__(
       "vcmpequd %0,%1,%2;\n"
@@ -291,7 +291,7 @@ vec_cmpequd (vui64_t a, vui64_t b)
        rr = vec_perm (r, r, permute);
        r= vec_and (r, rr);
     }
-  result = (vui64_t)r;
+  result = (vb64_t)r;
 #endif
   return (result);
 }
@@ -316,10 +316,10 @@ vec_cmpequd (vui64_t a, vui64_t b)
 *  greater then or equal result for each element.
 */
 static inline
-vi64_t
+vb64_t
 vec_cmpgesd (vi64_t a, vi64_t b)
 {
-  vi64_t r;
+  vb64_t r;
   /* vec_cmpge is implemented as the not of vec_cmplt. And vec_cmplt
      is implemented as vec_cmpgt with parms reversed.  */
   r = vec_cmpgtsd (b, a);
@@ -346,10 +346,10 @@ vec_cmpgesd (vi64_t a, vi64_t b)
  *  greater then or equal result for each element.
  */
 static inline
-vui64_t
+vb64_t
 vec_cmpgeud (vui64_t a, vui64_t b)
 {
-  vui64_t r;
+  vb64_t r;
   /* vec_cmpge is implemented as the not of vec_cmplt. And vec_cmplt
      is implemented as vec_cmpgt with parms reversed.  */
   r = vec_cmpgtud (b, a);
@@ -378,13 +378,13 @@ vec_cmpgeud (vui64_t a, vui64_t b)
  *  greater result for each element.
  */
 static inline
-vi64_t
+vb64_t
 vec_cmpgtsd (vi64_t a, vi64_t b)
 {
-  vi64_t result;
+  vb64_t result;
 #ifdef _ARCH_PWR8
 #if __GNUC__ >= 6
-  result = (vi64_t)vec_cmpgt(a, b);
+  result = vec_cmpgt(a, b);
 #else
   __asm__(
       "vcmpgtsd %0,%1,%2;\n"
@@ -402,7 +402,7 @@ vec_cmpgtsd (vi64_t a, vi64_t b)
    */
   _A = vec_xor ((vui64_t)a, signmask);
   _B = vec_xor ((vui64_t)b, signmask);
-  result = (vi64_t)vec_cmpgtud (_A, _B);
+  result = vec_cmpgtud (_A, _B);
 #endif
   return (result);
 }
@@ -429,13 +429,13 @@ vec_cmpgtsd (vi64_t a, vi64_t b)
  *  greater result for each element.
  */
 static inline
-vui64_t
+vb64_t
 vec_cmpgtud (vui64_t a, vui64_t b)
 {
-  vui64_t result;
+  vb64_t result;
 #ifdef _ARCH_PWR8
 #if __GNUC__ >= 6
-  result = (vui64_t)vec_cmpgt(a, b);
+  result = vec_cmpgt(a, b);
 #else
   __asm__(
       "vcmpgtud %0,%1,%2;\n"
@@ -471,7 +471,7 @@ vec_cmpgtud (vui64_t a, vui64_t b)
   /* Duplicate result word to dword width.  */
   y = vec_sld (c0, x, 12);
   r = vec_sel (x, y, c01);
-  result = (vui64_t)r;
+  result = (vb64_t)r;
 #endif
   return (result);
 }
@@ -496,10 +496,10 @@ vec_cmpgtud (vui64_t a, vui64_t b)
  *  greater result for each element.
  */
 static inline
-vi64_t
+vb64_t
 vec_cmplesd (vi64_t a, vi64_t b)
 {
-  vi64_t result;
+  vb64_t result;
   /* vec_cmple is implemented as the not of vec_cmpgt.   */
   result = vec_cmpgtsd (a, b);
   return vec_nor (result, result);
@@ -525,10 +525,10 @@ vec_cmplesd (vi64_t a, vi64_t b)
  *  greater result for each element.
  */
 static inline
-vui64_t
+vb64_t
 vec_cmpleud (vui64_t a, vui64_t b)
 {
-  vui64_t result;
+  vb64_t result;
   /* vec_cmple is implemented as the not of vec_cmpgt.   */
   result = vec_cmpgtud (a, b);
   return vec_nor (result, result);
@@ -553,7 +553,7 @@ vec_cmpleud (vui64_t a, vui64_t b)
  *  less result for each element.
  */
 static inline
-vi64_t
+vb64_t
 vec_cmpltsd (vi64_t a, vi64_t b)
 {
   return vec_cmpgtsd (b, a);
@@ -578,7 +578,7 @@ vec_cmpltsd (vi64_t a, vi64_t b)
  *  less result for each element.
  */
 static inline
-vui64_t
+vb64_t
 vec_cmpltud (vui64_t a, vui64_t b)
 {
   return vec_cmpgtud (b, a);
@@ -603,10 +603,10 @@ vec_cmpltud (vui64_t a, vui64_t b)
  *  not equal result for each element.
  */
 static inline
-vi64_t
+vb64_t
 vec_cmpnesd (vi64_t a, vi64_t b)
 {
-  return (vi64_t)vec_cmpneud ((vui64_t) a, (vui64_t) b);
+  return vec_cmpneud ((vui64_t) a, (vui64_t) b);
 }
 
 /** \brief Vector Compare Not Equal Unsigned Doubleword.
@@ -628,10 +628,10 @@ vec_cmpnesd (vi64_t a, vi64_t b)
  *  not equal result for each element.
  */
 static inline
-vui64_t
+vb64_t
 vec_cmpneud (vui64_t a, vui64_t b)
 {
-  vui64_t r;
+  vb64_t r;
   /* vec_cmpne is implemented as the not of vec_cmpeq.  */
   r = vec_cmpequd (a, b);
   return vec_nor (r, r);
@@ -692,7 +692,7 @@ vec_cmpsd_all_ge (vi64_t a, vi64_t b)
   result = vec_all_ge(a, b);
 #else
   vui32_t wt = { -1, -1, -1, -1};
-  vi64_t gt_bool = vec_cmpgesd (a, b);
+  vb64_t gt_bool = vec_cmpgesd (a, b);
   result = vec_all_eq((vui32_t)gt_bool, wt);
 #endif
   return (result);
@@ -724,7 +724,7 @@ vec_cmpsd_all_gt (vi64_t a, vi64_t b)
   result = vec_all_gt(a, b);
 #else
   vui32_t wt = { -1, -1, -1, -1};
-  vi64_t gt_bool = vec_cmpgtsd (a, b);
+  vb64_t gt_bool = vec_cmpgtsd (a, b);
   result = vec_all_eq((vui32_t)gt_bool, wt);
 #endif
   return (result);
@@ -803,7 +803,7 @@ vec_cmpsd_all_ne (vi64_t a, vi64_t b)
   result = vec_all_ne(a, b);
 #else
   vui32_t wt = { -1, -1, -1, -1};
-  vui64_t gt_bool = vec_cmpneud ((vui64_t)a, (vui64_t)b);
+  vb64_t gt_bool = vec_cmpneud ((vui64_t)a, (vui64_t)b);
   result = vec_all_eq((vui32_t)gt_bool, wt);
 #endif
   return (result);
@@ -834,7 +834,7 @@ vec_cmpsd_any_eq (vi64_t a, vi64_t b)
   result = vec_any_eq(a, b);
 #else
   vui32_t wt = { -1, -1, -1, -1};
-  vui64_t gt_bool = vec_cmpequd ((vui64_t)a, (vui64_t)b);
+  vb64_t gt_bool = vec_cmpequd ((vui64_t)a, (vui64_t)b);
   result = vec_any_eq((vui32_t)gt_bool, wt);
 #endif
   return (result);
@@ -861,15 +861,15 @@ static inline
 int
 vec_cmpsd_any_ge (vi64_t a, vi64_t b)
 {
-int result;
+  int result;
 #if defined (_ARCH_PWR8) && (__GNUC__ >= 6)
-result = vec_any_ge(a, b);
+  result = vec_any_ge(a, b);
 #else
-vui32_t wt = { -1, -1, -1, -1};
-vi64_t gt_bool = vec_cmpgesd (a, b);
-result = vec_any_eq((vui32_t)gt_bool, wt);
+  vui32_t wt = { -1, -1, -1, -1};
+  vb64_t gt_bool = vec_cmpgesd (a, b);
+  result = vec_any_eq((vui32_t)gt_bool, wt);
 #endif
-return (result);
+  return (result);
 }
 
 /** \brief Vector Compare any Greater Than Signed Doubleword.
@@ -898,7 +898,7 @@ vec_cmpsd_any_gt (vi64_t a, vi64_t b)
   result = vec_any_gt(a, b);
 #else
   vui32_t wt = { -1, -1, -1, -1};
-  vi64_t gt_bool = vec_cmpgtsd (a, b);
+  vb64_t gt_bool = vec_cmpgtsd (a, b);
   result = vec_any_eq((vui32_t)gt_bool, wt);
 #endif
   return (result);
@@ -977,7 +977,7 @@ vec_cmpsd_any_ne (vi64_t a, vi64_t b)
   result = vec_any_ne(a, b);
 #else
   vui32_t wt = { -1, -1, -1, -1};
-  vui64_t gt_bool = vec_cmpneud ((vui64_t)a, (vui64_t)b);
+  vb64_t gt_bool = vec_cmpneud ((vui64_t)a, (vui64_t)b);
   result = vec_any_eq((vui32_t)gt_bool, wt);
 #endif
   return (result);
@@ -1038,7 +1038,7 @@ vec_cmpud_all_ge (vui64_t a, vui64_t b)
   result = vec_all_ge(a, b);
 #else
   vui32_t wt = { -1, -1, -1, -1};
-  vui64_t gt_bool = vec_cmpgeud (a, b);
+  vb64_t gt_bool = vec_cmpgeud (a, b);
   result = vec_all_eq((vui32_t)gt_bool, wt);
 #endif
   return (result);
@@ -1070,7 +1070,7 @@ vec_cmpud_all_gt (vui64_t a, vui64_t b)
   result = vec_all_gt(a, b);
 #else
   vui32_t wt = { -1, -1, -1, -1};
-  vui64_t gt_bool = vec_cmpgtud (a, b);
+  vb64_t gt_bool = vec_cmpgtud (a, b);
   result = vec_all_eq((vui32_t)gt_bool, wt);
 #endif
   return (result);
@@ -1149,7 +1149,7 @@ vec_cmpud_all_ne (vui64_t a, vui64_t b)
   result = vec_all_ne(a, b);
 #else
   vui32_t wt = { -1, -1, -1, -1};
-  vui64_t gt_bool = vec_cmpneud (a, b);
+  vb64_t gt_bool = vec_cmpneud (a, b);
   result = vec_all_eq((vui32_t)gt_bool, wt);
 #endif
   return (result);
@@ -1180,7 +1180,7 @@ vec_cmpud_any_eq (vui64_t a, vui64_t b)
   result = vec_any_eq(a, b);
 #else
   vui32_t wt = { -1, -1, -1, -1};
-  vui64_t gt_bool = vec_cmpequd (a, b);
+  vb64_t gt_bool = vec_cmpequd (a, b);
   result = vec_any_eq((vui32_t)gt_bool, wt);
 #endif
   return (result);
@@ -1207,15 +1207,15 @@ static inline
 int
 vec_cmpud_any_ge (vui64_t a, vui64_t b)
 {
-int result;
+  int result;
 #if defined (_ARCH_PWR8) && (__GNUC__ >= 6)
-result = vec_any_ge(a, b);
+  result = vec_any_ge(a, b);
 #else
-vui32_t wt = { -1, -1, -1, -1};
-vui64_t gt_bool = vec_cmpgeud (a, b);
-result = vec_any_eq((vui32_t)gt_bool, wt);
+  vui32_t wt = { -1, -1, -1, -1};
+  vb64_t gt_bool = vec_cmpgeud (a, b);
+  result = vec_any_eq((vui32_t)gt_bool, wt);
 #endif
-return (result);
+  return (result);
 }
 
 /** \brief Vector Compare any Greater Than Unsigned Doubleword.
@@ -1244,7 +1244,7 @@ vec_cmpud_any_gt (vui64_t a, vui64_t b)
   result = vec_any_gt(a, b);
 #else
   vui32_t wt = { -1, -1, -1, -1};
-  vui64_t gt_bool = vec_cmpgtud (a, b);
+  vb64_t gt_bool = vec_cmpgtud (a, b);
   result = vec_any_eq((vui32_t)gt_bool, wt);
 #endif
   return (result);
@@ -1323,7 +1323,7 @@ vec_cmpud_any_ne (vui64_t a, vui64_t b)
   result = vec_any_ne(a, b);
 #else
   vui32_t wt = { -1, -1, -1, -1};
-  vui64_t gt_bool = vec_cmpneud (a, b);
+  vb64_t gt_bool = vec_cmpneud (a, b);
   result = vec_any_eq((vui32_t)gt_bool, wt);
 #endif
   return (result);


### PR DESCRIPTION
compares to return the appropriate vector bool.

	* src/vec_int64_ppc.h (vec_cmpgtsd, vec_cmpequd, vec_cmpgeud,
	vec_cmpgtud, vec_cmpneud): Change return type to vb64_t in
	function prototype.
	(vec_cmpeqsd): Change return type to vb64_t.
	(vec_cmpequd): Change return type to vb64_t.
	(vec_cmpgesd): Change return type to vb64_t.
	(vec_cmpgeud): Change return type to vb64_t.
	(vec_cmpgtsd): Change return type to vb64_t.
	(vec_cmpgtud): Change return type to vb64_t.
	(vec_cmplesd): Change return type to vb64_t.
	(vec_cmpleud): Change return type to vb64_t.
	(vec_cmpltsd): Change return type to vb64_t.
	(vec_cmpltud): Change return type to vb64_t.
	(vec_cmpnesd): Change return type to vb64_t.
	(vec_cmpneud): Change return type to vb64_t.
	(vec_cmpsd_all_ge, vec_cmpsd_all_gt, vec_cmpsd_all_ne,
	vec_cmpsd_any_eq, vec_cmpsd_any_ge, vec_cmpsd_any_gt,
	vec_cmpsd_any_ne): Change type of gt_bool to vb64_t.
	(vec_cmpud_all_ge, vec_cmpud_all_gt, vec_cmpud_all_ne,
	vec_cmpud_any_eq, vec_cmpud_any_ge, vec_cmpud_any_gt,
	vec_cmpud_any_ne): Change type of gt_bool to vb64_t.
	(vec_cmpsd_any_ge, vec_cmpud_any_ge): Reformat.

	* src/testsuite/arith128_test_i64.c (test_cmpud):
	Change type of j to vb64_t.
	* src/testsuite/arith128_test_i64.c (test_cmpsd):
	Change type of j to vb64_t.
	* src/testsuite/arith128_test_i64.c (test_cmpsd_all):
	Change type of j to vb64_t.
	* src/testsuite/arith128_test_i64.c (test_cmpsd_any):
	Change type of j to vb64_t.
	* src/testsuite/arith128_test_i64.c (test_cmpud_all):
	Change type of j to vb64_t.
	* src/testsuite/arith128_test_i64.c (test_cmpud_any):
	Change type of j to vb64_t.

	* src/testsuite/vec_int64_dummy.c (test_cmpequd, test_cmpneud,
	test_cmpgtud, test_cmpltud, test_cmpgeud, test_cmpleud,
 	test_cmpeqsd, test_cmpnesd, test_cmpgtsd, test_cmpltsd,
	test_cmpgesd,  test_cmplesd): Change return type to vb64_t.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>