### PR TITLE
More Fixes for vec_int64_ppc.h and functions for vec_int128_ppc.h.

### DIFF
--- a/src/vec_int64_ppc.h
+++ b/src/vec_int64_ppc.h
@@ -2883,7 +2883,7 @@ vec_spltd (vui64_t vra, const int ctl)
 static inline vui64_t
 vec_srdi (vui64_t vra, const unsigned int shb)
 {
-  vui64_t lshift;
+  vui64_t rshift;
   vui64_t result;
 
   if (shb < 64)
@@ -2892,14 +2892,17 @@ vec_srdi (vui64_t vra, const unsigned int shb)
          a shift amount for each element. For the immediate form the
          shift constant is splatted to all elements of the
          shift control.  */
+#if defined (__GNUC__) && (__GNUC__ < 8)
       if (__builtin_constant_p (shb) && (shb < 16))
-	lshift = (vui64_t) vec_splat_s32(shb);
+	rshift = (vui64_t) vec_splat_s32(shb);
       else
-	lshift = vec_splats ((unsigned long) shb);
-
+	rshift = vec_splats ((unsigned long) shb);
+#else
+      rshift = CONST_VINT128_DW (shb, shb);
+#endif
       /* Vector Shift right bytes based on the lower 6-bits of
-         corresponding element of lshift.  */
-      result = vec_vsrd (vra, lshift);
+         corresponding element of rshift.  */
+      result = vec_vsrd (vra, rshift);
     }
   else
     { /* shifts greater then 63 bits return zeros.  */
@@ -2929,7 +2932,7 @@ vec_srdi (vui64_t vra, const unsigned int shb)
 static inline vi64_t
 vec_sradi (vi64_t vra, const unsigned int shb)
 {
-  vui64_t lshift;
+  vui64_t rshift;
   vi64_t result;
 
   if (shb < 64)
@@ -2938,21 +2941,24 @@ vec_sradi (vi64_t vra, const unsigned int shb)
          a shift amount for each element. For the immediate form the
          shift constant is splatted to all elements of the
          shift control.  */
+#if defined (__GNUC__) && (__GNUC__ < 8)
       if (__builtin_constant_p (shb) && (shb < 16))
-	lshift = (vui64_t) vec_splat_s32(shb);
+	rshift = (vui64_t) vec_splat_s32(shb);
       else
-	lshift = vec_splats ((unsigned long) shb);
-
+	rshift = vec_splats ((unsigned long) shb);
+#else
+      rshift = CONST_VINT128_DW (shb, shb);
+#endif
       /* Vector Shift Right Algebraic Doublewords based on the lower 6-bits
-         of corresponding element of lshift.  */
-      result = vec_vsrad (vra, lshift);
+         of corresponding element of rshift.  */
+      result = vec_vsrad (vra, rshift);
     }
   else
     { /* shifts greater then 63 bits returns the sign bit propagated to
          all bits.   This is equivalent to shift Right Algebraic of
          63 bits.  */
-      lshift = (vui64_t) vec_splats(63);
-      result = vec_vsrad (vra, lshift);
+      rshift = (vui64_t) vec_splats(63);
+      result = vec_vsrad (vra, rshift);
     }
 
   return (vi64_t) result;


### PR DESCRIPTION
Also POWER9 and Endian fixes for vec_muludq, vec_mulluq.
Added vec_mulhuq. Specifics follow:
1) Unit tests for vec_sraqi detected a regression in GCC 8
in the code generation for builtins vec_sr, vec_sra, vec_vsrd,
vec_vsrad. This also failed unit tests for vec_srdi and vec_sradi.
Bill Schmidt is working the problem in Upstream (GCC9) and
will need a fix backported to GCC8 and AT12.
2) On testing the quadword multiplies (vec_muludq, vec_mulluq)
were not endian stable for POWER9. Corrected that using endian
stable merge and multiply doubleword operations. Also added vec_mulhuq
to support multiplicative inverse over quadword integers.
3) Added new quadword operations; vec_absduq,vec_avguq, vec_maxsq,
vec_maxuq, vec_minsq, vec_minuq, vec_mulhuq, vec_rlq, vec_rlqi,
vec_sldqi, vec_sraq, and vec_sraqi.

	* vec_int64_ppc.h (vec_srdi): Replace lshift with rshift.
	(vec_srdi [!(__GNUC__ < 8)]): Assign rshift from vector const.
	This is a work around for GCC 8 GIMMPLE const folding bug.
	(vec_sradi): Replace lshift with rshift.
	(vec_sradi [!(__GNUC__ < 8])): Assign rshift from vector const.
	This is a work around for GCC 8 GIMMPLE const folding bug.

	* vec_int128_ppc.h: Updated Doxygen comments in header.
	(i128_endian_issues_0_0): Added section; Endian problems with
	quadword implementations.
	(int128_examples_0_1): Added section; Vector Quadword Examples.
	(int128_examples_0_1_1): Added subsection; Printing Vector
	__int128 values.
	(int128_examples_0_1_2: Added subsection; Extending integer
	operations beyond Quadword.
	(///@cond INTERNAL): move all forward function declares to the
	top and wrap in Doxygen @cond.
	(vec_absduq,vec_avguq): New Functions.
	(vec_cmpsq_all_ne, vec_cmpuq_all_eq): White space fixes.
	(vec_maxsq, vec_maxuq, vec_minsq, vec_minuq): New Functions.
	(vec_muludq [_ARCH_PWR9]): Use endian stable vec_mrgald,
	vec_mrgahd, vec_vmuloud. White space fixes.
	(vec_mulluq [_ARCH_PWR9]): Use endian stable vec_mrgald,
	vec_mrgahd, vec_vmuloud. White space fixes.
	(vec_mulhuq): New Function.
	(vec_rlq, vec_rlqi): new Functions.
	(vec_sldq): Minor updates.
	(vec_sldqi): New Function.
	(vec_slqi): Use vui8_t type.
	(vec_sraq, vec_sraqi): New Function.
	(vec_srqi): Minor updates.
	(vec_sldq, vec_sldqi, vec_slq, vec_slqi, vec_sraq, vec_sraqi,
	vec_srqi): Reorder quadword shift operations alphabetically.
	(vec_subcuq, vec_vmuleud, vec_vmuloud):
	Minor updates.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>