### PR TITLE
Part3, Introduce vec_f128_ppc.h with initial __float128 support.

### DIFF
--- a/doc/pveclibmaindox.h
+++ b/doc/pveclibmaindox.h
@@ -181,12 +181,13 @@
 *  - vec_f64_ppc.h Operations on vector double values
 *  - vec_f32_ppc.h Operations on vector float values
 *
-*  \note The list above is more of an aspiration at this time.
-*  You will not find all of these headers or complete operation set
-*  and platform coverage in the current public github.
-*  But many of these headers do exist in private trees as we work
-*  on completing function and testing across compilers and PowerISA
-*  versions.
+*  \note The list above is complete in the current public github as a
+*  first pass. A backlog of functions remain to be implement
+*  across these headers. Development continues while we work on the
+*  backlog listed in:
+*  <a href="https://github.com/open-power-sdk/pveclib/issues/13">
+*  Issue #13 TODOs</a>
+*
 *
 *  The goal is to provide high quality implementations that adapt to
 *  the specifics of the compile target (-mcpu=) and compiler

--- a/doc/pveclibmaindox.h
+++ b/doc/pveclibmaindox.h
@@ -182,7 +182,7 @@
 *  - vec_f32_ppc.h Operations on vector float values
 *
 *  \note The list above is complete in the current public github as a
-*  first pass. A backlog of functions remain to be implement
+*  first pass. A backlog of functions remain to be implemented
 *  across these headers. Development continues while we work on the
 *  backlog listed in:
 *  <a href="https://github.com/open-power-sdk/pveclib/issues/13">

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,6 +9,7 @@ libpvec_la_SOURCES = tipowof10.c decpowof2.c
 libvecdummy_la_SOURCES = testsuite/vec_int128_dummy.c \
 	testsuite/vec_int64_dummy.c \
 	testsuite/vec_int32_dummy.c \
+	testsuite/vec_f128_dummy.c \
 	testsuite/vec_f64_dummy.c \
 	testsuite/vec_f32_dummy.c \
 	testsuite/vec_pwr9_dummy.c \
@@ -33,6 +34,7 @@ pveclib_testincludedir = $(includedir)/testsuite
 # on 'make install'
 pveclibinclude_HEADERS = \
 	vec_common_ppc.h \
+	vec_f128_ppc.h \
 	vec_f64_ppc.h \
 	vec_f32_ppc.h \
 	vec_int128_ppc.h \
@@ -60,6 +62,7 @@ pveclib_test_SOURCES = \
 	testsuite/vec_perf_f64.c \
 	testsuite/vec_perf_f32.c \
 	testsuite/vec_perf_i128.c \
+	testsuite/arith128_test_f128.c \
 	testsuite/arith128_test_f64.c \
 	testsuite/arith128_test_f32.c \
 	testsuite/arith128_test_i128.c \

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -148,9 +148,9 @@ libvecdummy_la_LIBADD =
 am__dirstamp = $(am__leading_dot)dirstamp
 am_libvecdummy_la_OBJECTS = testsuite/vec_int128_dummy.lo \
 	testsuite/vec_int64_dummy.lo testsuite/vec_int32_dummy.lo \
-	testsuite/vec_f64_dummy.lo testsuite/vec_f32_dummy.lo \
-	testsuite/vec_pwr9_dummy.lo testsuite/vec_bcd_dummy.lo \
-	testsuite/vec_char_dummy.lo
+	testsuite/vec_f128_dummy.lo testsuite/vec_f64_dummy.lo \
+	testsuite/vec_f32_dummy.lo testsuite/vec_pwr9_dummy.lo \
+	testsuite/vec_bcd_dummy.lo testsuite/vec_char_dummy.lo
 libvecdummy_la_OBJECTS = $(am_libvecdummy_la_OBJECTS)
 am__EXEEXT_1 = pveclib_test$(EXEEXT) vec_dummy$(EXEEXT)
 am_pveclib_test_OBJECTS = testsuite/pveclib_test.$(OBJEXT) \
@@ -158,6 +158,7 @@ am_pveclib_test_OBJECTS = testsuite/pveclib_test.$(OBJEXT) \
 	testsuite/vec_perf_f64.$(OBJEXT) \
 	testsuite/vec_perf_f32.$(OBJEXT) \
 	testsuite/vec_perf_i128.$(OBJEXT) \
+	testsuite/arith128_test_f128.$(OBJEXT) \
 	testsuite/arith128_test_f64.$(OBJEXT) \
 	testsuite/arith128_test_f32.$(OBJEXT) \
 	testsuite/arith128_test_i128.$(OBJEXT) \
@@ -569,6 +570,7 @@ libpvec_la_SOURCES = tipowof10.c decpowof2.c
 libvecdummy_la_SOURCES = testsuite/vec_int128_dummy.c \
 	testsuite/vec_int64_dummy.c \
 	testsuite/vec_int32_dummy.c \
+	testsuite/vec_f128_dummy.c \
 	testsuite/vec_f64_dummy.c \
 	testsuite/vec_f32_dummy.c \
 	testsuite/vec_pwr9_dummy.c \
@@ -587,6 +589,7 @@ pveclib_testincludedir = $(includedir)/testsuite
 # on 'make install'
 pveclibinclude_HEADERS = \
 	vec_common_ppc.h \
+	vec_f128_ppc.h \
 	vec_f64_ppc.h \
 	vec_f32_ppc.h \
 	vec_int128_ppc.h \
@@ -608,6 +611,7 @@ pveclib_test_SOURCES = \
 	testsuite/vec_perf_f64.c \
 	testsuite/vec_perf_f32.c \
 	testsuite/vec_perf_i128.c \
+	testsuite/arith128_test_f128.c \
 	testsuite/arith128_test_f64.c \
 	testsuite/arith128_test_f32.c \
 	testsuite/arith128_test_i128.c \
@@ -716,6 +720,8 @@ testsuite/vec_int64_dummy.lo: testsuite/$(am__dirstamp) \
 	testsuite/$(DEPDIR)/$(am__dirstamp)
 testsuite/vec_int32_dummy.lo: testsuite/$(am__dirstamp) \
 	testsuite/$(DEPDIR)/$(am__dirstamp)
+testsuite/vec_f128_dummy.lo: testsuite/$(am__dirstamp) \
+	testsuite/$(DEPDIR)/$(am__dirstamp)
 testsuite/vec_f64_dummy.lo: testsuite/$(am__dirstamp) \
 	testsuite/$(DEPDIR)/$(am__dirstamp)
 testsuite/vec_f32_dummy.lo: testsuite/$(am__dirstamp) \
@@ -747,6 +753,8 @@ testsuite/vec_perf_f64.$(OBJEXT): testsuite/$(am__dirstamp) \
 testsuite/vec_perf_f32.$(OBJEXT): testsuite/$(am__dirstamp) \
 	testsuite/$(DEPDIR)/$(am__dirstamp)
 testsuite/vec_perf_i128.$(OBJEXT): testsuite/$(am__dirstamp) \
+	testsuite/$(DEPDIR)/$(am__dirstamp)
+testsuite/arith128_test_f128.$(OBJEXT): testsuite/$(am__dirstamp) \
 	testsuite/$(DEPDIR)/$(am__dirstamp)
 testsuite/arith128_test_f64.$(OBJEXT): testsuite/$(am__dirstamp) \
 	testsuite/$(DEPDIR)/$(am__dirstamp)
@@ -788,6 +796,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/arith128_print.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/arith128_test_bcd.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/arith128_test_char.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/arith128_test_f128.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/arith128_test_f32.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/arith128_test_f64.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/arith128_test_i128.Po@am__quote@
@@ -798,6 +807,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/vec_bcd_dummy.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/vec_char_dummy.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/vec_dummy_main.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/vec_f128_dummy.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/vec_f32_dummy.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/vec_f64_dummy.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/vec_int128_dummy.Plo@am__quote@

--- a/src/testsuite/pveclib_test.c
+++ b/src/testsuite/pveclib_test.c
@@ -40,6 +40,7 @@
 #include <testsuite/arith128_test_bcd.h>
 #include <testsuite/arith128_test_f32.h>
 #include <testsuite/arith128_test_f64.h>
+#include <testsuite/arith128_test_f128.h>
 
 int
 main (void)
@@ -68,6 +69,7 @@ main (void)
 #if 1
   rc += test_vec_f64 ();
 #endif
+  rc += test_vec_f128 ();
 
   if (rc > 0)
     printf ("%d failures reported\n", rc);


### PR DESCRIPTION
Includes the Makefile.ac updates to install vec_f128_ppc.h and
build/run the f128 specific unit tests. Also updated the \note on the
\mainpage for current status.

	* doc/pveclibmaindox.h: Update \note with project status.

	* src/Makefile.am (libvecdummy_la_SOURCES):
	Add testsuite/vec_f128_dummy.c.
	(pveclibinclude_HEADERS): Add vec_f128_ppc.h.
	(pveclib_test_SOURCES): Add testsuite/arith128_test_f128.c.
	* src/Makefile.in: Regenerated via automake.

	* src/testsuite/pveclib_test.c:
	Include <testsuite/arith128_test_f128.h>
 	(main): Call test_vec_f128().

Signed-off-by: Steven Munroe <munroesj52@gmail.com>