### PR TITLE
Update vec_f64_ppc.h to use POWER9 test data class instructions.

### DIFF
--- a/src/testsuite/arith128_test_f64.c
+++ b/src/testsuite/arith128_test_f64.c
@@ -630,7 +630,7 @@ test_double_all_is (void)
     } else {
     }
 
-  i = (vf64_t) { -0.0, __DBL_DENORM_MIN__ };
+  i = (vf64_t) { __DBL_DENORM_MIN__, __DBL_DENORM_MIN__ };
 
 #ifdef __DEBUG_PRINT__
   print_v2f64x ("vec_all_issubnormal i=", i);
@@ -640,6 +640,18 @@ test_double_all_is (void)
     } else {
       rc += 1;
       print_v2f64x ("vec_all_issubnormal fail", i);
+    }
+
+  i = (vf64_t) { -0.0, __DBL_DENORM_MIN__ };
+
+#ifdef __DEBUG_PRINT__
+  print_v2f64x ("vec_all_issubnormal i=", i);
+#endif
+  if (vec_all_issubnormalf64 (i))
+    {
+      rc += 1;
+      print_v2f64x ("vec_all_issubnormal fail", i);
+    } else {
     }
 
   i = (vf64_t) CONST_VINT128_DW(__DOUBLE_NNAN, 1);

--- a/src/vec_f64_ppc.h
+++ b/src/vec_f64_ppc.h
@@ -292,7 +292,7 @@ vec_all_isinff64 (vf64_t vf64)
 #if _ARCH_PWR9
   const vui64_t vec_ones = CONST_VINT128_DW (-1, -1);
 #ifdef vec_test_data_class
-  tmp = (vui64_t)vec_test_data_class (vf64, 0x40);
+  tmp = (vui64_t)vec_test_data_class (vf64, 0x30);
 #else
   __asm__(
       "xvtstdcdp %x0,%x1,0x30;\n"
@@ -439,14 +439,14 @@ vec_all_issubnormalf64 (vf64_t vf64)
 #endif
   return vec_all_eq(tmp, vec_ones);
 #else
+  const vui64_t explow = CONST_VINT128_DW (0x0010000000000000,
+					   0x0010000000000000);
   const vui64_t signmask = CONST_VINT128_DW (0x8000000000000000UL,
 					     0x8000000000000000UL);
-  const vui64_t minnorm = CONST_VINT128_DW (0x0010000000000000UL,
-					    0x0010000000000000UL);
   const vui64_t vec_zero = CONST_VINT128_DW (0, 0);
 
   tmp = vec_andc ((vui64_t)vf64, signmask);
-  return vec_cmpud_all_gt (minnorm, tmp) && !vec_cmpud_all_eq (tmp, vec_zero);
+  return vec_cmpud_all_lt (tmp, explow) && vec_cmpud_all_ne (tmp, vec_zero);
 #endif
 }
 
@@ -572,7 +572,7 @@ vec_any_isinff64 (vf64_t vf64)
       : "wf" (vf64)
       :);
 #endif
-  return vec_all_eq(tmp, vec_ones);
+  return vec_any_eq(tmp, vec_ones);
 #else
   const vui64_t expmask = CONST_VINT128_DW (0x7ff0000000000000UL,
 					    0x7ff0000000000000UL);
@@ -618,7 +618,7 @@ vec_any_isnanf64 (vf64_t vf64)
       : "wf" (vf64)
       :);
 #endif
-  return vec_all_eq(tmp, vec_ones);
+  return vec_any_eq(tmp, vec_ones);
 #else
   const vui64_t signmask = CONST_VINT128_DW (0x8000000000000000UL,
 					     0x8000000000000000UL);
@@ -664,7 +664,7 @@ vec_any_isnormalf64 (vf64_t vf64)
       : "wf" (vf64)
       :);
 #endif
-  return vec_all_eq(tmp, vec_zero);
+  return vec_any_eq(tmp, vec_zero);
 #else
   vui64_t res;
   const vui64_t expmask = CONST_VINT128_DW (0x7ff0000000000000UL,
@@ -711,7 +711,7 @@ vec_any_issubnormalf64 (vf64_t vf64)
       : "wf" (vf64)
       :);
 #endif
-  return vec_all_eq(tmp, vec_ones);
+  return vec_any_eq(tmp, vec_ones);
 #else
   const vui64_t signmask = CONST_VINT128_DW (0x8000000000000000UL,
 					     0x8000000000000000UL);
@@ -763,7 +763,7 @@ vec_any_iszerof64 (vf64_t vf64)
       : "wf" (vf64)
       :);
 #endif
-  return vec_all_eq(tmp, vec_ones);
+  return vec_any_eq(tmp, vec_ones);
 #else
   const vui64_t signmask = CONST_VINT128_DW (0x8000000000000000UL,
 					     0x8000000000000000UL);


### PR DESCRIPTION
Fixes after POWER9 testing in mambo.

	* src/vec_f64_ppc.h (vec_all_isinff64 [_ARCH_PWR9]):
	Correct DMCX const value for vec_test_data_class().
        Should be 0x30 for +- Infinity.
	(vec_all_issubnormalf64 [!_ARCH_PWR9]): Correct logic for
	POWER8 vec_all_issubnormalf64 () code. Should be ALL (exponent < 1)
        AND ALL (NOT 0.0).
	(vec_any_isinff64 [_ARCH_PWR9]): Use vec_any_eq() for compare. Using
        vec_all_eq was a pasto. Should use vec_any_eq to convert the
        test_data_class to vector CC or int bool.
	(vec_any_isnanf64 [_ARCH_PWR9]): Ditto.
	(vec_any_isnormalf64 [_ARCH_PWR9]): Ditto.
	(vec_any_issubnormalf64 [_ARCH_PWR9]): Ditto.
	(vec_any_iszerof64 [_ARCH_PWR9]): Ditto.

	* src/testsuite/arith128_test_f64.c (test_double_all_is):
	Add test case for vec_all_issubnormalf64 for 2x
	__DBL_DENORM_MIN__ values. Correct test to detect false (was testing
        true) for vec_all_issubnormalf64 ({0.0, __DBL_DENORM_MIN__}) case.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>