### PR TITLE
Complete compiler & unit tests for unsigned BCD to binary operations.

### DIFF
--- a/src/testsuite/arith128_test_bcd.c
+++ b/src/testsuite/arith128_test_bcd.c
@@ -42,6 +42,62 @@
 #include <testsuite/arith128_test_bcd.h>
 
 vui8_t
+db_vec_ZN2i128 (vui8_t zone00, vui8_t zone16)
+{
+  vui8_t result = { 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+  const vui8_t dmask = vec_splat_u8 (15);
+  const vui8_t dx10 = vec_splat_u8 (10);
+  vui8_t znd00, znd16;
+  vui8_t ones, tens;
+  vui16_t ten00, ten16;
+  vui8_t e_perm =
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    { 0x00, 0x10, 0x02, 0x12, 0x04, 0x14, 0x06, 0x16, 0x08, 0x18, 0x0a, 0x1a,
+	0x0c, 0x1c, 0x0e, 0x1e };
+#else
+    { 0x01, 0x11, 0x03, 0x13, 0x05, 0x15, 0x07, 0x17, 0x09, 0x19, 0x0b, 0x1b,
+	0x0d, 0x1d, 0x0f, 0x1f };
+#endif
+  vui8_t /*i,*/ j, k, l, m/**/;
+
+  print_vint8x ("32xZoned   ", zone00);
+  print_vint8x ("           ", zone16);
+  print_vint8c ("32xZoned %c", zone00);
+  print_vint8c ("           ", zone16);
+
+  znd00 = vec_and (zone00, dmask);
+  znd16 = vec_and (zone16, dmask);
+  print_vint8x ("32xZD      ", znd00);
+  print_vint8x ("           ", znd16);
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  ones = vec_pack ((vui16_t) znd16, (vui16_t) znd00);
+#else
+  ones = vec_pack ((vui16_t) znd00, (vui16_t) znd16);
+#endif
+  print_vint8x ("ones       ", ones);
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  ten00 = vec_mulo (znd00, dx10);
+  ten16 = vec_mulo (znd16, dx10);
+  tens = vec_pack (ten16, ten00);
+#else
+  ten00 = vec_mule (znd00, dx10);
+  ten16 = vec_mule (znd16, dx10);
+  tens = vec_pack (ten00, ten16);
+#endif
+  print_vint8x ("tenx10     ", (vui8_t) ten00);
+  print_vint8x ("           ", (vui8_t) ten16);
+  print_vint8x ("tenxpack   ", tens);
+
+  result = vec_add (tens, ones);
+  print_vint8x ("Zone 100s  ", result);
+  print_vint8d ("           ", result);
+
+  return result;
+}
+
+vui8_t
 db_vec_BCD2i128 (vui8_t bcd32)
 {
   vui8_t result = { 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
@@ -96,7 +152,11 @@ db_vec_BC100s2i128 (vui8_t bc100s16)
   print_vint16d ("           ", (vui16_t)bc100s16);
 
   k = vec_splats ((unsigned char)156);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  l = vec_vmuloub (bc100s16, k);
+#else
   l = vec_vmuleub (bc100s16, k);
+#endif
   print_vint16x (" hd*156 ev ", l);
   print_vint16d ("           ", l);
 
@@ -117,7 +177,11 @@ db_vec_BC10ks2i128 (vui16_t bc10k8)
   print_vint32d ("           ", (vui32_t)bc10k8);
 
   k = vec_splats ((unsigned short)55536);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  l = vec_vmulouh (bc10k8, k);
+#else
   l = vec_vmuleuh (bc10k8, k);
+#endif
   print_vint32x (" hd*156 ev ", l);
   print_vint32d ("           ", l);
 
@@ -138,8 +202,8 @@ db_vec_BC100ms2i128 (vui32_t bc100m4)
   print_v2int64 ("           ", (vui64_t)bc100m4);
 
   k = vec_splats ((unsigned int)4194967296);
-#ifdef vec_vmuleuw
-  l = vec_vmuleuw (bc100m4, k);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  l = vec_mulouw (bc100m4, k);
 #else
   l = vec_muleuw (bc100m4, k);
 #endif
@@ -153,7 +217,7 @@ db_vec_BC100ms2i128 (vui32_t bc100m4)
 }
 
 vui128_t
-db_vec_BC10ts2i128 (vui64_t bc10t2)
+db_vec_BC10es2i128 (vui64_t bc10t2)
 {
   vui128_t result;
   vui64_t k;
@@ -176,14 +240,10 @@ db_vec_BC10ts2i128 (vui64_t bc10t2)
   print_vint128x (" cvt*10t   ", l);
   print_vint128  ("           ", l);
 #endif
+  /* k = 18436744073709551616UL */
   k = vec_splats ((unsigned long)0xFFDC790D903F0000UL);
-#if 0
-#ifdef vec_vmuleud
+#if 1
   l = vec_vmuleud (bc10t2, k);
-#else
-  l = vec_muleud (bc10t2, k);
-  k = (vui64_t)l;
-#endif
 #else
   print_vint128x (" cvt*10t k ", (vui128_t) k);
 
@@ -206,7 +266,7 @@ db_vec_BC10ts2i128 (vui64_t bc10t2)
 #ifdef __DEBUG_PRINT__
 #define test_vec_bcdctb100s(_l)	db_vec_BCD2i128(_l)
 #else
-#define test_vec_bcdctb100s(_l)	vec_bcdctb100s(_l)
+#define test_vec_bcdctb100s(_l)	vec_rdxct100b(_l)
 #endif
 
 int
@@ -235,7 +295,7 @@ test_48 (void)
   m = db_vec_BC100ms2i128 (l);
   print_v2int64 ("BC10Ts     ", m);
 
-  n = db_vec_BC10ts2i128 (m);
+  n = db_vec_BC10es2i128 (m);
   print_vint128 ("BCD10x     ", n);
 
   return (rc);
@@ -263,7 +323,7 @@ test_cvtbcd2c100 (void)
   print_vint8x ("BC100s     ", j);
   print_vint8d ("           ", j);
 #endif
-  rc += check_vuint128x ("vec_bcdctb100s:", (vui128_t) j, (vui128_t) e);
+  rc += check_vuint128x ("vec_rdxct100b:", (vui128_t) j, (vui128_t) e);
 
   i = (vui8_t) { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
@@ -277,7 +337,7 @@ test_cvtbcd2c100 (void)
   print_vint8x ("BC100s     ", j);
   print_vint8d ("           ", j);
 #endif
-  rc += check_vuint128x ("vec_bcdctb100s:", (vui128_t) j, (vui128_t) e);
+  rc += check_vuint128x ("vec_rdxct100b:", (vui128_t) j, (vui128_t) e);
 
   i = (vui8_t) { 0x01, 0x09, 0x10, 0x19, 0x20, 0x29, 0x30, 0x39,
                  0x40, 0x49, 0x50, 0x59, 0x60, 0x69, 0x70, 0x79 };
@@ -291,7 +351,7 @@ test_cvtbcd2c100 (void)
   print_vint8x ("BC100s     ", j);
   print_vint8d ("           ", j);
 #endif
-  rc += check_vuint128x ("vec_bcdctb100s:", (vui128_t) j, (vui128_t) e);
+  rc += check_vuint128x ("vec_rdxct100b:", (vui128_t) j, (vui128_t) e);
 
   i = (vui8_t) { 0x80, 0x81, 0x82, 0x83, 0x86, 0x87, 0x88, 0x89,
                  0x90, 0x91, 0x92, 0x93, 0x95, 0x96, 0x97, 0x98 };
@@ -305,7 +365,7 @@ test_cvtbcd2c100 (void)
   print_vint8x ("BC100s     ", j);
   print_vint8d ("           ", j);
 #endif
-  rc += check_vuint128x ("vec_bcdctb100s:", (vui128_t) j, (vui128_t) e);
+  rc += check_vuint128x ("vec_rdxct100b:", (vui128_t) j, (vui128_t) e);
 
   return (rc);
 }
@@ -457,6 +517,685 @@ test_bcd_addsub (void)
   return rc;
 }
 
+ //#define __DEBUG_PRINT__ 1
+ #ifdef __DEBUG_PRINT__
+ #define test_vec_BC10ks2i128(_l)	db_vec_BC100s2i128(_l)
+ #else
+ #define test_vec_BC10ks2i128(_l)	vec_rdxct10kh(_l)
+ #endif
+ int
+ test_cvtbcd2c10k (void)
+ {
+   vui8_t i;
+   vui16_t j, e;
+   int rc = 0;
+
+   printf ("\n%s Vector BCD 100s convert\n", __FUNCTION__);
+
+   i = (vui8_t) { 99, 99, 99, 99, 99, 99, 99, 99,
+ 	          99, 99, 99, 99, 99, 99, 99, 99 };
+   e = (vui16_t) { 9999, 9999, 9999, 9999,
+                  9999, 9999, 9999, 9999 };
+   j = test_vec_BC10ks2i128 (i);
+
+ #ifdef __DEBUG_PRINT__
+   print_vint8x ("BCD 9s     ", i);
+   print_vint8d ("           ", i);
+   print_vint16x ("BC10ks     ", j);
+   print_vint16d ("           ", j);
+ #endif
+   rc += check_vuint128x ("vec_rdxct10kh:", (vui128_t) j, (vui128_t) e);
+
+   i = (vui8_t) CONST_VINT8_B (  1,  9, 10, 19, 20, 29, 30, 39,
+                  40, 49, 50, 59, 60, 69, 70, 79 );
+   e = (vui16_t) CONST_VINT16_H ( 109, 1019, 2029, 3039,
+                   4049, 5059, 6069, 7079 );
+   j = test_vec_BC10ks2i128 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint8x ("BCD 9s     ", i);
+  print_vint8d ("           ", i);
+  print_vint16x ("BC10ks     ", j);
+  print_vint16d ("           ", j);
+#endif
+  rc += check_vuint128x ("vec_rdxct10kh:", (vui128_t) j, (vui128_t) e);
+
+  i = (vui8_t) CONST_VINT8_B ( 80, 81, 82, 83, 86, 87, 88, 89,
+                 90, 91, 92, 93, 95, 96, 97, 98 );
+  e = (vui16_t) CONST_VINT16_H ( 8081, 8283, 8687, 8889,
+                 9091, 9293, 9596, 9798 );
+
+  j = test_vec_BC10ks2i128 (i);
+
+#ifdef __DEBUG_PRINT__
+ print_vint8x ("BCD 9s     ", i);
+ print_vint8d ("           ", i);
+ print_vint16x ("BC10ks     ", j);
+ print_vint16d ("           ", j);
+#endif
+ rc += check_vuint128x ("vec_rdxct10kh:", (vui128_t) j, (vui128_t) e);
+
+  return rc;
+}
+
+ //#define __DEBUG_PRINT__ 1
+ #ifdef __DEBUG_PRINT__
+ #define test_vec_BC100ms2i128(_l)	db_vec_BC10ks2i128(_l)
+ #else
+ #define test_vec_BC100ms2i128(_l)	vec_rdxct100mw(_l)
+ #endif
+ int
+ test_cvtbcd2c100m (void)
+ {
+   vui16_t i;
+   vui32_t j, e;
+   int rc = 0;
+
+   printf ("\n%s Vector BCD 10Ks convert\n", __FUNCTION__);
+
+   i = (vui16_t) { 9999, 9999, 9999, 9999,
+ 	          9999, 9999, 9999, 9999 };
+   e = (vui32_t) { 99999999, 99999999,
+                  99999999, 99999999 };
+   j = test_vec_BC100ms2i128 (i);
+
+ #ifdef __DEBUG_PRINT__
+   print_vint16x ("BC10ks     ", i);
+   print_vint16d ("           ", i);
+   print_vint32x ("BC100ms    ", j);
+   print_vint32d ("           ", j);
+ #endif
+   rc += check_vuint128x ("vec_rdxct100mw:", (vui128_t) j, (vui128_t) e);
+
+   i = (vui16_t) CONST_VINT16_H (  109, 1019, 2029, 3039,
+                                  4049, 5059, 6069, 7079 );
+   e = (vui32_t) CONST_VINT32_W ( 1091019, 20293039,
+                                 40495059, 60697079 );
+   j = test_vec_BC100ms2i128 (i);
+
+ #ifdef __DEBUG_PRINT__
+   print_vint16x ("BC10ks     ", i);
+   print_vint16d ("           ", i);
+   print_vint32x ("BC100ms    ", j);
+   print_vint32d ("           ", j);
+ #endif
+   rc += check_vuint128x ("vec_rdxct100mw:", (vui128_t) j, (vui128_t) e);
+
+   i = (vui16_t) CONST_VINT16_H ( 8081, 8283, 8687, 8889,
+			          9091, 9293, 9596, 9798 );
+   e = (vui32_t) CONST_VINT32_W ( 80818283, 86878889,
+			          90919293, 95969798 );
+   j = test_vec_BC100ms2i128 (i);
+
+ #ifdef __DEBUG_PRINT__
+   print_vint16x ("BC10ks     ", i);
+   print_vint16d ("           ", i);
+   print_vint32x ("BC100ms    ", j);
+   print_vint32d ("           ", j);
+ #endif
+   rc += check_vuint128x ("vec_rdxct100mw:", (vui128_t) j, (vui128_t) e);
+
+   return rc;
+ }
+
+ //#define __DEBUG_PRINT__ 1
+ #ifdef __DEBUG_PRINT__
+ #define test_vec_BC10es2i128(_l)	db_vec_BC100ms2i128(_l)
+ #else
+ #define test_vec_BC10es2i128(_l)	vec_rdxct10E16d(_l)
+ #endif
+ int
+ test_cvtbcd2c10e (void)
+ {
+   vui32_t i;
+   vui64_t j, e;
+   int rc = 0;
+
+   printf ("\n%s Vector BCD 100Ms convert\n", __FUNCTION__);
+
+   i = (vui32_t) { 99999999, 99999999,
+ 	           99999999, 99999999 };
+   e = (vui64_t) { 9999999999999999UL,
+                   9999999999999999UL };
+   j = test_vec_BC10es2i128 (i);
+
+ #ifdef __DEBUG_PRINT__
+   print_vint32x  ("BC100ms    ", i);
+   print_vint32d  ("           ", i);
+   print_v2xint64 ("BC10es     ", j);
+   print_v2int64  ("           ", j);
+ #endif
+   rc += check_vuint128x ("vec_rdxct10E16d:", (vui128_t) j, (vui128_t) e);
+
+   i = (vui32_t) CONST_VINT32_W (  1091019, 20293039,
+	                          40495059, 60697079 );
+   e = (vui64_t) CONST_VINT64_DW ( 109101920293039UL,
+	                          4049505960697079UL );
+   j = test_vec_BC10es2i128 (i);
+
+ #ifdef __DEBUG_PRINT__
+   print_vint32x  ("BC100ms    ", i);
+   print_vint32d  ("           ", i);
+   print_v2xint64 ("BC10es     ", j);
+   print_v2int64  ("           ", j);
+ #endif
+   rc += check_vuint128x ("vec_rdxct10E16d:", (vui128_t) j, (vui128_t) e);
+
+   i = (vui32_t) CONST_VINT32_W ( 80818283, 86878889,
+			          90919293, 95969798 );
+   e = (vui64_t) CONST_VINT64_DW ( 8081828386878889UL,
+				   9091929395969798UL );
+   j = test_vec_BC10es2i128 (i);
+
+ #ifdef __DEBUG_PRINT__
+   print_vint32x  ("BC100ms    ", i);
+   print_vint32d  ("           ", i);
+   print_v2xint64 ("BC10es     ", j);
+   print_v2int64  ("           ", j);
+ #endif
+   rc += check_vuint128x ("vec_rdxct10E16d:", (vui128_t) j, (vui128_t) e);
+
+   return rc;
+ }
+
+ //#define __DEBUG_PRINT__ 1
+ #ifdef __DEBUG_PRINT__
+ #define test_vec_BC10e32i128(_l)	db_vec_BC10es2i128(_l)
+ #else
+ #define test_vec_BC10e32i128(_l)	vec_rdxct10e32q(_l)
+ #endif
+ int
+ test_cvtbcd2c10e32 (void)
+ {
+   vui64_t i;
+   vui128_t j, e;
+   int rc = 0;
+
+   printf ("\n%s Vector BCD 10es convert\n", __FUNCTION__);
+
+   i = (vui64_t) { 9999999999999999UL,
+ 	           9999999999999999UL };
+   /* e = 999999999999999999999999999999UQ  */
+   e = (vui128_t) { (__int128 ) 9999999999999999ll
+                  * (__int128 ) 10000000000000000ll
+                  + (__int128 ) 9999999999999999ll };
+   j = test_vec_BC10e32i128 (i);
+
+ #ifdef __DEBUG_PRINT__
+   print_v2xint64 ("BC10es    ", i);
+   print_v2int64  ("          ", i);
+   print_vint128x ("BC10e32   ", j);
+   print_vint128  ("          ", j);
+ #endif
+   rc += check_vuint128x ("vec_rdxct10e32q:", (vui128_t) j, (vui128_t) e);
+
+   i = (vui64_t) CONST_VINT64_DW (  109101920293039UL,
+		                   4049505960697079UL );
+   /* e = 1091019202930394049505960697079UQ  */
+   e = (vui128_t) { (__int128 ) 109101920293039ll
+                  * (__int128 ) 10000000000000000ll
+                  + (__int128 ) 4049505960697079ll };
+   j = test_vec_BC10e32i128 (i);
+
+ #ifdef __DEBUG_PRINT__
+   print_v2xint64 ("BC10es    ", i);
+   print_v2int64  ("          ", i);
+   print_vint128x ("BC10e32   ", j);
+   print_vint128  ("          ", j);
+ #endif
+   rc += check_vuint128x ("vec_rdxct10e32q:", (vui128_t) j, (vui128_t) e);
+
+   i = (vui64_t) CONST_VINT64_DW ( 8081828386878889UL,
+				   9091929395969798UL );
+   /* e = 80818283868788899091929395969798UQ  */
+   e = (vui128_t) { (__int128 ) 8081828386878889ll
+                  * (__int128 ) 10000000000000000ll
+                  + (__int128 ) 9091929395969798ll };
+   j = test_vec_BC10e32i128 (i);
+
+ #ifdef __DEBUG_PRINT__
+   print_v2xint64 ("BC10es    ", i);
+   print_v2int64  ("          ", i);
+   print_vint128x ("BC10e32   ", j);
+   print_vint128  ("          ", j);
+ #endif
+   rc += check_vuint128x ("vec_rdxct10e32q:", (vui128_t) j, (vui128_t) e);
+
+   return rc;
+ }
+
+ //#define __DEBUG_PRINT__ 1
+ #ifdef __DEBUG_PRINT__
+ #define test_vec_bcdcfz100s(_l, _m)	db_vec_ZN2i128(_l, _m)
+ #else
+ #define test_vec_bcdcfz100s(_l, _m)	vec_rdxcfzt100b(_l, _m)
+ #endif
+ int
+ test_cvtbcfz2c100 (void)
+ {
+   vui8_t i00, i16, j;
+   vui8_t e;
+   int rc = 0;
+
+   printf ("\n%s Vector Zoned convert\n", __FUNCTION__);
+
+   i00 = (vui8_t) { '9', '9', '9', '9', '9', '9', '9', '9',
+                    '9', '9', '9', '9', '9', '9', '9', '9' };
+   i16 = (vui8_t) { '9', '9', '9', '9', '9', '9', '9', '9',
+                    '9', '9', '9', '9', '9', '9', '9', '9' };
+   e = (vui8_t) { 99, 99, 99, 99, 99, 99, 99, 99,
+                  99, 99, 99, 99, 99, 99, 99, 99 };
+   j = test_vec_bcdcfz100s (i00, i16);
+
+ #ifdef __DEBUG_PRINT__
+   print_vint8c ("Zoned      ", i00);
+   print_vint8c ("           ", i16);
+   print_vint8x ("Zoned 100s ", j);
+   print_vint8d ("           ", j);
+ #endif
+   rc += check_vuint128x ("vec_rdxcfzt100b:", (vui128_t) j, (vui128_t) e);
+
+   i00 = (vui8_t) CONST_VINT8_B ( '0', '1', '0', '9', '1', '0', '1', '9',
+                                  '2', '0', '2', '9', '3', '0', '3', '9' );
+   i16 = (vui8_t) CONST_VINT8_B ( '4', '0', '4', '9', '5', '0', '5', '9',
+                                  '6', '0', '6', '9', '7', '0', '7', '9' );
+   e =   (vui8_t) CONST_VINT8_B (  1,  9, 10, 19, 20, 29, 30, 39,
+                                  40, 49, 50, 59, 60, 69, 70, 79 );
+   j = test_vec_bcdcfz100s (i00, i16);
+
+ #ifdef __DEBUG_PRINT__
+   print_vint8c ("Zoned      ", i00);
+   print_vint8c ("           ", i16);
+   print_vint8x ("Zoned 100s ", j);
+   print_vint8d ("           ", j);
+ #endif
+   rc += check_vuint128x ("vec_rdxcfzt100b:", (vui128_t) j, (vui128_t) e);
+
+   i00 = (vui8_t) CONST_VINT8_B ( '8', '0', '8', '1', '8', '2', '8', '3',
+                                  '8', '6', '8', '7', '8', '8', '8', '9' );
+   i16 = (vui8_t) CONST_VINT8_B ( '9', '0', '9', '1', '9', '2', '9', '3',
+                                  '9', '5', '9', '6', '9', '7', '9', '8' );
+   e =   (vui8_t) CONST_VINT8_B ( 80, 81, 82, 83, 86, 87, 88, 89,
+		                  90, 91, 92, 93, 95, 96, 97, 98 );
+   j = test_vec_bcdcfz100s (i00, i16);
+
+ #ifdef __DEBUG_PRINT__
+   print_vint8c ("Zoned      ", i00);
+   print_vint8c ("           ", i16);
+   print_vint8x ("Zoned 100s ", j);
+   print_vint8d ("           ", j);
+ #endif
+   rc += check_vuint128x ("vec_rdxcfzt100b:", (vui128_t) j, (vui128_t) e);
+
+   return rc;
+ }
+
+ //#define __DEBUG_PRINT__ 1
+ int
+ test_bcdctub (void)
+ {
+   vui8_t i;
+   vui8_t j;
+   vui8_t e;
+   int rc = 0;
+
+   printf ("\n%s Vector BCD convert\n", __FUNCTION__);
+
+   i = (vui8_t) { 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99,
+ 	         0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99 };
+   e = (vui8_t) { 99, 99, 99, 99, 99, 99, 99, 99,
+                  99, 99, 99, 99, 99, 99, 99, 99 };
+   j = vec_bcdctub ((vBCD_t) i);
+
+ #ifdef __DEBUG_PRINT__
+   print_vint8x ("BCD bytes  ", i);
+   print_vint8d ("           ", i);
+   print_vint8x ("char bytes ", j);
+   print_vint8d ("           ", j);
+ #endif
+   rc += check_vuint128x ("vec_bcdctub:", (vui128_t) j, (vui128_t) e);
+
+   i = (vui8_t) { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+   e = (vui8_t) { 00, 00, 00, 00, 00, 00, 00, 00,
+                  00, 00, 00, 00, 00, 00, 00, 00 };
+   j = vec_bcdctub ((vBCD_t) i);
+
+ #ifdef __DEBUG_PRINT__
+   print_vint8x ("BCD bytes  ", i);
+   print_vint8d ("           ", i);
+   print_vint8x ("char bytes ", j);
+   print_vint8d ("           ", j);
+ #endif
+   rc += check_vuint128x ("vec_bcdctub:", (vui128_t) j, (vui128_t) e);
+
+   i = (vui8_t) { 0x01, 0x09, 0x10, 0x19, 0x20, 0x29, 0x30, 0x39,
+                  0x40, 0x49, 0x50, 0x59, 0x60, 0x69, 0x70, 0x79 };
+   e = (vui8_t) { 1, 9, 10, 19, 20, 29, 30, 39,
+                 40, 49, 50, 59, 60, 69, 70, 79 };
+   j = vec_bcdctub ((vBCD_t) i);
+
+ #ifdef __DEBUG_PRINT__
+   print_vint8x ("BCD bytes  ", i);
+   print_vint8d ("           ", i);
+   print_vint8x ("char bytes ", j);
+   print_vint8d ("           ", j);
+ #endif
+   rc += check_vuint128x ("vec_bcdctub:", (vui128_t) j, (vui128_t) e);
+
+   i = (vui8_t) { 0x80, 0x81, 0x82, 0x83, 0x86, 0x87, 0x88, 0x89,
+                  0x90, 0x91, 0x92, 0x93, 0x95, 0x96, 0x97, 0x98 };
+   e = (vui8_t) { 80, 81, 82, 83, 86, 87, 88, 89,
+                  90, 91, 92, 93, 95, 96, 97, 98 };
+   j = vec_bcdctub ((vBCD_t) i);
+
+ #ifdef __DEBUG_PRINT__
+   print_vint8x ("BCD bytes  ", i);
+   print_vint8d ("           ", i);
+   print_vint8x ("char bytes ", j);
+   print_vint8d ("           ", j);
+ #endif
+   rc += check_vuint128x ("vec_bcdctub:", (vui128_t) j, (vui128_t) e);
+
+   return (rc);
+ }
+ //#undef __DEBUG_PRINT__
+
+ //#define __DEBUG_PRINT__ 1
+ int
+ test_bcdctuh (void)
+ {
+   vui16_t i;
+   vui16_t j, e;
+   int rc = 0;
+
+   printf ("\n%s Vector BCD halfword convert\n", __FUNCTION__);
+
+   i = (vui16_t) CONST_VINT16_H ( 0x9999, 0x9999, 0x9999, 0x9999,
+ 	                          0x9999, 0x9999, 0x9999, 0x9999 );
+   e = (vui16_t) CONST_VINT16_H ( 9999, 9999, 9999, 9999,
+                                  9999, 9999, 9999, 9999 );
+   j = vec_bcdctuh ((vBCD_t) i);
+
+ #ifdef __DEBUG_PRINT__
+   print_vint16x ("BCD halfwords ", i);
+   print_vint16d ("              ", i);
+   print_vint16x ("short int     ", j);
+   print_vint16d ("              ", j);
+ #endif
+   rc += check_vuint128x ("vec_bcdctuh:", (vui128_t) j, (vui128_t) e);
+
+   i = (vui16_t) CONST_VINT16_H ( 0x0109, 0x1019, 0x2029, 0x3039,
+                                  0x4049, 0x5059, 0x6069, 0x7079 );
+   e = (vui16_t) CONST_VINT16_H ( 109, 1019, 2029, 3039,
+                                 4049, 5059, 6069, 7079 );
+   j = vec_bcdctuh ((vBCD_t) i);
+
+#ifdef __DEBUG_PRINT__
+   print_vint16x ("BCD halfwords ", i);
+   print_vint16d ("              ", i);
+   print_vint16x ("short int     ", j);
+   print_vint16d ("              ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdctuh:", (vui128_t) j, (vui128_t) e);
+
+  i = (vui16_t) CONST_VINT16_H ( 0x8081, 0x8283, 0x8687, 0x8889,
+                                 0x9091, 0x9293, 0x9596, 0x9798 );
+  e = (vui16_t) CONST_VINT16_H ( 8081, 8283, 8687, 8889,
+                                 9091, 9293, 9596, 9798 );
+
+  j = vec_bcdctuh ((vBCD_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint16x ("BCD halfwords ", i);
+  print_vint16d ("              ", i);
+  print_vint16x ("short int     ", j);
+  print_vint16d ("              ", j);
+#endif
+ rc += check_vuint128x ("vec_bcdctuh:", (vui128_t) j, (vui128_t) e);
+
+  return rc;
+}
+ //#undef __DEBUG_PRINT__
+
+ //#define __DEBUG_PRINT__ 1
+ int
+ test_bcdctuw (void)
+ {
+   vui32_t i;
+   vui32_t j, e;
+   int rc = 0;
+
+   printf ("\n%s Vector BCD word convert\n", __FUNCTION__);
+
+   i = (vui32_t) CONST_VINT32_W ( 0x99999999, 0x99999999,
+ 	                          0x99999999, 0x99999999 );
+   e = (vui32_t) CONST_VINT32_W  ( 99999999, 99999999,
+                                   99999999, 99999999 );
+   j = vec_bcdctuw ((vBCD_t) i);
+
+ #ifdef __DEBUG_PRINT__
+   print_vint32x ("BCD words ", i);
+   print_vint32d ("          ", i);
+   print_vint32x ("int       ", j);
+   print_vint32d ("          ", j);
+ #endif
+   rc += check_vuint128x ("vec_bcdctuw:", (vui128_t) j, (vui128_t) e);
+
+   i = (vui32_t) CONST_VINT32_W ( 0x01091019, 0x20293039,
+                                  0x40495059, 0x60697079 );
+   e = (vui32_t) CONST_VINT32_W ( 1091019, 20293039,
+                                 40495059, 60697079 );
+   j = vec_bcdctuw ((vBCD_t) i);
+
+#ifdef __DEBUG_PRINT__
+   print_vint32x ("BCD words ", i);
+   print_vint32d ("          ", i);
+   print_vint32x ("int       ", j);
+   print_vint32d ("          ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdctuw:", (vui128_t) j, (vui128_t) e);
+
+  i = (vui32_t) CONST_VINT32_W ( 0x80818283, 0x86878889,
+                                 0x90919293, 0x95969798 );
+  e = (vui32_t) CONST_VINT32_W ( 80818283, 86878889,
+                                 90919293, 95969798 );
+
+  j = vec_bcdctuw ((vBCD_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint32x ("BCD words ", i);
+  print_vint32d ("          ", i);
+  print_vint32x ("int       ", j);
+  print_vint32d ("          ", j);
+#endif
+ rc += check_vuint128x ("vec_bcdctuw:", (vui128_t) j, (vui128_t) e);
+
+  return rc;
+}
+ //#undef __DEBUG_PRINT__
+
+ //#define __DEBUG_PRINT__ 1
+ int
+ test_bcdctud (void)
+ {
+   vui64_t i;
+   vui64_t j, e;
+   int rc = 0;
+
+   printf ("\n%s Vector BCD dword convert\n", __FUNCTION__);
+
+   i = (vui64_t) CONST_VINT64_DW ( 0x9999999999999999UL,
+ 	                           0x9999999999999999UL );
+   e = (vui64_t) CONST_VINT64_DW ( 9999999999999999UL,
+                                   9999999999999999UL );
+   j = vec_bcdctud ((vBCD_t) i);
+
+ #ifdef __DEBUG_PRINT__
+   print_v2xint64 ("BCD dwords ", i);
+   print_v2xint64 ("long int   ", j);
+   print_v2int64  ("           ", j);
+ #endif
+   rc += check_vuint128x ("vec_bcdctud:", (vui128_t) j, (vui128_t) e);
+
+   i = (vui64_t) CONST_VINT64_DW ( 0x0109101920293039UL,
+                                   0x4049505960697079UL );
+   e = (vui64_t) CONST_VINT64_DW ( 109101920293039UL,
+                                  4049505960697079UL );
+   j = vec_bcdctud ((vBCD_t) i);
+
+#ifdef __DEBUG_PRINT__
+   print_v2xint64 ("BCD dwords ", i);
+   print_v2xint64 ("long int   ", j);
+   print_v2int64  ("           ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdctud:", (vui128_t) j, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW ( 0x8081828386878889UL,
+                                  0x9091929395969798UL );
+  e = (vui64_t) CONST_VINT64_DW ( 8081828386878889UL,
+                                  9091929395969798UL );
+
+  j = vec_bcdctud ((vBCD_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("BCD dwords ", i);
+  print_v2xint64 ("long int   ", j);
+  print_v2int64  ("           ", j);
+#endif
+ rc += check_vuint128x ("vec_bcdctud:", (vui128_t) j, (vui128_t) e);
+
+  return rc;
+}
+ //#undef __DEBUG_PRINT__
+
+ //#define __DEBUG_PRINT__ 1
+ int
+ test_bcdctuq (void)
+ {
+   vui128_t i;
+   vui128_t j, e;
+   int rc = 0;
+
+   printf ("\n%s Vector BCD qword convert\n", __FUNCTION__);
+
+   i = CONST_VINT128_DW128 ( 0x9999999999999999UL,
+ 	                     0x9999999999999999UL );
+   /* e = 999999999999999999999999999999UQ  */
+   e = (vui128_t) { (__int128 ) 9999999999999999ll
+                  * (__int128 ) 10000000000000000ll
+                  + (__int128 ) 9999999999999999ll };
+   j = vec_bcdctuq ((vBCD_t) i);
+
+ #ifdef __DEBUG_PRINT__
+   print_vint128x ("BCD qwords ", i);
+   print_vint128x ("__int128   ", j);
+   print_vint128  ("           ", j);
+ #endif
+   rc += check_vuint128x ("vec_bcdctuq:", (vui128_t) j, (vui128_t) e);
+
+   i = CONST_VINT128_DW128 ( 0x0109101920293039UL,
+                             0x4049505960697079UL );
+   /* e = 1091019202930394049505960697079UQ  */
+   e = (vui128_t) { (__int128 ) 109101920293039ll
+                  * (__int128 ) 10000000000000000ll
+                  + (__int128 ) 4049505960697079ll };
+   j = vec_bcdctuq ((vBCD_t) i);
+
+#ifdef __DEBUG_PRINT__
+   print_vint128x ("BCD qwords ", i);
+   print_vint128x ("__int128   ", j);
+   print_vint128  ("           ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdctuq:", (vui128_t) j, (vui128_t) e);
+
+  i = CONST_VINT128_DW128 ( 0x8081828386878889UL,
+                            0x9091929395969798UL );
+  /* e = 80818283868788899091929395969798UQ  */
+  e = (vui128_t) { (__int128 ) 8081828386878889ll
+                 * (__int128 ) 10000000000000000ll
+                 + (__int128 ) 9091929395969798ll };
+
+  j = vec_bcdctuq ((vBCD_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qwords ", i);
+  print_vint128x ("__int128   ", j);
+  print_vint128  ("           ", j);
+#endif
+ rc += check_vuint128x ("vec_bcdctuq:", (vui128_t) j, (vui128_t) e);
+
+  return rc;
+}
+
+ //#define __DEBUG_PRINT__ 1
+ int
+ test_zndctuq (void)
+ {
+   vui8_t i00, i16;
+   vui128_t j, e;
+   int rc = 0;
+
+   printf ("\n%s Vector Zoned qword convert\n", __FUNCTION__);
+
+   i00 = (vui8_t) { '9', '9', '9', '9', '9', '9', '9', '9',
+                    '9', '9', '9', '9', '9', '9', '9', '9' };
+   i16 = (vui8_t) { '9', '9', '9', '9', '9', '9', '9', '9',
+                    '9', '9', '9', '9', '9', '9', '9', '9' };
+   /* e = 999999999999999999999999999999UQ  */
+   e = (vui128_t) { (__int128 ) 9999999999999999ll
+                  * (__int128 ) 10000000000000000ll
+                  + (__int128 ) 9999999999999999ll };
+   j = vec_zndctuq (i00, i16);
+
+ #ifdef __DEBUG_PRINT__
+   print_vint8c   ("Zoned      ", i00);
+   print_vint8c   ("           ", i16);
+   print_vint128x ("__int128   ", j);
+   print_vint128  ("           ", j);
+ #endif
+   rc += check_vuint128x ("vec_zndctuq:", (vui128_t) j, (vui128_t) e);
+
+   i00 = (vui8_t) CONST_VINT8_B ( '0', '1', '0', '9', '1', '0', '1', '9',
+                                  '2', '0', '2', '9', '3', '0', '3', '9' );
+   i16 = (vui8_t) CONST_VINT8_B ( '4', '0', '4', '9', '5', '0', '5', '9',
+                                  '6', '0', '6', '9', '7', '0', '7', '9' );
+   /* e = 1091019202930394049505960697079UQ  */
+   e = (vui128_t) { (__int128 ) 109101920293039ll
+                  * (__int128 ) 10000000000000000ll
+                  + (__int128 ) 4049505960697079ll };
+   j = vec_zndctuq (i00, i16);
+
+#ifdef __DEBUG_PRINT__
+   print_vint8c   ("Zoned      ", i00);
+   print_vint8c   ("           ", i16);
+   print_vint128x ("__int128   ", j);
+   print_vint128  ("           ", j);
+#endif
+  rc += check_vuint128x ("vec_zndctuq:", (vui128_t) j, (vui128_t) e);
+
+  i00 = (vui8_t) CONST_VINT8_B ( '8', '0', '8', '1', '8', '2', '8', '3',
+                                 '8', '6', '8', '7', '8', '8', '8', '9' );
+  i16 = (vui8_t) CONST_VINT8_B ( '9', '0', '9', '1', '9', '2', '9', '3',
+                                 '9', '5', '9', '6', '9', '7', '9', '8' );
+  /* e = 80818283868788899091929395969798UQ  */
+  e = (vui128_t) { (__int128 ) 8081828386878889ll
+                 * (__int128 ) 10000000000000000ll
+                 + (__int128 ) 9091929395969798ll };
+
+  j = vec_zndctuq (i00, i16);
+
+#ifdef __DEBUG_PRINT__
+  print_vint8c   ("Zoned      ", i00);
+  print_vint8c   ("           ", i16);
+  print_vint128x ("__int128   ", j);
+  print_vint128  ("           ", j);
+#endif
+ rc += check_vuint128x ("vec_zndctuq:", (vui128_t) j, (vui128_t) e);
+
+  return rc;
+}
+
 int
 test_vec_bcd (void)
 {
@@ -469,6 +1208,24 @@ test_vec_bcd (void)
   rc += test_bcd_muldiv ();
 
   rc += test_cvtbcd2c100 ();
+
+  rc += test_cvtbcd2c10k ();
+
+  rc += test_cvtbcd2c100m ();
+
+  rc += test_cvtbcd2c10e ();
+
+  rc += test_cvtbcd2c10e32 ();
+
+  rc += test_cvtbcfz2c100 ();
+
+  rc += test_bcdctub ();
+  rc += test_bcdctuh ();
+  rc += test_bcdctuw ();
+  rc += test_bcdctud ();
+  rc += test_bcdctuq ();
+
+  rc += test_zndctuq ();
 
 //  rc += test_48 ();
 

--- a/src/testsuite/arith128_test_bcd.c
+++ b/src/testsuite/arith128_test_bcd.c
@@ -62,7 +62,7 @@ db_vec_ZN2i128 (vui8_t zone00, vui8_t zone16)
 
   print_vint8x ("32xZoned   ", zone00);
   print_vint8x ("           ", zone16);
-  print_vint8c ("32xZoned %c", zone00);
+  print_vint8c ("32xZoned  c", zone00);
   print_vint8c ("           ", zone16);
 
   znd00 = vec_and (zone00, dmask);

--- a/src/testsuite/vec_bcd_dummy.c
+++ b/src/testsuite/vec_bcd_dummy.c
@@ -47,7 +47,7 @@ test_vec_DFP2BCD (_Decimal128 val)
 vui8_t
 test_vec_bcdctb100s (vui8_t a)
 {
-  return (vec_bcdctb100s (a));
+  return (vec_rdxct100b (a));
 }
 
 vui32_t
@@ -72,6 +72,74 @@ vui32_t
 test_vec_bcddiv (vui32_t a, vui32_t b)
 {
   return vec_bcddiv (a, b);
+}
+
+vui128_t
+test_vec_bcdctuq (vBCD_t a)
+{
+  return (vec_bcdctuq (a));
+}
+
+vui64_t
+test_vec_bcdctud (vBCD_t a)
+{
+  return (vec_bcdctud (a));
+}
+
+vui32_t
+test_vec_bcdctuw (vBCD_t a)
+{
+  return (vec_bcdctuw (a));
+}
+
+vui16_t
+test_vec_bcdctuh (vBCD_t a)
+{
+  return (vec_bcdctuh (a));
+}
+
+vui8_t
+test_vec_bcdctub (vBCD_t a)
+{
+  return (vec_bcdctub (a));
+}
+
+vui128_t
+example_vec_bcdctuq (vui8_t vra)
+{
+  vui8_t d100;
+  vui16_t d10k;
+  vui32_t d100m;
+  vui64_t d10e;
+  vui128_t result;
+
+  d100 = vec_rdxct100b ((vui8_t) vra);
+  d10k = vec_rdxct10kh (d100);
+  d100m = vec_rdxct100mw (d10k);
+  d10e = vec_rdxct10E16d (d100m);
+  result = vec_rdxct10e32q (d10e);
+
+  return result;
+}
+
+void
+example_vec_bcdctuq_loop (vui128_t *out, vui8_t* in, int cnt)
+{
+  vui8_t d100;
+  vui16_t d10k;
+  vui32_t d100m;
+  vui64_t d10e;
+  vui128_t result;
+  int i;
+
+  for (i = 0; i < cnt; i++)
+    {
+      d100 = vec_rdxct100b (*in++);
+      d10k = vec_rdxct10kh (d100);
+      d100m = vec_rdxct100mw (d10k);
+      d10e = vec_rdxct10E16d (d100m);
+      *out++ = vec_rdxct10e32q (d10e);
+    }
 }
 
 #if (__GNUC__ > 4)

--- a/src/testsuite/vec_char_dummy.c
+++ b/src/testsuite/vec_char_dummy.c
@@ -15,11 +15,17 @@
 #if __GNUC__ >= 8
 /* Generic vec_mul not supported for vector char until GCC 8.  */
 vui8_t
-__test_mulubm (vui8_t __A, vui8_t __B)
+__test_mulubm_gcc (vui8_t __A, vui8_t __B)
 {
   return vec_mul (__A, __B);
 }
 #endif
+
+vui8_t
+__test_mulubm (vui8_t __A, vui8_t __B)
+{
+  return vec_mulubm (__A, __B);
+}
 
 vui8_t
 __test_absdub (vui8_t __A, vui8_t __B)
@@ -133,4 +139,22 @@ vui8_t
 test_vec_vmrglb  (vui8_t a, vui8_t b)
 {
   return vec_vmrglb (a, b);
+}
+
+vui8_t
+test_vec_mrgalb (vui16_t vra, vui16_t vrb)
+{
+  return vec_mrgalb (vra, vrb);
+}
+
+vui8_t
+test_vec_vmrgob (vui8_t vra, vui8_t vrb)
+{
+  return vec_vmrgob (vra, vrb);
+}
+
+vui8_t
+test_vec_packub  (vui8_t a, vui8_t b)
+{
+  return vec_pack ((vui16_t) a, (vui16_t) b);
 }

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -31,6 +31,7 @@
 #include <vec_int128_ppc.h>
 #include <vec_f128_ppc.h>
 #include <vec_f32_ppc.h>
+#include <vec_bcd_ppc.h>
 
 vui8_t
 __test_absdub_PWR9 (vui8_t __A, vui8_t __B)
@@ -861,6 +862,24 @@ __test_vec_extract_sig_f32 (vf32_t val)
   return vec_extract_sig (val);
 }
 #endif
+
+vui128_t
+example_vec_bcdctuq_PWR9 (vui8_t vra)
+{
+  vui8_t d100;
+  vui16_t d10k;
+  vui32_t d100m;
+  vui64_t d10e;
+  vui128_t result;
+
+  d100 = vec_rdxct100b ((vui8_t) vra);
+  d10k = vec_rdxct10kh (d100);
+  d100m = vec_rdxct100mw (d10k);
+  d10e = vec_rdxct10E16d (d100m);
+  return vec_rdxct10e32q (d10e);
+
+  return result;
+}
 
 void
 example_qw_convert_decimal_PWR9 (vui64_t *ten_16, vui128_t value)


### PR DESCRIPTION
Add unit tests for radix decimal to binary conversion.
Add unit tests for BCD to binary conversion.
Add BCD compile tests. Add vector char compile tests.
Add POWER9 compile test.

	* src/testsuite/arith128_test_bcd.c (db_vec_ZN2i128):
	New debug function.
	(db_vec_BCD2i128, db_vec_BC10ks2i128, db_vec_BC100ms2i128):
	Correct for endian.
	(db_vec_BC10es2i128): Rename from db_vec_BC10ts2i128.
	Use vec_vmuleud.
	(test_48): Rename db_vec_BC10ts2i128 to db_vec_BC10es2i128.
	(test_cvtbcd2c100): Rename vec_bcdctb100s to vec_rdxct100b.
	(test_cvtbcd2c10k, test_cvtbcd2c100m, test_cvtbcd2c10e,
	test_cvtbcd2c10e32, test_cvtbcfz2c100): New functions.
	(test_bcdctub, test_bcdctuh, test_bcdctuw, test_bcdctud,
	test_bcdctuq, test_zndctuq): New functions.
	(test_vec_bcd): Add calls to test_cvtbcd2c10k, test_cvtbcd2c100m,
	test_cvtbcd2c10e, test_cvtbcd2c10e32, test_cvtbcfz2c100,
	test_bcdctub, test_bcdctuh, test_bcdctuw, test_bcdctud,
	test_bcdctuq, test_zndctuq.

	* src/testsuite/vec_bcd_dummy.c (test_vec_bcdctb100s):
	Rename vec_bcdctb100s to vec_rdxct100b.
	(test_vec_bcdctuq, test_vec_bcdctud, test_vec_bcdctuw,
	test_vec_bcdctuh test_vec_bcdctub): Add compile test functions.
	(example_vec_bcdctuq, example_vec_bcdctuq_loop):
	Add example functions.

	* src/testsuite/vec_char_dummy.c (__test_mulubm):
	Rename to __test_mulubm_gcc.
	(test_vec_mrgalb, test_vec_vmrgob, test_vec_packub):
	Add compile tests.

	* src/testsuite/vec_pwr9_dummy.c: Include <vec_bcd_ppc.h>.
	(example_vec_bcdctuq_PWR9): Add example function.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>