### PR TITLE
Per issue #29, change the vec_int128_ppc.h to return vector bool for …

### DIFF
--- a/src/testsuite/arith128_test_i128.c
+++ b/src/testsuite/arith128_test_i128.c
@@ -4765,10 +4765,191 @@ test_setbq (void)
 
 //#define __DEBUG_PRINT__ 1
 int
+test_cmpuq_p2 (void)
+{
+  vui128_t i1, i2, e;
+  vb128_t j;
+  int rc = 0;
+  printf ("test_cmpltuq\n");
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0, 0);
+  e =  CONST_VINT128_DW128(0, 0);
+  j = vec_cmpltuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpltuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpltuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 1);
+  i2 = CONST_VINT128_DW128(0, 0);
+  e =  CONST_VINT128_DW128(0, 0);
+  j = vec_cmpltuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpltuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpltuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0, 1);
+  e =  CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpltuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpltuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpltuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 1);
+  i2 = CONST_VINT128_DW128(0, 1);
+  e =  CONST_VINT128_DW128(0, 0);
+  j = vec_cmpltuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpltuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpltuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = CONST_VINT128_DW128(0, 0);
+  e =  CONST_VINT128_DW128(0, 0);
+  j = vec_cmpltuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpltuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpltuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpltuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpltuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpltuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  CONST_VINT128_DW128(0, 0);
+  j = vec_cmpltuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpltuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpltuq:", (vb128_t)j, (vb128_t) e);
+
+  printf ("test_cmpleuq\n");
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0, 0);
+  e =  CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpleuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpleuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpleuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 1);
+  i2 = CONST_VINT128_DW128(0, 0);
+  e =  CONST_VINT128_DW128(0, 0);
+  j = vec_cmpleuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpleuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpleuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0, 1);
+  e =  CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpleuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpleuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpleuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 1);
+  i2 = CONST_VINT128_DW128(0, 1);
+  e =  CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpleuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpleuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpleuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = CONST_VINT128_DW128(0, 0);
+  e =  CONST_VINT128_DW128(0, 0);
+  j = vec_cmpleuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpleuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpleuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0, 0);
+  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpleuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpleuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpleuq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpleuq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpleuq( ", i1);
+  print_vint128x ("         ,", i2);
+  print_vint128x ("        )=", j);
+#endif
+  rc += check_vb128c ("vec_cmpleuq:", (vb128_t)j, (vb128_t) e);
+
+  return (rc);
+}
+
+int
 test_cmpuq (void)
 {
   vui128_t i1, i2, e;
-  vui128_t j;
+  vb128_t j;
   int rc = 0;
 
   printf ("\ntest_cmpuq Vector Compare Unsigned Quadword\n");
@@ -5117,187 +5298,199 @@ test_cmpuq (void)
 #endif
   rc += check_vb128c ("vec_cmpgeuq:", (vb128_t)j, (vb128_t) e);
 
-  printf ("test_cmpltuq\n");
-
-  i1 = CONST_VINT128_DW128(0, 0);
-  i2 = CONST_VINT128_DW128(0, 0);
-  e =  CONST_VINT128_DW128(0, 0);
-  j = vec_cmpltuq(i1, i2);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x ("vcmpltuq( ", i1);
-  print_vint128x ("         ,", i2);
-  print_vint128x ("        )=", j);
+#if 1
+  rc += test_cmpuq_p2 ();
 #endif
-  rc += check_vb128c ("vec_cmpltuq:", (vb128_t)j, (vb128_t) e);
-
-  i1 = CONST_VINT128_DW128(0, 1);
-  i2 = CONST_VINT128_DW128(0, 0);
-  e =  CONST_VINT128_DW128(0, 0);
-  j = vec_cmpltuq(i1, i2);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x ("vcmpltuq( ", i1);
-  print_vint128x ("         ,", i2);
-  print_vint128x ("        )=", j);
-#endif
-  rc += check_vb128c ("vec_cmpltuq:", (vb128_t)j, (vb128_t) e);
-
-  i1 = CONST_VINT128_DW128(0, 0);
-  i2 = CONST_VINT128_DW128(0, 1);
-  e =  CONST_VINT128_DW128(-1, -1);
-  j = vec_cmpltuq(i1, i2);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x ("vcmpltuq( ", i1);
-  print_vint128x ("         ,", i2);
-  print_vint128x ("        )=", j);
-#endif
-  rc += check_vb128c ("vec_cmpltuq:", (vb128_t)j, (vb128_t) e);
-
-  i1 = CONST_VINT128_DW128(0, 1);
-  i2 = CONST_VINT128_DW128(0, 1);
-  e =  CONST_VINT128_DW128(0, 0);
-  j = vec_cmpltuq(i1, i2);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x ("vcmpltuq( ", i1);
-  print_vint128x ("         ,", i2);
-  print_vint128x ("        )=", j);
-#endif
-  rc += check_vb128c ("vec_cmpltuq:", (vb128_t)j, (vb128_t) e);
-
-  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
-  i2 = CONST_VINT128_DW128(0, 0);
-  e =  CONST_VINT128_DW128(0, 0);
-  j = vec_cmpltuq(i1, i2);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x ("vcmpltuq( ", i1);
-  print_vint128x ("         ,", i2);
-  print_vint128x ("        )=", j);
-#endif
-  rc += check_vb128c ("vec_cmpltuq:", (vb128_t)j, (vb128_t) e);
-
-  i1 = CONST_VINT128_DW128(0, 0);
-  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
-  e =  CONST_VINT128_DW128(-1, -1);
-  j = vec_cmpltuq(i1, i2);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x ("vcmpltuq( ", i1);
-  print_vint128x ("         ,", i2);
-  print_vint128x ("        )=", j);
-#endif
-  rc += check_vb128c ("vec_cmpltuq:", (vb128_t)j, (vb128_t) e);
-
-  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
-  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
-  e =  CONST_VINT128_DW128(0, 0);
-  j = vec_cmpltuq(i1, i2);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x ("vcmpltuq( ", i1);
-  print_vint128x ("         ,", i2);
-  print_vint128x ("        )=", j);
-#endif
-  rc += check_vb128c ("vec_cmpltuq:", (vb128_t)j, (vb128_t) e);
-
-  printf ("test_cmpleuq\n");
-
-  i1 = CONST_VINT128_DW128(0, 0);
-  i2 = CONST_VINT128_DW128(0, 0);
-  e =  CONST_VINT128_DW128(-1, -1);
-  j = vec_cmpleuq(i1, i2);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x ("vcmpleuq( ", i1);
-  print_vint128x ("         ,", i2);
-  print_vint128x ("        )=", j);
-#endif
-  rc += check_vb128c ("vec_cmpleuq:", (vb128_t)j, (vb128_t) e);
-
-  i1 = CONST_VINT128_DW128(0, 1);
-  i2 = CONST_VINT128_DW128(0, 0);
-  e =  CONST_VINT128_DW128(0, 0);
-  j = vec_cmpleuq(i1, i2);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x ("vcmpleuq( ", i1);
-  print_vint128x ("         ,", i2);
-  print_vint128x ("        )=", j);
-#endif
-  rc += check_vb128c ("vec_cmpleuq:", (vb128_t)j, (vb128_t) e);
-
-  i1 = CONST_VINT128_DW128(0, 0);
-  i2 = CONST_VINT128_DW128(0, 1);
-  e =  CONST_VINT128_DW128(-1, -1);
-  j = vec_cmpleuq(i1, i2);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x ("vcmpleuq( ", i1);
-  print_vint128x ("         ,", i2);
-  print_vint128x ("        )=", j);
-#endif
-  rc += check_vb128c ("vec_cmpleuq:", (vb128_t)j, (vb128_t) e);
-
-  i1 = CONST_VINT128_DW128(0, 1);
-  i2 = CONST_VINT128_DW128(0, 1);
-  e =  CONST_VINT128_DW128(-1, -1);
-  j = vec_cmpleuq(i1, i2);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x ("vcmpleuq( ", i1);
-  print_vint128x ("         ,", i2);
-  print_vint128x ("        )=", j);
-#endif
-  rc += check_vb128c ("vec_cmpleuq:", (vb128_t)j, (vb128_t) e);
-
-  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
-  i2 = CONST_VINT128_DW128(0, 0);
-  e =  CONST_VINT128_DW128(0, 0);
-  j = vec_cmpleuq(i1, i2);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x ("vcmpleuq( ", i1);
-  print_vint128x ("         ,", i2);
-  print_vint128x ("        )=", j);
-#endif
-  rc += check_vb128c ("vec_cmpleuq:", (vb128_t)j, (vb128_t) e);
-
-  i1 = CONST_VINT128_DW128(0, 0);
-  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
-  e =  CONST_VINT128_DW128(-1, -1);
-  j = vec_cmpleuq(i1, i2);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x ("vcmpleuq( ", i1);
-  print_vint128x ("         ,", i2);
-  print_vint128x ("        )=", j);
-#endif
-  rc += check_vb128c ("vec_cmpleuq:", (vb128_t)j, (vb128_t) e);
-
-  i1 = CONST_VINT128_DW128(0x8000000000000000, 0);
-  i2 = CONST_VINT128_DW128(0x8000000000000000, 0);
-  e =  CONST_VINT128_DW128(-1, -1);
-  j = vec_cmpleuq(i1, i2);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x ("vcmpleuq( ", i1);
-  print_vint128x ("         ,", i2);
-  print_vint128x ("        )=", j);
-#endif
-  rc += check_vb128c ("vec_cmpleuq:", (vb128_t)j, (vb128_t) e);
-
   return (rc);
 }
 
 //#define __DEBUG_PRINT__ 1
 int
+test_cmpsq_p2 (void)
+{
+  vi128_t i1, i2, e;
+  vb128_t j;
+  int rc = 0;
+  printf ("test_cmpltsq\n");
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
+  j = vec_cmpltsq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpltsq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpltsq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
+  j = vec_cmpltsq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpltsq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpltsq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpltsq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpltsq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpltsq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
+  j = vec_cmpltsq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpltsq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpltsq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
+  j = vec_cmpltsq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpltsq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpltsq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
+  j = vec_cmpltsq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpltsq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpltsq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
+  j = vec_cmpltsq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmpltsq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmpltsq:", (vb128_t)j, (vb128_t) e);
+
+  printf ("test_cmplesq\n");
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
+  j = vec_cmplesq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmplesq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmplesq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
+  j = vec_cmplesq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmplesq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmplesq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
+  j = vec_cmplesq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmplesq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmplesq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
+  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
+  j = vec_cmplesq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmplesq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmplesq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
+  j = vec_cmplesq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmplesq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmplesq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
+  j = vec_cmplesq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmplesq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmplesq:", (vb128_t)j, (vb128_t) e);
+
+  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
+  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
+  j = vec_cmplesq(i1, i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vcmplesq( ", (vui128_t)i1);
+  print_vint128x ("         ,", (vui128_t)i2);
+  print_vint128x ("        )=", (vui128_t)j);
+#endif
+  rc += check_vb128c ("vec_cmplesq:", (vb128_t)j, (vb128_t) e);
+
+  return (rc);
+}
+
+int
 test_cmpsq (void)
 {
   vi128_t i1, i2, e;
-  vi128_t j;
+  vb128_t j;
   int rc = 0;
 
   printf ("\ntest_cmpsq Vector Compare Unsigned Quadword\n");
@@ -5646,178 +5839,9 @@ test_cmpsq (void)
 #endif
   rc += check_vb128c ("vec_cmpgesq:", (vb128_t)j, (vb128_t) e);
 
-  printf ("test_cmpltsq\n");
-
-  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
-  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
-  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
-  j = vec_cmpltsq(i1, i2);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x ("vcmpltsq( ", (vui128_t)i1);
-  print_vint128x ("         ,", (vui128_t)i2);
-  print_vint128x ("        )=", (vui128_t)j);
+#if 1
+  rc += test_cmpsq_p2 ();
 #endif
-  rc += check_vb128c ("vec_cmpltsq:", (vb128_t)j, (vb128_t) e);
-
-  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
-  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
-  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
-  j = vec_cmpltsq(i1, i2);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x ("vcmpltsq( ", (vui128_t)i1);
-  print_vint128x ("         ,", (vui128_t)i2);
-  print_vint128x ("        )=", (vui128_t)j);
-#endif
-  rc += check_vb128c ("vec_cmpltsq:", (vb128_t)j, (vb128_t) e);
-
-  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
-  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
-  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
-  j = vec_cmpltsq(i1, i2);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x ("vcmpltsq( ", (vui128_t)i1);
-  print_vint128x ("         ,", (vui128_t)i2);
-  print_vint128x ("        )=", (vui128_t)j);
-#endif
-  rc += check_vb128c ("vec_cmpltsq:", (vb128_t)j, (vb128_t) e);
-
-  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
-  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
-  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
-  j = vec_cmpltsq(i1, i2);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x ("vcmpltsq( ", (vui128_t)i1);
-  print_vint128x ("         ,", (vui128_t)i2);
-  print_vint128x ("        )=", (vui128_t)j);
-#endif
-  rc += check_vb128c ("vec_cmpltsq:", (vb128_t)j, (vb128_t) e);
-
-  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
-  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
-  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
-  j = vec_cmpltsq(i1, i2);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x ("vcmpltsq( ", (vui128_t)i1);
-  print_vint128x ("         ,", (vui128_t)i2);
-  print_vint128x ("        )=", (vui128_t)j);
-#endif
-  rc += check_vb128c ("vec_cmpltsq:", (vb128_t)j, (vb128_t) e);
-
-  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
-  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
-  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
-  j = vec_cmpltsq(i1, i2);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x ("vcmpltsq( ", (vui128_t)i1);
-  print_vint128x ("         ,", (vui128_t)i2);
-  print_vint128x ("        )=", (vui128_t)j);
-#endif
-  rc += check_vb128c ("vec_cmpltsq:", (vb128_t)j, (vb128_t) e);
-
-  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
-  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
-  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
-  j = vec_cmpltsq(i1, i2);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x ("vcmpltsq( ", (vui128_t)i1);
-  print_vint128x ("         ,", (vui128_t)i2);
-  print_vint128x ("        )=", (vui128_t)j);
-#endif
-  rc += check_vb128c ("vec_cmpltsq:", (vb128_t)j, (vb128_t) e);
-
-  printf ("test_cmplesq\n");
-
-  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
-  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
-  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
-  j = vec_cmplesq(i1, i2);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x ("vcmplesq( ", (vui128_t)i1);
-  print_vint128x ("         ,", (vui128_t)i2);
-  print_vint128x ("        )=", (vui128_t)j);
-#endif
-  rc += check_vb128c ("vec_cmplesq:", (vb128_t)j, (vb128_t) e);
-
-  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
-  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
-  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
-  j = vec_cmplesq(i1, i2);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x ("vcmplesq( ", (vui128_t)i1);
-  print_vint128x ("         ,", (vui128_t)i2);
-  print_vint128x ("        )=", (vui128_t)j);
-#endif
-  rc += check_vb128c ("vec_cmplesq:", (vb128_t)j, (vb128_t) e);
-
-  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
-  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
-  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
-  j = vec_cmplesq(i1, i2);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x ("vcmplesq( ", (vui128_t)i1);
-  print_vint128x ("         ,", (vui128_t)i2);
-  print_vint128x ("        )=", (vui128_t)j);
-#endif
-  rc += check_vb128c ("vec_cmplesq:", (vb128_t)j, (vb128_t) e);
-
-  i1 = (vi128_t)CONST_VINT128_DW128(0, 1);
-  i2 = (vi128_t)CONST_VINT128_DW128(0, 1);
-  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
-  j = vec_cmplesq(i1, i2);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x ("vcmplesq( ", (vui128_t)i1);
-  print_vint128x ("         ,", (vui128_t)i2);
-  print_vint128x ("        )=", (vui128_t)j);
-#endif
-  rc += check_vb128c ("vec_cmplesq:", (vb128_t)j, (vb128_t) e);
-
-  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
-  i2 = (vi128_t)CONST_VINT128_DW128(0, 0);
-  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
-  j = vec_cmplesq(i1, i2);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x ("vcmplesq( ", (vui128_t)i1);
-  print_vint128x ("         ,", (vui128_t)i2);
-  print_vint128x ("        )=", (vui128_t)j);
-#endif
-  rc += check_vb128c ("vec_cmplesq:", (vb128_t)j, (vb128_t) e);
-
-  i1 = (vi128_t)CONST_VINT128_DW128(0, 0);
-  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
-  e =  (vi128_t)CONST_VINT128_DW128(0, 0);
-  j = vec_cmplesq(i1, i2);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x ("vcmplesq( ", (vui128_t)i1);
-  print_vint128x ("         ,", (vui128_t)i2);
-  print_vint128x ("        )=", (vui128_t)j);
-#endif
-  rc += check_vb128c ("vec_cmplesq:", (vb128_t)j, (vb128_t) e);
-
-  i1 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
-  i2 = (vi128_t)CONST_VINT128_DW128(0x8000000000000000, 0);
-  e =  (vi128_t)CONST_VINT128_DW128(-1, -1);
-  j = vec_cmplesq(i1, i2);
-
-#ifdef __DEBUG_PRINT__
-  print_vint128x ("vcmplesq( ", (vui128_t)i1);
-  print_vint128x ("         ,", (vui128_t)i2);
-  print_vint128x ("        )=", (vui128_t)j);
-#endif
-  rc += check_vb128c ("vec_cmplesq:", (vb128_t)j, (vb128_t) e);
-
   return (rc);
 }
 
@@ -5827,7 +5851,7 @@ test_cmpuq_all (void)
 {
   vui128_t i1, i2;
 #ifdef __DEBUG_PRINT__
-  vui128_t j;
+  vb128_t j;
 #endif
   int rc = 0;
 
@@ -6484,7 +6508,7 @@ test_cmpsq_all (void)
 {
   vi128_t i1, i2;
 #ifdef __DEBUG_PRINT__
-  vi128_t j;
+  vb128_t j;
 #endif
   int rc = 0;
 

--- a/src/testsuite/vec_int128_dummy.c
+++ b/src/testsuite/vec_int128_dummy.c
@@ -93,67 +93,67 @@ test_vec_subuqm_cuq (vui128_t *p, vui128_t a, vui128_t b)
   return vec_subuqm (a, b);
 }
 
-vi128_t
+vb128_t
 test_vec_cmpeqsq (vi128_t a, vi128_t b)
 {
   return (vec_cmpeqsq (a, b));
 }
 
-vi128_t
+vb128_t
 test_vec_cmpgesq (vi128_t a, vi128_t b)
 {
   return (vec_cmpgesq (a, b));
 }
 
-vi128_t
+vb128_t
 test_vec_cmpgtsq (vi128_t a, vi128_t b)
 {
   return (vec_cmpgtsq (a, b));
 }
 
-vi128_t
+vb128_t
 test_vec_cmplesq (vi128_t a, vi128_t b)
 {
   return (vec_cmplesq (a, b));
 }
 
-vi128_t
+vb128_t
 test_vec_cmpltsq (vi128_t a, vi128_t b)
 {
   return (vec_cmpltsq (a, b));
 }
 
-vui128_t
+vb128_t
 test_vec_cmpequq (vui128_t a, vui128_t b)
 {
   return (vec_cmpequq (a, b));
 }
 
-vui128_t
+vb128_t
 test_vec_cmpgtuq (vui128_t a, vui128_t b)
 {
   return (vec_cmpgtuq (a, b));
 }
 
-vui128_t
+vb128_t
 test_vec_cmpltuq (vui128_t a, vui128_t b)
 {
   return (vec_cmpltuq (a, b));
 }
 
-vui128_t
+vb128_t
 test_vec_cmpgeuq (vui128_t a, vui128_t b)
 {
   return (vec_cmpgeuq (a, b));
 }
 
-vui128_t
+vb128_t
 test_vec_cmpleuq (vui128_t a, vui128_t b)
 {
   return (vec_cmpleuq (a, b));
 }
 
-vui128_t
+vb128_t
 test_vec_cmpneuq (vui128_t a, vui128_t b)
 {
   return (vec_cmpneuq (a, b));

--- a/src/vec_int128_ppc.h
+++ b/src/vec_int128_ppc.h
@@ -550,12 +550,12 @@ vec_clzq (vui128_t vra)
   return ((vui128_t) result);
 }
 ///@cond INTERNAL
-static inline vui128_t vec_cmpequq (vui128_t vra, vui128_t vrb);
-static inline vui128_t vec_cmpgeuq (vui128_t vra, vui128_t vrb);
-static inline vui128_t vec_cmpgtuq (vui128_t vra, vui128_t vrb);
-static inline vui128_t vec_cmpleuq (vui128_t vra, vui128_t vrb);
-static inline vui128_t vec_cmpltuq (vui128_t vra, vui128_t vrb);
-static inline vui128_t vec_cmpneuq (vui128_t vra, vui128_t vrb);
+static inline vb128_t vec_cmpequq (vui128_t vra, vui128_t vrb);
+static inline vb128_t vec_cmpgeuq (vui128_t vra, vui128_t vrb);
+static inline vb128_t vec_cmpgtuq (vui128_t vra, vui128_t vrb);
+static inline vb128_t vec_cmpleuq (vui128_t vra, vui128_t vrb);
+static inline vb128_t vec_cmpltuq (vui128_t vra, vui128_t vrb);
+static inline vb128_t vec_cmpneuq (vui128_t vra, vui128_t vrb);
 static inline vui128_t vec_muleud (vui64_t a, vui64_t b);
 static inline vui128_t vec_muloud (vui64_t a, vui64_t b);
 static inline vb128_t vec_setb_cyq (vui128_t vcy);
@@ -581,11 +581,11 @@ static inline vui128_t vec_subuqm (vui128_t vra, vui128_t vrb);
  *  @return 128-bit vector boolean reflecting vector signed __int128
  *  compare equal.
  */
-static inline vi128_t
+static inline vb128_t
 vec_cmpeqsq (vi128_t vra, vi128_t vrb)
 {
   /* vec_cmpequq works for both signed and unsigned compares.  */
-  return (vi128_t)vec_cmpequq ((vui128_t) vra, (vui128_t) vrb);
+  return vec_cmpequq ((vui128_t) vra, (vui128_t) vrb);
 }
 
 /** \brief Vector Compare Equal Unsigned Quadword.
@@ -611,7 +611,7 @@ vec_cmpeqsq (vi128_t vra, vi128_t vrb)
  *  @return 128-bit vector boolean reflecting vector unsigned __int128
  *  compare equal.
  */
-static inline vui128_t
+static inline vb128_t
 vec_cmpequq (vui128_t vra, vui128_t vrb)
 {
 #ifdef _ARCH_PWR8
@@ -619,7 +619,7 @@ vec_cmpequq (vui128_t vra, vui128_t vrb)
 
   equd = (vui64_t) vec_cmpequd ((vui64_t) vra, (vui64_t) vrb);
   swapd = vec_swapd (equd);
-  return (vui128_t) vec_and (equd, swapd);
+  return (vb128_t) vec_and (equd, swapd);
 #else
   vui32_t equw, equ1, equ2, equ3;
 
@@ -651,7 +651,7 @@ vec_cmpequq (vui128_t vra, vui128_t vrb)
  *  @return 128-bit vector boolean reflecting vector signed __int128
  *  compare greater than.
  */
-static inline vi128_t
+static inline vb128_t
 vec_cmpgesq (vi128_t vra, vi128_t vrb)
 {
   const vui32_t signbit = CONST_VINT128_W (0x80000000, 0, 0, 0);
@@ -659,7 +659,7 @@ vec_cmpgesq (vi128_t vra, vi128_t vrb)
 
   _a = vec_xor ((vui32_t)vra, signbit);
   _b = vec_xor ((vui32_t)vrb, signbit);
-  return (vi128_t)vec_cmpgeuq ((vui128_t)_a, (vui128_t)_b);
+  return vec_cmpgeuq ((vui128_t)_a, (vui128_t)_b);
 }
 
 /** \brief Vector Compare Greater Than or Equal Unsigned Quadword.
@@ -686,7 +686,7 @@ vec_cmpgesq (vi128_t vra, vi128_t vrb)
  *  @return 128-bit vector boolean reflecting vector unsigned __int128
  *  compare greater than.
  */
-static inline vui128_t
+static inline vb128_t
 vec_cmpgeuq (vui128_t vra, vui128_t vrb)
 {
   vui128_t a_b;
@@ -712,7 +712,7 @@ vec_cmpgeuq (vui128_t vra, vui128_t vrb)
  *  @return 128-bit vector boolean reflecting vector signed __int128
  *  compare greater than.
  */
-static inline vi128_t
+static inline vb128_t
 vec_cmpgtsq (vi128_t vra, vi128_t vrb)
 {
   const vui32_t signbit = CONST_VINT128_W (0x80000000, 0, 0, 0);
@@ -720,7 +720,7 @@ vec_cmpgtsq (vi128_t vra, vi128_t vrb)
 
   _a = vec_xor ((vui32_t)vra, signbit);
   _b = vec_xor ((vui32_t)vrb, signbit);
-  return (vi128_t)vec_cmpgtuq ((vui128_t)_a, (vui128_t)_b);
+  return vec_cmpgtuq ((vui128_t)_a, (vui128_t)_b);
 }
 
 /** \brief Vector Compare Greater Than Unsigned Quadword.
@@ -747,7 +747,7 @@ vec_cmpgtsq (vi128_t vra, vi128_t vrb)
  *  @return 128-bit vector boolean reflecting vector unsigned __int128
  *  compare greater than.
  */
-static inline vui128_t
+static inline vb128_t
 vec_cmpgtuq (vui128_t vra, vui128_t vrb)
 {
   vui128_t b_a;
@@ -773,7 +773,7 @@ vec_cmpgtuq (vui128_t vra, vui128_t vrb)
  *  @return 128-bit vector boolean reflecting vector signed __int128
  *  compare less than or equal.
  */
-static inline vi128_t
+static inline vb128_t
 vec_cmplesq (vi128_t vra, vi128_t vrb)
 {
   const vui32_t signbit = CONST_VINT128_W (0x80000000, 0, 0, 0);
@@ -781,7 +781,7 @@ vec_cmplesq (vi128_t vra, vi128_t vrb)
 
   _a = vec_xor ((vui32_t)vra, signbit);
   _b = vec_xor ((vui32_t)vrb, signbit);
-  return (vi128_t)vec_cmpleuq ((vui128_t)_a, (vui128_t)_b);
+  return vec_cmpleuq ((vui128_t)_a, (vui128_t)_b);
 }
 
 /** \brief Vector Compare Less Than or Equal Unsigned Quadword.
@@ -808,7 +808,7 @@ vec_cmplesq (vi128_t vra, vi128_t vrb)
  *  @return 128-bit vector boolean reflecting vector unsigned __int128
  *  compare less than or equal.
  */
-static inline vui128_t
+static inline vb128_t
 vec_cmpleuq (vui128_t vra, vui128_t vrb)
 {
   vui128_t b_a;
@@ -835,7 +835,7 @@ vec_cmpleuq (vui128_t vra, vui128_t vrb)
  *  @return 128-bit vector boolean reflecting vector unsigned __int128
  *  compare less than.
  */
-static inline vi128_t
+static inline vb128_t
 vec_cmpltsq (vi128_t vra, vi128_t vrb)
 {
   const vui32_t signbit = CONST_VINT128_W(0x80000000, 0, 0, 0);
@@ -843,7 +843,7 @@ vec_cmpltsq (vi128_t vra, vi128_t vrb)
 
   _a = vec_xor ((vui32_t) vra, signbit);
   _b = vec_xor ((vui32_t) vrb, signbit);
-  return (vi128_t) vec_cmpltuq ((vui128_t) _a, (vui128_t) _b);
+  return vec_cmpltuq ((vui128_t) _a, (vui128_t) _b);
 }
 
 /** \brief Vector Compare Less Than Unsigned Quadword.
@@ -870,7 +870,7 @@ vec_cmpltsq (vi128_t vra, vi128_t vrb)
  *  @return 128-bit vector boolean reflecting vector unsigned __int128
  *  compare less than.
  */
-static inline vui128_t
+static inline vb128_t
 vec_cmpltuq (vui128_t vra, vui128_t vrb)
 {
   vui128_t  a_b;
@@ -895,11 +895,11 @@ vec_cmpltuq (vui128_t vra, vui128_t vrb)
  *  @return 128-bit vector boolean reflecting vector signed __int128
  *  compare not equal.
  */
-static inline vi128_t
+static inline vb128_t
 vec_cmpnesq (vi128_t vra, vi128_t vrb)
 {
   /* vec_cmpneuq works for both signed and unsigned compares.  */
-  return (vi128_t)vec_cmpneuq ((vui128_t) vra, (vui128_t) vrb);
+  return vec_cmpneuq ((vui128_t) vra, (vui128_t) vrb);
 }
 
 /** \brief Vector Compare Not Equal Unsigned Quadword.
@@ -927,7 +927,7 @@ vec_cmpnesq (vi128_t vra, vi128_t vrb)
  *  @return 128-bit vector boolean reflecting vector unsigned __int128
  *  compare equal.
  */
-static inline vui128_t
+static inline vb128_t
 vec_cmpneuq (vui128_t vra, vui128_t vrb)
 {
 #ifdef _ARCH_PWR8
@@ -936,7 +936,7 @@ vec_cmpneuq (vui128_t vra, vui128_t vrb)
   equd = (vui64_t) vec_cmpequd ((vui64_t) vra,
       (vui64_t) vrb);
   swapd = vec_swapd (equd);
-  return (vui128_t) vec_nand (equd, swapd);
+  return (vb128_t) vec_nand (equd, swapd);
 #else
   vui32_t equw, equ1, equ2, equ3;
 
@@ -949,7 +949,7 @@ vec_cmpneuq (vui128_t vra, vui128_t vrb)
   /* POWER7 does not have vnand nor xxlnand, so requires an extra vnor
      after the final vand.  */
   equw = vec_and (equw, equ2);
-  return (vui128_t) vec_nor (equw, equw);
+  return (vb128_t) vec_nor (equw, equw);
 #endif
 }
 


### PR DESCRIPTION
…compares.

	* src/vec_int128_ppc.h (vec_cmpequd, vec_cmpgeud, vec_cmpgtud,
	vec_cmpleud, vec_cmpltud, vec_cmpneud): Change return type to
	vb128_t in function prototype.
	(vec_cmpeqsq): Change return type to vb128_t.
	(vec_cmpequq): Change return type to vb128_t.
	(vec_cmpgesq): Change return type to vb128_t.
	(vec_cmpgeuq): Change return type to vb128_t.
	(vec_cmpgtsq): Change return type to vb128_t.
	(vec_cmpgtuq): Change return type to vb128_t.
	(vec_cmplesq): Change return type to vb128_t.
	(vec_cmpleuq): Change return type to vb128_t.
	(vec_cmpltsq): Change return type to vb128_t.
	(vec_cmpltuq): Change return type to vb128_t.
	(vec_cmpnesq): Change return type to vb128_t.
	(vec_cmpneuq): Change return type to vb128_t.

	* src/testsuite/arith128_test_i128.c (test_cmpuq_p2):
	new function.
	* src/testsuite/arith128_test_i238.c (test_cmpud):
	Change type of j to vb128_t. Move cmpltuq and cmpleuq tests to
	test_cmpuq_p2. Tail call test_cmpuq_p2.
	* src/testsuite/arith128_test_i128.c (test_cmpsq_p2):
	new function.
	* src/testsuite/arith128_test_i238.c (test_cmpsd):
	Change type of j to vb128_t. Move cmpltsq and cmplesq tests to
	test_cmpsq_p2. Tail call test_cmpsq_p2.
	* src/testsuite/arith128_test_i128.c (test_cmpsq_all):
	Change type of j to vb128_t.
	* src/testsuite/arith128_test_i128.c (test_cmpuq_all):
	Change type of j to vb128_t.

	* src/testsuite/vec_int128_dummy.c (test_cmpequq, test_cmpneuq,
	test_cmpgtuq, test_cmpltuq, test_cmpgeuq, test_cmpleuq,
 	test_cmpeqsq, test_cmpnesq, test_cmpgtsq, test_cmpltsq,
	test_cmpgesq, test_cmplesq): Change return type to vb128_t.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>