### PR TITLE
Update vec_char_ppc.h to add merge even/odd and multiply high

### DIFF
--- a/src/testsuite/arith128_test_char.c
+++ b/src/testsuite/arith128_test_char.c
@@ -296,6 +296,308 @@ test_popcntb (void)
   return (rc);
 }
 
+#define __DEBUG_PRINT__ 1
+int
+test_mrgeob (void)
+{
+  vui8_t i, j;
+  vui8_t k, e;
+  int rc = 0;
+
+  printf ("\ntest_mrgeob Vector Merge Even/Odd Bytes\n");
+
+  i = (vui8_t) { 10, 1, 20, 2, 30, 3, 40, 4,
+		50, 5, 60, 6, 70, 7, 80, 8 };
+  j = (vui8_t) { 90, 9, 0xa0, 10, 0xb0, 11, 0xc0, 12,
+		 0xd0, 13, 0xe0, 14, 0xf0, 15, 0xff, 0 };
+  e = (vui8_t) { 10, 90, 20, 160, 30, 0xb0, 40, 0xc0,
+		 50, 0xd0, 60, 0xe0, 70, 0xf0, 80, 0xff };
+  k = vec_mrgeb (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint8x ("mrgeb(\t{", i);
+  print_vint8x ("\t\t{", j);
+  print_vint8x ("\t\t{", k);
+#endif
+  rc += check_vuint128x ("vec_mrgeb:", (vui128_t) k, (vui128_t) e);
+
+  e = (vui8_t)
+	  { 1, 9, 2, 10, 3, 11, 4, 12, 5, 13, 6, 14, 7, 15, 8, 0 };
+  k = vec_mrgob (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint8x ("mrgeo(\t{", i);
+  print_vint8x ("\t\t{", j);
+  print_vint8x ("\t\t{", k);
+#endif
+  rc += check_vuint128x ("vec_mrgob:", (vui128_t) k, (vui128_t) e);
+
+  return (rc);
+}
+
+int
+test_mrgahlb (void)
+{
+  vui16_t i, j;
+  vui8_t k, e;
+  int rc = 0;
+
+  printf ("\ntest_mrgahlb Vector Merge Algebraic High/Low Bytes\n");
+
+  i = (vui16_t)CONST_VINT128_H(0xf101, 0xf202, 0xf303, 0xf404, 0xf505, 0xf606, 0xf707, 0xf808);
+  j = (vui16_t)CONST_VINT128_H(0xf909, 0xfa0a, 0xfb0b, 0xfc0c, 0xfd0d, 0xfe0e, 0xff0f, 0xf000);
+  e = (vui8_t)(vui16_t)CONST_VINT128_H(0xf1f9, 0xf2fa, 0xf3fb, 0xf4fc,
+			      0xf5fd, 0xf6fe, 0xf7ff, 0xf8f0);
+  k = vec_mrgahb(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint16x ("mrgahb(\t{", i);
+  print_vint16x ("\t\t{", j);
+  print_vint8x  ("\t\t{", k);
+#endif
+  rc += check_vuint128x ("vec_mrgahb:", (vui128_t)k, (vui128_t) e);
+
+  e = (vui8_t)CONST_VINT128_H(0x1, 0x5, 0x2, 0x6, 0x3, 0x7, 0x4, 0x8);
+  e = (vui8_t)(vui16_t)CONST_VINT128_H(0x0109, 0x020a, 0x030b, 0x040c,
+			      0x050d, 0x060e, 0x070f, 0x0800);
+  k = vec_mrgalb(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint16x ("mrgalb(\t{", i);
+  print_vint16x ("\t\t{", j);
+  print_vint8x  ("\t\t{", k);
+#endif
+  rc += check_vuint128x ("vec_mrgalb:", (vui128_t)k, (vui128_t) e);
+
+  return (rc);
+}
+
+int
+test_mulhub (void)
+{
+  vui8_t i, j;
+  vui8_t k, e;
+  int rc = 0;
+
+  printf ("\ntest_mulhub Vector Multiply High Unsigned Bytes\n");
+
+  i = (vui8_t)
+	  { -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 };
+  j = (vui8_t)
+	  { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+  e = (vui8_t)
+	  { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+  k = vec_mulhub (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint8x ("mulhub(\t{", i);
+  print_vint8x ("\t\t{", j);
+  print_vint8x ("\t\t{", k);
+#endif
+  rc += check_vuint128x ("vec_mulhub:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui8_t)
+	  { 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10,
+	      0x10, 0x10, 0x10, 0x10, 0x10 };
+  j = (vui8_t)
+	  { 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80, 0x90, 0xa0, 0xb0,
+	      0xc0, 0xd0, 0xe0, 0xf0, 0x00, };
+  e = (vui8_t)
+	  { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0 };
+  k = vec_mulhub (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint8x ("mulhub(\t{", i);
+  print_vint8x ("\t\t{", j);
+  print_vint8x ("\t\t{", k);
+#endif
+  rc += check_vuint128x ("vec_mulhub:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui8_t)
+	  { 100, 100, 100, 100, 100, 100, 100, 100,
+            255, 255, 255, 255, 255, 255, 255, 255 };
+  j = (vui8_t)
+	  { 85, 51, 42, 36, 25, 23, 19, 17,
+            85, 51, 42, 36, 25, 23, 19, 17 };
+  e = (vui8_t)
+	  { 33, 19, 16, 14, 9, 8, 7, 6,
+            84, 50, 41, 35, 24, 22, 18, 16 };
+  k = vec_mulhub (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint8x ("mulhub(\t{", i);
+  print_vint8x ("\t\t{", j);
+  print_vint8x ("\t\t{", k);
+#endif
+  rc += check_vuint128x ("vec_mulhub:", (vui128_t) k, (vui128_t) e);
+
+  return (rc);
+}
+
+int
+test_mulhsb (void)
+{
+  vi8_t i, j;
+  vi8_t k, e;
+  int rc = 0;
+
+  printf ("\ntest_mulhsb Vector Multiply High Signed Bytes\n");
+
+  i = (vi8_t)
+	  { -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 };
+  j = (vi8_t)
+	  { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+  e = (vi8_t)
+	  { -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 };
+  k = vec_mulhsb (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint8x ("mulhsb(\t{", (vui8_t) i);
+  print_vint8x ("\t\t{", (vui8_t) j);
+  print_vint8x ("\t\t{", (vui8_t) k);
+#endif
+  rc += check_vuint128x ("vec_mulhsb:", (vui128_t) k, (vui128_t) e);
+
+  i = (vi8_t)
+	  { -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 };
+  j = (vi8_t)
+	  { -1, -2, -3, -4, -5, -6, -7, -8, -9, -10, -11, -12, -13, -14, -15,
+	      -16 };
+  e = (vi8_t)
+	  { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+  k = vec_mulhsb (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint8x ("mulhsb(\t{", (vui8_t) i);
+  print_vint8x ("\t\t{", (vui8_t) j);
+  print_vint8x ("\t\t{", (vui8_t) k);
+#endif
+  rc += check_vuint128x ("vec_mulhsb:", (vui128_t) k, (vui128_t) e);
+
+  i = (vi8_t)
+	  { 16, 16, 16, 16, 16, 16, 16, 16, 8, 8, 8, 8, 8, 8, 8, 8 };
+  j = (vi8_t)
+	  { 16, 32, 48, 64, 80, 96, 112, 127, 16, 32, 48, 64, 80, 96, 112,
+		  127 };
+  e = (vi8_t)
+	  { 1, 2, 3, 4, 5, 6, 7, 7, 0, 1, 1, 2, 2, 3, 3, 3 };
+  k = vec_mulhsb (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint8x ("mulhsb(\t{", (vui8_t) i);
+  print_vint8x ("\t\t{", (vui8_t) j);
+  print_vint8x ("\t\t{", (vui8_t) k);
+#endif
+  rc += check_vuint128x ("vec_mulhsb:", (vui128_t) k, (vui128_t) e);
+
+  i = (vi8_t)
+	  { -16, -16, -16, -16, -16, -16, -16, -16, -8, -8, -8, -8, -8, -8, -8,
+	      -8 };
+  j = (vi8_t)
+	  { 16, 32, 48, 64, 80, 96, 112, 127, 16, 32, 48, 64, 80, 96, 112,
+		  127 };
+  e = (vi8_t)
+	  { -1, -2, -3, -4, -5, -6, -7, -8, -1, -1, -2, -2, -3, -3, -4, -4 };
+  k = vec_mulhsb (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint8x ("mulhsb(\t{", (vui8_t) i);
+  print_vint8x ("\t\t{", (vui8_t) j);
+  print_vint8x ("\t\t{", (vui8_t) k);
+#endif
+  rc += check_vuint128x ("vec_mulhsb:", (vui128_t) k, (vui128_t) e);
+
+  i = (vi8_t)
+	  { -16, -16, -16, -16, -16, -16, -16, -16, -8, -8, -8, -8, -8, -8, -8,
+	      -8 };
+  j = (vi8_t)
+	  { -16, -32, -48, -64, -80, -96, -112, -127, -16, -32, -48, -64, -80,
+	      -96, -112, -127 };
+  e = (vi8_t)
+	  { 1, 2, 3, 4, 5, 6, 7, 7, 0, 1, 1, 2, 2, 3, 3, 3 };
+  k = vec_mulhsb (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint8x ("mulhsb(\t{", (vui8_t) i);
+  print_vint8x ("\t\t{", (vui8_t) j);
+  print_vint8x ("\t\t{", (vui8_t) k);
+#endif
+  rc += check_vuint128x ("vec_mulhsb:", (vui128_t) k, (vui128_t) e);
+
+  return (rc);
+}
+
+int
+test_mulubm (void)
+{
+  vui8_t i, j, k, e;
+  int rc = 0;
+
+  printf ("\ntest_mulubm Vector Multiply Unsigned Byte Modulo\n");
+
+  i = (vui8_t) { 1, 2, 3, 4, 5, 6, 7, 8,
+		 9, 10, 11, 12, 13, 14, 15, 16 };
+  j = (vui8_t) { 0, 1, 2, 3, 4, 5, 6, 7,
+		 8, 9, 10, 11, 12, 13, 14, 15 };
+  e = (vui8_t) { 0, 2, 6, 12, 20, 30, 42, 56,
+		 72, 90, 110, 132, 156, 182, 210, 240};
+  k = vec_mulubm (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint8x ("mulubm(\t{", i);
+  print_vint8x ("\t\t{", j);
+  print_vint8x ("\t\t{", k);
+#endif
+  rc += check_vuint128x ("vec_mulubm:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui8_t) { -1, -2, -3, -4, -5, -6, -7, -8,
+		 -9, -10, -11, -12, -13, -14, -15, -16 };
+  j = (vui8_t) { 0, 1, 2, 3, 4, 5, 6, 7,
+		 8, 9, 10, 11, 12, 13, 14, 15 };
+  e = (vui8_t) { 0, -2, -6, -12, -20, -30, -42, -56,
+		 -72, -90, -110, 0x7c, 0x64, 0x4a, 0x2e, 0x10};
+  k = vec_mulubm (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint8x ("mulubm(\t{", i);
+  print_vint8x ("\t\t{", j);
+  print_vint8x ("\t\t{", k);
+#endif
+  rc += check_vuint128x ("vec_mulubm:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui8_t) { 1, 2, 3, 4, 5, 6, 7, 8,
+		 9, 10, 11, 12, 13, 14, 15, 16 };
+  j = (vui8_t) { 0, -1, -2, -3, -4, -5, -6, -7,
+		 -8, -9, -10, -11, -12, -13, -14, -15 };
+  e = (vui8_t) { 0, -2, -6, -12, -20, -30, -42, -56,
+		 -72, -90, -110, 0x7c, 0x64, 0x4a, 0x2e, 0x10};
+  k = vec_mulubm (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint8x ("mulubm(\t{", i);
+  print_vint8x ("\t\t{", j);
+  print_vint8x ("\t\t{", k);
+#endif
+  rc += check_vuint128x ("vec_mulubm:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui8_t) { -1, -2, -3, -4, -5, -6, -7, -8,
+		 -9, -10, -11, -12, -13, -14, -15, -16 };
+  j = (vui8_t) { 0, -1, -2, -3, -4, -5, -6, -7,
+		 -8, -9, -10, -11, -12, -13, -14, -15 };
+  e = (vui8_t) { 0, 2, 6, 12, 20, 30, 42, 56,
+		 72, 90, 110, 132, 156, 182, 210, 240};
+  k = vec_mulubm (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint8x ("mulubm(\t{", i);
+  print_vint8x ("\t\t{", j);
+  print_vint8x ("\t\t{", k);
+#endif
+  rc += check_vuint128x ("vec_mulubm:", (vui128_t)k, (vui128_t) e);
+
+  return (rc);
+}
+
 int
 test_vec_char (void)
 {
@@ -304,8 +606,13 @@ test_vec_char (void)
   printf ("\n%s\n", __FUNCTION__);
 #if 1
   rc += test_clzb ();
-  rc += test_popcntb();
-  rc += test_vec_ischar();
+  rc += test_popcntb ();
+  rc += test_vec_ischar ();
+  rc += test_mrgeob ();
+  rc += test_mrgahlb ();
+  rc += test_mulhub ();
+  rc += test_mulhsb ();
+  rc += test_mulubm ();
 #endif
   return (rc);
 }

--- a/src/testsuite/arith128_test_char.c
+++ b/src/testsuite/arith128_test_char.c
@@ -296,7 +296,7 @@ test_popcntb (void)
   return (rc);
 }
 
-#define __DEBUG_PRINT__ 1
+//#define __DEBUG_PRINT__ 1
 int
 test_mrgeob (void)
 {

--- a/src/testsuite/arith128_test_char.c
+++ b/src/testsuite/arith128_test_char.c
@@ -300,24 +300,23 @@ test_popcntb (void)
 int
 test_mrgeob (void)
 {
-  vui8_t i, j;
-  vui8_t k, e;
+  vui8_t i, j, k, e;
   int rc = 0;
 
   printf ("\ntest_mrgeob Vector Merge Even/Odd Bytes\n");
 
   i = (vui8_t) { 10, 1, 20, 2, 30, 3, 40, 4,
 		50, 5, 60, 6, 70, 7, 80, 8 };
-  j = (vui8_t) { 90, 9, 0xa0, 10, 0xb0, 11, 0xc0, 12,
-		 0xd0, 13, 0xe0, 14, 0xf0, 15, 0xff, 0 };
-  e = (vui8_t) { 10, 90, 20, 160, 30, 0xb0, 40, 0xc0,
-		 50, 0xd0, 60, 0xe0, 70, 0xf0, 80, 0xff };
+  j = (vui8_t) { 90, 9, 160, 10, 176, 11, 192, 12,
+                208, 13, 224, 14, 240, 15, 255, 0 };
+  e = (vui8_t) { 10, 90, 20, 160, 30, 176, 40, 192,
+		 50, 208, 60, 224, 70, 240, 80, 255 };
   k = vec_mrgeb (i, j);
 
 #ifdef __DEBUG_PRINT__
-  print_vint8x ("mrgeb(\t{", i);
-  print_vint8x ("\t\t{", j);
-  print_vint8x ("\t\t{", k);
+  print_vint8d ("mrgeb(\t{", i);
+  print_vint8d ("\t\t{", j);
+  print_vint8d ("\t\t{", k);
 #endif
   rc += check_vuint128x ("vec_mrgeb:", (vui128_t) k, (vui128_t) e);
 
@@ -326,9 +325,9 @@ test_mrgeob (void)
   k = vec_mrgob (i, j);
 
 #ifdef __DEBUG_PRINT__
-  print_vint8x ("mrgeo(\t{", i);
-  print_vint8x ("\t\t{", j);
-  print_vint8x ("\t\t{", k);
+  print_vint8d ("mrgob(\t{", i);
+  print_vint8d ("\t\t{", j);
+  print_vint8d ("\t\t{", k);
 #endif
   rc += check_vuint128x ("vec_mrgob:", (vui128_t) k, (vui128_t) e);
 
@@ -357,7 +356,6 @@ test_mrgahlb (void)
 #endif
   rc += check_vuint128x ("vec_mrgahb:", (vui128_t)k, (vui128_t) e);
 
-  e = (vui8_t)CONST_VINT128_H(0x1, 0x5, 0x2, 0x6, 0x3, 0x7, 0x4, 0x8);
   e = (vui8_t)(vui16_t)CONST_VINT128_H(0x0109, 0x020a, 0x030b, 0x040c,
 			      0x050d, 0x060e, 0x070f, 0x0800);
   k = vec_mrgalb(i, j);
@@ -381,8 +379,8 @@ test_mulhub (void)
 
   printf ("\ntest_mulhub Vector Multiply High Unsigned Bytes\n");
 
-  i = (vui8_t)
-	  { -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 };
+  // Same as vec_splats ((unsigned char)255), only faster
+  i = (vui8_t) vec_splat_u8 (-1);
   j = (vui8_t)
 	  { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
   e = (vui8_t)
@@ -403,7 +401,8 @@ test_mulhub (void)
 	  { 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80, 0x90, 0xa0, 0xb0,
 	      0xc0, 0xd0, 0xe0, 0xf0, 0x00, };
   e = (vui8_t)
-	  { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0 };
+	  { 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd,
+              0xe, 0xf, 0x0 };
   k = vec_mulhub (i, j);
 
 #ifdef __DEBUG_PRINT__
@@ -421,13 +420,31 @@ test_mulhub (void)
             85, 51, 42, 36, 25, 23, 19, 17 };
   e = (vui8_t)
 	  { 33, 19, 16, 14, 9, 8, 7, 6,
-            84, 50, 41, 35, 24, 22, 18, 16 };
+	    84, 50, 41, 35, 24, 22, 18, 16 };
   k = vec_mulhub (i, j);
 
 #ifdef __DEBUG_PRINT__
-  print_vint8x ("mulhub(\t{", i);
-  print_vint8x ("\t\t{", j);
-  print_vint8x ("\t\t{", k);
+  print_vint8d ("mulhub(\t{", i);
+  print_vint8d ("\t\t{", j);
+  print_vint8d ("\t\t{", k);
+#endif
+  rc += check_vuint128x ("vec_mulhub:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui8_t)
+	  { 100, 100, 100, 100, 100, 100, 100, 100,
+            255, 255, 255, 255, 255, 255, 255, 255 };
+  j = (vui8_t)
+	  { 255, 128, 127, 64, 63, 32, 31, 16,
+	    255, 128, 127, 64, 63, 32, 31, 16 };
+  e = (vui8_t)
+          { 99, 50, 49, 25, 24, 12, 12, 6,
+           254, 127, 126, 63, 62, 31, 30, 15 };
+  k = vec_mulhub (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint8d ("mulhub(\t{", i);
+  print_vint8d ("\t\t{", j);
+  print_vint8d ("\t\t{", k);
 #endif
   rc += check_vuint128x ("vec_mulhub:", (vui128_t) k, (vui128_t) e);
 

--- a/src/testsuite/vec_char_dummy.c
+++ b/src/testsuite/vec_char_dummy.c
@@ -27,6 +27,12 @@ __test_absdub (vui8_t __A, vui8_t __B)
   return vec_absdub (__A, __B);
 }
 
+vui8_t
+__test_sldo (vui8_t __A, vui8_t __B, vui8_t __C)
+{
+  return vec_shift_leftdo (__A, __B, __C);
+}
+
 
 vui8_t
 __test_clzb (vui8_t a)
@@ -115,4 +121,16 @@ vui8_t
 test_vec_tolower (vui8_t a)
 {
   return vec_tolower (a);
+}
+
+vui8_t
+test_vec_mergel  (vui8_t a, vui8_t b)
+{
+  return vec_mergel (a, b);
+}
+
+vui8_t
+test_vec_vmrglb  (vui8_t a, vui8_t b)
+{
+  return vec_vmrglb (a, b);
 }

--- a/src/vec_char_ppc.h
+++ b/src/vec_char_ppc.h
@@ -28,14 +28,28 @@
 
 /*!
  * \file  vec_char_ppc.h
- * \brief Header package containing a collection of char and 8-bit
- * integer computation functions implemented
- * with PowerISA VMX, VSX, and DFP instructions.
+ * \brief Header package containing a collection of 128-bit SIMD
+ * operations over 8-bit integer (char) elements.
+ *
+ * Most of these operations are implemented in a single VMX or VSX
+ * instruction on newer (POWER6/POWER7/POWER8/POWER9) processors.
+ * This header serves to fill in functional gaps for older
+ * (POWER7, POWER8) processors and provides in-line assembler
+ * implementations for older compilers that do not
+ * provide the build-ins.
  *
  * Most vector char (8-bit integer) operations are are already covered
  * by the original VMX (AKA Altivec) instructions. VMX intrinsic
  * (compiler built-ins) operations are defined in <altivec.h> and
  * described in the compiler documentation.
+ * PowerISA 2.07B (POWER8) added several useful byte operations
+ * (count leading zeros, population count) not included in the
+ * original VMX.
+ * PowerISA 3.0B (POWER9) adds several more (absolute difference,
+ * compare not equal, count trailing zeros, extend sign,
+ * extract/insert, and reverse bytes).
+ * Most of these intrinsic (compiler built-ins) operations are defined
+ * in <altivec.h> and described in the compiler documentation.
  *
  * \note The compiler disables associated <altivec.h> built-ins if the
  * <B>mcpu</B> target does not enable the specific instruction.
@@ -43,11 +57,6 @@
  * vec_vclzb will not be defined.  But vec_clzb is always defined in
  * this header, will generate the minimum code, appropriate for the
  * target, and produce correct results.
- *
- * This header serves to fill in functional gaps for older
- * (POWER7, POWER8) processors and provides a in-line assembler
- * implementation for older compilers that do not
- * provide the build-ins.
  *
  * This header covers operations that are either:
  *
@@ -61,17 +70,87 @@
  * Examples include Count Leading Zeros and Population Count.
  * - Commonly used operations, not covered by the ABI or
  * <altivec.h>, and require multiple instructions or
- * are not obvious.
- * Examples include the shift immediate operations and the common
- * ASCII character tests and case conversions.
+ * are not obvious.  Examples include the multiply high,
+ * ASCII character tests, and shift immediate operations.
+ *
+ * \section i8_endian_issues_0_0 Endian problems with byte operations
+ *
+ * It would be useful to provide a vector multiply high byte
+ * (return the high order 8-bits of the 16-bit product) operation.
+ * This can be used for multiplicative inverse (effectively integer
+ * divide) operations.  Neither integer multiply high nor divide
+ * are available as vector instructions.  However the multiply high
+ * byte operation can be composed from the existing multiply
+ * even/odd byte operations followed by the vector merge even
+ * byte operation.
+ * Similarly a multiply low (modulo) byte operation can be
+ * composed from the existing multiply even/odd byte
+ * operations followed by the vector merge odd byte operation.
+ *
+ * As a prerequisite we need to provide the merge even/odd byte
+ * operations.
+ * While PowerISA has added these operations for word and doubleword,
+ * instructions are not defined for byte and halfword.
+ * Fortunately vector merge operations are
+ * just a special case of vector permute.  So the vec_vmrgob() and
+ * vec_vmrgeb() implementation can use vec_perm and appropriate
+ * selection vectors to provide these merge operations.
+ *
+ * As described for other element sizes
+ * this is complicated by <I>little-endian</I> (LE) support as
+ * specified in the OpenPOWER ABI and as implemented in the compilers.
+ * Little-endian changes the effective vector element numbering and
+ * the location of even and odd elements.  This means that the vector
+ * built-ins provided by altivec.h may not generate the instructions
+ * you would expect.
+ * \sa \ref i16_endian_issues_0_0
+ * \sa \ref mainpage_endian_issues_1_1
+ *
+ * So this header defines endian independent byte operations
+ * vec_vmrgeb() and vec_vmrgob().  These operations are used in the
+ * implementation of the endian sensitive vec_mrgeb() and vec_mrgob().
+ * These support the OpenPOWER ABI mandated merge even/odd semantic.
+ *
+ * We also provide the merge algebraic high/low operations vec_mrgahb()
+ * and vec_mrgalb() to simplify extended precision arithmetic.
+ * These implementations use vec_vmrgeb() and vec_vmrgob() as
+ * extended precision byte order does not change with endian.
+ * These operations are used in turn to implement multiply
+ * byte high/low/modulo (vec_mulhsb(), vec_mulhub(), vec_mulubm()).
+ *
+ * These operations provide a basis for using the multiplicative
+ * inverse as a alternative to integer divide.
+ * \sa \ref int16_examples_0_1
+ *
+ * \section int8_perf_0_0 Performance data.
+ *
+ * The performance characteristics of the merge and multiply byte
+ * operations are very similar to the halfword implementations.
+ * (see \ref int16_perf_0_0).
+ *
+ * \subsection int8_perf_0_1 More information.
+ * High level performance estimates are provided as an aid to function
+ * selection when evaluating algorithms. For background on how
+ * <I>Latency</I> and <I>Throughput</I> are derived see:
+ * \ref perf_data
  *
  */
+
+///@cond INTERNAL
+static inline vui8_t vec_vmrgeb (vui8_t vra, vui8_t vrb);
+static inline vui8_t vec_vmrgob (vui8_t vra, vui8_t vrb);
+///@endcond
 
 /** \brief Vector Absolute Difference Unsigned byte.
  *
  * Compute the absolute difference for each byte.
  * For each unsigned byte, subtract B[i] from A[i] and return the
  * absolute value of the difference.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   |   4   | 1/cycle  |
+ *  |power9   |   3   | 2/cycle  |
  *
  * @param vra vector of 16 unsigned bytes
  * @param vrb vector of 16 unsigned bytes
@@ -113,6 +192,11 @@ vec_absdub (vui8_t vra, vui8_t vrb)
  *
  *  Warren, Henry S. Jr and <I>Hacker's Delight</I>, 2nd Edition,
  *  Addison Wesley, 2013. Chapter 5 Counting Bits, Figure 5-12.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   |   2   | 2/cycle  |
+ *  |power9   |   3   | 2/cycle  |
  *
  *  @param vra 128-bit vector treated as 16 x 8-bit integer (byte)
  *  elements.
@@ -182,6 +266,11 @@ vec_clzb (vui8_t vra)
  * that is either Lower Case Alpha ASCII or Upper Case ASCII.
  * False otherwise.
  *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 10-20 | 1/cycle  |
+ *  |power9   | 11-21 | 1/cycle  |
+ *
  * @param vec_str vector of 16 ASCII characters
  * @return vector bool char of the isalpha operation applied to each
  * character of vec_str. For each byte 0xff indicates true (isalpha),
@@ -236,6 +325,11 @@ vec_isalnum (vui8_t vec_str)
  * that is either Lower Case Alpha ASCII, Upper Case ASCII, or numeric ASCII.
  * False otherwise.
  *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 9-18  | 1/cycle  |
+ *  |power9   | 10-19 | 1/cycle  |
+ *
  * @param vec_str vector of 16 ASCII characters
  * @return vector bool char of the isalnum operation applied to each
  * character of vec_str. For each byte 0xff indicates true (isalpha),
@@ -280,6 +374,11 @@ vec_isalpha (vui8_t vec_str)
  * that is ASCII decimal digit.
  * False otherwise.
  *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 4-13  | 1/cycle  |
+ *  |power9   | 5-14  | 1/cycle  |
+ *
  * @param vec_str vector of 16 ASCII characters
  * @return vector bool char of the isdigit operation applied to each
  * character of vec_str. For each byte 0xff indicates true (isdigit),
@@ -306,6 +405,197 @@ vec_isdigit (vui8_t vec_str)
   return (result);
 }
 
+/** \brief Vector Merge Algebraic High Byte operation.
+ *
+ * Merge only the high byte from 16 x Algebraic halfwords
+ * across vectors vra and vrb. This is effectively the Vector Merge
+ * Even Byte operation that is not modified for Endian.
+ *
+ * For example merge the high 8-bits from each of 16 x 16-bit products
+ * as generated by vec_muleub/vec_muloub. This result is effectively
+ * a vector multiply high unsigned byte.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 2-13  | 2/cycle  |
+ *  |power9   | 3-14  | 2/cycle  |
+ *
+ * @param vra 128-bit vector unsigned short.
+ * @param vrb 128-bit vector unsigned short.
+ * @return A vector merge from only the high bytes of the 16 x
+ * Algebraic halfwords across vra and vrb.
+ */
+static inline vui8_t
+vec_mrgahb  (vui16_t vra, vui16_t vrb)
+{
+  return vec_vmrgeb ((vui8_t) vra, (vui8_t) vrb);
+}
+
+/** \brief Vector Merge Algebraic Low Byte operation.
+ *
+ * Merge only the low bytes from 16 x Algebraic halfwords
+ * across vectors vra and vrb. This is effectively the Vector Merge
+ * Odd Bytes operation that is not modified for Endian.
+ *
+ * For example merge the low 8-bits from each of 16 x 16-bit products
+ * as generated by vec_muleub/vec_muloub. This result is effectively
+ * a vector multiply low unsigned byte.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 2-13  | 2/cycle  |
+ *  |power9   | 3-14  | 2/cycle  |
+ *
+ * @param vra 128-bit vector unsigned int.
+ * @param vrb 128-bit vector unsigned int.
+ * @return A vector merge from only the high halfwords of the 8 x
+ * Algebraic words across vra and vrb.
+ */
+static inline vui8_t
+vec_mrgalb  (vui16_t vra, vui16_t vrb)
+{
+  return vec_vmrgob ((vui8_t) vra, (vui8_t) vrb);
+}
+
+/** \brief Vector Merge Even Bytes operation.
+ *
+ * Merge the even byte elements from the concatenation of 2 x
+ * vectors (vra and vrb).
+ *
+ * \note The element numbering changes between Big and Little Endian.
+ * So the compiler and this implementation adjusts the generated code
+ * to reflect this.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 2-13  | 2/cycle  |
+ *  |power9   | 3-14  | 2/cycle  |
+ *
+ * @param vra 128-bit vector unsigned char.
+ * @param vrb 128-bit vector unsigned char.
+ * @return A vector merge from only the even bytes of vra and vrb.
+ */
+static inline vui8_t
+vec_mrgeb  (vui8_t vra, vui8_t vrb)
+{
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  return vec_vmrgob ((vui8_t) vrb, (vui8_t) vra);
+#else
+  return vec_vmrgeb ((vui8_t) vra, (vui8_t) vrb);
+#endif
+}
+
+/** \brief Vector Merge Odd Halfwords operation.
+ *
+ * Merge the odd halfword elements from the concatenation of 2 x
+ * vectors (vra and vrb).
+ *
+ * \note The element numbering changes between Big and Little Endian.
+ * So the compiler and this implementation adjusts the generated code
+ * to reflect this.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 2-13  | 2/cycle  |
+ *  |power9   | 3-14  | 2/cycle  |
+ *
+ * @param vra 128-bit vector unsigned char.
+ * @param vrb 128-bit vector unsigned char.
+ * @return A vector merge from only the odd bytes of vra and vrb.
+ */
+static inline vui8_t
+vec_mrgob  (vui8_t vra, vui8_t vrb)
+{
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  return vec_vmrgeb ((vui8_t) vrb, (vui8_t) vra);
+#else
+  return vec_vmrgob ((vui8_t) vra, (vui8_t) vrb);
+#endif
+}
+
+/** \brief Vector Multiply High Signed Bytes.
+ *
+ *  Multiple the corresponding byte elements of two vector signed
+ *  char values and return the high order 8-bits, for each
+ *  16-bit product element.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 9-13  | 1/cycle  |
+ *  |power9   | 10-14 | 1/cycle  |
+ *
+ *  @param vra 128-bit vector signed char.
+ *  @param vrb 128-bit vector signed char.
+ *  @return vector of the high order 8-bits of the product of the
+ *  byte elements from vra and vrb.
+ */
+static inline vi8_t
+vec_mulhsb (vi8_t vra, vi8_t vrb)
+{
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  return (vi8_t) vec_mrgahb ((vui16_t)vec_mulo (vra, vrb),
+			     (vui16_t)vec_mule (vra, vrb));
+#else
+  return (vi8_t) vec_mrgahb ((vui16_t)vec_mule (vra, vrb),
+			     (vui16_t)vec_mulo (vra, vrb));
+#endif
+}
+
+/** \brief Vector Multiply High Unsigned Bytes.
+ *
+ *  Multiple the corresponding byte elements of two vector unsigned
+ *  char values and return the high order 8-bits, for each
+ *  16-bit product element.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 9-13  | 1/cycle  |
+ *  |power9   | 10-14 | 1/cycle  |
+ *
+ *  @param vra 128-bit vector unsigned char.
+ *  @param vrb 128-bit vector unsigned char.
+ *  @return vector of the high order 8-bits of the product of the
+ *  byte elements from vra and vrb.
+ */
+static inline vui8_t
+vec_mulhub (vui8_t vra, vui8_t vrb)
+{
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  return vec_mrgahb (vec_mulo (vra, vrb), vec_mule (vra, vrb));
+#else
+  return vec_mrgahb (vec_mule (vra, vrb), vec_mulo (vra, vrb));
+#endif
+}
+
+/** \brief Vector Multiply Unsigned Byte Modulo.
+ *
+ *  Multiple the corresponding byte elements of two vector unsigned
+ *  char values and return the low order 8-bits of the 16-bit product
+ *  for each element.
+ *
+ *  \note vec_mulubm can be used for unsigned or signed char integers.
+ *  It is the vector equivalent of Multiply Low Byte.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 9-13  | 1/cycle  |
+ *  |power9   | 10-14 | 1/cycle  |
+ *
+ *  @param vra 128-bit vector unsigned char.
+ *  @param vrb 128-bit vector unsigned char.
+ *  @return vector of the low order 8-bits of the unsigned product
+ *  of the byte elements from vra and vrb.
+ */
+static inline vui8_t
+vec_mulubm (vui8_t vra, vui8_t vrb)
+{
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  return vec_mrgalb (vec_mulo (vra, vrb), vec_mule (vra, vrb));
+#else
+  return vec_mrgalb (vec_mule (vra, vrb), vec_mulo (vra, vrb));
+#endif
+}
+
 /** \brief Vector Population Count byte.
  *
  *  Count the number of '1' bits (0-8) within each byte element of
@@ -318,6 +608,11 @@ vec_isdigit (vui8_t vec_str)
  *
  *  Warren, Henry S. Jr and <I>Hacker's Delight</I>, 2nd Edition,
  *  Addison Wesley, 2013. Chapter 5 Counting Bits, Figure 5-2.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   |   2   | 2/cycle  |
+ *  |power9   |   3   | 2/cycle  |
  *
  *  @param vra 128-bit vector treated as 16 x 8-bit integers (byte)
  *  elements.
@@ -379,15 +674,20 @@ vec_popcntb (vui8_t vra)
 
 /** \brief Vector Shift left Byte Immediate.
  *
- *	Shift left each byte element [0-15], 0-7 bits,
- *	as specified by an immediate value.
- *	The shift amount is a const unsigned int in the range 0-7.
- *	A shift count of 0 returns the original value of vra.
- *	Shift counts greater then 7 bits return zero.
+ *  Shift left each byte element [0-15], 0-7 bits,
+ *  as specified by an immediate value.
+ *  The shift amount is a const unsigned int in the range 0-7.
+ *  A shift count of 0 returns the original value of vra.
+ *  Shift counts greater then 7 bits return zero.
  *
- *	@param vra a 128-bit vector treated as a vector unsigned char.
- *	@param shb Shift amount in the range 0-7.
- *	@return 128-bit vector unsigned char, shifted left shb bits.
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 4-11  | 2/cycle  |
+ *  |power9   | 5-11  | 2/cycle  |
+ *
+ *  @param vra a 128-bit vector treated as a vector unsigned char.
+ *  @param shb Shift amount in the range 0-7.
+ *  @return 128-bit vector unsigned char, shifted left shb bits.
  */
 static inline vui8_t
 vec_slbi (vui8_t vra, const unsigned int shb)
@@ -420,16 +720,21 @@ vec_slbi (vui8_t vra, const unsigned int shb)
 
 /** \brief Vector Shift Right Algebraic Byte Immediate.
  *
- *	Shift right each byte element [0-15], 0-7 bits,
- *	as specified by an immediate value.
- *	The shift amount is a const unsigned int in the range 0-7.
- *	A shift count of 0 returns the original value of vra.
- *	Shift counts greater then 7 bits return the sign bit
- *	propagated to each bit of each element.
+ *  Shift right each byte element [0-15], 0-7 bits,
+ *  as specified by an immediate value.
+ *  The shift amount is a const unsigned int in the range 0-7.
+ *  A shift count of 0 returns the original value of vra.
+ *  Shift counts greater then 7 bits return the sign bit
+ *  propagated to each bit of each element.
  *
- *	@param vra a 128-bit vector treated as a vector signed char.
- *	@param shb Shift amount in the range 0-7.
- *	@return 128-bit vector signed char, shifted right shb bits.
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 4-11  | 2/cycle  |
+ *  |power9   | 5-11  | 2/cycle  |
+ *
+ *  @param vra a 128-bit vector treated as a vector signed char.
+ *  @param shb Shift amount in the range 0-7.
+ *  @return 128-bit vector signed char, shifted right shb bits.
  */
 static inline vi8_t
 vec_srabi (vi8_t vra, const unsigned int shb)
@@ -465,15 +770,20 @@ vec_srabi (vi8_t vra, const unsigned int shb)
 
 /** \brief Vector Shift Right Byte Immediate.
  *
- *	Shift right each byte element [0-15], 0-7 bits,
- *	as specified by an immediate value.
- *	The shift amount is a const unsigned int in the range 0-7.
- *	A shift count of 0 returns the original value of vra.
- *	Shift counts greater then 7 bits return zero.
+ *  Shift right each byte element [0-15], 0-7 bits,
+ *  as specified by an immediate value.
+ *  The shift amount is a const unsigned int in the range 0-7.
+ *  A shift count of 0 returns the original value of vra.
+ *  Shift counts greater then 7 bits return zero.
  *
- *	@param vra a 128-bit vector treated as a vector unsigned char.
- *	@param shb Shift amount in the range 0-7.
- *	@return 128-bit vector unsigned char, shifted right shb bits.
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 4-11  | 2/cycle  |
+ *  |power9   | 5-11  | 2/cycle  |
+ *
+ *  @param vra a 128-bit vector treated as a vector unsigned char.
+ *  @param shb Shift amount in the range 0-7.
+ *  @return 128-bit vector unsigned char, shifted right shb bits.
  */
 static inline vui8_t
 vec_srbi (vui8_t vra, const unsigned int shb)
@@ -513,6 +823,11 @@ vec_srbi (vui8_t vra, const unsigned int shb)
  * based on the result of a vector count leading zero of of the compare
  * boolean.
  *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   |  6-8  | 1/cycle  |
+ *  |power9   |  8-9  | 1/cycle  |
+ *
  * @param vrw upper 16-bytes of the 32-byte double vector.
  * @param vrx lower 16-bytes of the 32-byte double vector.
  * @param vrb Shift amount in bits 121:124.
@@ -534,12 +849,17 @@ vec_shift_leftdo (vui8_t vrw, vui8_t vrx, vui8_t vrb)
 
 /** \brief Vector toupper.
  *
- * Convert any Lower Case Alpha ASCII characters within a vector
- * unsigned char into the equivalent Upper Case character.
- * Return the result as a vector unsigned char.
+ *  Convert any Lower Case Alpha ASCII characters within a vector
+ *  unsigned char into the equivalent Upper Case character.
+ *  Return the result as a vector unsigned char.
  *
- * @param vec_str vector of 16 ASCII characters
- * @return vector char converted to upper case.
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 8-17  | 1/cycle  |
+ *  |power9   | 9-18  | 1/cycle  |
+ *
+ *  @param vec_str vector of 16 ASCII characters
+ *  @return vector char converted to upper case.
  */
 static inline vui8_t
 vec_toupper (vui8_t vec_str)
@@ -570,12 +890,17 @@ vec_toupper (vui8_t vec_str)
 
 /** \brief Vector tolower.
  *
- * Convert any Upper Case Alpha ASCII characters within a vector
- * unsigned char into the equivalent Lower Case character.
- * Return the result as a vector unsigned char.
+ *  Convert any Upper Case Alpha ASCII characters within a vector
+ *  unsigned char into the equivalent Lower Case character.
+ *  Return the result as a vector unsigned char.
  *
- * @param vec_str vector of 16 ASCII characters
- * @return vector char converted to lower case.
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 8-17  | 1/cycle  |
+ *  |power9   | 9-18  | 1/cycle  |
+ *
+ *  @param vec_str vector of 16 ASCII characters
+ *  @return vector char converted to lower case.
  */
 static inline vui8_t
 vec_tolower (vui8_t vec_str)
@@ -602,6 +927,112 @@ vec_tolower (vui8_t vec_str)
   result = vec_or (vec_str, cmask);
 
   return (result);
+}
+
+/** \brief Vector Merge Even Bytes.
+ *
+ * Merge the even byte elements from the concatenation of 2 x
+ * vectors (vra and vrb).
+ *
+ * \note This function implements the operation of a Vector Merge Even
+ * Bytes instruction, if the PowerISA included such an instruction.
+ * This implementation is NOT Endian sensitive and the function is
+ * stable across BE/LE implementations. Using Big Endian element
+ * numbering:
+ * - res[0] = vra[0];
+ * - res[1] = vrb[0];
+ * - res[2] = vra[2];
+ * - res[3] = vrb[2];
+ * - res[4] = vra[4];
+ * - res[5] = vrb[4];
+ * - res[6] = vra[6];
+ * - res[7] = vrb[6];
+ * - res[8] = vra[8];
+ * - res[9] = vrb[8];
+ * - res[10] = vra[10];
+ * - res[11] = vrb[10];
+ * - res[12] = vra[12];
+ * - res[13] = vrb[12];
+ * - res[14] = vra[14];
+ * - res[15] = vrb[14];
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 2-13  | 2/cycle  |
+ *  |power9   | 3-14  | 2/cycle  |
+ *
+ * @param vra 128-bit vector unsigned char.
+ * @param vrb 128-bit vector unsigned char.
+ * @return A vector merge from only the even bytes of vra and vrb.
+ */
+static inline vui8_t
+vec_vmrgeb (vui8_t vra, vui8_t vrb)
+{
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  const vui8_t permute =
+    { 0x01, 0x11, 0x03, 0x13, 0x05, 0x15, 0x07, 0x17, 0x09, 0x19, 0x0B, 0x1B,
+	0x0D, 0x1D, 0x0F, 0x1F };
+
+  return vec_perm (vrb, vra, (vui8_t) permute);
+#else
+  const vui8_t permute =
+    { 0x00, 0x10, 0x02, 0x12, 0x04, 0x14, 0x06, 0x16, 0x08, 0x18, 0x0A, 0x1A,
+	0x0C, 0x1C, 0x0E, 0x1E};
+
+  return vec_perm (vra, vrb, (vui8_t)permute);
+#endif
+}
+
+/** \brief Vector Merge Odd Byte.
+ *
+ * Merge the odd byte elements from the concatenation of 2 x
+ * vectors (vra and vrb).
+ *
+ * \note This function implements the operation of a Vector Merge Odd
+ * Bytes instruction, if the PowerISA included such an instruction.
+ * This implementation is NOT Endian sensitive and the function is
+ * stable across BE/LE implementations. Using Big Endian element
+ * numbering:
+ * - res[0] = vra[1];
+ * - res[1] = vrb[1];
+ * - res[2] = vra[3];
+ * - res[3] = vrb[3];
+ * - res[4] = vra[5];
+ * - res[5] = vrb[5];
+ * - res[6] = vra[7];
+ * - res[7] = vrb[7];
+ * - res[8] = vra[9];
+ * - res[9] = vrb[9];
+ * - res[10] = vra[11];
+ * - res[11] = vrb[11];
+ * - res[12] = vra[13];
+ * - res[13] = vrb[13];
+ * - res[14] = vra[15];
+ * - res[15] = vrb[15];
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 2-13  | 2/cycle  |
+ *  |power9   | 3-14  | 2/cycle  |
+ *
+ * @param vra 128-bit vector unsigned char.
+ * @param vrb 128-bit vector unsigned char.
+ * @return A vector merge from only the odd bytes of vra and vrb.
+ */
+static inline vui8_t
+vec_vmrgob (vui8_t vra, vui8_t vrb)
+{
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  const vui8_t permute =
+      { 0x00, 0x10, 0x02, 0x12, 0x04, 0x14, 0x06, 0x16, 0x08, 0x18, 0x0A, 0x1A,
+  	0x0C, 0x1C, 0x0E, 0x1E};
+  return vec_perm (vrb, vra, (vui8_t)permute);
+#else
+  const vui8_t permute =
+      { 0x01, 0x11, 0x03, 0x13, 0x05, 0x15, 0x07, 0x17, 0x09, 0x19, 0x0B, 0x1B,
+  	0x0D, 0x1D, 0x0F, 0x1F };
+  return vec_perm (vra, vrb, (vui8_t)permute);
+#endif
 }
 
 #endif /* VEC_CHAR_PPC_H_ */


### PR DESCRIPTION
Plus additional examples in the \file doxygen text.
Add latency info and clean up doxygent comment alignment.
Add more unit tests to cover new functions.

	* src/vec_char_ppc.h: Update \File Description.
	Add \section i8_endian_issues_0_0.
	Add \section int8_perf_0_0.
	Clean up doxygen comment alignment for consistency.
	For all function \brief descriptions add Latency and
	throughput tables.
	(vec_mrgahb, vec_mrgalb, vec_mrgeb, vec_mrgob, vec_mulhsb,
	vec_mulhub, vec_mulubm, vec_vmrgeb, vec_vmrgob): New Function.

	* src/testsuite/arith128_test_char.c (test_mrgeob, test_mulhub,
	test_mulhsb, test_mulubm): New Functions.
	(test_vec_char): Add calls to test_mrgeob, test_mrgahlb,
	test_mulhub, test_mulhsb, and test_mulubm.

	* src/testsuite/vec_char_dummy.c (__test_sldo, test_vec_mergel,
	test_vec_vmrglb): New Functions.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>