### PR TITLE
Cleanup vec_bcd_ppc.h. Use __builtin_bcdadd/bcdsub/denbcdq/ddedpdq

### DIFF
--- a/src/vec_int128_ppc.h
+++ b/src/vec_int128_ppc.h
@@ -518,6 +518,7 @@ static inline vui128_t vec_maxuq (vui128_t a, vui128_t b);
 static inline vui128_t vec_minuq (vui128_t a, vui128_t b);
 static inline vui128_t vec_muleud (vui64_t a, vui64_t b);
 static inline vui128_t vec_muloud (vui64_t a, vui64_t b);
+static inline vui128_t vec_muludq (vui128_t *mulu, vui128_t a, vui128_t b);
 static inline vb128_t vec_setb_cyq (vui128_t vcy);
 static inline vb128_t vec_setb_ncq (vui128_t vcy);
 static inline vb128_t vec_setb_sq (vi128_t vra);


### PR DESCRIPTION
where posible. Otherwise use inline asm where needed.
Turns out there are compiler bugs that prevent using the __builtin
functions on older compilers.
Also add a forward ref declare for vec_muludq in vec_int128_ppc.h.
This fixes a function not found when compiling -mcpu=power7.

	* src/vec_bcd_ppc.h: #define vBCD_t.
	(bcd_qauntize0): Format source.
	(vec_pack_Decimal128): New function.
	(vec_unpack_Decimal128): New function.
	(vec_BCD2DFP): Use vBCD_t. Format source.
	(vec_BCD2DFP [__GNUC__ < 5]) Else replace __asm with
	__builtin_denbcdq. Use vec_unpack_Decimal128.
	(vec_DFP2BCD): Use vBCD_t. Format source.
	(vec_DFP2BCD [__GNUC__ < 5]) Else replace __asm with
	__builtin_ddedpdq. Use vec_pack_Decimal128.
	(vec_bcdadd): Use vBCD_t. Format source.
	(vec_bcdadd [__GNUC__ < 7]) Else replace __asm with
	__builtin_bcdadd.
	(vec_bcddiv): Use vBCD_t. Format source.
	(vec_bcdmul): Use vBCD_t. Format source.
	(vec_bcdsub [__GNUC__ < 7]) Else replace __asm with
	__builtin_bcdsub.
	(vec_bcdctb100s): Format doxygen comments and source.
	Replace mule/mulo/perm with vec_mulubm.

	* vec_int128_ppc.h: Forward ref declare vec_muludq.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>