### PR TITLE
Update vec_int128_dummy.c, vec_int32_dummy.c, vec_int64_dummy.c vec_p…

### DIFF
--- a/src/testsuite/vec_int128_dummy.c
+++ b/src/testsuite/vec_int128_dummy.c
@@ -571,6 +571,12 @@ test_vec_slq  (vui128_t a, vui128_t sh)
 }
 
 vui128_t
+__test_vec_msumudm (vui64_t a, vui64_t b, vui128_t c)
+{
+  return (vec_msumudm (a, b, c));
+}
+
+vui128_t
 __test_muloud (vui64_t a, vui64_t b)
 {
   return (vec_muloud (a, b));
@@ -580,6 +586,30 @@ vui128_t
 __test_muleud (vui64_t a, vui64_t b)
 {
   return (vec_muleud (a, b));
+}
+
+vui64_t
+__test_muludm (vui64_t a, vui64_t b)
+{
+  return (vec_muludm (a, b));
+}
+
+vui64_t
+__test_mulhud (vui64_t a, vui64_t b)
+{
+  return (vec_mulhud (a, b));
+}
+
+vui128_t
+__test_vmuloud (vui64_t a, vui64_t b)
+{
+  return (vec_vmuloud (a, b));
+}
+
+vui128_t
+__test_vmuleud (vui64_t a, vui64_t b)
+{
+  return (vec_vmuleud (a, b));
 }
 
 vui128_t
@@ -630,6 +660,48 @@ test_mul4uq (vui128_t *__restrict__ mulu, vui128_t m1h, vui128_t m1l, vui128_t m
   mulu[1] = mplh;
   mulu[2] = mphl;
   mulu[3] = mphh;
+}
+
+void
+example_dw_convert_timebase (vui64_t *tb, vui32_t *timespec, int n)
+{
+  /* Magic numbers for multiplicative inverse to divide by 512,000,000
+     are 4835703278458516699 and shift right 27 bits.  */
+  const vui64_t mul_invs_clock =
+    { 4835703278458516699UL, 4835703278458516699UL };
+  const int shift_clock = 27;
+  /* Need const for TB clocks/second to extract remainder.  */
+  const vui64_t tb_clock_sec =
+    { 512000000, 512000000};
+  const int shift_512 = 9;
+  const vui64_t nano_512 =
+    { 1000, 1000};
+  vui64_t tb_v, tmp, tb_clocks, seconds, nseconds;
+  vui64_t timespec1, timespec2;
+  int i;
+
+  for (i = 0; i < n; i++)
+    {
+      tb_v = *tb++;
+      /* extract integer seconds from timebase vector.  */
+      tmp = vec_mulhud (tb_v, mul_invs_clock);
+      seconds = vec_srdi (tmp, shift_clock);
+      /* Extract remainder in tb clocks. */
+      tmp = vec_muludm (seconds, tb_clock_sec);
+      tb_clocks = vec_sub (tb_v, tmp);
+      /* Convert 512MHz timebase to nanoseconds.  */
+      /* nseconds = tb_clocks * 1000000000 / 512000000 */
+      /* reduces to (tb_clocks * 1000) >> 9 */
+      tmp = vec_muludm (tb_clocks, nano_512);
+      nseconds = vec_srdi (tmp, shift_512);
+      /* Use merge high/low to interleave seconds and nseconds
+       * into timespec.  */
+      timespec1 = vec_mergeh (seconds, nseconds);
+      timespec2 = vec_mergel (seconds, nseconds);
+      /* seconds and nanoseconds fit int 32-bits after conversion.
+       * So pack results and store the timespec.  */
+      *timespec++ = vec_vpkudum (timespec1, timespec2);
+    }
 }
 
 /* alternative algorithms tested and not selected due to code size

--- a/src/testsuite/vec_int128_dummy.c
+++ b/src/testsuite/vec_int128_dummy.c
@@ -688,7 +688,7 @@ example_dw_convert_timebase (vui64_t *tb, vui32_t *timespec, int n)
       seconds = vec_srdi (tmp, shift_clock);
       /* Extract remainder in tb clocks. */
       tmp = vec_muludm (seconds, tb_clock_sec);
-      tb_clocks = vec_sub (tb_v, tmp);
+      tb_clocks = vec_subudm (tb_v, tmp);
       /* Convert 512MHz timebase to nanoseconds.  */
       /* nseconds = tb_clocks * 1000000000 / 512000000 */
       /* reduces to (tb_clocks * 1000) >> 9 */

--- a/src/testsuite/vec_int32_dummy.c
+++ b/src/testsuite/vec_int32_dummy.c
@@ -280,6 +280,7 @@ example_convert_timebase (vui32_t *tb, vui32_t *timespec, int n)
 
 /* these are test to see exactly what the compilers will generate for
    specific built-ins.  */
+
 #if defined _ARCH_PWR8 && (__GNUC__ > 7)
 vui64_t
 __test_mulew (vui32_t vra, vui32_t vrb)
@@ -292,11 +293,12 @@ __test_mulow (vui32_t vra, vui32_t vrb)
 {
   return vec_mulo (vra, vrb);
 }
+#endif
 
+#if defined _ARCH_PWR7 && (__GNUC__ > 6)
 vui32_t
-__test_mulhw (vui32_t vra, vui32_t vrb)
+__test_mulluw (vui32_t vra, vui32_t vrb)
 {
-  return vec_mergee ((vui32_t)vec_mule (vra, vrb),
-		     (vui32_t)vec_mulo (vra, vrb));
+  return vec_mul (vra, vrb);
 }
 #endif

--- a/src/testsuite/vec_int64_dummy.c
+++ b/src/testsuite/vec_int64_dummy.c
@@ -23,6 +23,12 @@
 #include <vec_int64_ppc.h>
 
 vui64_t
+__test_vrld (vui64_t a, vui64_t b)
+{
+  return vec_vrld (a, b);
+}
+
+vui64_t
 __test_vsld (vui64_t a, vui64_t b)
 {
   return vec_vsld (a, b);
@@ -38,6 +44,24 @@ vi64_t
 __test_vsrad (vi64_t a, vui64_t b)
 {
   return vec_vsrad (a, b);
+}
+
+vui64_t
+test_rldi_1 (vui64_t a)
+{
+  return vec_rldi (a, 1);
+}
+
+vui64_t
+test_rldi_15 (vui64_t a)
+{
+  return vec_rldi (a, 15);
+}
+
+vui64_t
+test_rldi_32 (vui64_t a)
+{
+  return vec_rldi (a, 32);
 }
 
 vui64_t
@@ -304,6 +328,12 @@ test_addudm (vui64_t a, vui64_t b)
   return vec_addudm (a, b);
 }
 
+vui64_t
+test_absdud (vui64_t a, vui64_t b)
+{
+  return vec_absdud (a, b);
+}
+
 vb64_t
 test_cmpequd (vui64_t a, vui64_t b)
 {
@@ -394,6 +424,42 @@ __test_revbd (vui64_t vra)
   return vec_revbd (vra);
 }
 
+vi64_t
+__test_maxsd (vi64_t __VH, vi64_t __VL)
+{
+  return vec_maxsd (__VH, __VL);
+}
+
+vui64_t
+__test_maxud (vui64_t __VH, vui64_t __VL)
+{
+  return vec_maxud (__VH, __VL);
+}
+
+vi64_t
+__test_minsd (vi64_t __VH, vi64_t __VL)
+{
+  return vec_minsd (__VH, __VL);
+}
+
+vui64_t
+__test_minud (vui64_t __VH, vui64_t __VL)
+{
+  return vec_minud (__VH, __VL);
+}
+
+vui64_t
+__test_mrgahd (vui128_t __VH, vui128_t __VL)
+{
+  return vec_mrgahd (__VH, __VL);
+}
+
+vui64_t
+__test_mrgald (vui128_t __VH, vui128_t __VL)
+{
+  return vec_mrgald (__VH, __VL);
+}
+
 vui64_t
 __test_mrghd (vui64_t __VH, vui64_t __VL)
 {
@@ -439,13 +505,13 @@ __test_vpaste (vui64_t __VH, vui64_t __VL)
 vui64_t
 __test_spltd_0 (vui64_t __VH)
 {
-  return vec_spltd (__VH, 0);
+  return vec_xxspltd (__VH, 0);
 }
 
 vui64_t
 __test_spltd_1 (vui64_t __VH)
 {
-  return vec_spltd (__VH, 1);
+  return vec_xxspltd (__VH, 1);
 }
 
 vui64_t
@@ -486,4 +552,138 @@ __test_cmpleud (vui64_t a, vui64_t b)
 {
   return vec_cmple (a, b);
 }
+
+vui64_t
+__test_vmuludm (vui64_t vra, vui64_t vrb)
+{
+  vui64_t s32 = (vui64_t) { 32, 32 };
+  vui64_t z = (vui64_t) { 0, 0 };
+  vui64_t t4;
+  vui64_t t2, t3;
+  vui32_t t1;
+
+  t1 = (vui32_t)vec_vrld (vrb, s32);
+  t2 = vec_mulouw ((vui32_t)vra, (vui32_t)vrb);
+  t3 = vec_vmsumuwm ((vui32_t)vra, t1, z);
+  t4 = vec_vsld (t3, s32);
+  return (vui64_t)vec_addudm (t4, t2);
+}
+#endif
+
+#ifdef _ARCH_PWR7
+/* POWER 64-bit (vector long long) compiler tests.  */
+
+vui64_t
+__test_vrld_PWR7 (vui64_t a, vui64_t b)
+{
+  vui64_t r, hd, ld;
+  vui32_t t1, t2;
+  vui8_t shh, shl;
+
+  shh = vec_splat ((vui8_t)b, 7);
+  shl = vec_splat ((vui8_t)b, 15);
+  hd = vec_xxspltd (a, 0);
+  ld = vec_xxspltd (a, 1);
+  t1 = vec_vslo ((vui32_t)hd, shh);
+  t1 = vec_vsl (t1, shh);
+  t2 = vec_vslo ((vui32_t)ld, shl);
+  t2 = vec_vsl (t2, shl);
+  r = vec_mrghd ((vui64_t)t1, (vui64_t)t2);
+
+  return r;
+}
+
+vui64_t
+__test_xxpermdi_0 (vui64_t vra, vui64_t vrb)
+{
+  return vec_xxpermdi (vra, vrb, 0);
+}
+
+vui64_t
+__test_xxpermdi_1 (vui64_t vra, vui64_t vrb)
+{
+  return vec_xxpermdi (vra, vrb, 1);
+}
+
+vui64_t
+__test_xxpermdi_2 (vui64_t vra, vui64_t vrb)
+{
+  return vec_xxpermdi (vra, vrb, 2);
+}
+
+vui64_t
+__test_xxpermdi_3 (vui64_t vra, vui64_t vrb)
+{
+  return vec_xxpermdi (vra, vrb, 3);
+}
+
+vui64_t
+__test_mergeh (vui64_t a, vui64_t b)
+{
+  return vec_mergeh (a, b);
+}
+
+vui64_t
+__test_mergel (vui64_t a, vui64_t b)
+{
+  return vec_mergel (a, b);
+}
+
+#if (__GNUC__ > 6)
+
+vui64_t
+__test_vmsumuwm (vui32_t vra, vui32_t vrb, vui64_t vrc)
+{
+  return vec_vmsumuwm (vra, vrb, vrc);
+}
+
+vui64_t
+__test_splatd0 (vui64_t a)
+{
+  return vec_splat (a, 0);
+}
+
+vui64_t
+__test_splatd1 (vui64_t a)
+{
+  return vec_splat (a, 1);
+}
+
+#if (__GNUC__ > 7)
+
+vui64_t
+__test_mergee (vui64_t a, vui64_t b)
+{
+  return vec_mergee (a, b);
+}
+
+vui64_t
+__test_mergeo (vui64_t a, vui64_t b)
+{
+  return vec_mergeo (a, b);
+}
+
+vui64_t
+__test_mul (vui64_t a, vui64_t b)
+{
+  return vec_mul (a, b);
+}
+
+vui64_t
+__test_vmuludm_PWR7 (vui64_t vra, vui64_t vrb)
+{
+  vui64_t s32 = (vui64_t) { 32, 32 };
+  vui64_t z = (vui64_t) { 0, 0 };
+  vui64_t t4;
+  vui64_t t2, t3;
+  vui32_t t1;
+
+  t1 = (vui32_t)vec_vrld (vrb, s32);
+  t2 = vec_mulouw ((vui32_t)vra, (vui32_t)vrb);
+  t3 = vec_vmsumuwm ((vui32_t)vra, t1, z);
+  t4 = vec_vsld (t3, s32);
+  return (vui64_t)vec_addudm (t4, t2);
+}
+#endif
+#endif
 #endif

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -62,6 +62,30 @@ __test_muleud_PWR9 (vui64_t a, vui64_t b)
   return vec_muleud (a, b);
 }
 
+vui64_t
+__test_mulhud_PWR9 (vui64_t a, vui64_t b)
+{
+  return vec_mulhud (a, b);
+}
+
+vui64_t
+__test_muludm_PWR9 (vui64_t a, vui64_t b)
+{
+  return vec_muludm (a, b);
+}
+
+vui128_t
+__test_vmuloud_PWR9 (vui64_t a, vui64_t b)
+{
+  return vec_vmuloud (a, b);
+}
+
+vui128_t
+__test_vmuleud_PWR9 (vui64_t a, vui64_t b)
+{
+  return vec_vmuleud (a, b);
+}
+
 vui128_t
 __test_mulluq_PWR9 (vui128_t a, vui128_t b)
 {


### PR DESCRIPTION
…wr9_dummy.c

Eyeball code gen for merge/multiply operations and example.

	* src/testsuite/vec_int128_dummy.c (__test_vec_msumudm):
	New Function.
	(__test_muludm, __test_mulhud, __test_vmuloud, __test_vmuleud):
	New Functions.
	(example_dw_convert_timebase): New Function.

	* src/testsuite/vec_int32_dummy.c [_ARCH_PWR7 && (__GNUC__>6)]:
	(__test_mulluw): New Function.

	* src/testsuite/vec_int64_dummy.c (test_rldi_1, test_rldi_15,
	test_rldi_32): New Functions.
	(test_absdud): New Function.
	(__test_maxsd, __test_maxud, __test_minsd, __test_minud):
	New Functions.
	(__test_mrgahd, __test_mrgald): New Functions.
	(__test_spltd_0, __test_spltd_1): Replace deprecated vec_spltd
	with vec_xxspltd.
	(__test_vmuludm): New Function.
	[_ARCH_PWR7] (__test_vrld_PWR7, __test_xxpermdi_0
	__test_xxpermdi_1, __test_xxpermdi_2, __test_xxpermdi_3,
	_test_mergeh, _test_mergel): New Functions.
	[_ARCH_PWR7 && (__GNUC__>6)] (__test_vmsumuwm, __test_splatd0,
	__test_splatd1): New Functions.
	[_ARCH_PWR7 && (__GNUC__>7)] (__test_mergee, __test_mergeo,
	__test_mul, __test_vmuludm): New Functions.

	* src/testsuite/vec_pwr9_dummy.c (__test_mulhud_PWR9,
	__test_muludm_PWR9, __test_vmuloud_PWR9, __test_vmuleud_PWR9)
	New Functions.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>