### PR TITLE
Update vec_f64_ppc.h to use POWER9 test date class instructions.

### DIFF
--- a/src/testsuite/arith128_test_f64.c
+++ b/src/testsuite/arith128_test_f64.c
@@ -150,6 +150,91 @@ test_double_all_is (void)
 {
   vf64_t i;
   int rc = 0;
+  printf ("\n%s double is all finite\n", __FUNCTION__);
+
+  i = (vf64_t) { 0.0, -0.0 };
+
+#ifdef __DEBUG_PRINT__
+  print_v2f64x ("vec_all_isfinite i=", i);
+#endif
+  if (vec_all_isfinitef64 (i))
+    {
+    } else {
+      rc += 1;
+      print_v2f64x ("vec_all_isfinite fail", i);
+    }
+
+  i = (vf64_t) { __DBL_MAX__, __DBL_MIN__ };
+
+#ifdef __DEBUG_PRINT__
+  print_v2f64x ("vec_all_isfinite i=", i);
+#endif
+  if (vec_all_isfinitef64 (i))
+    {
+    } else {
+      rc += 1;
+      print_v2f64x ("vec_all_isfinite fail", i);
+    }
+
+  i = (vf64_t) { __DBL_EPSILON__, __DBL_DENORM_MIN__ };
+
+#ifdef __DEBUG_PRINT__
+  print_v2f64x ("vec_all_isfinite i=", i);
+#endif
+  if (vec_all_isfinitef64 (i))
+    {
+    } else {
+      rc += 1;
+      print_v2f64x ("vec_all_isfinite fail", i);
+    }
+
+  i = (vf64_t) CONST_VINT128_DW(__DOUBLE_INF, 0);
+
+#ifdef __DEBUG_PRINT__
+  print_v2f64x ("vec_all_isfinite i=", i);
+#endif
+  if (vec_all_isfinitef64 (i))
+    {
+      rc += 1;
+      print_v2f64x ("vec_all_isfinite fail", i);
+    } else {
+    }
+
+  i = (vf64_t) CONST_VINT128_DW( 0, __DOUBLE_NINF);
+
+#ifdef __DEBUG_PRINT__
+  print_v2f64x ("vec_all_isfinite i=", i);
+#endif
+  if (vec_all_isfinitef64 (i))
+    {
+      rc += 1;
+      print_v2f64x ("vec_all_isfinite fail", i);
+    } else {
+    }
+
+  i = (vf64_t) CONST_VINT128_DW(__DOUBLE_INF, __DOUBLE_NINF);
+
+#ifdef __DEBUG_PRINT__
+  print_v2f64x ("vec_all_isfinite i=", i);
+#endif
+  if (vec_all_isfinitef64 (i))
+    {
+      rc += 1;
+      print_v2f64x ("vec_all_isfinite fail", i);
+    } else {
+    }
+
+  i = (vf64_t) CONST_VINT128_DW(__DOUBLE_NAN, __DOUBLE_SNAN);
+
+#ifdef __DEBUG_PRINT__
+  print_v2f64x ("vec_all_isfinite i=", i);
+#endif
+  if (vec_all_isfinitef64 (i))
+    {
+      rc += 1;
+      print_v2f64x ("vec_all_isfinite fail", i);
+    } else {
+    }
 
   printf ("\n%s double is all infinity\n", __FUNCTION__);
 
@@ -736,6 +821,92 @@ test_double_any_is (void)
 {
   vf64_t i;
   int rc = 0;
+
+  printf ("\n%s double is any finite\n", __FUNCTION__);
+
+  i = (vf64_t) { 0.0, -0.0 };
+
+#ifdef __DEBUG_PRINT__
+  print_v2f64x ("vec_any_isfinite i=", i);
+#endif
+  if (vec_any_isfinitef64 (i))
+    {
+    } else {
+      rc += 1;
+      print_v2f64x ("vec_any_isfinite fail", i);
+    }
+
+  i = (vf64_t) { __DBL_MAX__, __DBL_MIN__ };
+
+#ifdef __DEBUG_PRINT__
+  print_v2f64x ("vec_any_isfinite i=", i);
+#endif
+  if (vec_any_isfinitef64 (i))
+    {
+    } else {
+      rc += 1;
+      print_v2f64x ("vec_any_isfinite fail", i);
+    }
+
+  i = (vf64_t) { __DBL_EPSILON__, __DBL_DENORM_MIN__ };
+
+#ifdef __DEBUG_PRINT__
+  print_v2f64x ("vec_any_isfinite i=", i);
+#endif
+  if (vec_any_isfinitef64 (i))
+    {
+    } else {
+      rc += 1;
+      print_v2f64x ("vec_any_isfinite fail", i);
+    }
+
+  i = (vf64_t) CONST_VINT128_DW(__DOUBLE_INF, 0 );
+
+#ifdef __DEBUG_PRINT__
+  print_v2f64x ("vec_any_isfinite i=", i);
+#endif
+  if (vec_any_isfinitef64 (i))
+    {
+    } else {
+      rc += 1;
+      print_v2f64x ("vec_any_isfinite fail", i);
+    }
+
+  i = (vf64_t) CONST_VINT128_DW( __DOUBLE_NINF, 0 );
+
+#ifdef __DEBUG_PRINT__
+  print_v2f64x ("vec_any_isfinite i=", i);
+#endif
+  if (vec_any_isfinitef64 (i))
+    {
+    } else {
+      rc += 1;
+      print_v2f64x ("vec_any_isfinite fail", i);
+    }
+
+  i = (vf64_t) CONST_VINT128_DW(__DOUBLE_INF, __DOUBLE_NINF);
+
+#ifdef __DEBUG_PRINT__
+  print_v2f64x ("vec_any_isfinite i=", i);
+#endif
+  if (vec_any_isfinitef64 (i))
+    {
+      rc += 1;
+      print_v2f64x ("vec_any_isfinite fail", i);
+    } else {
+    }
+
+  i = (vf64_t) CONST_VINT128_DW(__DOUBLE_NAN, __DOUBLE_SNAN);
+
+#ifdef __DEBUG_PRINT__
+  print_v2f64x ("vec_any_isfinite i=", i);
+#endif
+  if (vec_any_isfinitef64 (i))
+    {
+      rc += 1;
+      print_v2f64x ("vec_any_isfinite fail", i);
+    } else {
+    }
 
   printf ("\n%s double is any infinity\n", __FUNCTION__);
 
@@ -1499,6 +1670,117 @@ test_double_cpsgn (void)
 }
 
 int
+test_double_isfinite (void)
+{
+  vf64_t i;
+  vb64_t e, k;
+  int rc = 0;
+
+  printf ("\n%s double isfinite\n", __FUNCTION__);
+
+  i = (vf64_t){ 0.0, -0.0 };
+  e = (vb64_t) CONST_VINT128_DW(__DOUBLE_TRUE, __DOUBLE_TRUE);
+  k = vec_isfinitef64 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v2f64x ("vec_isfinitef64 i=", i);
+  print_v2b64c ("             k=", k);
+  print_v2b64x ("             k=", k);
+#endif
+  rc += check_v2b64c ("vec_isfinitef64 1:", k, e);
+
+  i = (vf64_t) CONST_VINT128_DW(__DOUBLE_INF, __DOUBLE_NINF);
+  e = (vb64_t) CONST_VINT128_DW(__DOUBLE_NTRUE, __DOUBLE_NTRUE);
+  k = vec_isfinitef64 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v2f64x ("vec_isfinitef64 i=", i);
+  print_v2b64c ("             k=", k);
+  print_v2b64x ("             k=", k);
+#endif
+  rc += check_v2b64c ("vec_isfinitef64 2:", k, e);
+
+  i = (vf64_t) CONST_VINT128_DW(0x7fefffffffffffffUL, 0x0001000000000000UL);
+  e = (vb64_t) CONST_VINT128_DW(__DOUBLE_TRUE, __DOUBLE_TRUE);
+  k = vec_isfinitef64 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v2f64x ("vec_isfinitef64 i=", i);
+  print_v2b64c ("             k=", k);
+  print_v2b64x ("             k=", k);
+#endif
+  rc += check_v2b64c ("vec_isfinitef64 3:", k, e);
+
+  i = (vf64_t) CONST_VINT128_DW(0x3ff0000000000000UL, 0x8000000000000001UL);
+  e = (vb64_t) CONST_VINT128_DW(__DOUBLE_TRUE, __DOUBLE_TRUE);
+  k = vec_isfinitef64 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v2f64x ("vec_isfinitef64 i=", i);
+  print_v2b64c ("             k=", k);
+  print_v2b64x ("             k=", k);
+#endif
+  rc += check_v2b64c ("vec_isfinitef64 4:", k, e);
+
+  i = (vf64_t) CONST_VINT128_DW(__DOUBLE_INF, 0x0001000000000000UL);
+  e = (vb64_t) CONST_VINT128_DW(__DOUBLE_NTRUE, __DOUBLE_TRUE);
+  k = vec_isfinitef64 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v2f64x ("vec_isfinitef64 i=", i);
+  print_v2b64c ("             k=", k);
+  print_v2b64x ("             k=", k);
+#endif
+  rc += check_v2b64c ("vec_isfinitef64 5:", k, e);
+
+  i = (vf64_t) CONST_VINT128_DW(__DOUBLE_INF, 0x3ff0000000000000UL);
+  e = (vb64_t) CONST_VINT128_DW(__DOUBLE_NTRUE, __DOUBLE_TRUE);
+  k = vec_isfinitef64 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v2f64x ("vec_isfinitef64 i=", i);
+  print_v2b64c ("             k=", k);
+  print_v2b64x ("             k=", k);
+#endif
+  rc += check_v2b64c ("vec_isfinitef64 6:", k, e);
+
+  i = (vf64_t) CONST_VINT128_DW(__DOUBLE_INF, 0x8000000000000001UL);
+  e = (vb64_t) CONST_VINT128_DW(__DOUBLE_NTRUE, __DOUBLE_TRUE);
+  k = vec_isfinitef64 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v2f64x ("vec_isfinitef64 i=", i);
+  print_v2b64c ("             k=", k);
+  print_v2b64x ("             k=", k);
+#endif
+  rc += check_v2b64c ("vec_isfinitef64 7:", k, e);
+
+  i = (vf64_t) CONST_VINT128_DW(__DOUBLE_NINF, 0x3ff0000000000000UL);
+  e = (vb64_t) CONST_VINT128_DW(__DOUBLE_NTRUE, __DOUBLE_TRUE);
+  k = vec_isfinitef64 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v2f64x ("vec_isfinitef64 i=", i);
+  print_v2b64c ("             k=", k);
+  print_v2b64x ("             k=", k);
+#endif
+  rc += check_v2b64c ("vec_isfinitef64 8:", k, e);
+
+  i = (vf64_t) CONST_VINT128_DW(0x3ff0000000000000UL, __DOUBLE_NINF);
+  e = (vb64_t) CONST_VINT128_DW(__DOUBLE_TRUE, __DOUBLE_NTRUE);
+  k = vec_isfinitef64 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_v2f64x ("vec_isfinitef64 i=", i);
+  print_v2b64c ("             k=", k);
+  print_v2b64x ("             k=", k);
+#endif
+  rc += check_v2b64c ("vec_isfinitef64 9:", k, e);
+
+  return (rc);
+}
+
+int
 test_double_isinf (void)
 {
   vf64_t i;
@@ -2221,6 +2503,7 @@ test_vec_f64 (void)
   rc += test_double_isnormal ();
   rc += test_double_issubnormal ();
   rc += test_double_iszero ();
+  rc += test_double_isfinite ();
 
   rc += test_time_f64 ();
 

--- a/src/testsuite/vec_f64_dummy.c
+++ b/src/testsuite/vec_f64_dummy.c
@@ -55,6 +55,12 @@ test512_all_f64_nan (vf64_t val0, vf64_t val1, vf64_t val2, vf64_t val3)
 }
 
 int
+test_all_f64_finite (vf64_t value)
+{
+  return (vec_all_isfinitef64 (value));
+}
+
+int
 test_all_f64_inf (vf64_t value)
 {
   return (vec_all_isinff64 (value));
@@ -82,6 +88,47 @@ int
 test_all_f64_zero (vf64_t value)
 {
 	return (vec_all_iszerof64 (value));
+}
+
+int
+test_any_f64_finite (vf64_t value)
+{
+  return (vec_any_isfinitef64 (value));
+}
+int
+test_any_f64_inf (vf64_t value)
+{
+  return (vec_any_isinff64 (value));
+}
+
+int
+test_any_f64_nan (vf64_t value)
+{
+	return (vec_any_isnanf64 (value));
+}
+
+int
+test_any_f64_norm (vf64_t value)
+{
+	return (vec_any_isnormalf64 (value));
+}
+
+int
+test_any_f64_subnorm (vf64_t value)
+{
+	return (vec_any_issubnormalf64 (value));
+}
+
+int
+test_any_f64_zero (vf64_t value)
+{
+	return (vec_any_iszerof64 (value));
+}
+
+vb64_t
+test_pred_f64_finite (vf64_t value)
+{
+  return (vec_isfinitef64 (value));
 }
 
 vb64_t
@@ -139,6 +186,80 @@ test_fpclassify_f64 (vf64_t value)
   result = vec_sel (result, VFP_SUBNORMAL, mask);
   mask = (vui64_t) vec_isnormalf64 (value);
   result = vec_sel (result, VFP_NORMAL, mask);
+
+  return result;
+}
+/* dummy sinf64 example. From Posix:
+ * If value is NaN then return a NaN.
+ * If value is +-0.0 then return value.
+ * If value is subnormal then return value.
+ * If value is +-Inf then return a NaN.
+ * Otherwise compute and return sin(value).
+ */
+vf64_t
+test_vec_sinf64 (vf64_t value)
+{
+  const vf64_t vec_f0 = { 0.0, 0.0 };
+  const vui64_t vec_f64_qnan =
+    { 0x7ff8000000000000, 0x7ff8000000000000 };
+  vf64_t result;
+  vb64_t normmask, infmask;
+
+  normmask = vec_isnormalf64 (value);
+  if (vec_any_isnormalf64 (value))
+    {
+      /* replace non-normal input values with safe values.  */
+      vf64_t safeval = vec_sel (vec_f0, value, normmask);
+      /* body of vec_sin(safeval) computation elided for this example.  */
+      result = vec_mul (safeval, safeval);
+    }
+  else
+    result = value;
+
+  /* merge non-normal input values back into result */
+  result = vec_sel (value, result, normmask);
+  /* Inf input value elements return quiet-nan.  */
+  infmask = vec_isinff64 (value);
+  result = vec_sel (result, (vf64_t) vec_f64_qnan, infmask);
+
+  return result;
+}
+
+/* dummy cosf64 example. From Posix:
+ * If value is NaN then return a NaN.
+ * If value is +-0.0 then return 1.0.
+ * If value is +-Inf then return a NaN.
+ * Otherwise compute and return sin(value).
+ */
+vf64_t
+test_vec_cosf64 (vf64_t value)
+{
+  vf64_t result;
+  const vf64_t vec_f0 = { 0.0, 0.0 };
+  const vf64_t vec_f1 = { 1.0, 1.0 };
+  const vui64_t vec_f64_qnan =
+    { 0x7ff8000000000000, 0x7ff8000000000000 };
+  vb64_t finitemask, infmask, zeromask;
+
+  finitemask = vec_isfinitef64 (value);
+  if (vec_any_isfinitef64 (value))
+    {
+      /* replace non-finite input values with safe values.  */
+      vf64_t safeval = vec_sel (vec_f0, value, finitemask);
+      /* body of vec_sin(safeval) computation elided for this example.  */
+      result = vec_mul (safeval, safeval);
+    }
+  else
+    result = value;
+
+  /* merge non-finite input values back into result */
+  result = vec_sel (value, result, finitemask);
+  /* Set +-0.0 input elements to exactly 1.0 in result.  */
+  zeromask = vec_iszerof64 (value);
+  result = vec_sel (result, vec_f1, zeromask);
+  /* Set Inf input elements to quiet-nan in result.  */
+  infmask = vec_isinff64 (value);
+  result = vec_sel (result, (vf64_t) vec_f64_qnan, infmask);
 
   return result;
 }

--- a/src/testsuite/vec_f64_dummy.c
+++ b/src/testsuite/vec_f64_dummy.c
@@ -69,25 +69,25 @@ test_all_f64_inf (vf64_t value)
 int
 test_all_f64_nan (vf64_t value)
 {
-	return (vec_all_isnanf64 (value));
+  return (vec_all_isnanf64 (value));
 }
 
 int
 test_all_f64_norm (vf64_t value)
 {
-	return (vec_all_isnormalf64 (value));
+  return (vec_all_isnormalf64 (value));
 }
 
 int
 test_all_f64_subnorm (vf64_t value)
 {
-	return (vec_all_issubnormalf64 (value));
+  return (vec_all_issubnormalf64 (value));
 }
 
 int
 test_all_f64_zero (vf64_t value)
 {
-	return (vec_all_iszerof64 (value));
+  return (vec_all_iszerof64 (value));
 }
 
 int
@@ -104,25 +104,25 @@ test_any_f64_inf (vf64_t value)
 int
 test_any_f64_nan (vf64_t value)
 {
-	return (vec_any_isnanf64 (value));
+  return (vec_any_isnanf64 (value));
 }
 
 int
 test_any_f64_norm (vf64_t value)
 {
-	return (vec_any_isnormalf64 (value));
+  return (vec_any_isnormalf64 (value));
 }
 
 int
 test_any_f64_subnorm (vf64_t value)
 {
-	return (vec_any_issubnormalf64 (value));
+  return (vec_any_issubnormalf64 (value));
 }
 
 int
 test_any_f64_zero (vf64_t value)
 {
-	return (vec_any_iszerof64 (value));
+  return (vec_any_iszerof64 (value));
 }
 
 vb64_t
@@ -274,73 +274,73 @@ test_load_vf64 ( vf64_t *val)
 int
 test_f64_isfinite (double value)
 {
-	return (__builtin_isfinite(value));
+  return (__builtin_isfinite (value));
 }
 
 int
 test_f64_isinf (double value)
 {
-	return (__builtin_isinf(value));
+  return (__builtin_isinf (value));
 }
 
 int
 test_f64_isnan (double value)
 {
-	return (__builtin_isnan(value));
+  return (__builtin_isnan (value));
 }
 
 int
 test_f64_isnormal (double value)
 {
-	return (__builtin_isnormal(value));
+  return (__builtin_isnormal (value));
 }
 
 vf64_t
-test_ibm128_vf64_vec ( long double lval)
+test_ibm128_vf64_vec (long double lval)
 {
-	return ( vec_unpack_longdouble (lval) );
+  return (vec_unpack_longdouble (lval));
 }
 
 long double
-test_vf64_ibm128_vec ( vf64_t lval)
+test_vf64_ibm128_vec (vf64_t lval)
 {
-	return ( vec_pack_longdouble (lval) );
+  return (vec_pack_longdouble (lval));
 }
 
 vf64_t
-test_ibm128_vf64_asm ( long double lval)
+test_ibm128_vf64_asm (long double lval)
 {
 #ifdef _ARCH_PWR7
-	vf64_t     t;
-        __asm__(
-        	"xxmrghd %x0,%1,%L1;\n"
-            : "=wa" (t)
-            : "f" (lval)
-            : );
-        return (t);
+  vf64_t t;
+  __asm__(
+      "xxmrghd %x0,%1,%L1;\n"
+      : "=wa" (t)
+      : "f" (lval)
+      : );
+  return (t);
 #else
-        U_128   t;
-        t.ldbl128 = lval;
-        return (t.vf2);
+  U_128 t;
+  t.ldbl128 = lval;
+  return (t.vf2);
 #endif
 }
 
 long double
-test_vf64_ibm128_asm ( vf64_t lval)
+test_vf64_ibm128_asm (vf64_t lval)
 {
 #ifdef _ARCH_PWR7
-	long double     t;
-        __asm__(
-        	"xxlor %0,%x1,%x1;\n"
-        	"\txxswapd %L0,%x1;\n"
-            : "=f" (t)
-            : "wa" (lval)
-            : );
-        return (t);
+  long double t;
+  __asm__(
+      "xxlor %0,%x1,%x1;\n"
+      "\txxswapd %L0,%x1;\n"
+      : "=f" (t)
+      : "wa" (lval)
+      : );
+  return (t);
 #else
-        U_128   t;
-        t.vf2 = lval;
-        return (t.ldbl128);
+  U_128 t;
+  t.vf2 = lval;
+  return (t.ldbl128);
 #endif
 }
 

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -270,6 +270,112 @@ test_vec_iszerof32_PWR9 (vf32_t value)
 {
   return (vec_iszerof32 (value));
 }
+int
+test_vec_all_finitef64_PWR9 (vf64_t value)
+{
+  return (vec_all_isfinitef64 (value));
+}
+
+int
+test_vec_all_inff64_PWR9 (vf64_t value)
+{
+  return (vec_all_isinff64 (value));
+}
+
+int
+test_vec_all_nanf64_PWR9 (vf64_t value)
+{
+  return (vec_all_isnanf64 (value));
+}
+
+int
+test_vec_all_normalf64_PWR9 (vf64_t value)
+{
+  return (vec_all_isnormalf64 (value));
+}
+
+int
+test_vec_all_subnormalf64_PWR9 (vf64_t value)
+{
+  return (vec_all_issubnormalf64 (value));
+}
+
+int
+test_vec_all_zerof64_PWR9 (vf64_t value)
+{
+  return (vec_all_iszerof64 (value));
+}
+int
+test_vec_any_finitef64_PWR9 (vf64_t value)
+{
+  return (vec_any_isfinitef64 (value));
+}
+
+int
+test_vec_any_inff64_PWR9 (vf64_t value)
+{
+  return (vec_any_isinff64 (value));
+}
+
+int
+test_vec_any_nanf64_PWR9 (vf64_t value)
+{
+  return (vec_any_isnanf64 (value));
+}
+
+int
+test_vec_any_normalf64_PWR9 (vf64_t value)
+{
+  return (vec_any_isnormalf64 (value));
+}
+
+int
+test_vec_any_subnormalf64_PWR9 (vf64_t value)
+{
+  return (vec_any_issubnormalf64 (value));
+}
+
+int
+test_vec_any_zerof64_PWR9 (vf64_t value)
+{
+  return (vec_any_iszerof64 (value));
+}
+
+vb64_t
+test_vec_isfinitef64_PWR9 (vf64_t value)
+{
+  return (vec_isfinitef64 (value));
+}
+
+vb64_t
+test_vec_isinff64_PWR9 (vf64_t value)
+{
+  return (vec_isinff64 (value));
+}
+
+vb64_t
+test_vec_isnanf64_PWR9 (vf64_t value)
+{
+  return (vec_isnanf64 (value));
+}
+
+vb64_t
+test_vec_isnormalf64_PWR9 (vf64_t value)
+{
+  return (vec_isnormalf64 (value));
+}
+
+vb64_t
+test_vec_issubnormalf64_PWR9 (vf64_t value)
+{
+  return (vec_issubnormalf64 (value));
+}
+
+vb64_t
+test_vec_iszerof64_PWR9 (vf64_t value)
+{
+  return (vec_iszerof64 (value));
+}
 
 vb128_t
 test_vec_isfinitef128_PWR9 (__binary128 f128)

--- a/src/vec_f64_ppc.h
+++ b/src/vec_f64_ppc.h
@@ -28,19 +28,24 @@
 /*!
  * \file  vec_f64_ppc.h
  * \brief Header package containing a collection of 128-bit SIMD
- * operations over 64-bit double floating point elements.
+ * operations over 64-bit double-precision floating point elements.
  *
- * Most vector double (64-bit float) operations are implemented
- * with PowerISA-2.06 (POWER7 and later) VSX instructions.
+ * Many vector double-precision (64-bit float) operations are
+ * implemented with PowerISA-2.06 Vector Scalar Extended (VSX)
+ * (POWER7 and later) instructions. Most VSX instructions provide
+ * access to 64 combined scalar/vector registers.
+ * PowerISA-3.0 (POWER9) provides additional vector double operations;
+ * convert with round, convert to/from integer, insert/extract exponent
+ * and significand, and test data class.
  * Most of these operations (compiler built-ins, or intrinsics) are
  * defined in <altivec.h> and described in the
  * <a href="https://gcc.gnu.org/onlinedocs/">compiler documentation</a>.
  *
  * \note The compiler disables associated <altivec.h> built-ins if the
  * <B>mcpu</B> target does not enable the specific instruction.
- * For example if you compile with <B>-mcpu=power7</B>, most of the
- * doubleword integer add, subtract, and compare operations useful
- * for floating point classification are not defined.
+ * For example if you compile with <B>-mcpu=power8</B>, the
+ * double-precision vector converts, insert/extract and test data class
+ * built-ins are are not defined.
  * This header provides the appropriate substitutions,
  * will generate the minimum code, appropriate for the target,
  * and produce correct results.
@@ -48,8 +53,25 @@
  * \note Most ppc64le compilers will default to -mcpu=power8 if not
  * specified.
  *
+ * \note GCC 7.3 defines vector forms of the test data class,
+ * extract significand, and extract/insert_exp
+ * for float and double.
+ * These built-ins are not defined in GCC 6.4. See
+ * <a href="https://gcc.gnu.org/onlinedocs/">compiler documentation</a>.
+ * These are useful operations and can be implement in a few
+ * vector logical instruction for earlier machines.
+ *
+ * So it is reasonable for this header to provide vector forms
+ * of the double-precision floating point classification functions
+ * (isnormal/subnormal/finite/inf/nan/zero, etc.).
+ * These functions can be implemented directly using (one or more)
+ * POWER9 instructions, or a few vector logical and integer compare
+ * instructions for POWER7/8. Each is comfortably small enough to be
+ * in-lined and inherently faster than the equivalent POSIX or compiler
+ * built-in runtime scalar functions.
+ *
  * Most of these operations are implemented in a few instructions
- * on newer (POWER8/POWER9) processors.
+ * on newer (POWER7/POWER8/POWER9) processors.
  * This header serves to fill in functional gaps for older
  * (POWER7, POWER8) processors and provides an inline assembler
  * implementation for older compilers that do not
@@ -62,15 +84,114 @@
  * (even if the equivalent function requires more instructions).
  * - Defined in the OpenPOWER ABI but <I>not</I> yet defined in
  * <altivec.h> provided by available compilers in common use.
- * Examples include vector double even/odd.
- * - Providing special vector float tests for special conditions
+ * Examples include vector double even/odd conversions.
+ * - Providing special vector double tests for special conditions
  * without generating extraneous floating-point exceptions.
  * This is important for implementing vectorized forms of ISO C99 Math
- * functions. Examples include vector isnan, isinf, etc.
- * - Commonly used operations, not covered by the ABI or
- * <altivec.h>, and require multiple instructions or
- * are not obvious.
- * See example ISO C99 functions above.
+ * functions. Examples include vector double isnan, isinf, etc.
+ * - Commonly used operations, not covered by the ABI or <altivec.h>,
+ * and require multiple instructions or are not obvious.
+ * For example converts that change element size and imply
+ * converting two vectors in to one vector of smaller elements, or
+ * one vector into two vectors of larger elements.
+ * Another example the special case of packing/unpacking am IBM long
+ * double between a pair of Floating-point registers (FPRs) and a
+ * single vector register (VR).
+ *
+ * \section f64_examples_0_0 Examples
+ * For example: using the the classification functions for implementing
+ * the math library function sine and cosine.
+ * The POSIX specification requires that special input values are
+ * processed without raising extraneous floating point exceptions and
+ * return specific floating point values in response.
+ * For example the sin() function.
+ * - If the input <I>value</I> is NaN then return a NaN.
+ * - If the input <I>value</I> is +-0.0 then return <I>value</I>.
+ * - If the input <I>value</I> is subnormal then return <I>value</I>.
+ * - If the input <I>value</I> is +-Inf then return a quiet-NaN.
+ * - Otherwise compute and return sin(value).
+ *
+ * The following code example uses functions from this header to
+ * address the POSIX requirements for special values input to
+ * for a vectorized sinf():
+ * \code
+vf64_t
+test_vec_sinf64 (vf64_t value)
+{
+  const vf64_t vec_f0 = { 0.0, 0.0 };
+  const vui64_t vec_f64_qnan =
+    { 0x7ff8000000000000, 0x7ff8000000000000 };
+  vf64_t result;
+  vb64_t normmask, infmask;
+
+  normmask = vec_isnormalf64 (value);
+  if (vec_any_isnormalf64 (value))
+    {
+      // replace non-normal input values with safe values.
+      vf64_t safeval = vec_sel (vec_f0, value, normmask);
+      // body of vec_sin(safeval) computation elided for this example.
+    }
+  else
+    result = value;
+
+  // merge non-normal input values back into result
+  result = vec_sel (value, result, normmask);
+  // Inf input value elements return quiet-nan.
+  infmask = vec_isinff64 (value);
+  result = vec_sel (result, (vf64_t) vec_f64_qnan, infmask);
+
+  return result;
+}
+ * \endcode
+ * The code generated for this fragment runs between 24 (-mcpu=power9)
+ * and 40 (-mcpu=power8) instructions. The normal execution path is
+ * 14 to 25 instructions respectively.
+ *
+ * Another example the cos() function.
+ * - If the input <I>value</I> is NaN then return a NaN.
+ * - If the input <I>value</I> is +-0.0 then return <I>1.0</I>.
+ * - If the input <I>value</I> is +-Inf then return a quiet-NaN.
+ * - Otherwise compute and return cos(value).
+ *
+ * The following code example uses functions from this header to
+ * address the POSIX requirements for special values input to
+ * vectorized cosf():
+ * \code
+vf64_t
+test_vec_cosf64 (vf64_t value)
+{
+  vf64_t result;
+  const vf64_t vec_f0 = { 0.0, 0.0 };
+  const vf64_t vec_f1 = { 1.0, 1.0 };
+  const vui64_t vec_f64_qnan =
+    { 0x7ff8000000000000, 0x7ff8000000000000 };
+  vb64_t finitemask, infmask, zeromask;
+
+  finitemask = vec_isfinitef64 (value);
+  if (vec_any_isfinitef64 (value))
+    {
+      // replace non-finite input values with safe values.
+      vf64_t safeval = vec_sel (vec_f0, value, finitemask);
+      // body of vec_sin(safeval) computation elided for this example.
+    }
+  else
+    result = value;
+
+  // merge non-finite input values back into result
+  result = vec_sel (value, result, finitemask);
+  // Set +-0.0 input elements to exactly 1.0 in result.
+  zeromask = vec_iszerof64 (value);
+  result = vec_sel (result, vec_f1, zeromask);
+  // Set Inf input elements to quiet-nan in result.
+  infmask = vec_isinff64 (value);
+  result = vec_sel (result, (vf64_t) vec_f64_qnan, infmask);
+
+  return result;
+}
+ * \endcode
+ *
+ * Neither example raises floating point exceptions or sets
+ * <B>errno</B>, as appropriate for a vector math library.
  *
  * \section f64_perf_0_0 Performance data.
  * High level performance estimates are provided as an aid to function
@@ -78,58 +199,6 @@
  * <I>Latency</I> and <I>Throughput</I> are derived see:
  * \ref perf_data
  */
-
-/*! \brief vector of 64-bit binary64 elements.
- *  Same as vector double for PPC.  */
-typedef __vector double __vbinary64;
-
-/** \brief Copy the pair of doubles from a IBM long double to a vector
- * double.
- *
- *  @param lval IBM long double as FPR pair.
- *  @return vector double values containing the IBM long double.
- */
-static inline vf64_t
-vec_unpack_longdouble (long double lval)
-{
-#ifdef _ARCH_PWR7
-  vf64_t t;
-  __asm__(
-      "xxmrghd %x0,%1,%L1;\n"
-      : "=wa" (t)
-      : "f" (lval)
-      : );
-  return (t);
-#else
-  U_128 t;
-  t.ldbl128 = lval;
-  return (t.vf2);
-#endif
-}
-
-/** \brief Copy the pair of doubles from a vector to IBM long double.
- *
- *  @param lval vector double values containing the IBM long double.
- *  @return IBM long double as FPR pair.
- */
-static inline long double
-vec_pack_longdouble (vf64_t lval)
-{
-#ifdef _ARCH_PWR7
-  long double t;
-  __asm__(
-      "xxlor %0,%x1,%x1;\n"
-      "\txxswapd %L0,%x1;\n"
-      : "=f" (t)
-      : "wa" (lval)
-      : );
-  return (t);
-#else
-  U_128 t;
-  t.vf2 = lval;
-  return (t.ldbl128);
-#endif
-}
 
 /** \brief Vector double absolute value.
  *
@@ -154,6 +223,49 @@ vec_absf64 (vf64_t vf64x)
 #endif
 }
 
+/** \brief Return true if all 2x64-bit vector double values are Finite
+ *  (Not NaN nor Inf).
+ *
+ *  A IEEE Binary64 finite value has an exponent between 0x000 and
+ *  0x7fe (a 0x7ff indicates NaN or Inf).  The significand can be
+ *  any value.
+ *  The sign bit is ignored.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 4-20  | 2/cycle  |
+ *  |power9   |   6   | 1/cycle  |
+ *
+ *  \note This function will not raise VXSNAN or VXVC (FE_INVALID)
+ *  exceptions. A normal __binary64 compare can.
+ *
+ *  @param vf64 a vector of __binary64 values.
+ *  @return an int containing 0 or 1.
+ */
+static inline int
+vec_all_isfinitef64 (vf64_t vf64)
+{
+  vui64_t tmp;
+#if _ARCH_PWR9
+  const vui64_t vec_zero = CONST_VINT128_DW(0, 0);
+#ifdef vec_test_data_class
+  tmp = (vui64_t)vec_test_data_class (vf64, 0x70);
+#else
+  __asm__(
+      "xvtstdcdp %x0,%x1,0x70;\n"
+      : "=wa" (tmp)
+      : "wf" (vf64)
+      :);
+#endif
+  return vec_all_eq(tmp, vec_zero);
+#else
+  const vui64_t expmask = CONST_VINT128_DW(0x7ff0000000000000UL,
+					   0x7ff0000000000000UL);
+  tmp = vec_and ((vui64_t)vf64, expmask);
+  return !vec_cmpud_any_eq(tmp, expmask);
+#endif
+}
+
 /** \brief Return true if all 2x64-bit vector double values
  *  are infinity.
  *
@@ -167,7 +279,7 @@ vec_absf64 (vf64_t vf64x)
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
  *  |power8   | 6-20  | 2/cycle  |
- *  |power9   | 5-14  | 2/cycle  |
+ *  |power9   |   6   | 1/cycle  |
  *
  *  @param vf64 a vector of __binary64 values.
  *  @return boolean int, true if all 2 double values are infinity
@@ -176,24 +288,27 @@ static inline int
 vec_all_isinff64 (vf64_t vf64)
 {
   vui64_t tmp;
-  const vui64_t expmask = CONST_VINT128_DW(0x7ff0000000000000UL,
-					   0x7ff0000000000000UL);
-  int result;
 
 #if _ARCH_PWR9
-  /* P9 has a 2 cycle xvabsdp and eliminates a const load. */
-  tmp = (vui64_t) vec_abs (vf64);
+  const vui64_t vec_ones = CONST_VINT128_DW(-1, -1);
+#ifdef vec_test_data_class
+  tmp = (vui64_t)vec_test_data_class (vf64, 0x40);
+#else
+  __asm__(
+      "xvtstdcdp %x0,%x1,0x30;\n"
+      : "=wa" (tmp)
+      : "wf" (vf64)
+      :);
+#endif
+  return vec_all_eq(tmp, vec_ones);
 #else
   const vui64_t signmask = CONST_VINT128_DW(0x8000000000000000UL,
 					    0x8000000000000000UL);
+  const vui64_t expmask = CONST_VINT128_DW(0x7ff0000000000000UL,
+					   0x7ff0000000000000UL);
   tmp = vec_andc ((vui64_t)vf64, signmask);
+  return vec_cmpud_all_eq(tmp, expmask);
 #endif
-#if _ARCH_PWR8
-  result = vec_all_eq(tmp, expmask);
-#else
-  result = vec_cmpud_all_eq(tmp, expmask);
-#endif
-  return (result);
 }
 
 /** \brief Return true if all 2x64-bit vector double
@@ -209,7 +324,7 @@ vec_all_isinff64 (vf64_t vf64)
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
  *  |power8   | 6-20  | 2/cycle  |
- *  |power9   | 5-14  | 2/cycle  |
+ *  |power9   |   6   | 1/cycle  |
  *
  *  @param vf64 a vector of __binary64 values.
  *  @return a boolean int, true if all 2 vector double values are
@@ -218,25 +333,28 @@ vec_all_isinff64 (vf64_t vf64)
 static inline int
 vec_all_isnanf64 (vf64_t vf64)
 {
-  vui64_t tmp2;
-  const vui64_t expmask = CONST_VINT128_DW(0x7ff0000000000000UL,
-					   0x7ff0000000000000UL);
-  int result;
+  vui64_t tmp;
 
 #if _ARCH_PWR9
-  /* P9 has a 2 cycle xvabsdp and eliminates a const load. */
-  tmp2 = (vui64_t) vec_abs (vf64);
+  const vui64_t vec_ones = CONST_VINT128_DW(-1, -1);
+#ifdef vec_test_data_class
+  tmp = (vui64_t)vec_test_data_class (vf64, 0x40);
+#else
+  __asm__(
+      "xvtstdcdp %x0,%x1,0x40;\n"
+      : "=wa" (tmp)
+      : "wf" (vf64)
+      :);
+#endif
+  return vec_all_eq(tmp, vec_ones);
 #else
   const vui64_t signmask = CONST_VINT128_DW(0x8000000000000000UL,
 					    0x8000000000000000UL);
-  tmp2 = vec_andc ((vui64_t)vf64, signmask);
+  const vui64_t expmask = CONST_VINT128_DW(0x7ff0000000000000UL,
+					   0x7ff0000000000000UL);
+  tmp = vec_andc ((vui64_t)vf64, signmask);
+  return vec_cmpud_all_gt(tmp, expmask);
 #endif
-#if _ARCH_PWR8
-  result = vec_all_gt(tmp2, expmask);
-#else
-  result = vec_cmpud_all_gt(tmp2, expmask);
-#endif
-  return (result);
 }
 
 /** \brief Return true if all 2x64-bit vector double
@@ -253,7 +371,7 @@ vec_all_isnanf64 (vf64_t vf64)
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
  *  |power8   | 10-28 | 1/cycle  |
- *  |power9   | 8-16  | 1/cycle  |
+ *  |power9   |   6   | 1/cycle  |
  *
  *  @param vf64 a vector of __binary64 values.
  *  @return a boolean int, true if all 2 vector double values are
@@ -263,16 +381,24 @@ static inline int
 vec_all_isnormalf64 (vf64_t vf64)
 {
   vui64_t tmp;
+  const vui64_t vec_zero = CONST_VINT128_DW(0, 0);
+#if _ARCH_PWR9
+#ifdef vec_test_data_class
+  tmp = (vui64_t)vec_test_data_class (vf64, 0x7f);
+#else
+  __asm__(
+      "xvtstdcdp %x0,%x1,0x7f;\n"
+      : "=wa" (tmp)
+      : "wf" (vf64)
+      :);
+#endif
+  return vec_all_eq(tmp, vec_zero);
+#else
   const vui64_t expmask = CONST_VINT128_DW(0x7ff0000000000000UL,
 					   0x7ff0000000000000UL);
-  const vui64_t veczero = CONST_VINT128_DW(0, 0);
-
   tmp = vec_and ((vui64_t) vf64, expmask);
-#ifdef _ARCH_PWR8
-  return !(vec_any_eq (tmp, expmask) || vec_any_eq(tmp, veczero));
-#else
   return !(vec_cmpud_any_eq (tmp, expmask)
-        || vec_cmpud_any_eq (tmp, veczero));
+        || vec_cmpud_any_eq (tmp, vec_zero));
 #endif
 }
 
@@ -289,7 +415,7 @@ vec_all_isnormalf64 (vf64_t vf64)
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
  *  |power8   | 10-30 | 1/cycle  |
- *  |power9   | 10-19 | 1/cycle  |
+ *  |power9   |   6   | 1/cycle  |
  *
  *  @param vf64 a vector of __binary64 values.
  *  @return a boolean int, true if all of 2 vector double values are
@@ -298,26 +424,30 @@ vec_all_isnormalf64 (vf64_t vf64)
 static inline int
 vec_all_issubnormalf64 (vf64_t vf64)
 {
-  vui64_t tmp2;
-  const vui64_t minnorm = CONST_VINT128_DW(0x0010000000000000UL,
-					   0x0010000000000000UL);
-  const vui64_t vec_zero = CONST_VINT128_DW(0, 0);
-  int result;
+  vui64_t tmp;
 
 #if _ARCH_PWR9
-  /* P9 has a 2 cycle xvabsdp and eliminates a const load. */
-  tmp2 = (vui64_t) vec_abs (vf64);
+  const vui64_t vec_ones = CONST_VINT128_DW(-1, -1);
+#ifdef vec_test_data_class
+  tmp = (vui64_t)vec_test_data_class (vf64, 0x03);
+#else
+  __asm__(
+      "xvtstdcdp %x0,%x1,0x03;\n"
+      : "=wa" (tmp)
+      : "wf" (vf64)
+      :);
+#endif
+  return vec_all_eq(tmp, vec_ones);
 #else
   const vui64_t signmask = CONST_VINT128_DW(0x8000000000000000UL,
 					    0x8000000000000000UL);
-  tmp2 = vec_andc ((vui64_t)vf64, signmask);
+  const vui64_t minnorm = CONST_VINT128_DW(0x0010000000000000UL,
+					   0x0010000000000000UL);
+  const vui64_t vec_zero = CONST_VINT128_DW(0, 0);
+
+  tmp = vec_andc ((vui64_t)vf64, signmask);
+  return vec_cmpud_all_gt (minnorm, tmp) && !vec_cmpud_all_eq (tmp, vec_zero);
 #endif
-#if _ARCH_PWR8
-  result = vec_all_lt (tmp2, minnorm) && !vec_all_eq (tmp2, vec_zero);
-#else
-  result = vec_cmpud_all_gt (minnorm, tmp2) && !vec_cmpud_all_eq (tmp2, vec_zero);
-#endif
-  return (result);
 }
 
 /** \brief Return true if all 2x64-bit vector double
@@ -333,7 +463,7 @@ vec_all_issubnormalf64 (vf64_t vf64)
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
  *  |power8   | 6-20  | 2/cycle  |
- *  |power9   | 5     | 2/cycle  |
+ *  |power9   |   6   | 1/cycle  |
  *
  *  @param vf64 a vector of __binary64 values.
  *  @return a boolean int, true if all 2 vector double values are
@@ -342,24 +472,71 @@ vec_all_issubnormalf64 (vf64_t vf64)
 static inline int
 vec_all_iszerof64 (vf64_t vf64)
 {
-  vui64_t tmp2;
-  const vui64_t vec_zero = CONST_VINT128_DW(0, 0);
-  int result;
+  vui64_t tmp;
 
 #if _ARCH_PWR9
-  /* P9 has a 2 cycle xvabsdp and eliminates a const load. */
-  tmp2 = (vui64_t) vec_abs (vf64);
+  const vui64_t vec_ones = CONST_VINT128_DW(-1, -1);
+#ifdef vec_test_data_class
+  tmp = (vui64_t)vec_test_data_class (vf64, 0x0c);
+#else
+  __asm__(
+      "xvtstdcdp %x0,%x1,0x0c;\n"
+      : "=wa" (tmp)
+      : "wf" (vf64)
+      :);
+#endif
+  return vec_all_eq(tmp, vec_ones);
 #else
   const vui64_t signmask = CONST_VINT128_DW(0x8000000000000000UL,
 					    0x8000000000000000UL);
-  tmp2 = vec_andc ((vui64_t)vf64, signmask);
+  const vui64_t vec_zero = CONST_VINT128_DW(0, 0);
+
+  tmp = vec_andc ((vui64_t)vf64, signmask);
+  return vec_all_eq((vui32_t)tmp, (vui32_t)vec_zero);
 #endif
-#if _ARCH_PWR8
-  result = vec_all_eq(tmp2, vec_zero);
+}
+
+/** \brief Return true if any of 2x64-bit vector double values are
+ *  Finite (Not NaN nor Inf).
+ *
+ *  A IEEE Binary64 finite value has an exponent between 0x000 and
+ *  0x7fe (a 0x7ff indicates NaN or Inf).  The significand can be
+ *  any value.
+ *  The sign bit is ignored.
+ *
+ *  \note This function will not raise VXSNAN or VXVC (FE_INVALID)
+ *  exceptions. A normal double compare can.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 4-20  | 2/cycle  |
+ *  |power9   |   6   | 1/cycle  |
+ *
+ *  @param vf64 a vector of __binary64 values.
+ *  @return an int containing 0 or 1.
+ */
+static inline int
+vec_any_isfinitef64 (vf64_t vf64)
+{
+  vui64_t tmp;
+#if _ARCH_PWR9
+  const vui64_t vec_zero = CONST_VINT128_DW(0, 0);
+#ifdef vec_test_data_class
+  tmp = (vui64_t)vec_test_data_class (vf64, 0x70);
 #else
-  result = vec_all_eq((vui32_t)tmp2, (vui32_t)vec_zero);
+  __asm__(
+      "xvtstdcdp %x0,%x1,0x70;\n"
+      : "=wa" (tmp)
+      : "wf" (vf64)
+      :);
 #endif
-  return (result);
+  return vec_any_eq(tmp, vec_zero);
+#else
+  const vui64_t expmask = CONST_VINT128_DW(0x7ff0000000000000UL,
+					   0x7ff0000000000000UL);
+  tmp = vec_and ((vui64_t)vf64, expmask);
+  return !vec_cmpud_all_eq(tmp, expmask);
+#endif
 }
 
 /** \brief Return true if any of 2x64-bit vector double values
@@ -374,7 +551,7 @@ vec_all_iszerof64 (vf64_t vf64)
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
  *  |power8   | 6-20  | 2/cycle  |
- *  |power9   | 5-14  | 2/cycle  |
+ *  |power9   |   6   | 1/cycle  |
  *
  *  @param vf64 a vector of __binary32 values.
  *  @return boolean int, true if any of 2 double values are infinity
@@ -383,24 +560,27 @@ static inline int
 vec_any_isinff64 (vf64_t vf64)
 {
   vui64_t tmp;
-  const vui64_t expmask = CONST_VINT128_DW(0x7ff0000000000000UL,
-					   0x7ff0000000000000UL);
-  int result;
 
 #if _ARCH_PWR9
-  /* P9 has a 2 cycle xvabsdp and eliminates a const load. */
-  tmp = (vui64_t) vec_abs (vf64);
+  const vui64_t vec_ones = CONST_VINT128_DW(-1, -1);
+#ifdef vec_test_data_class
+  tmp = (vui64_t)vec_test_data_class (vf64, 0x30);
 #else
+  __asm__(
+      "xvtstdcdp %x0,%x1,0x30;\n"
+      : "=wa" (tmp)
+      : "wf" (vf64)
+      :);
+#endif
+  return vec_all_eq(tmp, vec_ones);
+#else
+  const vui64_t expmask = CONST_VINT128_DW(0x7ff0000000000000UL,
+					   0x7ff0000000000000UL);
   const vui64_t signmask = CONST_VINT128_DW(0x8000000000000000UL,
 					    0x8000000000000000UL);
   tmp = vec_andc ((vui64_t)vf64, signmask);
+  return vec_cmpud_any_eq(tmp, expmask);
 #endif
-#if _ARCH_PWR8
-  result = vec_any_eq(tmp, expmask);
-#else
-  result = vec_cmpud_any_eq(tmp, expmask);
-#endif
-  return (result);
 }
 
 /** \brief Return true if any of 2x64-bit vector double
@@ -416,7 +596,7 @@ vec_any_isinff64 (vf64_t vf64)
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
  *  |power8   | 6-20  | 2/cycle  |
- *  |power9   | 5-14  | 2/cycle  |
+ *  |power9   |   6   | 1/cycle  |
  *
  *  @param vf64 a vector of __binary64 values.
  *  @return a boolean int, true if any of 2 vector double values are
@@ -425,25 +605,28 @@ vec_any_isinff64 (vf64_t vf64)
 static inline int
 vec_any_isnanf64 (vf64_t vf64)
 {
-  vui64_t tmp2;
-  const vui64_t expmask = CONST_VINT128_DW(0x7ff0000000000000UL,
-					   0x7ff0000000000000UL);
-  int result;
+  vui64_t tmp;
 
 #if _ARCH_PWR9
-  /* P9 has a 2 cycle xvabsdp and eliminates a const load. */
-  tmp2 = (vui64_t) vec_abs (vf64);
+  const vui64_t vec_ones = CONST_VINT128_DW(-1, -1);
+#ifdef vec_test_data_class
+  tmp = (vui64_t)vec_test_data_class (vf64, 0x40);
+#else
+  __asm__(
+      "xvtstdcdp %x0,%x1,0x40;\n"
+      : "=wa" (tmp)
+      : "wf" (vf64)
+      :);
+#endif
+  return vec_all_eq(tmp, vec_ones);
 #else
   const vui64_t signmask = CONST_VINT128_DW(0x8000000000000000UL,
 					    0x8000000000000000UL);
-  tmp2 = vec_andc ((vui64_t)vf64, signmask);
+  const vui64_t expmask = CONST_VINT128_DW(0x7ff0000000000000UL,
+					   0x7ff0000000000000UL);
+  tmp = vec_andc ((vui64_t)vf64, signmask);
+  return vec_cmpud_any_gt(tmp, expmask);
 #endif
-#if _ARCH_PWR8
-  result = vec_any_gt(tmp2, expmask);
-#else
-  result = vec_cmpud_any_gt(tmp2, expmask);
-#endif
-  return (result);
 }
 
 /** \brief Return true if any of 2x64-bit vector double
@@ -460,7 +643,7 @@ vec_any_isnanf64 (vf64_t vf64)
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
  *  |power8   | 6-20  | 1/cycle  |
- *  |power9   | 5-14  | 1/cycle  |
+ *  |power9   |   6   | 1/cycle  |
  *
  *  @param vf64 a vector of __binary64 values.
  *  @return a boolean int, true if any of 2 vector double values are
@@ -469,19 +652,28 @@ vec_any_isnanf64 (vf64_t vf64)
 static inline int
 vec_any_isnormalf64 (vf64_t vf64)
 {
-  vui64_t tmp, res;
+  const vui64_t vec_zero = CONST_VINT128_DW(0, 0);
+  vui64_t tmp;
+#if _ARCH_PWR9
+#ifdef vec_test_data_class
+  tmp = (vui64_t)vec_test_data_class (vf64, 0x7f);
+#else
+  __asm__(
+      "xvtstdcdp %x0,%x1,0x7f;\n"
+      : "=wa" (tmp)
+      : "wf" (vf64)
+      :);
+#endif
+  return vec_all_eq(tmp, vec_zero);
+#else
+  vui64_t res;
   const vui64_t expmask = CONST_VINT128_DW(0x7ff0000000000000UL,
 					   0x7ff0000000000000UL);
-  const vui64_t veczero = CONST_VINT128_DW(0, 0);
 
   tmp = vec_and ((vui64_t) vf64, expmask);
-#ifdef _ARCH_PWR8
-  res = (vui64_t) vec_nor (vec_cmpeq (tmp, expmask), vec_cmpeq (tmp, veczero));
-  return vec_any_gt(res, veczero);
-#else
   res = (vui64_t) vec_nor (vec_cmpequd (tmp, expmask),
-			   vec_cmpequd (tmp, veczero));
-  return vec_cmpud_any_gt (res, veczero);
+			   vec_cmpequd (tmp, vec_zero));
+  return vec_cmpud_any_gt (res, vec_zero);
 #endif
 }
 
@@ -498,7 +690,7 @@ vec_any_isnormalf64 (vf64_t vf64)
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
  *  |power8   | 10-18 | 1/cycle  |
- *  |power9   | 14    | 1/cycle  |
+ *  |power9   |   6   | 1/cycle  |
  *
  *  @param vf64 a vector of __binary64 values.
  *  @return true if any of 2 vector double values are subnormal.
@@ -506,33 +698,34 @@ vec_any_isnormalf64 (vf64_t vf64)
 static inline int
 vec_any_issubnormalf64 (vf64_t vf64)
 {
-  vui64_t tmp, tmpz, tmp2;
-  const vui64_t minnorm = CONST_VINT128_DW(0x0010000000000000UL,
-					   0x0010000000000000UL);
-  const vui64_t vec_zero = CONST_VINT128_DW(0, 0);
-  vb64_t vsubnorm;
-  int result;
+  vui64_t tmp;
 
 #if _ARCH_PWR9
-  /* P9 has a 2 cycle xvabsdp and eliminates a const load. */
-  tmp2 = (vui64_t) vec_abs (vf64);
+  const vui64_t vec_ones = CONST_VINT128_DW(-1, -1);
+#ifdef vec_test_data_class
+  tmp = (vui64_t)vec_test_data_class (vf64, 0x03);
+#else
+  __asm__(
+      "xvtstdcdp %x0,%x1,0x03;\n"
+      : "=wa" (tmp)
+      : "wf" (vf64)
+      :);
+#endif
+  return vec_all_eq(tmp, vec_ones);
 #else
   const vui64_t signmask = CONST_VINT128_DW(0x8000000000000000UL,
 					    0x8000000000000000UL);
+  const vui64_t minnorm = CONST_VINT128_DW(0x0010000000000000UL,
+					   0x0010000000000000UL);
+  const vui64_t vec_zero = CONST_VINT128_DW(0, 0);
+  vui64_t tmpz, tmp2, vsubnorm;
+
   tmp2 = vec_andc ((vui64_t)vf64, signmask);
-#endif
-#ifdef _ARCH_PWR8
-  tmp = (vui64_t) vec_cmplt(tmp2, minnorm);
-  tmpz = (vui64_t) vec_cmpeq (tmp2, vec_zero);
-  vsubnorm = (vb64_t) vec_andc (tmp, tmpz);
-  result = vec_any_ne(vsubnorm, vec_zero);
-#else
   tmp = (vui64_t) vec_cmpltud(tmp2, minnorm);
   tmpz = (vui64_t) vec_cmpequd (tmp2, vec_zero);
-  vsubnorm = (vb64_t) vec_andc (tmp, tmpz);
-  result = vec_cmpud_any_ne((vui64_t)vsubnorm, vec_zero);
+  vsubnorm = vec_andc (tmp, tmpz);
+  return vec_cmpud_any_ne(vsubnorm, vec_zero);
 #endif
-  return (result);
 }
 
 /** \brief Return true if any of 2x64-bit vector double
@@ -548,7 +741,7 @@ vec_any_issubnormalf64 (vf64_t vf64)
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
  *  |power8   | 6-20  | 2/cycle  |
- *  |power9   | 5     | 2/cycle  |
+ *  |power9   |   6   | 1/cycle  |
  *
  *  @param vf64 a vector of __binary64 values.
  *  @return a boolean int, true if any of 2 vector double values are
@@ -557,26 +750,27 @@ vec_any_issubnormalf64 (vf64_t vf64)
 static inline int
 vec_any_iszerof64 (vf64_t vf64)
 {
-  vui64_t tmp2;
-  const vui64_t vec_zero = CONST_VINT128_DW(0, 0);
-  int result;
+  vui64_t tmp;
 
 #if _ARCH_PWR9
-  /* P9 has a 2 cycle xvabsdp and eliminates a const load. */
-  tmp2 = (vui64_t) vec_abs (vf64);
+  const vui64_t vec_ones = CONST_VINT128_DW(-1, -1);
+#ifdef vec_test_data_class
+  tmp = (vui64_t)vec_test_data_class (vf64, 0x0c);
+#else
+  __asm__(
+      "xvtstdcdp %x0,%x1,0x0c;\n"
+      : "=wa" (tmp)
+      : "wf" (vf64)
+      :);
+#endif
+  return vec_all_eq(tmp, vec_ones);
 #else
   const vui64_t signmask = CONST_VINT128_DW(0x8000000000000000UL,
 					    0x8000000000000000UL);
-  tmp2 = vec_andc ((vui64_t)vf64, signmask);
+  const vui64_t vec_zero = CONST_VINT128_DW(0, 0);
+  tmp = vec_andc ((vui64_t)vf64, signmask);
+  return vec_cmpud_any_eq(tmp, vec_zero);
 #endif
-  result = vec_any_eq(tmp2, vec_zero);
-#if _ARCH_PWR8
-  /* P8 has Vector Compare Equal To Unsigned Doubleword. */
-  result = vec_any_eq(tmp2, vec_zero);
-#else
-  result = vec_cmpud_any_eq(tmp2, vec_zero);
-#endif
-  return (result);
 }
 
 /** \brief Copy the sign bit from vf64y merged with magnitude from
@@ -607,6 +801,55 @@ vec_copysignf64 (vf64_t vf64x , vf64_t vf64y)
 #endif
 }
 
+/** \brief Return 2x64-bit vector boolean true values for each double
+ *  element that is Finite (Not NaN nor Inf).
+ *
+ *  A IEEE Binary64 finite value has an exponent between 0x000 and
+ *  0x7fe (a 0x7ff indicates NaN or Inf).  The significand can be
+ *  any value.
+ *
+ *  Using the vec_cmpeq conditional to generate the predicate mask for
+ *  NaN / Inf and then invert this for the finite condition.
+ *  The sign bit is ignored.
+ *
+ *  \note This function will not raise VXSNAN or VXVC (FE_INVALID)
+ *  exceptions. A normal double compare can.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 6-15  | 2/cycle  |
+ *  |power9   |   5   | 2/cycle  |
+ *
+ *  @param vf64 a vector of __binary64 values.
+ *  @return a vector boolean long, each containing all 0s(false)
+ *  or 1s(true).
+ */
+static inline vb64_t
+vec_isfinitef64 (vf64_t vf64)
+{
+  vb64_t tmp2;
+#if defined (_ARCH_PWR9)
+#ifdef vec_test_data_class
+  tmp2 = vec_test_data_class (vf64, 0x70);
+#else
+  __asm__(
+      "xvtstdcdp %x0,%x1,0x70;\n"
+      : "=wa" (tmp2)
+      : "wf" (vf64)
+      :);
+#endif
+  return vec_nor (tmp2, tmp2); // vec_not
+#else
+  const vui64_t expmask = CONST_VINT128_DW(0x7ff0000000000000UL,
+					   0x7ff0000000000000UL);
+  vui64_t tmp;
+
+  tmp = vec_and ((vui64_t)vf64, expmask);
+  tmp2 = vec_cmpequd (tmp, expmask);
+  return vec_nor (tmp2, tmp2); // vec_not
+#endif
+}
+
 /** \brief Return 2x64-bit vector boolean true values for each double,
  *  if infinity.
  *
@@ -619,7 +862,7 @@ vec_copysignf64 (vf64_t vf64x , vf64_t vf64y)
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
  *  |power8   | 4-13  | 2/cycle  |
- *  |power9   | 5-14  | 2/cycle  |
+ *  |power9   |   3   | 2/cycle  |
  *
  *  @param vf64 a vector of __binary64 values.
  *  @return a vector boolean long long, each containing all 0s(false)
@@ -628,24 +871,25 @@ vec_copysignf64 (vf64_t vf64x , vf64_t vf64y)
 static inline vb64_t
 vec_isinff64 (vf64_t vf64)
 {
-  vui64_t tmp;
-  const vui64_t expmask = CONST_VINT128_DW(0x7ff0000000000000UL,
-					   0x7ff0000000000000UL);
   vb64_t result;
 
 #if _ARCH_PWR9
-  /* P9 has a 2 cycle xvabsdp and eliminates a const load. */
-  tmp = (vui64_t)vec_abs (vf64);
+#ifdef vec_test_data_class
+  result = vec_test_data_class (vf64, 0x30);
 #else
+  __asm__(
+      "xvtstdcdp %x0,%x1,0x30;\n"
+      : "=wa" (result)
+      : "wf" (vf64)
+      :);
+#endif
+#else
+  vui64_t tmp;
+  const vui64_t expmask = CONST_VINT128_DW(0x7ff0000000000000UL,
+					   0x7ff0000000000000UL);
   const vui64_t signmask = CONST_VINT128_DW(0x8000000000000000UL,
 					    0x8000000000000000UL);
   tmp = vec_andc ((vui64_t) vf64, signmask);
-#endif
-#if _ARCH_PWR8
-  /* P8 has Vector Compare Equal To Unsigned Doubleword. */
-  result = vec_cmpeq (tmp, expmask);
-#else
-  /* P7 and earlier only have word compares. */
   result = (vb64_t)vec_cmpequd (tmp, expmask);
 #endif
   return (result);
@@ -661,7 +905,7 @@ vec_isinff64 (vf64_t vf64)
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
  *  |power8   | 4-13  | 2/cycle  |
- *  |power9   | 5-14  | 2/cycle  |
+ *  |power9   |   3   | 2/cycle  |
  *
  *  @param vf64 a vector of __binary64 values.
  *  @return a vector boolean long long, each containing all 0s(false)
@@ -670,25 +914,26 @@ vec_isinff64 (vf64_t vf64)
 static inline vb64_t
 vec_isnanf64 (vf64_t vf64)
 {
-  vui64_t tmp2;
-  const vui64_t expmask = CONST_VINT128_DW(0x7ff0000000000000UL,
-					   0x7ff0000000000000UL);
   vb64_t result;
 
 #if _ARCH_PWR9
-  /* P9 has a 2 cycle xvabsdp and eliminates a const load. */
-  tmp2 = (vui64_t) vec_abs (vf64);
+#ifdef vec_test_data_class
+  result = vec_test_data_class (vf64, 0x40);
 #else
+  __asm__(
+      "xvtstdcdp %x0,%x1,0x40;\n"
+      : "=wa" (result)
+      : "wf" (vf64)
+      :);
+#endif
+#else
+  vui64_t tmp;
+  const vui64_t expmask = CONST_VINT128_DW(0x7ff0000000000000UL,
+					   0x7ff0000000000000UL);
   const vui64_t signmask = CONST_VINT128_DW(0x8000000000000000UL,
 					    0x8000000000000000UL);
-  tmp2 = vec_andc ((vui64_t)vf64, signmask);
-#endif
-#if _ARCH_PWR8
-  /* P8 has Vector Compare Equal To Unsigned Doubleword. */
-  result = vec_cmpgt (tmp2, expmask);
-#else
-  /* P7 and earlier only have word compares. */
-  result = (vb64_t)vec_cmpgtud (tmp2, expmask);
+  tmp = vec_andc ((vui64_t)vf64, signmask);
+  result = (vb64_t)vec_cmpgtud (tmp, expmask);
 #endif
   return (result);
 }
@@ -706,7 +951,7 @@ vec_isnanf64 (vf64_t vf64)
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
  *  |power8   | 6-15  | 1/cycle  |
- *  |power9   | 7-16  | 1/cycle  |
+ *  |power9   |   5   | 1/cycle  |
  *
  *  @param vf64 a vector of __binary64 values.
  *  @return a vector boolean long long, each containing all 0s(false)
@@ -715,21 +960,28 @@ vec_isnanf64 (vf64_t vf64)
 static inline vb64_t
 vec_isnormalf64 (vf64_t vf64)
 {
+#if _ARCH_PWR9
+  vb64_t tmp2;
+#ifdef vec_test_data_class
+  tmp2 = vec_test_data_class (vf64, 0x7f);
+#else
+  __asm__(
+      "xvtstdcdp %x0,%x1,0x7f;\n"
+      : "=wa" (tmp2)
+      : "wf" (vf64)
+      :);
+#endif
+  return vec_nor (tmp2, tmp2); // vec_not
+#else
   const vui64_t expmask = CONST_VINT128_DW(0x7ff0000000000000UL,
 					   0x7ff0000000000000UL);
   const vui64_t veczero = CONST_VINT128_DW(0UL, 0UL);
   vui64_t tmp;
-  vb64_t result;
 
   tmp = vec_and ((vui64_t) vf64, expmask);
-#ifdef _ARCH_PWR8
-  result = (vb64_t) vec_nor (vec_cmpeq (tmp, expmask),
-			     vec_cmpeq (tmp, veczero));
-#else
-  result = (vb64_t) vec_nor (vec_cmpequd (tmp, expmask),
-			     vec_cmpequd (tmp, veczero));
+  return (vb64_t) vec_nor (vec_cmpequd (tmp, expmask),
+			   vec_cmpequd (tmp, veczero));
 #endif
-  return (result);
 }
 
 /** \brief Return 2x64-bit vector boolean true values, for each double
@@ -745,7 +997,7 @@ vec_isnormalf64 (vf64_t vf64)
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
  *  |power8   | 6-16  | 1/cycle  |
- *  |power9   | 7-16  | 1/cycle  |
+ *  |power9   |   3   | 1/cycle  |
  *
  *  @param vf64 a vector of __binary64 values.
  *  @return a vector boolean long long, each containing all 0s(false)
@@ -754,28 +1006,28 @@ vec_isnormalf64 (vf64_t vf64)
 static inline vb64_t
 vec_issubnormalf64 (vf64_t vf64)
 {
-  vui64_t tmp, tmpz, tmp2;
-  const vui64_t minnorm = CONST_VINT128_DW(0x0010000000000000UL,
-					   0x0010000000000000UL);
-  const vui64_t vec_zero = CONST_VINT128_DW(0, 0);
   vb64_t result;
 
 #if _ARCH_PWR9
-  /* P9 has a 2 cycle xvabsdp and eliminates a const load. */
-  tmp2 = (vui64_t) vec_abs (vf64);
+#ifdef vec_test_data_class
+  result = vec_test_data_class (vf64, 0x03);
 #else
+  __asm__(
+      "xvtstdcdp %x0,%x1,0x03;\n"
+      : "=wa" (result)
+      : "wf" (vf64)
+      :);
+#endif
+#else
+  vui64_t tmp;
+  const vui64_t minnorm = CONST_VINT128_DW(0x0010000000000000UL,
+					   0x0010000000000000UL);
+  const vui64_t vec_zero = CONST_VINT128_DW(0, 0);
   const vui64_t signmask = CONST_VINT128_DW(0x8000000000000000UL,
 					    0x8000000000000000UL);
-  tmp2 = vec_andc ((vui64_t) vf64, signmask);
-#endif
-#ifdef _ARCH_PWR8
-  tmp = (vui64_t) vec_cmplt(tmp2, minnorm);
-  tmpz = (vui64_t) vec_cmpeq (tmp2, vec_zero);
-  result = (vb64_t) vec_andc (tmp, tmpz);
-#else
-  tmp = (vui64_t) vec_cmpltud(tmp2, minnorm);
-  tmpz = (vui64_t) vec_cmpequd (tmp2, vec_zero);
-  result = (vb64_t ) vec_andc (tmp, tmpz);
+  tmp = vec_andc ((vui64_t) vf64, signmask);
+  result = vec_andc (vec_cmpltud (tmp, minnorm),
+		     vec_cmpequd (tmp, vec_zero));
 #endif
   return (result);
 }
@@ -793,7 +1045,7 @@ vec_issubnormalf64 (vf64_t vf64)
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
  *  |power8   | 4-13  | 2/cycle  |
- *  |power9   | 5     | 2/cycle  |
+ *  |power9   |   3   | 2/cycle  |
  *
  *  @param vf64 a vector of __binary32 values.
  *  @return a vector boolean int, each containing all 0s(false)
@@ -802,26 +1054,75 @@ vec_issubnormalf64 (vf64_t vf64)
 static inline vb64_t
 vec_iszerof64 (vf64_t vf64)
 {
-  vui64_t tmp2;
-  const vui64_t vec_zero = CONST_VINT128_DW(0, 0);
   vb64_t result;
 
 #if _ARCH_PWR9
-  /* P9 has a 2 cycle xvabsdp and eliminates a const load. */
-  tmp2 = (vui64_t) vec_abs (vf64);
+#ifdef vec_test_data_class
+  result = vec_test_data_class (vf64, 0x0c);
 #else
+  __asm__(
+      "xvtstdcdp %x0,%x1,0x0c;\n"
+      : "=wa" (result)
+      : "wf" (vf64)
+      :);
+#endif
+#else
+  vui64_t tmp2;
+  const vui64_t vec_zero = CONST_VINT128_DW(0, 0);
   const vui64_t signmask = CONST_VINT128_DW(0x8000000000000000UL,
 					    0x8000000000000000UL);
   tmp2 = vec_andc ((vui64_t)vf64, signmask);
-#endif
-#if _ARCH_PWR8
-  /* P8 has Vector Compare Equal To Unsigned Doubleword. */
-  result = vec_cmpeq (tmp2, vec_zero);
-#else
-  /* P7 and earlier only have word compares has. */
   result = (vb64_t)vec_cmpequd (tmp2, vec_zero);
 #endif
   return (result);
+}
+
+/** \brief Copy the pair of doubles from a vector to IBM long double.
+ *
+ *  @param lval vector double values containing the IBM long double.
+ *  @return IBM long double as FPR pair.
+ */
+static inline long double
+vec_pack_longdouble (vf64_t lval)
+{
+#ifdef _ARCH_PWR7
+  long double t;
+  __asm__(
+      "xxlor %0,%x1,%x1;\n"
+      "\txxswapd %L0,%x1;\n"
+      : "=f" (t)
+      : "wa" (lval)
+      : );
+  return (t);
+#else
+  U_128 t;
+  t.vf2 = lval;
+  return (t.ldbl128);
+#endif
+}
+
+/** \brief Copy the pair of doubles from a IBM long double to a vector
+ * double.
+ *
+ *  @param lval IBM long double as FPR pair.
+ *  @return vector double values containing the IBM long double.
+ */
+static inline vf64_t
+vec_unpack_longdouble (long double lval)
+{
+#ifdef _ARCH_PWR7
+  vf64_t t;
+  __asm__(
+      "xxmrghd %x0,%1,%L1;\n"
+      : "=wa" (t)
+      : "f" (lval)
+      : );
+  return (t);
+#else
+  U_128 t;
+  t.ldbl128 = lval;
+  return (t.vf2);
+#endif
 }
 
 #endif /* VEC_F64_PPC_H_ */

--- a/src/vec_f64_ppc.h
+++ b/src/vec_f64_ppc.h
@@ -34,7 +34,7 @@
  * implemented with PowerISA-2.06 Vector Scalar Extended (VSX)
  * (POWER7 and later) instructions. Most VSX instructions provide
  * access to 64 combined scalar/vector registers.
- * PowerISA-3.0 (POWER9) provides additional vector double operations;
+ * PowerISA-3.0 (POWER9) provides additional vector double operations:
  * convert with round, convert to/from integer, insert/extract exponent
  * and significand, and test data class.
  * Most of these operations (compiler built-ins, or intrinsics) are
@@ -58,8 +58,8 @@
  * for float and double.
  * These built-ins are not defined in GCC 6.4. See
  * <a href="https://gcc.gnu.org/onlinedocs/">compiler documentation</a>.
- * These are useful operations and can be implement in a few
- * vector logical instruction for earlier machines.
+ * These are useful operations and can be implemented in a few
+ * vector logical instructions for earlier machines.
  *
  * So it is reasonable for this header to provide vector forms
  * of the double-precision floating point classification functions
@@ -91,11 +91,11 @@
  * functions. Examples include vector double isnan, isinf, etc.
  * - Commonly used operations, not covered by the ABI or <altivec.h>,
  * and require multiple instructions or are not obvious.
- * For example converts that change element size and imply
- * converting two vectors in to one vector of smaller elements, or
+ * For example, converts that change element size and imply
+ * converting two vectors into one vector of smaller elements, or
  * one vector into two vectors of larger elements.
- * Another example the special case of packing/unpacking am IBM long
- * double between a pair of Floating-point registers (FPRs) and a
+ * Another example is the special case of packing/unpacking an IBM long
+ * double between a pair of floating-point registers (FPRs) and a
  * single vector register (VR).
  *
  * \section f64_examples_0_0 Examples
@@ -104,7 +104,7 @@
  * The POSIX specification requires that special input values are
  * processed without raising extraneous floating point exceptions and
  * return specific floating point values in response.
- * For example the sin() function.
+ * For example, the sin() function.
  * - If the input <I>value</I> is NaN then return a NaN.
  * - If the input <I>value</I> is +-0.0 then return <I>value</I>.
  * - If the input <I>value</I> is subnormal then return <I>value</I>.
@@ -217,8 +217,8 @@ vec_absf64 (vf64_t vf64x)
   /* Requires VSX but eliminates a const load. */
   return vec_abs (vf64x);
 #else
-  const vui32_t signmask = CONST_VINT128_DW(0x8000000000000000UL,
-                                            0x8000000000000000UL);
+  const vui32_t signmask = CONST_VINT128_DW (0x8000000000000000UL,
+                                             0x8000000000000000UL);
   return (vf64_t)vec_andc ((vui32_t)vf64x, signmask);
 #endif
 }
@@ -247,7 +247,7 @@ vec_all_isfinitef64 (vf64_t vf64)
 {
   vui64_t tmp;
 #if _ARCH_PWR9
-  const vui64_t vec_zero = CONST_VINT128_DW(0, 0);
+  const vui64_t vec_zero = CONST_VINT128_DW (0, 0);
 #ifdef vec_test_data_class
   tmp = (vui64_t)vec_test_data_class (vf64, 0x70);
 #else
@@ -259,8 +259,8 @@ vec_all_isfinitef64 (vf64_t vf64)
 #endif
   return vec_all_eq(tmp, vec_zero);
 #else
-  const vui64_t expmask = CONST_VINT128_DW(0x7ff0000000000000UL,
-					   0x7ff0000000000000UL);
+  const vui64_t expmask = CONST_VINT128_DW (0x7ff0000000000000UL,
+					    0x7ff0000000000000UL);
   tmp = vec_and ((vui64_t)vf64, expmask);
   return !vec_cmpud_any_eq(tmp, expmask);
 #endif
@@ -290,7 +290,7 @@ vec_all_isinff64 (vf64_t vf64)
   vui64_t tmp;
 
 #if _ARCH_PWR9
-  const vui64_t vec_ones = CONST_VINT128_DW(-1, -1);
+  const vui64_t vec_ones = CONST_VINT128_DW (-1, -1);
 #ifdef vec_test_data_class
   tmp = (vui64_t)vec_test_data_class (vf64, 0x40);
 #else
@@ -302,10 +302,10 @@ vec_all_isinff64 (vf64_t vf64)
 #endif
   return vec_all_eq(tmp, vec_ones);
 #else
-  const vui64_t signmask = CONST_VINT128_DW(0x8000000000000000UL,
-					    0x8000000000000000UL);
-  const vui64_t expmask = CONST_VINT128_DW(0x7ff0000000000000UL,
-					   0x7ff0000000000000UL);
+  const vui64_t signmask = CONST_VINT128_DW (0x8000000000000000UL,
+					     0x8000000000000000UL);
+  const vui64_t expmask = CONST_VINT128_DW (0x7ff0000000000000UL,
+					    0x7ff0000000000000UL);
   tmp = vec_andc ((vui64_t)vf64, signmask);
   return vec_cmpud_all_eq(tmp, expmask);
 #endif
@@ -336,7 +336,7 @@ vec_all_isnanf64 (vf64_t vf64)
   vui64_t tmp;
 
 #if _ARCH_PWR9
-  const vui64_t vec_ones = CONST_VINT128_DW(-1, -1);
+  const vui64_t vec_ones = CONST_VINT128_DW (-1, -1);
 #ifdef vec_test_data_class
   tmp = (vui64_t)vec_test_data_class (vf64, 0x40);
 #else
@@ -348,10 +348,10 @@ vec_all_isnanf64 (vf64_t vf64)
 #endif
   return vec_all_eq(tmp, vec_ones);
 #else
-  const vui64_t signmask = CONST_VINT128_DW(0x8000000000000000UL,
-					    0x8000000000000000UL);
-  const vui64_t expmask = CONST_VINT128_DW(0x7ff0000000000000UL,
-					   0x7ff0000000000000UL);
+  const vui64_t signmask = CONST_VINT128_DW (0x8000000000000000UL,
+					     0x8000000000000000UL);
+  const vui64_t expmask = CONST_VINT128_DW (0x7ff0000000000000UL,
+					    0x7ff0000000000000UL);
   tmp = vec_andc ((vui64_t)vf64, signmask);
   return vec_cmpud_all_gt(tmp, expmask);
 #endif
@@ -381,7 +381,7 @@ static inline int
 vec_all_isnormalf64 (vf64_t vf64)
 {
   vui64_t tmp;
-  const vui64_t vec_zero = CONST_VINT128_DW(0, 0);
+  const vui64_t vec_zero = CONST_VINT128_DW (0, 0);
 #if _ARCH_PWR9
 #ifdef vec_test_data_class
   tmp = (vui64_t)vec_test_data_class (vf64, 0x7f);
@@ -394,8 +394,8 @@ vec_all_isnormalf64 (vf64_t vf64)
 #endif
   return vec_all_eq(tmp, vec_zero);
 #else
-  const vui64_t expmask = CONST_VINT128_DW(0x7ff0000000000000UL,
-					   0x7ff0000000000000UL);
+  const vui64_t expmask = CONST_VINT128_DW (0x7ff0000000000000UL,
+					    0x7ff0000000000000UL);
   tmp = vec_and ((vui64_t) vf64, expmask);
   return !(vec_cmpud_any_eq (tmp, expmask)
         || vec_cmpud_any_eq (tmp, vec_zero));
@@ -427,7 +427,7 @@ vec_all_issubnormalf64 (vf64_t vf64)
   vui64_t tmp;
 
 #if _ARCH_PWR9
-  const vui64_t vec_ones = CONST_VINT128_DW(-1, -1);
+  const vui64_t vec_ones = CONST_VINT128_DW (-1, -1);
 #ifdef vec_test_data_class
   tmp = (vui64_t)vec_test_data_class (vf64, 0x03);
 #else
@@ -439,11 +439,11 @@ vec_all_issubnormalf64 (vf64_t vf64)
 #endif
   return vec_all_eq(tmp, vec_ones);
 #else
-  const vui64_t signmask = CONST_VINT128_DW(0x8000000000000000UL,
-					    0x8000000000000000UL);
-  const vui64_t minnorm = CONST_VINT128_DW(0x0010000000000000UL,
-					   0x0010000000000000UL);
-  const vui64_t vec_zero = CONST_VINT128_DW(0, 0);
+  const vui64_t signmask = CONST_VINT128_DW (0x8000000000000000UL,
+					     0x8000000000000000UL);
+  const vui64_t minnorm = CONST_VINT128_DW (0x0010000000000000UL,
+					    0x0010000000000000UL);
+  const vui64_t vec_zero = CONST_VINT128_DW (0, 0);
 
   tmp = vec_andc ((vui64_t)vf64, signmask);
   return vec_cmpud_all_gt (minnorm, tmp) && !vec_cmpud_all_eq (tmp, vec_zero);
@@ -475,7 +475,7 @@ vec_all_iszerof64 (vf64_t vf64)
   vui64_t tmp;
 
 #if _ARCH_PWR9
-  const vui64_t vec_ones = CONST_VINT128_DW(-1, -1);
+  const vui64_t vec_ones = CONST_VINT128_DW (-1, -1);
 #ifdef vec_test_data_class
   tmp = (vui64_t)vec_test_data_class (vf64, 0x0c);
 #else
@@ -487,9 +487,9 @@ vec_all_iszerof64 (vf64_t vf64)
 #endif
   return vec_all_eq(tmp, vec_ones);
 #else
-  const vui64_t signmask = CONST_VINT128_DW(0x8000000000000000UL,
-					    0x8000000000000000UL);
-  const vui64_t vec_zero = CONST_VINT128_DW(0, 0);
+  const vui64_t signmask = CONST_VINT128_DW (0x8000000000000000UL,
+					     0x8000000000000000UL);
+  const vui64_t vec_zero = CONST_VINT128_DW (0, 0);
 
   tmp = vec_andc ((vui64_t)vf64, signmask);
   return vec_all_eq((vui32_t)tmp, (vui32_t)vec_zero);
@@ -520,7 +520,7 @@ vec_any_isfinitef64 (vf64_t vf64)
 {
   vui64_t tmp;
 #if _ARCH_PWR9
-  const vui64_t vec_zero = CONST_VINT128_DW(0, 0);
+  const vui64_t vec_zero = CONST_VINT128_DW (0, 0);
 #ifdef vec_test_data_class
   tmp = (vui64_t)vec_test_data_class (vf64, 0x70);
 #else
@@ -532,8 +532,8 @@ vec_any_isfinitef64 (vf64_t vf64)
 #endif
   return vec_any_eq(tmp, vec_zero);
 #else
-  const vui64_t expmask = CONST_VINT128_DW(0x7ff0000000000000UL,
-					   0x7ff0000000000000UL);
+  const vui64_t expmask = CONST_VINT128_DW (0x7ff0000000000000UL,
+					    0x7ff0000000000000UL);
   tmp = vec_and ((vui64_t)vf64, expmask);
   return !vec_cmpud_all_eq(tmp, expmask);
 #endif
@@ -562,7 +562,7 @@ vec_any_isinff64 (vf64_t vf64)
   vui64_t tmp;
 
 #if _ARCH_PWR9
-  const vui64_t vec_ones = CONST_VINT128_DW(-1, -1);
+  const vui64_t vec_ones = CONST_VINT128_DW (-1, -1);
 #ifdef vec_test_data_class
   tmp = (vui64_t)vec_test_data_class (vf64, 0x30);
 #else
@@ -574,10 +574,10 @@ vec_any_isinff64 (vf64_t vf64)
 #endif
   return vec_all_eq(tmp, vec_ones);
 #else
-  const vui64_t expmask = CONST_VINT128_DW(0x7ff0000000000000UL,
-					   0x7ff0000000000000UL);
-  const vui64_t signmask = CONST_VINT128_DW(0x8000000000000000UL,
-					    0x8000000000000000UL);
+  const vui64_t expmask = CONST_VINT128_DW (0x7ff0000000000000UL,
+					    0x7ff0000000000000UL);
+  const vui64_t signmask = CONST_VINT128_DW (0x8000000000000000UL,
+					     0x8000000000000000UL);
   tmp = vec_andc ((vui64_t)vf64, signmask);
   return vec_cmpud_any_eq(tmp, expmask);
 #endif
@@ -608,7 +608,7 @@ vec_any_isnanf64 (vf64_t vf64)
   vui64_t tmp;
 
 #if _ARCH_PWR9
-  const vui64_t vec_ones = CONST_VINT128_DW(-1, -1);
+  const vui64_t vec_ones = CONST_VINT128_DW (-1, -1);
 #ifdef vec_test_data_class
   tmp = (vui64_t)vec_test_data_class (vf64, 0x40);
 #else
@@ -620,10 +620,10 @@ vec_any_isnanf64 (vf64_t vf64)
 #endif
   return vec_all_eq(tmp, vec_ones);
 #else
-  const vui64_t signmask = CONST_VINT128_DW(0x8000000000000000UL,
-					    0x8000000000000000UL);
-  const vui64_t expmask = CONST_VINT128_DW(0x7ff0000000000000UL,
-					   0x7ff0000000000000UL);
+  const vui64_t signmask = CONST_VINT128_DW (0x8000000000000000UL,
+					     0x8000000000000000UL);
+  const vui64_t expmask = CONST_VINT128_DW (0x7ff0000000000000UL,
+					    0x7ff0000000000000UL);
   tmp = vec_andc ((vui64_t)vf64, signmask);
   return vec_cmpud_any_gt(tmp, expmask);
 #endif
@@ -652,7 +652,7 @@ vec_any_isnanf64 (vf64_t vf64)
 static inline int
 vec_any_isnormalf64 (vf64_t vf64)
 {
-  const vui64_t vec_zero = CONST_VINT128_DW(0, 0);
+  const vui64_t vec_zero = CONST_VINT128_DW (0, 0);
   vui64_t tmp;
 #if _ARCH_PWR9
 #ifdef vec_test_data_class
@@ -667,8 +667,8 @@ vec_any_isnormalf64 (vf64_t vf64)
   return vec_all_eq(tmp, vec_zero);
 #else
   vui64_t res;
-  const vui64_t expmask = CONST_VINT128_DW(0x7ff0000000000000UL,
-					   0x7ff0000000000000UL);
+  const vui64_t expmask = CONST_VINT128_DW (0x7ff0000000000000UL,
+					    0x7ff0000000000000UL);
 
   tmp = vec_and ((vui64_t) vf64, expmask);
   res = (vui64_t) vec_nor (vec_cmpequd (tmp, expmask),
@@ -701,7 +701,7 @@ vec_any_issubnormalf64 (vf64_t vf64)
   vui64_t tmp;
 
 #if _ARCH_PWR9
-  const vui64_t vec_ones = CONST_VINT128_DW(-1, -1);
+  const vui64_t vec_ones = CONST_VINT128_DW (-1, -1);
 #ifdef vec_test_data_class
   tmp = (vui64_t)vec_test_data_class (vf64, 0x03);
 #else
@@ -713,11 +713,11 @@ vec_any_issubnormalf64 (vf64_t vf64)
 #endif
   return vec_all_eq(tmp, vec_ones);
 #else
-  const vui64_t signmask = CONST_VINT128_DW(0x8000000000000000UL,
-					    0x8000000000000000UL);
-  const vui64_t minnorm = CONST_VINT128_DW(0x0010000000000000UL,
-					   0x0010000000000000UL);
-  const vui64_t vec_zero = CONST_VINT128_DW(0, 0);
+  const vui64_t signmask = CONST_VINT128_DW (0x8000000000000000UL,
+					     0x8000000000000000UL);
+  const vui64_t minnorm = CONST_VINT128_DW (0x0010000000000000UL,
+					    0x0010000000000000UL);
+  const vui64_t vec_zero = CONST_VINT128_DW (0, 0);
   vui64_t tmpz, tmp2, vsubnorm;
 
   tmp2 = vec_andc ((vui64_t)vf64, signmask);
@@ -753,7 +753,7 @@ vec_any_iszerof64 (vf64_t vf64)
   vui64_t tmp;
 
 #if _ARCH_PWR9
-  const vui64_t vec_ones = CONST_VINT128_DW(-1, -1);
+  const vui64_t vec_ones = CONST_VINT128_DW (-1, -1);
 #ifdef vec_test_data_class
   tmp = (vui64_t)vec_test_data_class (vf64, 0x0c);
 #else
@@ -765,9 +765,9 @@ vec_any_iszerof64 (vf64_t vf64)
 #endif
   return vec_all_eq(tmp, vec_ones);
 #else
-  const vui64_t signmask = CONST_VINT128_DW(0x8000000000000000UL,
-					    0x8000000000000000UL);
-  const vui64_t vec_zero = CONST_VINT128_DW(0, 0);
+  const vui64_t signmask = CONST_VINT128_DW (0x8000000000000000UL,
+					     0x8000000000000000UL);
+  const vui64_t vec_zero = CONST_VINT128_DW (0, 0);
   tmp = vec_andc ((vui64_t)vf64, signmask);
   return vec_cmpud_any_eq(tmp, vec_zero);
 #endif
@@ -840,8 +840,8 @@ vec_isfinitef64 (vf64_t vf64)
 #endif
   return vec_nor (tmp2, tmp2); // vec_not
 #else
-  const vui64_t expmask = CONST_VINT128_DW(0x7ff0000000000000UL,
-					   0x7ff0000000000000UL);
+  const vui64_t expmask = CONST_VINT128_DW (0x7ff0000000000000UL,
+					    0x7ff0000000000000UL);
   vui64_t tmp;
 
   tmp = vec_and ((vui64_t)vf64, expmask);
@@ -885,10 +885,10 @@ vec_isinff64 (vf64_t vf64)
 #endif
 #else
   vui64_t tmp;
-  const vui64_t expmask = CONST_VINT128_DW(0x7ff0000000000000UL,
-					   0x7ff0000000000000UL);
-  const vui64_t signmask = CONST_VINT128_DW(0x8000000000000000UL,
-					    0x8000000000000000UL);
+  const vui64_t expmask = CONST_VINT128_DW (0x7ff0000000000000UL,
+					    0x7ff0000000000000UL);
+  const vui64_t signmask = CONST_VINT128_DW (0x8000000000000000UL,
+					     0x8000000000000000UL);
   tmp = vec_andc ((vui64_t) vf64, signmask);
   result = (vb64_t)vec_cmpequd (tmp, expmask);
 #endif
@@ -928,10 +928,10 @@ vec_isnanf64 (vf64_t vf64)
 #endif
 #else
   vui64_t tmp;
-  const vui64_t expmask = CONST_VINT128_DW(0x7ff0000000000000UL,
-					   0x7ff0000000000000UL);
-  const vui64_t signmask = CONST_VINT128_DW(0x8000000000000000UL,
-					    0x8000000000000000UL);
+  const vui64_t expmask = CONST_VINT128_DW (0x7ff0000000000000UL,
+					    0x7ff0000000000000UL);
+  const vui64_t signmask = CONST_VINT128_DW (0x8000000000000000UL,
+					     0x8000000000000000UL);
   tmp = vec_andc ((vui64_t)vf64, signmask);
   result = (vb64_t)vec_cmpgtud (tmp, expmask);
 #endif
@@ -973,9 +973,9 @@ vec_isnormalf64 (vf64_t vf64)
 #endif
   return vec_nor (tmp2, tmp2); // vec_not
 #else
-  const vui64_t expmask = CONST_VINT128_DW(0x7ff0000000000000UL,
-					   0x7ff0000000000000UL);
-  const vui64_t veczero = CONST_VINT128_DW(0UL, 0UL);
+  const vui64_t expmask = CONST_VINT128_DW (0x7ff0000000000000UL,
+					    0x7ff0000000000000UL);
+  const vui64_t veczero = CONST_VINT128_DW (0UL, 0UL);
   vui64_t tmp;
 
   tmp = vec_and ((vui64_t) vf64, expmask);
@@ -1020,11 +1020,11 @@ vec_issubnormalf64 (vf64_t vf64)
 #endif
 #else
   vui64_t tmp;
-  const vui64_t minnorm = CONST_VINT128_DW(0x0010000000000000UL,
-					   0x0010000000000000UL);
-  const vui64_t vec_zero = CONST_VINT128_DW(0, 0);
-  const vui64_t signmask = CONST_VINT128_DW(0x8000000000000000UL,
-					    0x8000000000000000UL);
+  const vui64_t minnorm = CONST_VINT128_DW (0x0010000000000000UL,
+					    0x0010000000000000UL);
+  const vui64_t vec_zero = CONST_VINT128_DW (0, 0);
+  const vui64_t signmask = CONST_VINT128_DW (0x8000000000000000UL,
+					     0x8000000000000000UL);
   tmp = vec_andc ((vui64_t) vf64, signmask);
   result = vec_andc (vec_cmpltud (tmp, minnorm),
 		     vec_cmpequd (tmp, vec_zero));
@@ -1068,9 +1068,9 @@ vec_iszerof64 (vf64_t vf64)
 #endif
 #else
   vui64_t tmp2;
-  const vui64_t vec_zero = CONST_VINT128_DW(0, 0);
-  const vui64_t signmask = CONST_VINT128_DW(0x8000000000000000UL,
-					    0x8000000000000000UL);
+  const vui64_t vec_zero = CONST_VINT128_DW (0, 0);
+  const vui64_t signmask = CONST_VINT128_DW (0x8000000000000000UL,
+					     0x8000000000000000UL);
   tmp2 = vec_andc ((vui64_t)vf64, signmask);
   result = (vb64_t)vec_cmpequd (tmp2, vec_zero);
 #endif


### PR DESCRIPTION
Simplify POWER8/POWER7 vector long int compares using pveclib
functions. Add appropriate unit tests.

	* src/vec_f64_ppc.h: Update \file description.
	Add \section f64_examples_0_0.
	* src/vec_f64_ppc.h: Remove typedef __vbinary64. Use vf64_t
	from vec_common_ppc.h.
	(vec_unpack_longdouble, vec_pack_longdouble): Move down file
	to preserve alphabetical order of function names.
	(vec_all_isfinitef64): New function.
	(vec_all_isinff64 [_ARCH_PWR9]): Use vec_test_data_class().
	(vec_all_isnanf64 [_ARCH_PWR9]): Use vec_test_data_class().
	(vec_all_isnormalf64 [_ARCH_PWR9]): Use vec_test_data_class().
	(vec_all_issubnormalf64 [_ARCH_PWR9]):
	Use vec_test_data_class().
	(vec_any_iszerof64 [_ARCH_PWR9]): Use vec_test_data_class().
	(vec_any_isfinitef64): New function.
	(vec_any_isinff64 [_ARCH_PWR9]): Use vec_test_data_class().
	(vec_any_isnanf64 [_ARCH_PWR9]): Use vec_test_data_class().
	(vec_any_isnormalf64 [_ARCH_PWR9]): Use vec_test_data_class().
	(vec_any_issubnormalf64 [_ARCH_PWR9]):
	Use vec_test_data_class().
	(vec_any_iszerof64 [_ARCH_PWR9]): Use vec_test_data_class().
	(vec_isfinitef64): New function.
	(vec_isinff64 [_ARCH_PWR9]): Use vec_test_data_class().
	(vec_isnanf64 [_ARCH_PWR9]): Use vec_test_data_class().
	(vec_isnormalf64 [_ARCH_PWR9]): Use vec_test_data_class().
	(vec_issubnormalf64 [_ARCH_PWR9]): Use vec_test_data_class().
	(vec_iszerof64 [_ARCH_PWR9]): Use vec_test_data_class().

	* src/testsuite/vec_pwr9_dummy.c (test_vec_all_finitef64_PWR9,
	test_vec_all_inff64_PWR9, test_vec_all_nanf64_PWR9,
	test_vec_all_normalf64_PWR9, test_vec_all_subnormalf64_PWR9
	test_vec_all_zerof64_PWR9, test_vec_any_finitef64_PWR9,
	test_vec_any_inff64_PWR9, test_vec_any_nanf64_PWR9,
	test_vec_any_normalf64_PWR9, test_vec_any_subnormalf64_PWR9
	test_vec_any_zerof64_PWR9, test_vec_isfinitef64_PWR9,
	test_vec_isinff64_PWR9, test_vec_isnanf64_PWR9,
	test_vec_isnormalf64_PWR9, test_vec_issubnormalf64_PWR9):
	New Functions.

	* src/testsuite/vec_f64_dummy.c (test_all_f64_finite):
	New Function.
	* src/testsuite/vec_f64_dummy.c (test_any_f64_finite,
	test_any_f64_inf, test_any_f64_nan, test_any_f64_norm,
	test_any_f64_subnorm, test_any_f64_zero, test_pred_f64_finite):
	New Functions.
	* src/testsuite/vec_f64_dummy.c (test_vec_sinf64,
	test_vec_cosf64): New Functions.

	* src/testsuite/arith128_test_f64.c (test_double_all_is):
	Add tests for vec_all_infinitef64().
	* src/testsuite/arith128_test_f64.c (test_double_any_is):
	Add tests for vec_all_infinitef64().
	* src/testsuite/arith128_test_f64.c (test_double_isfinite):
	New function.
	* src/testsuite/arith128_test_f64.c (test_vec_f64):
	Call test_double_isfinite.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>