### PR TITLE
Introduce vec_f128_ppc.h with initial __float128 support.

### DIFF
--- a/src/testsuite/arith128_print.c
+++ b/src/testsuite/arith128_print.c
@@ -1176,11 +1176,11 @@ print_dfp128p2 (char *prefix, _Decimal128 val128, long exp)
 }
 
 int
-check_f128bool_priv (char *prefix, __float128 val128, __f128_bool boolis,
-                     __f128_bool shouldbe)
+check_f128bool_priv (char *prefix, __float128 val128, vb128_t boolis,
+                     vb128_t shouldbe)
 {
   int rc = 0;
-  if (!vec_all_eq (boolis, shouldbe))
+  if (!vec_all_eq ((vui32_t)boolis, (vui32_t)shouldbe))
     {
       rc = 1;
       print_vfloat128x (prefix, val128);

--- a/src/testsuite/arith128_print.h
+++ b/src/testsuite/arith128_print.h
@@ -232,15 +232,15 @@ check_isf128 (char *prefix, __float128 val128, int val, int shouldbe)
 }
 
 extern int
-check_f128bool_priv (char *prefix, __float128 val128, __f128_bool boolis,
-                     __f128_bool shouldbe);
+check_f128bool_priv (char *prefix, __float128 val128, vb128_t boolis,
+                     vb128_t shouldbe);
 
 static inline int
-check_f128bool (char *prefix, __float128 val128, __f128_bool boolis,
-                __f128_bool shouldbe)
+check_f128bool (char *prefix, __float128 val128, vb128_t boolis,
+                vb128_t shouldbe)
 {
   int rc = 0;
-  if (!vec_all_eq(boolis, shouldbe))
+  if (!vec_all_eq((vui32_t)boolis, (vui32_t)shouldbe))
     {
       rc = check_f128bool_priv (prefix, val128, boolis, shouldbe);
     }
@@ -253,7 +253,7 @@ check_f128 (char *prefix, __float128 val128, __float128 f128is,
             __float128 shouldbe)
 {
   __VF_128 xfer;
-  __f128_bool boolis, boolshould;
+  vb128_t boolis, boolshould;
   int rc = 0;
 
   xfer.vf1 = f128is;
@@ -261,7 +261,7 @@ check_f128 (char *prefix, __float128 val128, __float128 f128is,
   xfer.vf1 = shouldbe;
   boolshould = xfer.vbool1;
 
-  if (!vec_all_eq(boolis, boolshould))
+  if (!vec_all_eq((vui32_t)boolis, (vui32_t)boolshould))
     {
       rc = check_f128bool_priv (prefix, val128, boolis, boolshould);
     }

--- a/src/testsuite/arith128_test_f128.c
+++ b/src/testsuite/arith128_test_f128.c
@@ -1,0 +1,4254 @@
+/*
+ Copyright (c) [2016, 2018] IBM Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ arith128_test_f128.c
+
+ Contributors:
+      IBM Corporation, Steven Munroe
+      Created on: Apr 18, 2016
+      Commited on: Oct 10, 2018
+ */
+
+
+#define __STDC_WANT_DEC_FP__    1
+
+#include <stdint.h>
+#include <stdio.h>
+#include <float.h>
+
+#include "arith128.h"
+#include <testsuite/arith128_print.h>
+#include "vec_int128_ppc.h"
+#include "vec_f128_ppc.h"
+#include <testsuite/arith128_test_f128.h>
+
+#undef __DEBUG_PRINT__
+//#define __DEBUG_PRINT__
+#ifdef __DEBUG_PRINT__
+
+static vb128_t
+db_vec_isfinitef128 (__binary128 f128)
+{
+	const vui32_t expmask  = CONST_VINT128_W(0x7fff0000, 0, 0, 0);
+	vui32_t tmp, t128;
+	vb128_t tmp2, tmp3;
+	vb128_t result = (vb128_t)CONST_VINT128_W(0, 0, 0, 0);
+
+	t128 = vec_xfer_bin128_2_vui32t (f128);
+	tmp = vec_and (t128, expmask);
+	tmp2 = vec_cmpeq(tmp, expmask);
+	tmp3 = vec_splat (tmp2,VEC_W_H);
+	result = vec_nor (tmp3, tmp3); // vec_not
+
+	print_vfloat128x ("db_vec_isfinitef128", f128);
+	print_vint128x   ("               t128:", (vui128_t)t128);
+	print_vint128x   ("                tmp:", (vui128_t)tmp);
+	print_vint128x   ("               tmp2:", (vui128_t)tmp2);
+	print_vint128x   ("               tmp3:", (vui128_t)tmp3);
+	print_vint128x   ("             result:", (vui128_t)result);
+
+	return (result);
+}
+#else
+#endif
+
+const vui32_t signmask32  = {0x80000000, 0, 0, 0};
+const vui64_t signmask64  = {0x8000000000000000, 0};
+
+const vui64_t vf128_zero  = CONST_VINT64_DW(0x0000000000000000, 0);
+const vui64_t vf128_nzero = CONST_VINT64_DW(0x8000000000000000, 0);
+
+const vui64_t vf128_one   = CONST_VINT64_DW(0x3fff000000000000, 0);
+const vui64_t vf128_none  = CONST_VINT64_DW(0xbfff000000000000, 0);
+
+const vui64_t vf128_max   = CONST_VINT64_DW(0x7ffeffffffffffff, 0xffffffffffffffff);
+const vui64_t vf128_nmax  = CONST_VINT64_DW(0xfffeffffffffffff, 0xffffffffffffffff);
+
+const vui64_t vf128_min   = CONST_VINT64_DW(0x0001000000000000, 0x0000000000000000);
+const vui64_t vf128_nmin  = CONST_VINT64_DW(0x8001000000000000, 0x0000000000000000);
+
+const vui64_t vf128_sub   = CONST_VINT64_DW(0x0000ffffffffffff, 0xffffffffffffffff);
+const vui64_t vf128_nsub  = CONST_VINT64_DW(0x8000ffffffffffff, 0xffffffffffffffff);
+
+const vui64_t vf128_inf   = CONST_VINT64_DW(0x7fff000000000000, 0);
+const vui64_t vf128_ninf  = CONST_VINT64_DW(0xffff000000000000, 0);
+
+const vui64_t vf128_nan   = CONST_VINT64_DW(0x7fff800000000000, 0);
+const vui64_t vf128_nnan  = CONST_VINT64_DW(0xffff800000000000, 0);
+
+const vui64_t vf128_snan  = CONST_VINT64_DW(0x7fff400000000000, 0);
+const vui64_t vf128_nsnan = CONST_VINT64_DW(0xffff000080000000, 0);
+
+const vui32_t vf128_true = CONST_VINT32_W(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+const vui32_t vf128_false = CONST_VINT32_W(0, 0, 0, 0);
+
+int
+test_isinf_signf128 (void)
+{
+  const __binary128 f128_zero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000000000000000, 0));
+  const __binary128 f128_nzero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000000000000000, 0));
+
+  const __binary128 f128_one = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x3fff000000000000, 0));
+  const __binary128 f128_none = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xbfff000000000000, 0));
+
+  const __binary128 f128_max = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7ffeffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nmax = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xfffeffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_min = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0001000000000000, 0x0000000000000000));
+  const __binary128 f128_nmin = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8001000000000000, 0x0000000000000000));
+
+  const __binary128 f128_sub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000ffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nsub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000ffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_inf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff000000000000, 0));
+  const __binary128 f128_ninf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000000000000, 0));
+
+  const __binary128 f128_nan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff800000000000, 0));
+  const __binary128 f128_nnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff800000000000, 0));
+
+  const __binary128 f128_snan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff400000000000, 0));
+  const __binary128 f128_nsnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000080000000, 0));
+
+  __float128 x;
+  long tests_count = 0;
+  int test, expt;
+  int rc = 0;
+
+  printf ("\ntest_isinf_signf128 f128 -> int , ...\n");
+
+#if 1
+  tests_count++;
+  x = (__float128) f128_zero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinf_signf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_isinf_signf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nzero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinf_signf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_isinf_signf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_one;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinf_signf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_isinf_signf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_none;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinf_signf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_isinf_signf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_max;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinf_signf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_isinf_signf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmax;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinf_signf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_isinf_signf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_min;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinf_signf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_isinf_signf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmin;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinf_signf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_isinf_signf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_sub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinf_signf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_isinf_signf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinf_signf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_isinf_signf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_inf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinf_signf128 (x);
+  expt = 1;
+  rc += check_isf128 ("check vec_isinf_signf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_ninf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinf_signf128 (x);
+  expt = -1;
+  rc += check_isf128 ("check vec_isinf_signf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinf_signf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_isinf_signf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinf_signf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_isinf_signf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_snan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinf_signf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_isinf_signf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinf_signf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_isinf_signf128", x, test, expt);
+#endif
+  /* accumulate the number of values tested, in case we are doing
+   * detail timing and want to compute function averages.  */
+  tcount += tests_count;
+  printf ("\ntest_isinf_signf128, tests=%ld fails=%d\n", tests_count, rc);
+
+  return (rc);
+}
+
+int
+test_setb_qp (void)
+{
+  const __binary128 f128_zero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000000000000000, 0));
+  const __binary128 f128_nzero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000000000000000, 0));
+
+  const __binary128 f128_one = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x3fff000000000000, 0));
+  const __binary128 f128_none = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xbfff000000000000, 0));
+
+  const __binary128 f128_max = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7ffeffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nmax = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xfffeffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_min = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0001000000000000, 0x0000000000000000));
+  const __binary128 f128_nmin = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8001000000000000, 0x0000000000000000));
+
+  const __binary128 f128_sub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000ffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nsub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000ffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_inf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff000000000000, 0));
+  const __binary128 f128_ninf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000000000000, 0));
+
+  const __binary128 f128_nan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff800000000000, 0));
+  const __binary128 f128_nnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff800000000000, 0));
+
+  const __binary128 f128_snan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff400000000000, 0));
+  const __binary128 f128_nsnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000080000000, 0));
+
+  __float128 x;
+  vb128_t test, expt;
+  long tests_count = 0;
+  int rc = 0;
+
+  printf ("\ntest_setb_qp f128 -> vector bool , ...\n");
+
+#if 1
+  tests_count++;
+  x = (__float128) f128_zero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_setb_qp (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_setb_qp", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nzero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_setb_qp (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_setb_qp", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_one;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_setb_qp (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_setb_qp", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_none;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_setb_qp (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_setb_qp", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_max;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_setb_qp (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_setb_qp", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmax;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_setb_qp (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_setb_qp", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_min;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_setb_qp (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_setb_qp", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmin;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_setb_qp (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_setb_qp", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_sub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_setb_qp (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_setb_qp", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_setb_qp (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_setb_qp", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_inf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_setb_qp (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_setb_qp", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_ninf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_setb_qp (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_setb_qp", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_setb_qp (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_setb_qp", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_setb_qp (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_setb_qp", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_snan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_setb_qp (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_setb_qp", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_setb_qp (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_setb_qp", x, test, expt);
+#endif
+
+  /* accumulate the number of values tested, in case we are doing
+   * detail timing and want to compute function averages.  */
+  tcount += tests_count;
+  printf ("\ntest_setb_qp, tests=%ld fails=%d\n", tests_count, rc);
+
+  return (rc);
+}
+
+int
+test_signbitf128 (void)
+{
+  const __binary128 f128_zero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000000000000000, 0));
+  const __binary128 f128_nzero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000000000000000, 0));
+
+  const __binary128 f128_one = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x3fff000000000000, 0));
+  const __binary128 f128_none = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xbfff000000000000, 0));
+
+  const __binary128 f128_max = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7ffeffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nmax = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xfffeffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_min = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0001000000000000, 0x0000000000000000));
+  const __binary128 f128_nmin = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8001000000000000, 0x0000000000000000));
+
+  const __binary128 f128_sub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000ffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nsub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000ffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_inf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff000000000000, 0));
+  const __binary128 f128_ninf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000000000000, 0));
+
+  const __binary128 f128_nan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff800000000000, 0));
+  const __binary128 f128_nnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff800000000000, 0));
+
+  const __binary128 f128_snan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff400000000000, 0));
+  const __binary128 f128_nsnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000080000000, 0));
+
+  __float128 x;
+  long tests_count = 0;
+  int test, expt;
+  int rc = 0;
+
+#ifdef __DEBUG_PRINT__
+  x = (__float128)f128_zero;
+  print_vfloat128x(" x=  ", x);
+  x = (__float128)f128_nzero;
+  print_vfloat128x(" x=  ", x);
+  x = (__float128)f128_one;
+  print_vfloat128x(" x=  ", x);
+  x = (__float128)f128_none;
+  print_vfloat128x(" x=  ", x);
+  x = (__float128)f128_max;
+  print_vfloat128x(" x=  ", x);
+  x = (__float128)f128_nmax;
+  print_vfloat128x(" x=  ", x);
+  x = (__float128)f128_min;
+  print_vfloat128x(" x=  ", x);
+  x = (__float128)f128_nmin;
+  print_vfloat128x(" x=  ", x);
+  x = (__float128)f128_sub;
+  print_vfloat128x(" x=  ", x);
+  x = (__float128)f128_nsub;
+  print_vfloat128x(" x=  ", x);
+  x = (__float128)f128_inf;
+  print_vfloat128x(" x=  ", x);
+  x = (__float128)f128_ninf;
+  print_vfloat128x(" x=  ", x);
+  x = (__float128)f128_nan;
+  print_vfloat128x(" x=  ", x);
+  x = (__float128)f128_nnan;
+  print_vfloat128x(" x=  ", x);
+  x = (__float128)f128_snan;
+  print_vfloat128x(" x=  ", x);
+  x = (__float128)f128_nsnan;
+  print_vfloat128x(" x=  ", x);
+#endif
+
+  printf ("\ntest_signbitf128 f128 -> int bool , ...\n");
+
+#if 1
+  tests_count++;
+  x = (__float128) f128_zero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_signbitf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_signbitf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nzero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_signbitf128 (x);
+  expt = 1;
+  rc += check_isf128 ("check vec_signbitf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_one;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_signbitf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_signbitf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_none;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_signbitf128 (x);
+  expt = 1;
+  rc += check_isf128 ("check vec_signbitf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_max;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_signbitf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_signbitf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmax;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_signbitf128 (x);
+  expt = 1;
+  rc += check_isf128 ("check vec_signbitf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_min;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_signbitf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_signbitf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmin;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_signbitf128 (x);
+  expt = 1;
+  rc += check_isf128 ("check vec_signbitf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_sub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_signbitf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_signbitf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_signbitf128 (x);
+  expt = 1;
+  rc += check_isf128 ("check vec_signbitf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_inf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_signbitf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_signbitf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_ninf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_signbitf128 (x);
+  expt = 1;
+  rc += check_isf128 ("check vec_signbitf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_signbitf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_signbitf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_signbitf128 (x);
+  expt = 1;
+  rc += check_isf128 ("check vec_signbitf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_snan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_signbitf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_signbitf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_signbitf128 (x);
+  expt = 1;
+  rc += check_isf128 ("check vec_signbitf128", x, test, expt);
+#endif
+  /* accumulate the number of values tested, in case we are doing
+   * detail timing and want to compute function averages.  */
+  tcount += tests_count;
+  printf ("\ntest_signbitf128, tests=%ld fails=%d\n", tests_count, rc);
+  return (rc);
+}
+
+int
+test_isinff128 (void)
+{
+  const __binary128 f128_zero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000000000000000, 0));
+  const __binary128 f128_nzero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000000000000000, 0));
+
+  const __binary128 f128_one = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x3fff000000000000, 0));
+  const __binary128 f128_none = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xbfff000000000000, 0));
+
+  const __binary128 f128_max = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7ffeffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nmax = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xfffeffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_min = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0001000000000000, 0x0000000000000000));
+  const __binary128 f128_nmin = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8001000000000000, 0x0000000000000000));
+
+  const __binary128 f128_sub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000ffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nsub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000ffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_inf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff000000000000, 0));
+  const __binary128 f128_ninf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000000000000, 0));
+
+  const __binary128 f128_nan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff800000000000, 0));
+  const __binary128 f128_nnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff800000000000, 0));
+
+  const __binary128 f128_snan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff400000000000, 0));
+  const __binary128 f128_nsnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000080000000, 0));
+
+  __float128 x;
+  vb128_t test, expt;
+  long tests_count = 0;
+  int rc = 0;
+
+  printf ("\ntest_isinff128 f128 -> vector bool ...\n");
+  /* this version (with #undef __DEBUG_PRINT__) is silent if there
+   * are no errors.  Better for profiling.  */
+
+#if 1
+  tests_count++;
+  x = (__float128) f128_zero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinff128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isinff128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nzero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinff128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isinff128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_one;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinff128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isinff128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_none;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinff128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isinff128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_max;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinff128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isinff128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmax;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinff128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isinff128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_min;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinff128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isinff128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmin;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinff128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isinff128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_sub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinff128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isinff128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinff128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isinff128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_inf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinff128 (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_isinff128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_ninf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinff128 (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_isinff128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinff128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isinff128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinff128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isinff128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_snan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinff128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isinff128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isinff128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isinff128", x, test, expt);
+#endif
+
+  /* accumulate the number of values tested, in case we are doing
+   * detail timing and want to compute function averages.  */
+  tcount += tests_count;
+  printf ("\ntest_isinff128, tests=%ld fails=%d\n", tests_count, rc);
+  return (rc);
+}
+
+int
+test_isnanf128 (void)
+{
+  const __binary128 f128_zero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000000000000000, 0));
+  const __binary128 f128_nzero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000000000000000, 0));
+
+  const __binary128 f128_one = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x3fff000000000000, 0));
+  const __binary128 f128_none = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xbfff000000000000, 0));
+
+  const __binary128 f128_max = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7ffeffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nmax = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xfffeffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_min = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0001000000000000, 0x0000000000000000));
+  const __binary128 f128_nmin = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8001000000000000, 0x0000000000000000));
+
+  const __binary128 f128_sub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000ffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nsub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000ffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_inf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff000000000000, 0));
+  const __binary128 f128_ninf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000000000000, 0));
+
+  const __binary128 f128_nan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff800000000000, 0));
+  const __binary128 f128_nnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff800000000000, 0));
+
+  const __binary128 f128_snan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff400000000000, 0));
+  const __binary128 f128_nsnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000080000000, 0));
+
+  __float128 x;
+  vb128_t test, expt;
+  long tests_count = 0;
+  int rc = 0;
+
+  printf ("\ntest_isnanf128 f128 -> vector bool ...\n");
+  /* this version (with #undef __DEBUG_PRINT__) is silent if there
+   * are no errors.  Better for profiling.  */
+
+#if 1
+  tests_count++;
+  x = (__float128) f128_zero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnanf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nzero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnanf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_one;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnanf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_none;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnanf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_max;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnanf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmax;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnanf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_min;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnanf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmin;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnanf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_sub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnanf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnanf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_inf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnanf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_ninf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnanf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnanf128 (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnanf128 (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_snan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnanf128 (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnanf128 (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_isnanf128", x, test, expt);
+#endif
+
+  /* accumulate the number of values tested, in case we are doing
+   * detail timing and want to compute function averages.  */
+  tcount += tests_count;
+  printf ("\ntest_isnanf128, tests=%ld fails=%d\n", tests_count, rc);
+  return (rc);
+}
+
+int
+test_isfinitef128 (void)
+{
+  const __binary128 f128_zero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000000000000000, 0));
+  const __binary128 f128_nzero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000000000000000, 0));
+
+  const __binary128 f128_one = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x3fff000000000000, 0));
+  const __binary128 f128_none = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xbfff000000000000, 0));
+
+  const __binary128 f128_max = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7ffeffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nmax = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xfffeffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_min = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0001000000000000, 0x0000000000000000));
+  const __binary128 f128_nmin = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8001000000000000, 0x0000000000000000));
+
+  const __binary128 f128_sub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000ffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nsub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000ffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_inf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff000000000000, 0));
+  const __binary128 f128_ninf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000000000000, 0));
+
+  const __binary128 f128_nan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff800000000000, 0));
+  const __binary128 f128_nnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff800000000000, 0));
+
+  const __binary128 f128_snan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff400000000000, 0));
+  const __binary128 f128_nsnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000080000000, 0));
+
+  __float128 x;
+  vb128_t test, expt;
+  long tests_count = 0;
+  int rc = 0;
+
+  printf ("\ntest_isfinitef128 f128 -> vector bool ...\n");
+  /* this version (with #undef __DEBUG_PRINT__) is silent if there
+   * are no errors.  Better for profiling.  */
+
+#if 1
+  tests_count++;
+  x = (__float128) f128_zero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isfinitef128 (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_isfinitef128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nzero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isfinitef128 (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_isfinitef128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_one;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isfinitef128 (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_isfinitef128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_none;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isfinitef128 (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_isfinitef128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_max;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isfinitef128 (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_isfinitef128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmax;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isfinitef128 (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_isfinitef128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_min;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isfinitef128 (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_isfinitef128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmin;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isfinitef128 (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_isfinitef128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_sub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isfinitef128 (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_isfinitef128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isfinitef128 (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_isfinitef128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_inf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isfinitef128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isfinitef128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_ninf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isfinitef128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isfinitef128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isfinitef128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isfinitef128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isfinitef128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isfinitef128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_snan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isfinitef128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isfinitef128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isfinitef128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isfinitef128", x, test, expt);
+#endif
+
+  /* accumulate the number of values tested, in case we are doing
+   * detail timing and want to compute function averages.  */
+  tcount += tests_count;
+  printf ("\ntest_isfinitef128, tests=%ld fails=%d\n", tests_count, rc);
+  return (rc);
+}
+
+int
+test_isnormalf128 (void)
+{
+  const __binary128 f128_zero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000000000000000, 0));
+  const __binary128 f128_nzero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000000000000000, 0));
+
+  const __binary128 f128_one = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x3fff000000000000, 0));
+  const __binary128 f128_none = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xbfff000000000000, 0));
+
+  const __binary128 f128_max = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7ffeffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nmax = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xfffeffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_min = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0001000000000000, 0x0000000000000000));
+  const __binary128 f128_nmin = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8001000000000000, 0x0000000000000000));
+
+  const __binary128 f128_sub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000ffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nsub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000ffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_inf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff000000000000, 0));
+  const __binary128 f128_ninf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000000000000, 0));
+
+  const __binary128 f128_nan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff800000000000, 0));
+  const __binary128 f128_nnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff800000000000, 0));
+
+  const __binary128 f128_snan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff400000000000, 0));
+  const __binary128 f128_nsnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000080000000, 0));
+
+  __float128 x;
+  vb128_t test, expt;
+  long tests_count = 0;
+  int rc = 0;
+
+  printf ("\ntest_isnormalf128 f128 -> vector bool ...\n");
+  /* this version (with #undef __DEBUG_PRINT__) is silent if there
+   * are no errors.  Better for profiling.  */
+
+#if 1
+  tests_count++;
+  x = (__float128) f128_zero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnormalf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nzero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnormalf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_one;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnormalf128 (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_isnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_none;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnormalf128 (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_isnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_max;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnormalf128 (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_isnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmax;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnormalf128 (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_isnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_min;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnormalf128 (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_isnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmin;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnormalf128 (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_isnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_sub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnormalf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnormalf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_inf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnormalf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_ninf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnormalf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnormalf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnormalf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_snan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnormalf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_isnormalf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_isnormalf128", x, test, expt);
+#endif
+  /* accumulate the number of values tested, in case we are doing
+   * detail timing and want to compute function averages.  */
+  tcount += tests_count;
+  printf ("\ntest_isnormalf128, tests=%ld fails=%d\n", tests_count, rc);
+  return (rc);
+}
+
+//#define __DEBUG_PRINT__ 1
+int
+test_issubnormalf128 (void)
+{
+  const __binary128 f128_zero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000000000000000, 0));
+  const __binary128 f128_nzero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000000000000000, 0));
+
+  const __binary128 f128_one = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x3fff000000000000, 0));
+  const __binary128 f128_none = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xbfff000000000000, 0));
+
+  const __binary128 f128_max = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7ffeffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nmax = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xfffeffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_min = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0001000000000000, 0x0000000000000000));
+  const __binary128 f128_nmin = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8001000000000000, 0x0000000000000000));
+
+  const __binary128 f128_sub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000ffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nsub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000ffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_sub2 = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000000000000000, 0x0000000000000001));
+  const __binary128 f128_nsub2 = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000000000000000, 0x0000000000000001));
+
+  const __binary128 f128_inf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff000000000000, 0));
+  const __binary128 f128_ninf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000000000000, 0));
+
+  const __binary128 f128_nan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff800000000000, 0));
+  const __binary128 f128_nnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff800000000000, 0));
+
+  const __binary128 f128_snan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff400000000000, 0));
+  const __binary128 f128_nsnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000080000000, 0));
+
+  __float128 x;
+  vb128_t test, expt;
+  long tests_count = 0;
+  int rc = 0;
+
+  printf ("\ntest_issubnormalf128 f128 -> vector bool ...\n");
+  /* this version (with #undef __DEBUG_PRINT__) is silent if there
+   * are no errors.  Better for profiling.  */
+
+#if 1
+  tests_count++;
+  x = (__float128) f128_zero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_issubnormalf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nzero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_issubnormalf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_one;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_issubnormalf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_none;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_issubnormalf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_max;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_issubnormalf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmax;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_issubnormalf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_min;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_issubnormalf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmin;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_issubnormalf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_sub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_issubnormalf128 (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_issubnormalf128 (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_sub2;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_issubnormalf128 (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsub2;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_issubnormalf128 (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_inf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_issubnormalf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_ninf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_issubnormalf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_issubnormalf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_issubnormalf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_snan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_issubnormalf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_issubnormalf128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_issubnormalf128", x, test, expt);
+#endif
+  /* accumulate the number of values tested, in case we are doing
+   * detail timing and want to compute function averages.  */
+  tcount += tests_count;
+  printf ("\ntest_issubnormalf128, tests=%ld fails=%d\n", tests_count, rc);
+  return (rc);
+}
+#undef __DEBUG_PRINT__
+
+//#define __DEBUG_PRINT__ 1
+int
+test_iszerof128 (void)
+{
+  const __binary128 f128_zero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000000000000000, 0));
+  const __binary128 f128_nzero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000000000000000, 0));
+
+  const __binary128 f128_one = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x3fff000000000000, 0));
+  const __binary128 f128_none = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xbfff000000000000, 0));
+
+  const __binary128 f128_max = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7ffeffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nmax = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xfffeffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_min = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0001000000000000, 0x0000000000000000));
+  const __binary128 f128_nmin = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8001000000000000, 0x0000000000000000));
+
+  const __binary128 f128_sub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000ffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nsub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000ffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_sub2 = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000000000000000, 0x0000000000000001));
+  const __binary128 f128_nsub2 = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000000000000000, 0x0000000000000001));
+
+  const __binary128 f128_inf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff000000000000, 0));
+  const __binary128 f128_ninf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000000000000, 0));
+
+  const __binary128 f128_nan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff800000000000, 0));
+  const __binary128 f128_nnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff800000000000, 0));
+
+  const __binary128 f128_snan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff400000000000, 0));
+  const __binary128 f128_nsnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000080000000, 0));
+
+  __float128 x;
+  vb128_t test, expt;
+  long tests_count = 0;
+  int rc = 0;
+
+  printf ("\ntest_iszerof128 f128 -> vector bool ...\n");
+  /* this version (with #undef __DEBUG_PRINT__) is silent if there
+   * are no errors.  Better for profiling.  */
+
+#if 1
+  tests_count++;
+  x = (__float128) f128_zero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_iszerof128 (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nzero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_iszerof128 (x);
+  expt = (vb128_t) vf128_true;
+  rc += check_f128bool ("check vec_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_one;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_iszerof128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_none;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_iszerof128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_max;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_iszerof128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmax;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_iszerof128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_min;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_iszerof128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmin;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_iszerof128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_sub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_iszerof128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_iszerof128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_sub2;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_iszerof128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsub2;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_iszerof128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_inf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_iszerof128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_ninf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_iszerof128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_iszerof128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_iszerof128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_snan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_iszerof128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_iszerof128 (x);
+  expt = (vb128_t) vf128_false;
+  rc += check_f128bool ("check vec_iszerof128", x, test, expt);
+#endif
+  /* accumulate the number of values tested, in case we are doing
+   * detail timing and want to compute function averages.  */
+  tcount += tests_count;
+  printf ("\ntest_iszerof128, tests=%ld fails=%d\n", tests_count, rc);
+  return (rc);
+}
+#undef __DEBUG_PRINT__
+
+//#define __DEBUG_PRINT__ 1
+int
+test_absf128 (void)
+{
+  const __binary128 f128_zero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000000000000000, 0));
+  const __binary128 f128_nzero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000000000000000, 0));
+
+  const __binary128 f128_one = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x3fff000000000000, 0));
+  const __binary128 f128_none = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xbfff000000000000, 0));
+
+  const __binary128 f128_max = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7ffeffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nmax = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xfffeffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_min = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0001000000000000, 0x0000000000000000));
+  const __binary128 f128_nmin = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8001000000000000, 0x0000000000000000));
+
+  const __binary128 f128_sub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000ffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nsub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000ffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_inf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff000000000000, 0));
+  const __binary128 f128_ninf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000000000000, 0));
+
+  const __binary128 f128_nan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff800000000000, 0));
+  const __binary128 f128_nnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff800000000000, 0));
+
+  const __binary128 f128_snan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff400000000000, 0));
+  const __binary128 f128_nsnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff400000000000, 0));
+
+
+  __float128 x;
+  __float128 t, e;
+  long tests_count = 0;
+  int rc = 0;
+
+  printf ("\ntest_absf128 f128 -> f128 ...\n");
+
+#if 1
+  tests_count++;
+  x = (__float128) f128_zero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_absf128 (x);
+  e = (__float128) f128_zero;
+  rc += check_f128 ("check vec_absf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nzero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_absf128 (x);
+  e = (__float128) f128_zero;
+  rc += check_f128 ("check vec_absf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_one;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_absf128 (x);
+  e = f128_one;
+  rc += check_f128 ("check vec_absf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_none;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_absf128 (x);
+  e = f128_one;
+  rc += check_f128 ("check vec_absf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_max;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_absf128 (x);
+  e = f128_max;
+  rc += check_f128 ("check vec_absf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmax;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_absf128 (x);
+  e = f128_max;
+  rc += check_f128 ("check vec_absf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_min;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_absf128 (x);
+  e = f128_min;
+  rc += check_f128 ("check vec_absf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmin;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_absf128 (x);
+  e = f128_min;
+  rc += check_f128 ("check vec_absf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_sub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_absf128 (x);
+  e = f128_sub;
+  rc += check_f128 ("check vec_absf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_absf128 (x);
+  e = f128_sub;
+  rc += check_f128 ("check vec_absf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_inf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_absf128 (x);
+  e = f128_inf;
+  rc += check_f128 ("check vec_absf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_ninf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_absf128 (x);
+  e = f128_inf;
+  rc += check_f128 ("check vec_absf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_absf128 (x);
+  e = f128_nan;
+  rc += check_f128 ("check vec_absf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_absf128 (x);
+  e = f128_nan;
+  rc += check_f128 ("check vec_absf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_snan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_absf128 (x);
+  e = f128_snan;
+  rc += check_f128 ("check vec_absf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_absf128 (x);
+  e = f128_snan;
+  rc += check_f128 ("check vec_absf128", x, t, e);
+#endif
+  /* accumulate the number of values tested, in case we are doing
+   * detail timing and want to compute function averages.  */
+  tcount += tests_count;
+  printf ("\ntest_absf128, tests=%ld fails=%d\n", tests_count, rc);
+  return (rc);
+}
+#undef __DEBUG_PRINT__
+
+//#define __DEBUG_PRINT__ 1
+int
+test_copysignf128 (void)
+{
+  const __binary128 f128_zero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000000000000000, 0));
+  const __binary128 f128_nzero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000000000000000, 0));
+
+  const __binary128 f128_one = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x3fff000000000000, 0));
+  const __binary128 f128_none = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xbfff000000000000, 0));
+
+  const __binary128 f128_max = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7ffeffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nmax = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xfffeffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_min = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0001000000000000, 0x0000000000000000));
+  const __binary128 f128_nmin = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8001000000000000, 0x0000000000000000));
+
+  const __binary128 f128_sub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000ffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nsub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000ffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_inf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff000000000000, 0));
+  const __binary128 f128_ninf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000000000000, 0));
+
+  const __binary128 f128_nan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff800000000000, 0));
+  const __binary128 f128_nnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff800000000000, 0));
+
+  const __binary128 f128_snan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff400000000000, 0));
+
+  __float128 x, y, t, e;
+  long tests_count = 0;
+  int rc = 0;
+
+  printf ("\ntest_copysignf128 f128 -> f128 ...\n");
+
+#if 1
+  tests_count++;
+  x = (__float128) f128_zero;
+  y = (__float128) f128_zero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = (__float128) f128_zero;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nzero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = (__float128) f128_zero;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_one;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = f128_one;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_none;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = f128_one;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_max;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = f128_max;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmax;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = f128_max;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_min;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = f128_min;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmin;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = f128_min;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_sub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = f128_sub;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = f128_sub;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_inf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = f128_inf;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_ninf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = f128_inf;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = f128_nan;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = f128_nan;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_snan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = f128_snan;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+
+#if 1
+  tests_count++;
+  x = (__float128) f128_zero;
+  y = (__float128) f128_nzero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = (__float128) f128_nzero;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nzero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = (__float128) f128_nzero;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_one;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = f128_none;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_none;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = f128_none;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_max;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = f128_nmax;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmax;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = f128_nmax;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_min;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = f128_nmin;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmin;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = f128_nmin;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_sub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = f128_nsub;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = f128_nsub;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_inf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = f128_ninf;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_ninf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = f128_ninf;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = f128_nnan;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = f128_nnan;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+  /* accumulate the number of values tested, in case we are doing
+   * detail timing and want to compute function averages.  */
+  tcount += tests_count;
+  printf ("\ntest_copysignf128, tests=%ld fails=%d\n", tests_count, rc);
+  return (rc);
+}
+#undef __DEBUG_PRINT__
+
+//#define __DEBUG_PRINT__ 1
+int
+test_const_f128 (void)
+{
+  const __binary128 f128_inf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff000000000000, 0));
+
+  const __binary128 f128_nan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff800000000000, 0));
+
+  const __binary128 f128_snan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff400000000000, 0));
+
+  __float128 x, t, e;
+  long tests_count = 0;
+  int rc = 0;
+  /* this version (with #undef __DEBUG_PRINT__) is silent if there
+   * are no errors.  Better for profiling.  */
+#if 1
+  tests_count++;
+  x = vec_const_huge_valf128 ();
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x (" x=  ", x);
+#endif
+  t = x;
+  e = f128_inf;
+  rc += check_f128 ("check __huge_valf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = vec_const_inff128 ();
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x (" x=  ", x);
+#endif
+  t = x;
+  e = f128_inf;
+  rc += check_f128 ("check inff128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = vec_const_nanf128 ();
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x (" x=  ", x);
+#endif
+  t = x;
+  e = f128_nan;
+  rc += check_f128 ("check inff128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = vec_const_nansf128 ();
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x (" x=  ", x);
+#endif
+  t = x;
+  e = f128_snan;
+  rc += check_f128 ("check inff128", x, t, e);
+#endif
+
+  /* accumulate the number of values tested, in case we are doing
+   * detail timing and want to compute function averages.  */
+  tcount += tests_count;
+  return (rc);
+}
+#undef __DEBUG_PRINT__
+
+int
+test_all_isfinitef128 (void)
+{
+  const __binary128 f128_zero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000000000000000, 0));
+  const __binary128 f128_nzero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000000000000000, 0));
+
+  const __binary128 f128_one = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x3fff000000000000, 0));
+  const __binary128 f128_none = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xbfff000000000000, 0));
+
+  const __binary128 f128_max = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7ffeffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nmax = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xfffeffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_min = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0001000000000000, 0x0000000000000000));
+  const __binary128 f128_nmin = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8001000000000000, 0x0000000000000000));
+
+  const __binary128 f128_sub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000ffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nsub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000ffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_inf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff000000000000, 0));
+  const __binary128 f128_ninf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000000000000, 0));
+
+  const __binary128 f128_nan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff800000000000, 0));
+  const __binary128 f128_nnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff800000000000, 0));
+
+  const __binary128 f128_snan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff400000000000, 0));
+  const __binary128 f128_nsnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000080000000, 0));
+
+  __float128 x;
+  long tests_count = 0;
+  int test, expt;
+  int rc = 0;
+
+  printf ("\ntest_all_isfinitef128 f128 -> bool int , ...\n");
+  /* this version (with #undef __DEBUG_PRINT__) is silent if there
+   * are no errors.  Better for profiling.  */
+#if 1
+  tests_count++;
+  x = (__float128)f128_zero;
+#ifdef __DEBUG_PRINT__
+	print_vfloat128x(" x=  ", x);
+#endif
+	test = vec_all_isfinitef128 (x);
+	expt = 1;
+	rc += check_isf128 ("check vec_all_isfinitef128", x, test, expt) ;
+#endif
+#if 1
+  tests_count++;
+  x = (__float128)f128_nzero;
+#ifdef __DEBUG_PRINT__
+	print_vfloat128x(" x=  ", x);
+#endif
+	test = vec_all_isfinitef128 (x);
+	expt = 1;
+	rc += check_isf128 ("check vec_all_isfinitef128", x, test, expt) ;
+#endif
+#if 1
+  tests_count++;
+  x = (__float128)f128_one;
+#ifdef __DEBUG_PRINT__
+	print_vfloat128x(" x=  ", x);
+#endif
+	test = vec_all_isfinitef128 (x);
+	expt = 1;
+	rc += check_isf128 ("check vec_all_isfinitef128", x, test, expt) ;
+#endif
+#if 1
+  tests_count++;
+  x = (__float128)f128_none;
+#ifdef __DEBUG_PRINT__
+	print_vfloat128x(" x=  ", x);
+#endif
+	test = vec_all_isfinitef128 (x);
+	expt = 1;
+	rc += check_isf128 ("check vec_all_isfinitef128", x, test, expt) ;
+#endif
+#if 1
+  tests_count++;
+  x = (__float128)f128_max;
+#ifdef __DEBUG_PRINT__
+	print_vfloat128x(" x=  ", x);
+#endif
+	test = vec_all_isfinitef128 (x);
+	expt = 1;
+	rc += check_isf128 ("check vec_all_isfinitef128", x, test, expt) ;
+#endif
+#if 1
+  tests_count++;
+  x = (__float128)f128_nmax;
+#ifdef __DEBUG_PRINT__
+	print_vfloat128x(" x=  ", x);
+#endif
+	test = vec_all_isfinitef128 (x);
+	expt = 1;
+	rc += check_isf128 ("check vec_all_isfinitef128", x, test, expt) ;
+#endif
+#if 1
+  tests_count++;
+  x = (__float128)f128_min;
+#ifdef __DEBUG_PRINT__
+	print_vfloat128x(" x=  ", x);
+#endif
+	test = vec_all_isfinitef128 (x);
+	expt = 1;
+	rc += check_isf128 ("check vec_all_isfinitef128", x, test, expt) ;
+#endif
+#if 1
+  tests_count++;
+  x = (__float128)f128_nmin;
+#ifdef __DEBUG_PRINT__
+	print_vfloat128x(" x=  ", x);
+#endif
+	test = vec_all_isfinitef128 (x);
+	expt = 1;
+	rc += check_isf128 ("check vec_all_isfinitef128", x, test, expt) ;
+#endif
+#if 1
+  tests_count++;
+  x = (__float128)f128_sub;
+#ifdef __DEBUG_PRINT__
+	print_vfloat128x(" x=  ", x);
+#endif
+	test = vec_all_isfinitef128 (x);
+	expt = 1;
+	rc += check_isf128 ("check vec_all_isfinitef128", x, test, expt) ;
+#endif
+#if 1
+  tests_count++;
+  x = (__float128)f128_nsub;
+#ifdef __DEBUG_PRINT__
+	print_vfloat128x(" x=  ", x);
+#endif
+	test = vec_all_isfinitef128 (x);
+	expt = 1;
+	rc += check_isf128 ("check vec_all_isfinitef128", x, test, expt) ;
+#endif
+#if 1
+  tests_count++;
+  x = (__float128)f128_inf;
+#ifdef __DEBUG_PRINT__
+	print_vfloat128x(" x=  ", x);
+#endif
+	test = vec_all_isfinitef128 (x);
+	expt = 0;
+	rc += check_isf128 ("check vec_all_isfinitef128", x, test, expt) ;
+#endif
+#if 1
+  tests_count++;
+  x = (__float128)f128_ninf;
+#ifdef __DEBUG_PRINT__
+	print_vfloat128x(" x=  ", x);
+#endif
+	test = vec_all_isfinitef128 (x);
+	expt = 0;
+	rc += check_isf128 ("check vec_all_isfinitef128", x, test, expt) ;
+#endif
+#if 1
+  tests_count++;
+  x = (__float128)f128_nan;
+#ifdef __DEBUG_PRINT__
+	print_vfloat128x(" x=  ", x);
+#endif
+	test = vec_all_isfinitef128 (x);
+	expt = 0;
+	rc += check_isf128 ("check vec_all_isfinitef128", x, test, expt) ;
+#endif
+#if 1
+  tests_count++;
+  x = (__float128)f128_nnan;
+#ifdef __DEBUG_PRINT__
+	print_vfloat128x(" x=  ", x);
+#endif
+	test = vec_all_isfinitef128 (x);
+	expt = 0;
+	rc += check_isf128 ("check vec_all_isfinitef128", x, test, expt) ;
+#endif
+#if 1
+  tests_count++;
+  x = (__float128)f128_snan;
+#ifdef __DEBUG_PRINT__
+	print_vfloat128x(" x=  ", x);
+#endif
+	test = vec_all_isfinitef128 (x);
+	expt = 0;
+	rc += check_isf128 ("check vec_all_isfinitef128", x, test, expt) ;
+#endif
+#if 1
+  tests_count++;
+  x = (__float128)f128_nsnan;
+#ifdef __DEBUG_PRINT__
+	print_vfloat128x(" x=  ", x);
+#endif
+	test = vec_all_isfinitef128 (x);
+	expt = 0;
+	rc += check_isf128 ("check vec_all_isfinitef128", x, test, expt) ;
+#endif
+
+  /* accumulate the number of values tested, in case we are doing
+   * detail timing and want to compute function averages.  */
+  tcount += tests_count;
+  printf ("\ntest_all_isfinitef128, tests=%ld fails=%d\n", tests_count, rc);
+
+  return (rc);
+}
+
+int
+test_all_isnanf128 (void)
+{
+  const __binary128 f128_zero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000000000000000, 0));
+  const __binary128 f128_nzero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000000000000000, 0));
+
+  const __binary128 f128_one = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x3fff000000000000, 0));
+  const __binary128 f128_none = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xbfff000000000000, 0));
+
+  const __binary128 f128_max = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7ffeffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nmax = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xfffeffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_min = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0001000000000000, 0x0000000000000000));
+  const __binary128 f128_nmin = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8001000000000000, 0x0000000000000000));
+
+  const __binary128 f128_sub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000ffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nsub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000ffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_inf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff000000000000, 0));
+  const __binary128 f128_ninf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000000000000, 0));
+
+  const __binary128 f128_nan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff800000000000, 0));
+  const __binary128 f128_nnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff800000000000, 0));
+
+  const __binary128 f128_snan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff400000000000, 0));
+  const __binary128 f128_nsnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000080000000, 0));
+
+  __float128 x;
+  long tests_count = 0;
+  int test, expt;
+  int rc = 0;
+
+  printf ("\ntest_all_isnanf128 f128 -> bool int , ...\n");
+
+#if 1
+  tests_count++;
+  x = (__float128) f128_zero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnanf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nzero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnanf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_one;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnanf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_none;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnanf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_max;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnanf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmax;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnanf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_min;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnanf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmin;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnanf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_sub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnanf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnanf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_inf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnanf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_ninf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnanf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnanf128 (x);
+  expt = 1;
+  rc += check_isf128 ("check vec_all_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnanf128 (x);
+  expt = 1;
+  rc += check_isf128 ("check vec_all_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_snan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnanf128 (x);
+  expt = 1;
+  rc += check_isf128 ("check vec_all_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnanf128 (x);
+  expt = 1;
+  rc += check_isf128 ("check vec_all_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = vec_const_nanf128 ();
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnanf128 (x);
+  expt = 1;
+  rc += check_isf128 ("check vec_all_isnanf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = vec_const_nansf128 ();
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnanf128 (x);
+  expt = 1;
+  rc += check_isf128 ("check vec_all_isnanf128", x, test, expt);
+#endif
+
+  /* accumulate the number of values tested, in case we are doing
+   * detail timing and want to compute function averages.  */
+  tcount += tests_count;
+  printf ("\ntest_all_isnanf128, tests=%ld fails=%d\n", tests_count, rc);
+
+  return (rc);
+}
+
+int
+test_all_isinff128 (void)
+{
+  const __binary128 f128_zero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000000000000000, 0));
+  const __binary128 f128_nzero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000000000000000, 0));
+
+  const __binary128 f128_one = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x3fff000000000000, 0));
+  const __binary128 f128_none = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xbfff000000000000, 0));
+
+  const __binary128 f128_max = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7ffeffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nmax = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xfffeffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_min = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0001000000000000, 0x0000000000000000));
+  const __binary128 f128_nmin = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8001000000000000, 0x0000000000000000));
+
+  const __binary128 f128_sub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000ffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nsub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000ffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_inf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff000000000000, 0));
+  const __binary128 f128_ninf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000000000000, 0));
+
+  const __binary128 f128_nan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff800000000000, 0));
+  const __binary128 f128_nnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff800000000000, 0));
+
+  const __binary128 f128_snan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff400000000000, 0));
+  const __binary128 f128_nsnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000080000000, 0));
+
+  __float128 x;
+  long tests_count = 0;
+  int test, expt;
+  int rc = 0;
+
+  printf ("\ntest_all_isinff128 f128 -> bool int , ...\n");
+
+#if 1
+  tests_count++;
+  x = (__float128) f128_zero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isinff128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isinff128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nzero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isinff128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isinff128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_one;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isinff128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isinff128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_none;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isinff128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isinff128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_max;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isinff128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isinff128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmax;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isinff128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isinff128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_min;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isinff128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isinff128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmin;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isinff128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isinff128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_sub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isinff128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isinff128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isinff128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isinff128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_inf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isinff128 (x);
+  expt = 1;
+  rc += check_isf128 ("check vec_all_isinff128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_ninf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isinff128 (x);
+  expt = 1;
+  rc += check_isf128 ("check vec_all_isinff128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isinff128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isinff128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isinff128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isinff128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_snan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isinff128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isinff128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isinff128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isinff128", x, test, expt);
+#endif
+
+  /* accumulate the number of values tested, in case we are doing
+   * detail timing and want to compute function averages.  */
+  tcount += tests_count;
+  printf ("\ntest_all_isinff128, tests=%ld fails=%d\n", tests_count, rc);
+
+  return (rc);
+}
+
+int
+test_all_isnormalf128 (void)
+{
+  const __binary128 f128_zero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000000000000000, 0));
+  const __binary128 f128_nzero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000000000000000, 0));
+
+  const __binary128 f128_one = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x3fff000000000000, 0));
+  const __binary128 f128_none = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xbfff000000000000, 0));
+
+  const __binary128 f128_max = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7ffeffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nmax = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xfffeffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_min = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0001000000000000, 0x0000000000000000));
+  const __binary128 f128_nmin = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8001000000000000, 0x0000000000000000));
+
+  const __binary128 f128_sub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000ffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nsub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000ffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_inf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff000000000000, 0));
+  const __binary128 f128_ninf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000000000000, 0));
+
+  const __binary128 f128_nan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff800000000000, 0));
+  const __binary128 f128_nnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff800000000000, 0));
+
+  const __binary128 f128_snan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff400000000000, 0));
+  const __binary128 f128_nsnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000080000000, 0));
+
+  __float128 x;
+  long tests_count = 0;
+  int test, expt;
+  int rc = 0;
+
+  printf ("\ntest_all_isnormalf128 f128 -> bool int , ...\n");
+
+#if 1
+  tests_count++;
+  x = (__float128) f128_zero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnormalf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nzero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnormalf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_one;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnormalf128 (x);
+  expt = 1;
+  rc += check_isf128 ("check vec_all_isnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_none;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnormalf128 (x);
+  expt = 1;
+  rc += check_isf128 ("check vec_all_isnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_max;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnormalf128 (x);
+  expt = 1;
+  rc += check_isf128 ("check vec_all_isnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmax;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnormalf128 (x);
+  expt = 1;
+  rc += check_isf128 ("check vec_all_isnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_min;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnormalf128 (x);
+  expt = 1;
+  rc += check_isf128 ("check vec_all_isnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmin;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnormalf128 (x);
+  expt = 1;
+  rc += check_isf128 ("check vec_all_isnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_sub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnormalf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnormalf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_inf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnormalf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_ninf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnormalf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnormalf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnormalf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_snan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnormalf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_isnormalf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_isnormalf128", x, test, expt);
+#endif
+
+  /* accumulate the number of values tested, in case we are doing
+   * detail timing and want to compute function averages.  */
+  tcount += tests_count;
+  printf ("\ntest_all_isnormalf128, tests=%ld fails=%d\n", tests_count, rc);
+
+  return (rc);
+}
+
+int
+test_all_issubnormalf128 (void)
+{
+  const __binary128 f128_zero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000000000000000, 0));
+  const __binary128 f128_nzero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000000000000000, 0));
+
+  const __binary128 f128_one = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x3fff000000000000, 0));
+  const __binary128 f128_none = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xbfff000000000000, 0));
+
+  const __binary128 f128_max = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7ffeffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nmax = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xfffeffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_min = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0001000000000000, 0x0000000000000000));
+  const __binary128 f128_nmin = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8001000000000000, 0x0000000000000000));
+
+  const __binary128 f128_sub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000ffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nsub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000ffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_submin = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000000000000000, 0x0000000000000001));
+  const __binary128 f128_nsubmin = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000000000000000, 0x0000000000000001));
+
+  const __binary128 f128_inf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff000000000000, 0));
+  const __binary128 f128_ninf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000000000000, 0));
+
+  const __binary128 f128_nan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff800000000000, 0));
+  const __binary128 f128_nnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff800000000000, 0));
+
+  const __binary128 f128_snan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff400000000000, 0));
+  const __binary128 f128_nsnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000080000000, 0));
+
+  __float128 x;
+  long tests_count = 0;
+  int test, expt;
+  int rc = 0;
+  tcount = 0;
+
+  printf ("\ntest_all_issubnormalf128 f128 -> bool int , ...\n");
+
+#if 1
+  tests_count++;
+  x = (__float128) f128_zero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_issubnormalf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nzero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_issubnormalf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_one;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_issubnormalf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_none;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_issubnormalf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_max;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_issubnormalf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmax;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_issubnormalf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_min;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_issubnormalf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmin;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_issubnormalf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_sub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_issubnormalf128 (x);
+  expt = 1;
+  rc += check_isf128 ("check vec_all_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_issubnormalf128 (x);
+  expt = 1;
+  rc += check_isf128 ("check vec_all_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_submin;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_issubnormalf128 (x);
+  expt = 1;
+  rc += check_isf128 ("check vec_all_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsubmin;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_issubnormalf128 (x);
+  expt = 1;
+  rc += check_isf128 ("check vec_all_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_inf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_issubnormalf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_ninf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_issubnormalf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_issubnormalf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_issubnormalf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_snan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_issubnormalf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_issubnormalf128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_issubnormalf128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_issubnormalf128", x, test, expt);
+#endif
+
+  /* accumulate the number of values tested, in case we are doing
+   * detail timing and want to compute function averages.  */
+  tcount += tests_count;
+  printf ("\ntest_all_issubnormalf128, tests=%ld fails=%d\n", tests_count, rc);
+
+  return (rc);
+}
+
+int
+test_all_iszerof128 (void)
+{
+  const __binary128 f128_zero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000000000000000, 0));
+  const __binary128 f128_nzero = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000000000000000, 0));
+
+  const __binary128 f128_one = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x3fff000000000000, 0));
+  const __binary128 f128_none = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xbfff000000000000, 0));
+
+  const __binary128 f128_max = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7ffeffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nmax = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xfffeffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_min = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0001000000000000, 0x0000000000000000));
+  const __binary128 f128_nmin = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8001000000000000, 0x0000000000000000));
+
+  const __binary128 f128_sub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000ffffffffffff, 0xffffffffffffffff));
+  const __binary128 f128_nsub = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000ffffffffffff, 0xffffffffffffffff));
+
+  const __binary128 f128_submin = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x0000000000000000, 0x0000000000000001));
+  const __binary128 f128_nsubmin = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x8000000000000000, 0x0000000000000001));
+
+  const __binary128 f128_inf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff000000000000, 0));
+  const __binary128 f128_ninf = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000000000000, 0));
+
+  const __binary128 f128_nan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff800000000000, 0));
+  const __binary128 f128_nnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff800000000000, 0));
+
+  const __binary128 f128_snan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0x7fff400000000000, 0));
+  const __binary128 f128_nsnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff000080000000, 0));
+
+  __float128 x;
+  long tests_count = 0;
+  int test, expt;
+  int rc = 0;
+
+  printf ("\ntest_all_iszerof128 f128 -> bool int , ...\n");
+
+#if 1
+  tests_count++;
+  x = (__float128) f128_zero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_iszerof128 (x);
+  expt = 1;
+  rc += check_isf128 ("check vec_all_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nzero;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_iszerof128 (x);
+  expt = 1;
+  rc += check_isf128 ("check vec_all_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_one;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_iszerof128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_none;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_iszerof128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_max;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_iszerof128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmax;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_iszerof128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_min;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_iszerof128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nmin;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_iszerof128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_sub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_iszerof128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsub;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_iszerof128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_submin;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_iszerof128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsubmin;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_iszerof128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_inf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_iszerof128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_ninf;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_iszerof128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_iszerof128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_iszerof128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_snan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_iszerof128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_iszerof128", x, test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (__float128) f128_nsnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  test = vec_all_iszerof128 (x);
+  expt = 0;
+  rc += check_isf128 ("check vec_all_iszerof128", x, test, expt);
+#endif
+
+  /* accumulate the number of values tested, in case we are doing
+   * detail timing and want to compute function averages.  */
+  tcount += tests_count;
+  printf ("\ntest_all_iszerof128, tests=%ld fails=%d\n", tests_count, rc);
+
+  return (rc);
+}
+
+int
+test_all_is_f128 (void)
+{
+    int rc = 0;
+    tcount = 0;
+
+    printf ("\ntest_all_is_f128, ...\n");
+
+    rc += test_all_isfinitef128 ();
+    rc += test_all_isinff128 ();
+    rc += test_all_isnanf128 ();
+    rc += test_all_isnormalf128 ();
+    rc += test_all_issubnormalf128 ();
+    rc += test_all_iszerof128 ();
+    rc += test_isinf_signf128 ();
+    rc += test_signbitf128 ();
+
+    printf ("\ntest_all_is f128, tests=%ld fails=%d\n", tcount, rc);
+
+    return (rc);
+}
+
+int
+test_vec_bool_f128 (void)
+{
+    int rc = 0;
+    tcount = 0;
+
+    printf ("\ntest_vec_bool_f128, ...\n");
+
+    rc += test_setb_qp ();
+    rc += test_isinff128 ();
+    rc += test_isnanf128 ();
+    rc += test_isfinitef128 ();
+    rc += test_isnormalf128 ();
+    rc += test_issubnormalf128 ();
+    rc += test_iszerof128 ();
+
+    printf ("\ntest_vec_bool f128, tests=%ld fails=%d\n", tcount, rc);
+
+    return (rc);
+}
+
+int
+test_vec_f128_f128 (void)
+{
+    int rc = 0;
+    tcount = 0;
+
+    printf ("\ntest_vec_f128 -> f128, ...\n");
+
+    rc += test_absf128 ();
+    rc += test_copysignf128 ();
+
+    printf ("\ntest_vec_f128 f128, tests=%ld fails=%d\n", tcount, rc);
+
+    return (rc);
+}
+
+int
+test_vec_f128 (void)
+{
+  int rc = 0;
+
+  printf ("\n%s\n", __FUNCTION__);
+
+  rc += test_const_f128 ();
+  rc += test_all_is_f128 ();
+  rc += test_vec_bool_f128 ();
+  rc += test_vec_f128_f128 ();
+
+//  rc += test_time_f128 ();
+
+  return (rc);
+}

--- a/src/testsuite/arith128_test_f128.c
+++ b/src/testsuite/arith128_test_f128.c
@@ -18,9 +18,7 @@
  Contributors:
       IBM Corporation, Steven Munroe
       Created on: Apr 18, 2016
-      Commited on: Oct 10, 2018
  */
-
 
 #define __STDC_WANT_DEC_FP__    1
 
@@ -61,7 +59,6 @@ db_vec_isfinitef128 (__binary128 f128)
 
 	return (result);
 }
-#else
 #endif
 
 const vui32_t signmask32  = {0x80000000, 0, 0, 0};
@@ -832,8 +829,6 @@ test_isinff128 (void)
   int rc = 0;
 
   printf ("\ntest_isinff128 f128 -> vector bool ...\n");
-  /* this version (with #undef __DEBUG_PRINT__) is silent if there
-   * are no errors.  Better for profiling.  */
 
 #if 1
   tests_count++;
@@ -1052,8 +1047,6 @@ test_isnanf128 (void)
   int rc = 0;
 
   printf ("\ntest_isnanf128 f128 -> vector bool ...\n");
-  /* this version (with #undef __DEBUG_PRINT__) is silent if there
-   * are no errors.  Better for profiling.  */
 
 #if 1
   tests_count++;
@@ -1272,8 +1265,6 @@ test_isfinitef128 (void)
   int rc = 0;
 
   printf ("\ntest_isfinitef128 f128 -> vector bool ...\n");
-  /* this version (with #undef __DEBUG_PRINT__) is silent if there
-   * are no errors.  Better for profiling.  */
 
 #if 1
   tests_count++;
@@ -1492,8 +1483,6 @@ test_isnormalf128 (void)
   int rc = 0;
 
   printf ("\ntest_isnormalf128 f128 -> vector bool ...\n");
-  /* this version (with #undef __DEBUG_PRINT__) is silent if there
-   * are no errors.  Better for profiling.  */
 
 #if 1
   tests_count++;
@@ -1717,8 +1706,6 @@ test_issubnormalf128 (void)
   int rc = 0;
 
   printf ("\ntest_issubnormalf128 f128 -> vector bool ...\n");
-  /* this version (with #undef __DEBUG_PRINT__) is silent if there
-   * are no errors.  Better for profiling.  */
 
 #if 1
   tests_count++;
@@ -1963,8 +1950,6 @@ test_iszerof128 (void)
   int rc = 0;
 
   printf ("\ntest_iszerof128 f128 -> vector bool ...\n");
-  /* this version (with #undef __DEBUG_PRINT__) is silent if there
-   * are no errors.  Better for profiling.  */
 
 #if 1
   tests_count++;
@@ -2741,8 +2726,6 @@ test_const_f128 (void)
   __float128 x, t, e;
   long tests_count = 0;
   int rc = 0;
-  /* this version (with #undef __DEBUG_PRINT__) is silent if there
-   * are no errors.  Better for profiling.  */
 #if 1
   tests_count++;
   x = vec_const_huge_valf128 ();
@@ -2840,8 +2823,7 @@ test_all_isfinitef128 (void)
   int rc = 0;
 
   printf ("\ntest_all_isfinitef128 f128 -> bool int , ...\n");
-  /* this version (with #undef __DEBUG_PRINT__) is silent if there
-   * are no errors.  Better for profiling.  */
+
 #if 1
   tests_count++;
   x = (__float128)f128_zero;

--- a/src/testsuite/arith128_test_f128.h
+++ b/src/testsuite/arith128_test_f128.h
@@ -1,0 +1,25 @@
+/*
+ Copyright (c) [2016, 2018] IBM Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ arith128_test_f128.c
+
+ Contributors:
+      IBM Corporation, Steven Munroe
+      Created on: Apr 18, 2016
+      Commited on: Oct 10, 2018
+ */
+
+/* Collection function for all f128 unit tests.  */
+int test_vec_f128 (void);

--- a/src/testsuite/arith128_test_f128.h
+++ b/src/testsuite/arith128_test_f128.h
@@ -18,7 +18,6 @@
  Contributors:
       IBM Corporation, Steven Munroe
       Created on: Apr 18, 2016
-      Commited on: Oct 10, 2018
  */
 
 /* Collection function for all f128 unit tests.  */

--- a/src/testsuite/vec_f128_dummy.c
+++ b/src/testsuite/vec_f128_dummy.c
@@ -1,0 +1,291 @@
+/*
+ Copyright (c) [2017, 2018] IBM Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ arith128_test_f128.c
+
+ Contributors:
+      IBM Corporation, Steven Munroe
+      Created on: Jul 31, 2017
+      Commited on: Oct 10, 2018
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <fenv.h>
+#include <float.h>
+#ifdef __FLOAT128_TYPE__
+#define __STDC_WANT_IEC_60559_TYPES_EXT__ 1
+#define __STDC_WANT_IEC_60559_FUNCS_EXT__ 1
+#endif
+#include <math.h>
+
+//#define __DEBUG_PRINT__
+#include "vec_f128_ppc.h"
+
+__binary128
+test_vec_absf128 (__binary128 f128)
+{
+  return vec_absf128 (f128);
+}
+
+__binary128
+test_const_vec_huge_valf128 (void)
+{
+  return vec_const_huge_valf128 ();
+}
+
+__binary128
+test_const_vec_nanf128 (void)
+{
+  return vec_const_nanf128 ();
+}
+
+__binary128
+test_const_vec_nansf128 (void)
+{
+  return vec_const_nansf128 ();
+}
+
+__binary128
+test_const_vec_inff128 (void)
+{
+  return vec_const_inff128 ();
+}
+
+__binary128
+test_vec_copysignf128 (__binary128 f128x , __binary128 f128y)
+{
+  return vec_copysignf128 (f128x , f128y);
+}
+
+vb128_t
+test_vec_isfinitef128 (__binary128 f128)
+{
+  return vec_isfinitef128 (f128);
+}
+
+vb128_t
+test_vec_isinff128 (__binary128 value)
+{
+  return (vec_isinff128 (value));
+}
+
+vb128_t
+test_vec_isnanf128 (__binary128 value)
+{
+  return (vec_isnanf128 (value));
+}
+
+vb128_t
+test_vec_isnormalf128 (__binary128 f128)
+{
+  return vec_isnormalf128 (f128);
+}
+
+vb128_t
+test_vec_issubnormalf128 (__binary128 f128)
+{
+  return vec_issubnormalf128 (f128);
+}
+
+vb128_t
+test_vec_iszerof128 (__binary128 f128)
+{
+  return vec_iszerof128 (f128);
+}
+
+int
+test_vec_all_finitef128 (__binary128 value)
+{
+  return (vec_all_isfinitef128 (value));
+}
+
+int
+test_vec_all_inff128 (__binary128 value)
+{
+  return (vec_all_isinff128 (value));
+}
+
+int
+test_vec_all_nanf128 (__binary128 value)
+{
+  return (vec_all_isnanf128 (value));
+}
+
+int
+test_vec_all_normalf128 (__binary128 value)
+{
+  return (vec_all_isnormalf128 (value));
+}
+
+int
+test_vec_all_subnormalf128 (__binary128 value)
+{
+  return (vec_all_issubnormalf128 (value));
+}
+
+int
+test_vec_all_zerof128 (__binary128 value)
+{
+  return (vec_all_iszerof128 (value));
+}
+#ifdef __FLOAT128_TYPE__
+/* dummy sinf128 example. From Posix:
+ * If value is NaN then return a NaN.
+ * If value is +-0.0 then return value.
+ * If value is subnormal then return value.
+ * If value is +-Inf then return a NaN.
+ * Otherwise compute and return sin(value).
+ */
+__binary128
+test_sinf128 (__binary128 value)
+{
+  __binary128 result;
+
+  if (vec_all_isnormalf128 (value))
+    {
+      /* body of taylor series.  */
+      result = 0.0q;
+    }
+  else
+    {
+      if (vec_all_isinff128 (value))
+	result = vec_const_nanf128 ();
+      else
+	result = value;
+    }
+
+  return result;
+}
+/* dummy codf128 example. From Posix:
+ * If value is NaN then return a NaN.
+ * If value is +-0.0 then return 1.0.
+ * If value is +-Inf then return a NaN.
+ * Otherwise compute and return sin(value).
+ */
+__binary128
+test_cosf128 (__binary128 value)
+{
+  __binary128 result;
+
+  if (vec_all_isfinitef128 (value))
+    {
+      if (vec_all_iszerof128 (value))
+	result = 1.0Q;
+      else
+	{
+	  /* body of taylor series.  */
+	  result = 0.0q;
+	}
+    }
+  else
+    {
+      if (vec_all_isinff128 (value))
+	result = vec_const_nanf128 ();
+      else
+	result = value;
+    }
+
+  return result;
+}
+#endif
+
+/* Mostly compiler and library tests follow to see what the various
+ * will do.  */
+
+vb128_t
+_test_f128_isinff128 (__Float128 value)
+{
+  return (vec_isinff128 (value));
+}
+
+int
+_test_f128_isinf_sign (__Float128 value)
+{
+  return (vec_isinf_signf128 (value));
+}
+
+vb128_t
+_test_f128_isnan (__Float128 value)
+{
+  return (vec_isnanf128 (value));
+}
+
+vb128_t
+_test_pred_f128_finite (__Float128 value)
+{
+  return (vec_isfinitef128 (value));
+}
+
+vb128_t
+_test_pred_f128_normal (__Float128 value)
+{
+  return (vec_isnormalf128 (value));
+}
+
+vb128_t
+_test_pred_f128_subnormal (__Float128 value)
+{
+  return (vec_issubnormalf128 (value));
+}
+
+vui16_t
+_test_xfer_bin128_2_vui16t (__binary128 f128)
+{
+  return vec_xfer_bin128_2_vui16t (f128);
+}
+
+#ifdef __FLOAT128_TYPE__
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+int
+test_gcc_f128_signbit (__Float128 value)
+{
+	return (__signbitf128(value));
+}
+
+int
+test_gcc_f128_isinf (__Float128 value)
+{
+	return (__isinff128(value));
+}
+
+int
+test_gcc_float128_isnan (__Float128 value)
+{
+	return (__isnanf128(value));
+}
+__Float128
+test_gcc_f128_copysign (__Float128 valx, __Float128 valy)
+{
+	return (__copysignf128(valx, valy));
+}
+int
+
+test_glibc_f128_classify (__Float128 value)
+{
+	if (__finitef128(value))
+	return 1;
+
+	if (__isinff128(value))
+	return 2;
+
+	if (__isnanf128(value))
+	return 3;
+	/* finite */
+	return 0;
+}
+#endif
+#endif
+

--- a/src/testsuite/vec_f128_dummy.c
+++ b/src/testsuite/vec_f128_dummy.c
@@ -151,25 +151,26 @@ test_vec_all_zerof128 (__binary128 value)
  */
 __binary128
 test_sinf128 (__binary128 value)
-{
-  __binary128 result;
+  {
+    __binary128 result;
 
-  if (vec_all_isnormalf128 (value))
-    {
-      /* body of taylor series.  */
-      result = 0.0q;
-    }
-  else
-    {
-      if (vec_all_isinff128 (value))
-	result = vec_const_nanf128 ();
-      else
-	result = value;
-    }
+    if (vec_all_isnormalf128 (value))
+      {
+	/* body of vec_sin() computation elided for this example.  */
+	result = 0.0q;
+      }
+    else
+      {
+	if (vec_all_isinff128 (value))
+	  result = vec_const_nanf128 ();
+	else
+	  result = value;
+      }
 
-  return result;
-}
-/* dummy codf128 example. From Posix:
+    return result;
+  }
+
+/* dummy cosf128 example. From Posix:
  * If value is NaN then return a NaN.
  * If value is +-0.0 then return 1.0.
  * If value is +-Inf then return a NaN.
@@ -177,33 +178,30 @@ test_sinf128 (__binary128 value)
  */
 __binary128
 test_cosf128 (__binary128 value)
-{
-  __binary128 result;
+  {
+    __binary128 result;
 
-  if (vec_all_isfinitef128 (value))
-    {
-      if (vec_all_iszerof128 (value))
-	result = 1.0Q;
-      else
-	{
-	  /* body of taylor series.  */
-	  result = 0.0q;
-	}
-    }
-  else
-    {
-      if (vec_all_isinff128 (value))
-	result = vec_const_nanf128 ();
-      else
-	result = value;
-    }
+    if (vec_all_isfinitef128 (value))
+      {
+	if (vec_all_iszerof128 (value))
+	  result = 1.0Q;
+	else
+	  {
+	    /* body of vec_cos() computation elided for this example.  */
+	    result = 0.0q;
+	  }
+      }
+    else
+      {
+	if (vec_all_isinff128 (value))
+	  result = vec_const_nanf128 ();
+	else
+	  result = value;
+      }
 
-  return result;
-}
+    return result;
+  }
 #endif
-
-/* Mostly compiler and library tests follow to see what the various
- * will do.  */
 
 vb128_t
 _test_f128_isinff128 (__Float128 value)
@@ -248,44 +246,48 @@ _test_xfer_bin128_2_vui16t (__binary128 f128)
 }
 
 #ifdef __FLOAT128_TYPE__
+/* Mostly compiler and library tests follow to see what the various
+ * compilers will do.  */
+
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 int
 test_gcc_f128_signbit (__Float128 value)
-{
-	return (__signbitf128(value));
-}
+  {
+    return (__signbitf128(value));
+  }
 
 int
 test_gcc_f128_isinf (__Float128 value)
-{
-	return (__isinff128(value));
-}
+  {
+    return (__isinff128(value));
+  }
 
 int
 test_gcc_float128_isnan (__Float128 value)
-{
-	return (__isnanf128(value));
-}
+  {
+    return (__isnanf128(value));
+  }
+
 __Float128
 test_gcc_f128_copysign (__Float128 valx, __Float128 valy)
-{
-	return (__copysignf128(valx, valy));
-}
+  {
+    return (__copysignf128(valx, valy));
+  }
+
 int
-
 test_glibc_f128_classify (__Float128 value)
-{
-	if (__finitef128(value))
-	return 1;
+  {
+    if (__finitef128(value))
+    return 1;
 
-	if (__isinff128(value))
-	return 2;
+    if (__isinff128(value))
+    return 2;
 
-	if (__isnanf128(value))
-	return 3;
-	/* finite */
-	return 0;
-}
+    if (__isnanf128(value))
+    return 3;
+    /* finite */
+    return 0;
+  }
 #endif
 #endif
 

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -245,26 +245,27 @@ test_vec_all_zerof128_PWR9 (__binary128 value)
  * Otherwise compute and return sin(value).
  */
 __binary128
-test_sinf128_PWR9 (__binary128 value)
-{
-  __binary128 result;
+test_sinf128 (__binary128 value)
+  {
+    __binary128 result;
 
-  if (vec_all_isnormalf128 (value))
-    {
-      /* body of taylor series.  */
-      result = 0.0q;
-    }
-  else
-    {
-      if (vec_all_isinff128 (value))
-	result = vec_const_nanf128 ();
-      else
-	result = value;
-    }
+    if (vec_all_isnormalf128 (value))
+      {
+	/* body of vec_sin() computation elided for this example.  */
+	result = 0.0q;
+      }
+    else
+      {
+	if (vec_all_isinff128 (value))
+	  result = vec_const_nanf128 ();
+	else
+	  result = value;
+      }
 
-  return result;
-}
-/* dummy codf128 example. From Posix:
+    return result;
+  }
+
+/* dummy cosf128 example. From Posix:
  * If value is NaN then return a NaN.
  * If value is +-0.0 then return 1.0.
  * If value is +-Inf then return a NaN.
@@ -272,29 +273,29 @@ test_sinf128_PWR9 (__binary128 value)
  */
 __binary128
 test_cosf128 (__binary128 value)
-{
-  __binary128 result;
+  {
+    __binary128 result;
 
-  if (vec_all_isfinitef128 (value))
-    {
-      if (vec_all_iszerof128 (value))
-	result = 1.0Q;
-      else
-	{
-	  /* body of taylor series.  */
-	  result = 0.0q;
-	}
-    }
-  else
-    {
-      if (vec_all_isinff128 (value))
-	result = vec_const_nanf128 ();
-      else
-	result = value;
-    }
+    if (vec_all_isfinitef128 (value))
+      {
+	if (vec_all_iszerof128 (value))
+	  result = 1.0q;
+	else
+	  {
+	    /* body of vec_cos() computation elided for this example.  */
+	    result = 0.0q;
+	  }
+      }
+    else
+      {
+	if (vec_all_isinff128 (value))
+	  result = vec_const_nanf128 ();
+	else
+	  result = value;
+      }
 
-  return result;
-}
+    return result;
+  }
 #endif
 
 #ifdef vec_cmpne
@@ -382,7 +383,9 @@ __test_scalar_insert_exp_f64 (double sig, unsigned long long int exp)
 #endif
 
 #ifdef scalar_cmp_exp_eq
-#if 0 // there is an instruction for this, but not supported yet.  */
+#if 0
+/* there is an instruction for this, but is not supported in
+   GCC (8.2) yet.  */
 int
 __test_scalar_cmp_exp_eq_f128 (__ieee128 vra, __ieee128 vrb)
 {

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -24,6 +24,7 @@
 #pragma GCC target ("cpu=power9")
 
 #include <vec_int128_ppc.h>
+#include <vec_f128_ppc.h>
 
 vui8_t
 __test_absdub_PWR9 (vui8_t __A, vui8_t __B)
@@ -157,6 +158,145 @@ __test_revbw_PWR9 (vui32_t a)
   return vec_revbw (a);
 }
 
+vb128_t
+test_vec_isfinitef128_PWR9 (__binary128 f128)
+{
+  return vec_isfinitef128 (f128);
+}
+
+vb128_t
+test_vec_isinff128_PWR9 (__binary128 f128)
+{
+  return vec_isinff128 (f128);
+}
+
+vb128_t
+test_vec_isnanf128_PWR9 (__binary128 f128)
+{
+  return vec_isnanf128 (f128);
+}
+
+vb128_t
+test_vec_isnormalf128_PWR9 (__binary128 f128)
+{
+  return vec_isnormalf128 (f128);
+}
+
+vb128_t
+test_vec_issubnormalf128_PWR9 (__binary128 f128)
+{
+  return vec_issubnormalf128 (f128);
+}
+
+vb128_t
+test_vec_iszerof128_PWR9 (__binary128 f128)
+{
+  return vec_iszerof128 (f128);
+}
+
+int
+test_vec_all_normalf128_PWR9 (__binary128 value)
+{
+  return (vec_all_isnormalf128 (value));
+}
+
+int
+test_vec_all_finitef128_PWR9 (__binary128 value)
+{
+  return (vec_all_isfinitef128 (value));
+}
+
+int
+test_vec_all_subnormalf128_PWR9 (__binary128 value)
+{
+  return (vec_all_issubnormalf128 (value));
+}
+
+int
+test_vec_all_inff128_PWR9 (__binary128 value)
+{
+  return (vec_all_isinff128 (value));
+}
+
+int
+test_vec_isinf_signf128_PWR9 (__binary128 value)
+{
+  return (vec_isinf_signf128 (value));
+}
+
+int
+test_vec_all_nanf128_PWR9 (__binary128 value)
+{
+  return (vec_all_isnanf128 (value));
+}
+
+int
+test_vec_all_zerof128_PWR9 (__binary128 value)
+{
+  return (vec_all_iszerof128 (value));
+}
+
+#ifdef __FLOAT128_TYPE__
+/* dummy sinf128 example. From Posix:
+ * If value is NaN then return a NaN.
+ * If value is +-0.0 then return value.
+ * If value is subnormal then return value.
+ * If value is +-Inf then return a NaN.
+ * Otherwise compute and return sin(value).
+ */
+__binary128
+test_sinf128_PWR9 (__binary128 value)
+{
+  __binary128 result;
+
+  if (vec_all_isnormalf128 (value))
+    {
+      /* body of taylor series.  */
+      result = 0.0q;
+    }
+  else
+    {
+      if (vec_all_isinff128 (value))
+	result = vec_const_nanf128 ();
+      else
+	result = value;
+    }
+
+  return result;
+}
+/* dummy codf128 example. From Posix:
+ * If value is NaN then return a NaN.
+ * If value is +-0.0 then return 1.0.
+ * If value is +-Inf then return a NaN.
+ * Otherwise compute and return sin(value).
+ */
+__binary128
+test_cosf128 (__binary128 value)
+{
+  __binary128 result;
+
+  if (vec_all_isfinitef128 (value))
+    {
+      if (vec_all_iszerof128 (value))
+	result = 1.0Q;
+      else
+	{
+	  /* body of taylor series.  */
+	  result = 0.0q;
+	}
+    }
+  else
+    {
+      if (vec_all_isinff128 (value))
+	result = vec_const_nanf128 ();
+      else
+	result = value;
+    }
+
+  return result;
+}
+#endif
+
 #ifdef vec_cmpne
 vb64_t
 __test_cmpnedp_PWR9 (vf64_t a, vf64_t b)
@@ -171,6 +311,154 @@ __test_cmpneud_PWR9 (vui64_t a, vui64_t b)
 }
 #endif
 
+#ifdef scalar_test_data_class
+int
+__test_scalar_test_data_class_f128 (__binary128 val)
+{
+  return scalar_test_data_class (val, 0x7f);
+}
+
+int
+__test_scalar_test_data_class_f64 (double val)
+{
+  return scalar_test_data_class (val, 0x7f);
+}
+
+int
+__test_scalar_test_data_class_f32 (float val)
+{
+  return scalar_test_data_class (val, 0x7f);
+}
+#endif
+
+#ifdef scalar_test_neg
+int
+__test_scalar_test_neg (__ieee128 val)
+{
+  return scalar_test_neg (val);
+}
+#endif
+
+#ifdef scalar_extract_exp
+long long int
+__test_scalar_extract_exp_f128 (__ieee128 val)
+{
+  return scalar_extract_exp (val);
+}
+
+int
+__test_scalar_extract_exp_f64 (double val)
+{
+  return scalar_extract_exp (val);
+}
+#endif
+
+#ifdef scalar_extract_sig
+__int128
+__test_scalar_extract_sig_f128 (__ieee128 val)
+{
+  return scalar_extract_sig (val);
+}
+
+long long int
+__test_scalar_extract_sig_f64 (double val)
+{
+  return scalar_extract_sig (val);
+}
+#endif
+
+#ifdef scalar_insert_exp
+__ieee128
+__test_scalar_insert_exp_f128 (__ieee128 sig, unsigned long long int exp)
+{
+  return scalar_insert_exp (sig, exp);
+}
+
+double
+__test_scalar_insert_exp_f64 (double sig, unsigned long long int exp)
+{
+  return scalar_insert_exp (sig, exp);
+}
+#endif
+
+#ifdef scalar_cmp_exp_eq
+#if 0 // there is an instruction for this, but not supported yet.  */
+int
+__test_scalar_cmp_exp_eq_f128 (__ieee128 vra, __ieee128 vrb)
+{
+  return scalar_cmp_exp_eq (vra, vrb);
+}
+#endif
+int
+__test_scalar_cmp_exp_eq_f64 (double vra, double vrb)
+{
+  return scalar_cmp_exp_eq (vra, vrb);
+}
+#endif
+
+#ifdef vec_insert_exp
+vf64_t
+__test_vec_insert_exp_f64b (vui64_t sig, vui64_t exp)
+{
+  return vec_insert_exp (sig, exp);
+}
+vf64_t
+__test_vec_insert_exp_f64 (vf64_t sig, vui64_t exp)
+{
+  return vec_insert_exp (sig, exp);
+}
+
+vf32_t
+__test_vec_insert_exp_f32b (vui32_t sig, vui32_t exp)
+{
+  return vec_insert_exp (sig, exp);
+}
+vf32_t
+__test_vec_insert_exp_f32 (vf32_t sig, vui32_t exp)
+{
+  return vec_insert_exp (sig, exp);
+}
+#endif
+
+#ifdef vec_test_data_class
+vb64_t
+__test_vec_test_data_class_f64 (vf64_t val)
+{
+  return vec_test_data_class (val, 0x7f);
+}
+
+vb32_t
+__test_vec_test_data_class_f32 (vf32_t val)
+{
+  return vec_test_data_class (val, 0x7f);
+}
+#endif
+
+#ifdef vec_extract_exp
+vui64_t
+__test_vec_extract_exp_f64 (vf64_t val)
+{
+  return vec_extract_exp (val);
+}
+vui32_t
+__test_vec_extract_exp_f32 (vf32_t val)
+{
+  return vec_extract_exp (val);
+}
+#endif
+
+#ifdef vec_extract_sig
+vui64_t
+__test_vec_extract_sig_f64 (vf64_t val)
+{
+  return vec_extract_sig (val);
+}
+vui32_t
+__test_vec_extract_sig_f32 (vf32_t val)
+{
+  return vec_extract_sig (val);
+}
+#endif
 
 void
 test_muluq_4x1_PWR9 (vui128_t *__restrict__ mulu, vui128_t m10, vui128_t m11, vui128_t m12, vui128_t m13, vui128_t m2)


### PR DESCRIPTION
Part2 including Unit tests, and dummy compile sources.

	* src/testsuite/arith128_test_f128.c: New file.
	* src/testsuite/arith128_test_f128.h: New file.
	* src/testsuite/vec_f128_dummy.c: New file.

	*src/testsuite/vec_pwr9_dummy.c: Include <vec_f128_ppc.h>.
	(test_vec_isfinitef128_PWR9, test_vec_isinff128_PWR9,
	test_vec_isnanf128_PWR9, test_vec_isnormalf128_PWR9,
	test_vec_issubnormalf128_PWR9, test_vec_iszerof128_PWR9,
	test_vec_all_normalf128_PWR9, test_vec_all_finitef128_PWR9,
	test_vec_all_subnormalf128_PWR9, test_vec_all_inff128_PWR9,
	test_vec_isinf_signf128_PWR9, test_vec_all_nanf128_PWR9,
	test_vec_all_zerof128_PWR9): New Functions.
	[ __FLOAT128_TYPE__] (test_sinf128_PWR9, test_cosf128):
	New Functions.
	[scalar_test_data_class] (__test_scalar_test_data_class_f128,
	__test_scalar_test_data_class_f64,
	__test_scalar_test_data_class_f32): New Functions.
	[scalar_test_neg] (__test_scalar_test_neg):
	New Function.
	[scalar_extract_exp] (__test_scalar_extract_exp_f128,
	__test_scalar_extract_exp_f64): New Functions.
	[scalar_extract_sig] (__test_scalar_extract_sig_f128,
	__test_scalar_extract_sig_f64): New Functions.
	[scalar_insert_exp] (__test_scalar_insert_exp_f128,
	__test_scalar_insert_exp_f64): New Functions.
	[scalar_cmp_exp_eq] (__test_scalar_cmp_exp_eq_f128,
	__test_scalar_cmp_exp_eq_f64): New functions.
	[vec_insert_exp] (__test_vec_insert_exp_f64b,
	__test_vec_insert_exp_f64, __test_vec_insert_exp_f32b,
	__test_vec_insert_exp_f32): New Functions.
	[vec_test_data_class] (__test_vec_test_data_class_f64,
	__test_vec_test_data_class_f32): New Functions.
	[vec_xtract_exp] (__test_vec_extract_exp_f64,
	__test_vec_extract_exp_f32): New Functions.
	[vec_xtract_sig] (__test_vec_extract_sig_f64,
	__test_vec_extract_sig_f32): New Functions.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>