### PR TITLE
More vec_bcd_ppc.h compile and unit tests.

### DIFF
--- a/src/testsuite/arith128_test_bcd.c
+++ b/src/testsuite/arith128_test_bcd.c
@@ -50,15 +50,6 @@ db_vec_ZN2i128 (vui8_t zone00, vui8_t zone16)
   vui8_t znd00, znd16;
   vui8_t ones, tens;
   vui16_t ten00, ten16;
-  vui8_t e_perm =
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-    { 0x00, 0x10, 0x02, 0x12, 0x04, 0x14, 0x06, 0x16, 0x08, 0x18, 0x0a, 0x1a,
-	0x0c, 0x1c, 0x0e, 0x1e };
-#else
-    { 0x01, 0x11, 0x03, 0x13, 0x05, 0x15, 0x07, 0x17, 0x09, 0x19, 0x0b, 0x1b,
-	0x0d, 0x1d, 0x0f, 0x1f };
-#endif
-  vui8_t /*i,*/ j, k, l, m/**/;
 
   print_vint8x ("32xZoned   ", zone00);
   print_vint8x ("           ", zone16);
@@ -125,15 +116,9 @@ db_vec_BCD2i128 (vui8_t bcd32)
   print_vint8d ("           ", l);
   print_vint8x (" hd*6 odd  ", m);
   print_vint8d ("           ", m);
-#if 0
-  j = vec_vpkuhum ((vui16_t)l, (vui16_t)m);
-  print_vint8x (" hd*6 pack ", j);
-  print_vint8d ("           ", j);
-#else
   j = vec_perm (l, m, e_perm);
   print_vint8x (" hd*6 perm ", j);
   print_vint8d ("           ", j);
-#endif
   result = vec_sub (bcd32, j);
   print_vint8x ("BCD - hd*6 ", result);
   print_vint8d ("           ", result);
@@ -228,31 +213,9 @@ db_vec_BC10es2i128 (vui64_t bc10t2)
   print_v2xint64("           ", (vui64_t) bc10t2);
   print_vint128 ("           ", (vui128_t) bc10t2);
 
-#if 0
-  vui128_t v10_16 = (vui128_t)CONST_VINT128_DW (0, 10000000000000000UL);
-  vui128_t v2_64 = (vui128_t)CONST_VINT128_DW (1, 0);
-  print_vint128x (" v2_64     ", v2_64);
-  print_vint128  ("           ", v2_64);
-  print_vint128x (" v10_16    ", v10_16);
-  print_vint128  ("           ", v10_16);
-
-  l = vec_sub (v2_64, v10_16);
-  print_vint128x (" cvt*10t   ", l);
-  print_vint128  ("           ", l);
-#endif
   /* k = 18436744073709551616UL */
   k = vec_splats ((unsigned long)0xFFDC790D903F0000UL);
-#if 1
   l = vec_vmuleud (bc10t2, k);
-#else
-  print_vint128x (" cvt*10t k ", (vui128_t) k);
-
-  l = vec_srqi ((vui128_t)bc10t2, 64);
-
-  print_vint128x (" bc10t2>>64", l);
-  print_vint128  ("           ", l);
-  l = vec_mulluq (l, (vui128_t) k);
-#endif
   print_vint128x (" hd*10t ev ", l);
   print_vint128  ("           ", l);
 
@@ -262,44 +225,447 @@ db_vec_BC10es2i128 (vui64_t bc10t2)
   return result;
 }
 
+vBCD_t
+db_vec_bcddiv (vBCD_t a, vBCD_t b)
+{
+  vBCD_t t;
+  _Decimal128 d_t, d_a, d_b, d_d;
+  print_vint128x ("vec_bcddiv (", (vui128_t) a);
+  print_vint128x ("           ,", (vui128_t) b);
+  d_a = vec_BCD2DFP (a);
+  d_b = vec_BCD2DFP (b);
+  printf (" BCD2DFP   ( %36.34DDg\n           , %36.34DDg)\n", d_a, d_b);
+  d_d = d_a / d_b;
+  printf (" a / b     ( %36.34DDg\n", d_d);
+  d_t = vec_quantize0_Decimal128 (d_d);
+  printf (" quantize  ( %36.34DDg\n", d_t);
+  t = vec_DFP2BCD (d_t);
+  print_vint128x (" result    =", (vui128_t) t);
+  return (t);
+}
+
+vBCD_t
+db_vec_bcdmul (vBCD_t a, vBCD_t b)
+{
+  vBCD_t t;
+  vBCD_t low_a, low_b, high_a, high_b;
+  const vBCD_t dword_mask = (vBCD_t) CONST_VINT128_DW(15, -1);
+  _Decimal128 d_t, d_a, d_b, d_p;
+  print_vint128x ("vec_bcdmul (", (vui128_t) a);
+  print_vint128x ("           ,", (vui128_t) b);
+
+  low_a = vec_and (a, dword_mask);
+  low_b = vec_and (b, dword_mask);
+  print_vint128x ("vec_bcdlow (", (vui128_t) low_a);
+  print_vint128x ("           ,", (vui128_t) low_b);
+  d_a = vec_BCD2DFP (low_a);
+  d_b = vec_BCD2DFP (low_b);
+  printf (" BCD2DFP   ( %36.34DDg\n           , %36.34DDg)\n", d_a, d_b);
+  d_p = d_a * d_b;
+  printf (" a * b  ll ( %36.34DDg\n", d_p);
+
+  if (vec_cmpuq_all_eq ((vui128_t) low_a, (vui128_t) a)
+      && vec_cmpuq_all_eq ((vui128_t) low_b, (vui128_t) b))
+    {
+      d_t = d_p;
+    }
+  else
+    {
+      _Decimal128 d_ah, d_bh, d_hl, d_lh, d_h;
+      high_a = vec_bcdsrqi (a, 16);
+      high_b = vec_bcdsrqi (b, 16);
+      print_vint128x ("vec_bcdhigh(", (vui128_t) high_a);
+      print_vint128x ("           ,", (vui128_t) high_b);
+      d_ah = vec_BCD2DFP (high_a);
+      d_bh = vec_BCD2DFP (high_b);
+      printf (" BCD2DFP hh( %36.34DDg\n           , %36.34DDg)\n", d_ah, d_bh);
+
+      d_hl = d_ah * d_b;
+      printf (" a * b   hl( %36.34DDg\n", d_hl);
+
+      d_lh = d_a * d_bh;
+      printf (" a * b   lh( %36.34DDg\n", d_hl);
+
+      d_h = d_hl + d_lh;
+      printf (" hl+lh     ( %36.34DDg\n", d_h);
+      d_h = __builtin_dscliq (d_h, 17);
+      d_h = __builtin_dscriq (d_h, 1);
+      printf (" a * b < lh( %36.34DDg\n", d_h);
+
+      d_t = d_p + d_h;
+      printf (" ll+hl+lh  ( %36.34DDg\n", d_t);
+    }
+  t = vec_DFP2BCD (d_t);
+  print_vint128x (" result    =", (vui128_t) t);
+  return (t);
+}
+
+vBCD_t
+db_vec_bcdmulh (vBCD_t a, vBCD_t b)
+{
+  vBCD_t t;
+  vBCD_t low_a, low_b, high_a, high_b;
+  const vBCD_t dword_mask = (vBCD_t) CONST_VINT128_DW(15, -1);
+  _Decimal128 d_t, d_al, d_bl, d_p;
+  print_vint128x ("vec_bcdmul (", (vui128_t) a);
+  print_vint128x ("           ,", (vui128_t) b);
+
+  low_a = vec_and (a, dword_mask);
+  low_b = vec_and (b, dword_mask);
+  print_vint128x ("vec_bcdlow (", (vui128_t) low_a);
+  print_vint128x ("           ,", (vui128_t) low_b);
+  d_al = vec_BCD2DFP (low_a);
+  d_bl = vec_BCD2DFP (low_b);
+  printf (" BCD2DFP   ( %36.34DDg\n           , %36.34DDg)\n", d_al, d_bl);
+  d_p = d_al * d_bl;
+  printf (" a * b  ll ( %36.34DDg\n", d_p);
+  if (vec_cmpuq_all_eq ((vui128_t) low_a, (vui128_t) a)
+      && vec_cmpuq_all_eq ((vui128_t) low_b, (vui128_t) b))
+    {
+      d_t = __builtin_dscriq (d_p, 31);
+    }
+  else
+    {
+      _Decimal128 d_ah, d_bh, d_hl, d_lh, d_h, d_ll, d_m;
+      high_a = vec_bcdsrqi (a, 16);
+      high_b = vec_bcdsrqi (b, 16);
+      print_vint128x ("vec_bcdhigh(", (vui128_t) high_a);
+      print_vint128x ("           ,", (vui128_t) high_b);
+      d_ah = vec_BCD2DFP (high_a);
+      d_bh = vec_BCD2DFP (high_b);
+      printf (" BCD2DFP hh( %36.34DDg\n           , %36.34DDg)\n", d_ah, d_bh);
+      d_hl = d_ah * d_bl;
+      printf (" a * b   hl( %36.34DDg\n", d_hl);
+      d_ll = __builtin_dscriq (d_p, 16);
+      printf (" d_p >> 16 ( %36.34DDg\n", d_ll);
+
+      d_lh = d_al * d_bh;
+      printf (" a * b   lh( %36.34DDg\n", d_hl);
+
+      d_m = d_hl + d_lh + d_ll;
+      printf (" hl+lh+ll  ( %36.34DDg\n", d_m);
+      d_m = __builtin_dscriq (d_m, 15);
+      printf (" d_m >> 15 ( %36.34DDg\n", d_m);
+
+      d_h = d_ah * d_bh;
+      printf (" a * b   hh( %36.34DDg\n", d_h);
+      d_h = __builtin_dscliq (d_h, 1);
+      printf (" d_h << 1  ( %36.34DDg\n", d_h);
+
+      d_t = d_m + d_h;
+      printf (" hh+d_m    ( %36.34DDg\n", d_t);
+    }
+  t = vec_DFP2BCD (d_t);
+  print_vint128x (" result    =", (vui128_t) t);
+  return (t);
+}
+
+vBCD_t
+db_vec_cbcdmul (vBCD_t *p_high, vBCD_t a, vBCD_t b)
+{
+  vBCD_t t;
+  vBCD_t low_a, low_b, high_a, high_b;
+  const vBCD_t dword_mask = (vBCD_t) CONST_VINT128_DW(15, -1);
+  _Decimal128 d_t, d_al, d_bl, d_p;
+  print_vint128x ("vec_bcdmul (", (vui128_t) a);
+  print_vint128x ("           ,", (vui128_t) b);
+
+  low_a = vec_and (a, dword_mask);
+  low_b = vec_and (b, dword_mask);
+  print_vint128x ("vec_bcdlow (", (vui128_t) low_a);
+  print_vint128x ("           ,", (vui128_t) low_b);
+  d_al = vec_BCD2DFP (low_a);
+  d_bl = vec_BCD2DFP (low_b);
+  printf (" BCD2DFP   ( %36.34DDg\n           , %36.34DDg)\n", d_al, d_bl);
+  d_p = d_al * d_bl;
+  printf (" a * b  ll ( %36.34DDg\n", d_p);
+  if (vec_cmpuq_all_eq ((vui128_t) low_a, (vui128_t) a)
+      && vec_cmpuq_all_eq ((vui128_t) low_b, (vui128_t) b))
+    {
+      d_t = __builtin_dscriq (d_p, 31);
+      *p_high = vec_DFP2BCD (d_t);
+      d_t = d_p;
+    }
+  else
+    {
+      _Decimal128 d_ah, d_bh, d_hl, d_lh, d_h, d_hh, d_ll, d_m, d_mp;
+      high_a = vec_bcdsrqi (a, 16);
+      high_b = vec_bcdsrqi (b, 16);
+      print_vint128x ("vec_bcdhigh(", (vui128_t) high_a);
+      print_vint128x ("           ,", (vui128_t) high_b);
+      d_ah = vec_BCD2DFP (high_a);
+      d_bh = vec_BCD2DFP (high_b);
+      printf (" BCD2DFP hh( %36.34DDg\n           , %36.34DDg)\n", d_ah, d_bh);
+      d_hl = d_ah * d_bl;
+      printf (" a * b   hl( %36.34DDg\n", d_hl);
+      d_ll = __builtin_dscriq (d_p, 16);
+      printf (" d_p >> 16 ( %36.34DDg\n", d_ll);
+
+      d_lh = d_al * d_bh;
+      printf (" a * b   lh( %36.34DDg\n", d_hl);
+
+      d_mp = d_hl + d_lh;
+      d_m = d_mp + d_ll;
+      printf (" hl+lh+ll  ( %36.34DDg\n", d_m);
+      d_m = __builtin_dscriq (d_m, 15);
+      printf (" d_m >> 15 ( %36.34DDg\n", d_m);
+
+      d_hh = d_ah * d_bh;
+      printf (" a * b   hh( %36.34DDg\n", d_hh);
+      d_hh = __builtin_dscliq (d_hh, 1);
+      printf (" d_h << 1  ( %36.34DDg\n", d_hh);
+
+      d_t = d_m + d_hh;
+      printf (" hh+d_m    ( %36.34DDg\n", d_t);
+      *p_high = vec_DFP2BCD (d_t);
+
+      d_h = __builtin_dscliq (d_mp, 17);
+      d_h = __builtin_dscriq (d_h, 1);
+      printf (" a * b < lh( %36.34DDg\n", d_h);
+
+      d_t = d_p + d_h;
+      printf (" ll+hl+lh  ( %36.34DDg\n", d_t);
+    }
+  t = vec_DFP2BCD (d_t);
+  print_vint128x (" result    =", (vui128_t) t);
+  return (t);
+}
+
+vBCD_t
+db_vec_bcdaddcsq (vBCD_t a, vBCD_t b)
+{
+  vBCD_t t;
+  vBCD_t sum_ab, xor_b, xor_a, xor_ab, cp, cm;
+  print_vint128x ("vec_bcdaddcsq (", (vui128_t) a);
+  print_vint128x ("            + ,", (vui128_t) b);
+
+  sum_ab = vec_bcdadd (a, b);
+  print_vint128x ("            ) =", (vui128_t) sum_ab);
+
+  xor_a = vec_and (vec_xor (sum_ab, a), _BCD_CONST_SIGN_MASK);
+  xor_b = vec_and (vec_xor (sum_ab, b), _BCD_CONST_SIGN_MASK);
+  print_vint128x ("    xor(sum,a)=", (vui128_t) xor_a);
+  print_vint128x ("    xor(sum,b)=", (vui128_t) xor_b);
+  cp = vec_and (xor_a, xor_b);
+  print_vint128x ("  xor_a&xor_b =", (vui128_t) cp);
+
+  xor_ab = vec_and (vec_xor (a, b), _BCD_CONST_SIGN_MASK);
+  print_vint128x ("    xor(sum,a)=", (vui128_t) xor_a);
+  print_vint128x ("      xor(a,b)=", (vui128_t) xor_ab);
+  cm = vec_and (xor_a, xor_ab);
+  print_vint128x (" xor_a&xor_ab =", (vui128_t) cm);
+
+  if (vec_all_eq(cp, cm))
+    t = _BCD_CONST_ZERO;
+  else
+    {
+      t = vec_or (_BCD_CONST_PLUS_ONE, cm);
+    }
+
+  print_vint128x (" result       =", (vui128_t) t);
+  return (t);
+}
+
+// still experimental
+static inline _Decimal128
+vec_copysign_Decimal128 (_Decimal128 x, _Decimal128 y)
+{
+  _Decimal128 t;
+  __asm__(
+      "fcpsgn %0,%2,%1;\n"
+      "fmr %L0,%L1;\n"
+      : "=d" (t)
+      : "d" (x), "d" (y)
+      : );
+  return (t);
+}
+
+vBCD_t
+db_vec_cbcdaddcsq (vBCD_t *c, vBCD_t a, vBCD_t b)
+{
+  vBCD_t sum_ab, t;
+  print_vint128x ("vec_cbcdaddcsq (", (vui128_t) a);
+  print_vint128x ("             + ,", (vui128_t) b);
+#ifdef _ARCH_PWR8
+
+  vBCD_t sign_a, sign_ab;
+  vBCD_t ex = (vBCD_t) CONST_VINT128_W(0, 0, 0, 0x0000000d);
+
+  sum_ab = (vBCD_t) __builtin_bcdadd ((vi128_t) a, (vi128_t) b, 0);
+  print_vint128x ("             ) =", (vui128_t) sum_ab);
+
+  t = _BCD_CONST_ZERO;
+  if (__builtin_expect (__builtin_bcdadd_ov ((vi128_t) a, (vi128_t) b, 0), 0))
+    {
+      t = vec_bcdcpsgn (_BCD_CONST_PLUS_ONE, sum_ab);
+    }
+  else // Not a carry, but might be a borrow
+    {
+      t = _BCD_CONST_ZERO;
+      sign_ab = vec_bcdcpsgn (sum_ab, a);
+      if (!vec_all_eq(sign_ab, sum_ab))
+	{
+	  vBCD_t nines = vec_bcdcpsgn (_BCD_CONST_PLUS_NINES, a);
+	  vBCD_t c10s = vec_bcdcpsgn (_BCD_CONST_PLUS_ONE, a);
+	  t = vec_bcdcpsgn (_BCD_CONST_PLUS_ONE, sum_ab);
+	  sum_ab = vec_bcdaddesqm (nines, sum_ab, c10s);
+	}
+    }
+#else
+  vBCD_t sign_ab;
+  _Decimal128 d_a, d_b, d_s, d_t, d_m;
+  vui32_t mz = CONST_VINT128_W(0, 0, 0, 0x0000000d);
+  d_a = vec_BCD2DFP (a);
+  d_b = vec_BCD2DFP (b);
+  d_s = d_a + d_b;
+  printf (" sum_ab  = %36.34DDg\n", d_s);
+  sum_ab = vec_DFP2BCD (d_s);
+  // Shift right 31 digits, leaving the carry.
+  d_t = __builtin_dscriq (d_s, 31);
+  printf (" sum>31  = %36.34DDg\n", d_t);
+  t = vec_DFP2BCD (d_t);
+  // fix up spurious negative zeros
+  if (vec_all_eq((vui32_t ) t, mz))
+    t = _BCD_CONST_ZERO;
+  sign_ab = vec_bcdcpsgn (sum_ab, a);
+  if (!vec_all_eq(sign_ab, sum_ab))
+    {
+#if 0
+      // Optimization for P7 but failed test. need to come back to this
+      const _Decimal128 ten31 = 10000000000000000000000000000000.0DL;
+      t = vec_bcdcpsgn (_BCD_CONST_PLUS_ONE, sum_ab);
+      d_m = vec_copysign_Decimal128 (ten31, d_a);
+      d_s = d_m + d_s;
+      printf (" ~sum_ab = %36.34DDg\n", d_s);
+      sum_ab = vec_DFP2BCD (d_s);
+      print_vint128x (" ~sum_ab      =", (vui128_t) sum_ab);
+#else
+      vBCD_t nines = vec_bcdcpsgn (_BCD_CONST_PLUS_NINES, a);
+      vBCD_t c10s = vec_bcdcpsgn (_BCD_CONST_PLUS_ONE, a);
+      t = vec_bcdcpsgn (_BCD_CONST_PLUS_ONE, sum_ab);
+      sum_ab = vec_bcdaddesqm (nines, sum_ab, c10s);
+#endif
+    }
+#endif
+  print_vint128x (" carry/borrow =", (vui128_t) t);
+  *c = t;
+  print_vint128x (" result       =", (vui128_t) sum_ab);
+  return (sum_ab);
+}
+
+vBCD_t
+db_vec_cbcdaddecsq (vBCD_t *co, vBCD_t a, vBCD_t b, vBCD_t ci)
+{
+  vBCD_t sum_abc, t, c;
+  print_vint128x ("vec_cbcdaddcsq (", (vui128_t) a);
+  print_vint128x ("             + ,", (vui128_t) b);
+  print_vint128x ("             + ,", (vui128_t) ci);
+#ifdef _ARCH_PWR8
+  vBCD_t sum_ab, sign_abc;
+
+  sum_ab = vec_bcdadd (a, b);
+  sum_abc = vec_bcdadd (sum_ab, ci);
+  print_vint128x (" sum a+b     ) =", (vui128_t) sum_ab);
+  print_vint128x (" sum a+b+c   ) =", (vui128_t) sum_abc);
+
+  if (__builtin_expect (
+	  (__builtin_bcdadd_ov ((vi128_t) a, (vi128_t) b, 0)
+	      || __builtin_bcdadd_ov ((vi128_t) sum_ab, (vi128_t) ci, 0)),
+	  0))
+    {
+      c = vec_bcdcpsgn (_BCD_CONST_PLUS_ONE, sum_abc);
+    }
+  else // (a + b + c) did not overflow, what about (a + b + c)
+    {
+      c = _BCD_CONST_ZERO;
+      sign_abc = vec_bcdcpsgn (sum_abc, a);
+      print_vint128x (" sign a+b+c  ) =", (vui128_t) sign_abc);
+      if (!vec_all_eq(sign_abc, sum_abc))
+	{
+	  c = vec_bcdcpsgn (_BCD_CONST_PLUS_ONE, sum_abc);
+	  vBCD_t nines = vec_bcdcpsgn (_BCD_CONST_PLUS_NINES, a);
+	  vBCD_t c10s = vec_bcdcpsgn (_BCD_CONST_PLUS_ONE, a);
+	  t = vec_bcdcpsgn (_BCD_CONST_PLUS_ONE, sum_abc);
+	  sum_abc = vec_bcdaddesqm (nines, sum_abc, c10s);
+	}
+    }
+  t = sum_abc;
+#else
+  const vui32_t mz = CONST_VINT128_W(0, 0, 0, 0x0000000d);
+  vBCD_t sign_abc;
+  _Decimal128 d_a, d_b, d_c, d_s, d_t, d_m;
+  d_a = vec_BCD2DFP (a);
+  d_b = vec_BCD2DFP (b);
+  d_c = vec_BCD2DFP (ci);
+  d_s = d_a + d_b + d_c;
+  printf (" sum_abc = %36.34DDg\n", d_s);
+  sum_abc = vec_DFP2BCD (d_s);
+  // Shift right 31 digits, leaving the carry.
+  d_t = __builtin_dscriq (d_s, 31);
+  printf (" sum>31  = %36.34DDg\n", d_t);
+  c = vec_DFP2BCD (d_t);
+  // fix up spurious negative zeros
+  if (vec_all_eq((vui32_t ) c, mz))
+    c = _BCD_CONST_ZERO;
+
+  sign_abc = vec_bcdcpsgn (sum_abc, a);
+  if (!vec_all_eq(sign_abc, sum_abc))
+    {
+#if 0
+      // Optimization for P7 but failed test. need to come back to this
+      const _Decimal128 ten31 = 10000000000000000000000000000000.0DL;
+      c = vec_bcdcpsgn (_BCD_CONST_PLUS_ONE, sum_abc);
+      d_m = vec_copysign_Decimal128 (ten31, d_a);
+      d_s = d_m + d_s;
+      sum_abc = vec_DFP2BCD (d_s);
+      printf (" ~sum_abc= %36.34DDg\n", d_s);
+      print_vint128x (" t            =", (vui128_t) sum_abc);
+#else
+      c = vec_bcdcpsgn (_BCD_CONST_PLUS_ONE, sum_abc);
+      vBCD_t nines = vec_bcdcpsgn (_BCD_CONST_PLUS_NINES, a);
+      vBCD_t c10s = vec_bcdcpsgn (_BCD_CONST_PLUS_ONE, a);
+      t = vec_bcdcpsgn (_BCD_CONST_PLUS_ONE, sum_abc);
+      sum_abc = vec_bcdaddesqm (nines, sum_abc, c10s);
+#endif
+    }
+  t = sum_abc;
+#endif
+  print_vint128x (" carry/borrow =", (vui128_t) c);
+  *co = c;
+  print_vint128x (" result       =", (vui128_t) t);
+  return (t);
+}
+
+vBCD_t
+db_vec_bcdsubcsq (vBCD_t a, vBCD_t b)
+{
+  vBCD_t t;
+  vBCD_t sum_ab, xor_a, xor_ab, c;
+  print_vint128x ("vec_bcdsubcuq (", (vui128_t) a);
+  print_vint128x ("            + ,", (vui128_t) b);
+
+  sum_ab = vec_bcdsub (a, b);
+  print_vint128x ("            ) =", (vui128_t) sum_ab);
+
+  xor_a = vec_and (vec_xor (sum_ab, a), _BCD_CONST_SIGN_MASK);
+  xor_ab = vec_and (vec_xor (a, b), _BCD_CONST_SIGN_MASK);
+  print_vint128x ("    xor(sum,a)=", (vui128_t) xor_a);
+  print_vint128x ("      xor(a,b)=", (vui128_t) xor_ab);
+  c = vec_and (xor_a, xor_ab);
+  print_vint128x ("  xor_a&xor_b =", (vui128_t) c);
+
+  t = vec_or (_BCD_CONST_PLUS_ONE, c);
+
+  print_vint128x (" result       =", (vui128_t) t);
+  return (t);
+}
+
 //#define __DEBUG_PRINT__ 1
 #ifdef __DEBUG_PRINT__
 #define test_vec_bcdctb100s(_l)	db_vec_BCD2i128(_l)
 #else
 #define test_vec_bcdctb100s(_l)	vec_rdxct100b(_l)
 #endif
-
-int
-test_48 (void)
-{
-  vui8_t i, j;
-  vui16_t k;
-  vui32_t l;
-  vui64_t m;
-  vui128_t n;
-  int rc = 0;
-
-  i = (vui8_t) {0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99};
-  j = test_vec_bcdctb100s (i);
-  print_vint8x ("BCD 9s     ", i);
-  print_vint8d ("           ", i);
-  print_vint8x ("BC100s     ", j);
-  print_vint8d ("           ", j);
-
-  k = db_vec_BC100s2i128 (j);
-  print_vint16d ("BC10Ks     ", k);
-
-  l = db_vec_BC10ks2i128 (k);
-  print_vint32d ("BC100Ms    ", l);
-
-  m = db_vec_BC100ms2i128 (l);
-  print_v2int64 ("BC10Ts     ", m);
-
-  n = db_vec_BC10es2i128 (m);
-  print_vint128 ("BCD10x     ", n);
-
-  return (rc);
-}
 
 //#define __DEBUG_PRINT__ 1
 int
@@ -438,8 +804,16 @@ test_bcd_addsub (void)
 
   return rc;
 }
+//#undef __DEBUG_PRINT__
 
-
+//#define __DEBUG_PRINT__ 1
+#ifdef __DEBUG_PRINT__
+#define test_vec_bcddiv(_l, _k)	db_vec_bcddiv(_l, _k)
+#define test_vec_bcdmul(_l, _k)	db_vec_bcdmul(_l, _k)
+#else
+#define test_vec_bcddiv(_l, _k)	vec_bcddiv(_l, _k)
+#define test_vec_bcdmul(_l, _k)	vec_bcdmul(_l, _k)
+#endif
  int
  test_bcd_muldiv (void)
  {
@@ -451,7 +825,7 @@ test_bcd_addsub (void)
 
   i = (vBCD_t) CONST_VINT128_W (0, 0, 0, 0x0000001c);
   j = (vBCD_t) CONST_VINT128_W (0, 0, 0, 0x9999999c);
-  k = vec_bcdmul (i, j);
+  k = test_vec_bcdmul (i, j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("bcd (1*9999999)", k, i, j);
@@ -461,7 +835,7 @@ test_bcd_addsub (void)
 
   i = (vBCD_t) CONST_VINT128_W (0, 0, 0, 0x9999999c);
   j = (vBCD_t) CONST_VINT128_W (0, 0, 0, 0x9999999c);
-  k = vec_bcdmul (i, j);
+  k = test_vec_bcdmul (i, j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("bcd (9999999*9999999)", k, i, j);
@@ -471,7 +845,7 @@ test_bcd_addsub (void)
 
   i = (vBCD_t) CONST_VINT128_W (0, 0, 0x99999999, 0x9999999c);
   j = (vBCD_t) CONST_VINT128_W (0, 0, 0x99999999, 0x9999999c);
-  k = vec_bcdmul (i, j);
+  k = test_vec_bcdmul (i, j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("bcd (999999999999999*999999999999999)", k, i, j);
@@ -483,7 +857,7 @@ test_bcd_addsub (void)
   i = (vBCD_t) CONST_VINT128_W (0x09999999, 0x99999998,
 				0x00000000, 0x0000001c);
   j = (vBCD_t) CONST_VINT128_W (0, 0, 0x99999999, 0x9999999c);
-  k = vec_bcddiv (i, j);
+  k = test_vec_bcddiv (i, j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("bcd (999999999999998000000000000001/999999999999999)", k, i, j);
@@ -494,18 +868,18 @@ test_bcd_addsub (void)
 
   i = (vBCD_t) CONST_VINT128_W (0, 0, 0x99999999, 0x9999999c);
   j = (vBCD_t) CONST_VINT128_W (0, 0x99999999, 0x99999999, 0x9999999c);
-  k = vec_bcdmul (i, j);
+  k = test_vec_bcdmul (i, j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("bcd (999999999999999*99999999999999999999999)", k, i, j);
 #endif
-  e = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000,
-				0x00000000, 0x0000000c);
+  e = (vBCD_t) CONST_VINT128_W (0x99999998, 0x99999999,
+				0x00000000, 0x0000001c);
   rc += check_vuint128x ("vec_bcdmul:", (vui128_t) k, (vui128_t) e);
 
   i = (vBCD_t) CONST_VINT128_W (0, 0, 0x00000001, 0x0000000c);
   j = (vBCD_t) CONST_VINT128_W (0, 0, 0, 0x3c);
-  k = vec_bcddiv (i, j);
+  k = test_vec_bcddiv (i, j);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x_sum ("bcd (10000000/3)", k, i, j);
@@ -514,8 +888,97 @@ test_bcd_addsub (void)
 				0x00000000, 0x3333333c);
   rc += check_vuint128x ("vec_bcddiv:", (vui128_t) k, (vui128_t) e);
 
+  i = (vBCD_t) CONST_VINT128_W (0, 0x9, 0x99999999, 0x9999999c);
+  j = (vBCD_t) CONST_VINT128_W (0, 0x9, 0x99999999, 0x9999999c);
+  k = test_vec_bcdmul (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd (9999999999999999*9999999999999999)", k, i, j);
+#endif
+  e = (vBCD_t) CONST_VINT128_W (0x99999999, 0x99999980,
+				0x00000000, 0x0000001c);
+  rc += check_vuint128x ("vec_bcdmul:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W (0, 0x99, 0x99999999, 0x9999999c);
+  j = (vBCD_t) CONST_VINT128_W (0, 0x99, 0x99999999, 0x9999999c);
+  k = test_vec_bcdmul (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd (99999999999999999*99999999999999999)", k, i, j);
+#endif
+  e = (vBCD_t) CONST_VINT128_W (0x99999999, 0x99999800,
+				0x00000000, 0x0000001c);
+  rc += check_vuint128x ("vec_bcdmul:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W (0, 0x999, 0x99999999, 0x9999999c);
+  j = (vBCD_t) CONST_VINT128_W (0, 0x999, 0x99999999, 0x9999999c);
+  k = test_vec_bcdmul (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd (999999999999999999*999999999999999999)", k, i, j);
+#endif
+  e = (vBCD_t) CONST_VINT128_W (0x99999999, 0x99998000,
+				0x00000000, 0x0000001c);
+  rc += check_vuint128x ("vec_bcdmul:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W (0x99999999, 0x99999999, 0x99999999, 0x9999999c);
+  j = (vBCD_t) CONST_VINT128_W (0x99999999, 0x99999999, 0x99999999, 0x9999999c);
+  k = test_vec_bcdmul (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd ((10**31-1)*(10**31-1))", k, i, j);
+#endif
+  e = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000,
+				0x00000000, 0x0000001c);
+  rc += check_vuint128x ("vec_bcdmul:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W (0x99999999, 0x99999999, 0x99999999, 0x9999999d);
+  j = (vBCD_t) CONST_VINT128_W (0x99999999, 0x99999999, 0x99999999, 0x9999999c);
+  k = test_vec_bcdmul (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd ((10**31-1)*(10**31-1))", k, i, j);
+#endif
+  e = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000,
+				0x00000000, 0x0000001d);
+  rc += check_vuint128x ("vec_bcdmul:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W (0x99999999, 0x99999999, 0x99999999, 0x9999999c);
+  j = (vBCD_t) CONST_VINT128_W (0x99999999, 0x99999999, 0x99999999, 0x9999999d);
+  k = test_vec_bcdmul (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd ((10**31-1)*(10**31-1))", k, i, j);
+#endif
+  e = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000,
+				0x00000000, 0x0000001d);
+  rc += check_vuint128x ("vec_bcdmul:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W (0x99999999, 0x99999999, 0x99999999, 0x9999999d);
+  j = (vBCD_t) CONST_VINT128_W (0x99999999, 0x99999999, 0x99999999, 0x9999999d);
+  k = test_vec_bcdmul (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd ((10**31-1)*(10**31-1))", k, i, j);
+#endif
+  e = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000,
+				0x00000000, 0x0000001c);
+  rc += check_vuint128x ("vec_bcdmul:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W (0x99999999, 0x99999999, 0x99999999, 0x9999999d);
+  j = (vBCD_t) CONST_VINT128_W (0, 0, 0, 0xc);
+  k = test_vec_bcdmul (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd ((10**31-1)*(10**31-1))", k, i, j);
+#endif
+  e = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000,
+				0x00000000, 0x0000000c);
+  rc += check_vuint128x ("vec_bcdmul:", (vui128_t) k, (vui128_t) e);
+
   return rc;
 }
+#undef __DEBUG_PRINT__
 
  //#define __DEBUG_PRINT__ 1
  #ifdef __DEBUG_PRINT__
@@ -1195,6 +1658,2619 @@ test_bcd_addsub (void)
 
   return rc;
 }
+ //#undef __DEBUG_PRINT__
+
+ //#define __DEBUG_PRINT__ 1
+ int
+ test_setb_bcdsq (void)
+ {
+   vui128_t i;
+   vb128_t j, e;
+   int rc = 0;
+
+   printf ("\n%s Vector BCD setbool from sign\n", __FUNCTION__);
+
+   i = CONST_VINT128_DW128 ( 0x9999999999999999UL,
+ 	                     0x999999999999999dUL );
+   e = (vb128_t) vec_splat_s8(-1);
+   j = vec_setbool_bcdsq ((vBCD_t) i);
+
+ #ifdef __DEBUG_PRINT__
+   print_vint128x ("BCD qword   ", i);
+   print_vb128c   ("vector bool ", j);
+   print_vb128x   ("            ", j);
+ #endif
+   rc += check_vuint128x ("vec_setbool_bcdsq:", (vui128_t) j, (vui128_t) e);
+
+   i = CONST_VINT128_DW128 ( 0x9999999999999999UL,
+ 	                     0x999999999999999bUL );
+   e = (vb128_t) vec_splat_s8(-1);
+   j = vec_setbool_bcdsq ((vBCD_t) i);
+
+ #ifdef __DEBUG_PRINT__
+   print_vint128x ("BCD qword   ", i);
+   print_vb128c   ("vector bool ", j);
+   print_vb128x   ("            ", j);
+ #endif
+   rc += check_vuint128x ("vec_setbool_bcdsq:", (vui128_t) j, (vui128_t) e);
+
+   i = CONST_VINT128_DW128 ( 0x9999999999999999UL,
+ 	                     0x999999999999999cUL );
+   e = (vb128_t) vec_splat_s8(0);
+   j = vec_setbool_bcdsq ((vBCD_t) i);
+
+ #ifdef __DEBUG_PRINT__
+   print_vint128x ("BCD qword   ", i);
+   print_vb128c   ("vector bool ", j);
+   print_vb128x   ("            ", j);
+ #endif
+   rc += check_vuint128x ("vec_setbool_bcdsq:", (vui128_t) j, (vui128_t) e);
+
+   i = CONST_VINT128_DW128 ( 0x9999999999999999UL,
+ 	                     0x999999999999999aUL );
+   e = (vb128_t) vec_splat_s8(0);
+   j = vec_setbool_bcdsq ((vBCD_t) i);
+
+ #ifdef __DEBUG_PRINT__
+   print_vint128x ("BCD qword   ", i);
+   print_vb128c   ("vector bool ", j);
+   print_vb128x   ("            ", j);
+ #endif
+   rc += check_vuint128x ("vec_setbool_bcdsq:", (vui128_t) j, (vui128_t) e);
+
+   i = CONST_VINT128_DW128 ( 0x9999999999999999UL,
+ 	                     0x999999999999999eUL );
+   e = (vb128_t) vec_splat_s8(0);
+   j = vec_setbool_bcdsq ((vBCD_t) i);
+
+ #ifdef __DEBUG_PRINT__
+   print_vint128x ("BCD qword   ", i);
+   print_vb128c   ("vector bool ", j);
+   print_vb128x   ("            ", j);
+ #endif
+   rc += check_vuint128x ("vec_setbool_bcdsq:", (vui128_t) j, (vui128_t) e);
+
+   i = CONST_VINT128_DW128 ( 0x9999999999999999UL,
+ 	                     0x999999999999999fUL );
+   e = (vb128_t) vec_splat_s8(0);
+   j = vec_setbool_bcdsq ((vBCD_t) i);
+
+ #ifdef __DEBUG_PRINT__
+   print_vint128x ("BCD qword   ", i);
+   print_vb128c   ("vector bool ", j);
+   print_vb128x   ("            ", j);
+ #endif
+   rc += check_vuint128x ("vec_setbool_bcdsq:", (vui128_t) j, (vui128_t) e);
+
+  return rc;
+}
+ //#undef __DEBUG_PRINT__
+
+//#define __DEBUG_PRINT__ 1
+int
+test_setb_bcdinv (void)
+{
+  vui128_t i;
+  vb128_t j, e;
+  int rc = 0;
+
+  printf ("\n%s Vector BCD setbool from invalid\n", __FUNCTION__);
+
+  i = CONST_VINT128_DW128 ( 0x9999999999999999UL,
+	                     0x999999999999999dUL );
+  e = (vb128_t) vec_splat_s8(0);
+  j = vec_setbool_bcdinv ((vBCD_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword   ", i);
+  print_vb128c   ("vector bool ", j);
+  print_vb128x   ("            ", j);
+#endif
+  rc += check_vuint128x ("vec_setbool_bcdinv:", (vui128_t) j, (vui128_t) e);
+
+  i = CONST_VINT128_DW128 ( 0x9999999999999999UL,
+	                     0x999999999999999bUL );
+  e = (vb128_t) vec_splat_s8(0);
+  j = vec_setbool_bcdinv ((vBCD_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword   ", i);
+  print_vb128c   ("vector bool ", j);
+  print_vb128x   ("            ", j);
+#endif
+  rc += check_vuint128x ("vec_setbool_bcdinv:", (vui128_t) j, (vui128_t) e);
+
+  i = CONST_VINT128_DW128 ( 0x9999999999999999UL,
+	                     0x999999999999999cUL );
+  e = (vb128_t) vec_splat_s8(0);
+  j = vec_setbool_bcdinv ((vBCD_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword   ", i);
+  print_vb128c   ("vector bool ", j);
+  print_vb128x   ("            ", j);
+#endif
+  rc += check_vuint128x ("vec_setbool_bcdinv:", (vui128_t) j, (vui128_t) e);
+
+  i = CONST_VINT128_DW128 ( 0x9999999999999999UL,
+	                     0x999999999999999aUL );
+  e = (vb128_t) vec_splat_s8(0);
+  j = vec_setbool_bcdinv ((vBCD_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword   ", i);
+  print_vb128c   ("vector bool ", j);
+  print_vb128x   ("            ", j);
+#endif
+  rc += check_vuint128x ("vec_setbool_bcdinv:", (vui128_t) j, (vui128_t) e);
+
+  i = CONST_VINT128_DW128 ( 0x9999999999999999UL,
+	                     0x999999999999999eUL );
+  e = (vb128_t) vec_splat_s8(0);
+  j = vec_setbool_bcdinv ((vBCD_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword   ", i);
+  print_vb128c   ("vector bool ", j);
+  print_vb128x   ("            ", j);
+#endif
+  rc += check_vuint128x ("vec_setbool_bcdinv:", (vui128_t) j, (vui128_t) e);
+
+  i = CONST_VINT128_DW128 ( 0x9999999999999999UL,
+	                     0x999999999999999fUL );
+  e = (vb128_t) vec_splat_s8(0);
+  j = vec_setbool_bcdinv ((vBCD_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword   ", i);
+  print_vb128c   ("vector bool ", j);
+  print_vb128x   ("            ", j);
+#endif
+  rc += check_vuint128x ("vec_setbool_bcdinv:", (vui128_t) j, (vui128_t) e);
+
+  i = CONST_VINT128_DW128 ( 0x0UL, 0xfUL );
+  e = (vb128_t) vec_splat_s8(0);
+  j = vec_setbool_bcdinv ((vBCD_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword   ", i);
+  print_vb128c   ("vector bool ", j);
+  print_vb128x   ("            ", j);
+#endif
+  rc += check_vuint128x ("vec_setbool_bcdinv:", (vui128_t) j, (vui128_t) e);
+
+  i = CONST_VINT128_DW128 ( 0UL, 0UL );
+  e = (vb128_t) vec_splat_s8(-1);
+  j = vec_setbool_bcdinv ((vBCD_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword   ", i);
+  print_vb128c   ("vector bool ", j);
+  print_vb128x   ("            ", j);
+#endif
+  rc += check_vuint128x ("vec_setbool_bcdinv:", (vui128_t) j, (vui128_t) e);
+
+  i = CONST_VINT128_DW128 ( 0x9999999999999999UL,
+	                    0x9999999999999999UL );
+  e = (vb128_t) vec_splat_s8(-1);
+  j = vec_setbool_bcdinv ((vBCD_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword   ", i);
+  print_vb128c   ("vector bool ", j);
+  print_vb128x   ("            ", j);
+#endif
+  rc += check_vuint128x ("vec_setbool_bcdinv:", (vui128_t) j, (vui128_t) e);
+
+  i = CONST_VINT128_DW128 ( 0x9999999999999999UL,
+	                    0xa99999999999999cUL );
+  e = (vb128_t) vec_splat_s8(-1);
+  j = vec_setbool_bcdinv ((vBCD_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword   ", i);
+  print_vb128c   ("vector bool ", j);
+  print_vb128x   ("            ", j);
+#endif
+  rc += check_vuint128x ("vec_setbool_bcdinv:", (vui128_t) j, (vui128_t) e);
+
+  i = CONST_VINT128_DW128 ( 0x9999999999999999UL,
+	                    0x0a9999999999999cUL );
+  e = (vb128_t) vec_splat_s8(-1);
+  j = vec_setbool_bcdinv ((vBCD_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword   ", i);
+  print_vb128c   ("vector bool ", j);
+  print_vb128x   ("            ", j);
+#endif
+  rc += check_vuint128x ("vec_setbool_bcdinv:", (vui128_t) j, (vui128_t) e);
+
+  i = CONST_VINT128_DW128 ( 0xa999999999999999UL,
+	                    0x0cUL );
+  e = (vb128_t) vec_splat_s8(-1);
+  j = vec_setbool_bcdinv ((vBCD_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword   ", i);
+  print_vb128c   ("vector bool ", j);
+  print_vb128x   ("            ", j);
+#endif
+  rc += check_vuint128x ("vec_setbool_bcdinv:", (vui128_t) j, (vui128_t) e);
+
+  i = CONST_VINT128_DW128 ( 0x0a99999999999999UL,
+	                    0x0cUL );
+  e = (vb128_t) vec_splat_s8(-1);
+  j = vec_setbool_bcdinv ((vBCD_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword   ", i);
+  print_vb128c   ("vector bool ", j);
+  print_vb128x   ("            ", j);
+#endif
+  rc += check_vuint128x ("vec_setbool_bcdinv:", (vui128_t) j, (vui128_t) e);
+
+ return rc;
+}
+//#undef __DEBUG_PRINT__
+
+//#define __DEBUG_PRINT__ 1
+int
+test_signbit_bcdsq (void)
+{
+  vui128_t i;
+//  vb128_t j;
+  int rc = 0;
+
+  printf ("\n%s Vector BCD signbit\n", __FUNCTION__);
+
+  i = CONST_VINT128_DW128 ( 0x9999999999999999UL,
+	                     0x999999999999999dUL );
+
+  if (vec_signbit_bcdsq ((vBCD_t) i))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_signbit_bcdsq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_setbool_bcdsq ((vBCD_t) i);
+      print_vint128x ("BCD qword   ", i);
+      print_vb128c   ("vector bool ", j);
+      print_vb128x   ("            ", j);
+#endif
+    }
+
+  i = CONST_VINT128_DW128 ( 0x9999999999999999UL,
+	                     0x999999999999999bUL );
+  if (vec_signbit_bcdsq ((vBCD_t) i))
+    {
+    } else {
+      rc += 1;
+      printf ("vec_signbit_bcdsq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_setbool_bcdsq ((vBCD_t) i);
+      print_vint128x ("BCD qword   ", i);
+      print_vb128c   ("vector bool ", j);
+      print_vb128x   ("            ", j);
+#endif
+    }
+
+  i = CONST_VINT128_DW128 ( 0x9999999999999999UL,
+	                     0x999999999999999cUL );
+  if (vec_signbit_bcdsq ((vBCD_t) i))
+    {
+      rc += 1;
+      printf ("vec_signbit_bcdsq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_setbool_bcdsq ((vBCD_t) i);
+      print_vint128x ("BCD qword   ", i);
+      print_vb128c   ("vector bool ", j);
+      print_vb128x   ("            ", j);
+#endif
+    } else {
+    }
+
+  i = CONST_VINT128_DW128 ( 0x9999999999999999UL,
+	                     0x999999999999999aUL );
+  if (vec_signbit_bcdsq ((vBCD_t) i))
+    {
+      rc += 1;
+      printf ("vec_signbit_bcdsq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_setbool_bcdsq ((vBCD_t) i);
+      print_vint128x ("BCD qword   ", i);
+      print_vb128c   ("vector bool ", j);
+      print_vb128x   ("            ", j);
+#endif
+    } else {
+    }
+
+  i = CONST_VINT128_DW128 ( 0x9999999999999999UL,
+	                     0x999999999999999eUL );
+  if (vec_signbit_bcdsq ((vBCD_t) i))
+    {
+      rc += 1;
+      printf ("vec_signbit_bcdsq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_setbool_bcdsq ((vBCD_t) i);
+      print_vint128x ("BCD qword   ", i);
+      print_vb128c   ("vector bool ", j);
+      print_vb128x   ("            ", j);
+#endif
+    } else {
+    }
+
+  i = CONST_VINT128_DW128 ( 0x9999999999999999UL,
+	                     0x999999999999999fUL );
+  if (vec_signbit_bcdsq ((vBCD_t) i))
+    {
+      rc += 1;
+      printf ("vec_signbit_bcdsq fail\n");
+#ifdef __DEBUG_PRINT__
+      j = vec_setbool_bcdsq ((vBCD_t) i);
+      print_vint128x ("BCD qword   ", i);
+      print_vb128c   ("vector bool ", j);
+      print_vb128x   ("            ", j);
+#endif
+    } else {
+    }
+
+ return rc;
+}
+//#undef __DEBUG_PRINT__
+
+//#define __DEBUG_PRINT__ 1
+int
+test_bcdcpsgn (void)
+{
+  vui128_t i1, i2;
+  vui128_t j, e;
+  int rc = 0;
+
+  printf ("\n%s Vector BCD copy sign\n", __FUNCTION__);
+
+  i1 = CONST_VINT128_DW128 ( 0x9999999999999999UL,
+	                     0x999999999999999dUL );
+  i2 = (vui128_t) _BCD_CONST_PLUS_ONE;
+  e  = CONST_VINT128_DW128 ( 0x9999999999999999UL,
+	                     0x999999999999999cUL );
+  j =  (vui128_t) vec_bcdcpsgn ((vBCD_t) i1, (vBCD_t) i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword 1 ", i1);
+  print_vint128x ("BCD qword 2 ", i2);
+  print_vb128x   ("cpsgn       ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdcpsgn:", (vui128_t) j, (vui128_t) e);
+
+  i1 = (vui128_t) _BCD_CONST_PLUS_ONE;
+  i2 = CONST_VINT128_DW128 ( 0x9999999999999999UL,
+	                     0x999999999999999dUL );
+  e  = (vui128_t) _BCD_CONST_MINUS_ONE;
+  j =  (vui128_t) vec_bcdcpsgn ((vBCD_t) i1, (vBCD_t) i2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword 1 ", i1);
+  print_vint128x ("BCD qword 2 ", i2);
+  print_vb128x   ("cpsgn       ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdcpsgn:", (vui128_t) j, (vui128_t) e);
+
+ return rc;
+}
+//#undef __DEBUG_PRINT__
+
+//#define __DEBUG_PRINT__ 1
+int
+test_bcdctsq (void)
+{
+  vui128_t i;
+  vi128_t j, e;
+  int rc = 0;
+
+  printf ("\n%s Vector Signed BCD qword convert\n", __FUNCTION__);
+
+  i = CONST_VINT128_DW128 ( 0x9999999999999999UL,
+	                     0x999999999999999cUL );
+  /* e = 99999999999999999999999999999UQ  */
+  e = (vi128_t) { (__int128 ) 999999999999999ll
+                 * (__int128 ) 10000000000000000ll
+                 + (__int128 ) 9999999999999999ll };
+  j = vec_bcdctsq ((vBCD_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qwords ", i);
+  print_vint128x ("__int128   ", j);
+  print_vint128  ("           ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdctsq:", (vui128_t) j, (vui128_t) e);
+
+  i = CONST_VINT128_DW128 ( 0x0109101920293039UL,
+                            0x404950596069707cUL );
+  /* e = 109101920293039404950596069707UQ  */
+  e = (vi128_t) { (__int128 ) 10910192029303ll
+                 * (__int128 ) 10000000000000000ll
+                 + (__int128 ) 9404950596069707ll };
+  j = vec_bcdctsq ((vBCD_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qwords ", i);
+  print_vint128x ("__int128   ", j);
+  print_vint128  ("           ", j);
+#endif
+ rc += check_vuint128x ("vec_bcdctsq:", (vui128_t) j, (vui128_t) e);
+
+ i = CONST_VINT128_DW128 ( 0x8081828386878889UL,
+                           0x909192939596979cUL );
+ /* e = 8081828386878889909192939596979UQ  */
+ e = (vi128_t) { (__int128 ) 808182838687888ll
+                * (__int128 ) 10000000000000000ll
+                + (__int128 ) 9909192939596979ll };
+
+ j = vec_bcdctsq ((vBCD_t) i);
+
+#ifdef __DEBUG_PRINT__
+ print_vint128x ("BCD qwords ", i);
+ print_vint128x ("__int128   ", j);
+ print_vint128  ("           ", j);
+#endif
+rc += check_vuint128x ("vec_bcdctsq:", (vui128_t) j, (vui128_t) e);
+
+i = CONST_VINT128_DW128 ( 0x9999999999999999UL,
+	                     0x999999999999999dUL );
+/* e = 99999999999999999999999999999UQ  */
+e = (vi128_t) { (__int128 ) -999999999999999ll
+               * (__int128 ) 10000000000000000ll
+               + (__int128 ) -9999999999999999ll };
+j = vec_bcdctsq ((vBCD_t) i);
+
+#ifdef __DEBUG_PRINT__
+print_vint128x ("BCD qwords ", i);
+print_vint128x ("__int128   ", j);
+print_vint128  ("           ", j);
+#endif
+rc += check_vuint128x ("vec_bcdctsq:", (vui128_t) j, (vui128_t) e);
+
+i = CONST_VINT128_DW128 ( 0x0109101920293039UL,
+                          0x404950596069707dUL );
+/* e = 109101920293039404950596069707UQ  */
+e = (vi128_t) { (__int128 ) -10910192029303ll
+               * (__int128 ) 10000000000000000ll
+               + (__int128 ) -9404950596069707ll };
+j = vec_bcdctsq ((vBCD_t) i);
+
+#ifdef __DEBUG_PRINT__
+print_vint128x ("BCD qwords ", i);
+print_vint128x ("__int128   ", j);
+print_vint128  ("           ", j);
+#endif
+rc += check_vuint128x ("vec_bcdctsq:", (vui128_t) j, (vui128_t) e);
+
+i = CONST_VINT128_DW128 ( 0x8081828386878889UL,
+                         0x909192939596979dUL );
+/* e = 8081828386878889909192939596979UQ  */
+e = (vi128_t) { (__int128 ) -808182838687888ll
+              * (__int128 ) 10000000000000000ll
+              + (__int128 ) -9909192939596979ll };
+
+j = vec_bcdctsq ((vBCD_t) i);
+
+#ifdef __DEBUG_PRINT__
+print_vint128x ("BCD qwords ", i);
+print_vint128x ("__int128   ", j);
+print_vint128  ("           ", j);
+#endif
+rc += check_vuint128x ("vec_bcdctsq:", (vui128_t) j, (vui128_t) e);
+
+ return rc;
+}
+//#undef __DEBUG_PRINT__
+
+//#define __DEBUG_PRINT__ 1
+int
+test_bcds (void)
+{
+  vui128_t i, j, e;
+  vi8_t s;
+  int rc = 0;
+
+  printf ("\n%s Vector Decimal Shift\n", __FUNCTION__);
+
+  i = CONST_VINT128_DW128 ( 0x1011121314151617UL,
+	                    0x202122232425262cUL );
+  s = (vi8_t) CONST_VINT128_DW (1, 0);
+  e = CONST_VINT128_DW128 ( 0x0111213141516172UL,
+	                    0x021222324252620cUL );
+  j =  (vui128_t) vec_bcds ((vBCD_t) i, s);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  print_vint128x ("BCD shift ", (vui128_t) s);
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcds:", (vui128_t) j, (vui128_t) e);
+
+  s = (vi8_t) CONST_VINT128_DW (2, 0);
+  e = CONST_VINT128_DW128 ( 0x1112131415161720UL,
+	                    0x212223242526200cUL );
+  j =  (vui128_t) vec_bcds ((vBCD_t) i, s);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  print_vint128x ("BCD shift ", (vui128_t) s);
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcds:", (vui128_t) j, (vui128_t) e);
+
+  s = (vi8_t) CONST_VINT128_DW (15, 0);
+  e = CONST_VINT128_DW128 ( 0x7202122232425262UL,
+	                    0x000000000000000cUL );
+  j =  (vui128_t) vec_bcds ((vBCD_t) i, s);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  print_vint128x ("BCD shift ", (vui128_t) s);
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcds:", (vui128_t) j, (vui128_t) e);
+
+  s = (vi8_t) CONST_VINT128_DW (31, 0);
+  e = CONST_VINT128_DW128 ( 0x0000000000000000UL,
+	                    0x000000000000000cUL );
+  j =  (vui128_t) vec_bcds ((vBCD_t) i, s);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  print_vint128x ("BCD shift ", (vui128_t) s);
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcds:", (vui128_t) j, (vui128_t) e);
+
+  i = CONST_VINT128_DW128 ( 0x1011121314151617UL,
+	                    0x202122232425262dUL );
+  s = (vi8_t) CONST_VINT128_DW (-1, 0);
+  e = CONST_VINT128_DW128 ( 0x0101112131415161UL,
+	                    0x720212223242526dUL );
+  j =  (vui128_t) vec_bcds ((vBCD_t) i, s);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  print_vint128x ("BCD shift ", (vui128_t) s);
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcds:", (vui128_t) j, (vui128_t) e);
+
+  s = (vi8_t) CONST_VINT128_DW (-2, 0);
+  e = CONST_VINT128_DW128 ( 0x0010111213141516UL,
+	                    0x172021222324252dUL );
+  j =  (vui128_t) vec_bcds ((vBCD_t) i, s);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  print_vint128x ("BCD shift ", (vui128_t) s);
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcds:", (vui128_t) j, (vui128_t) e);
+
+  s = (vi8_t) CONST_VINT128_DW (-15, 0);
+  e = CONST_VINT128_DW128 ( 0x0000000000000001UL,
+	                    0x011121314151617dUL );
+  j =  (vui128_t) vec_bcds ((vBCD_t) i, s);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  print_vint128x ("BCD shift ", (vui128_t) s);
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcds:", (vui128_t) j, (vui128_t) e);
+
+  s = (vi8_t) CONST_VINT128_DW (-31, 0);
+  e = CONST_VINT128_DW128 ( 0x0000000000000000UL,
+	                    0x000000000000000dUL );
+  j =  (vui128_t) vec_bcds ((vBCD_t) i, s);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  print_vint128x ("BCD shift ", (vui128_t) s);
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcds:", (vui128_t) j, (vui128_t) e);
+
+ return rc;
+}
+//#undef __DEBUG_PRINT__
+
+//#define __DEBUG_PRINT__ 1
+int
+test_bcdus (void)
+{
+  vui128_t i, j, e;
+  vi8_t s;
+  int rc = 0;
+
+  printf ("\n%s Vector Decimal Unsigned Shift\n", __FUNCTION__);
+
+  i = CONST_VINT128_DW128 ( 0x1011121314151617UL,
+	                    0x2021222324252627UL );
+  s = (vi8_t) CONST_VINT128_DW (1, 0);
+  e = CONST_VINT128_DW128 ( 0x0111213141516172UL,
+	                    0x0212223242526270UL );
+  j =  (vui128_t) vec_bcdus ((vBCD_t) i, s);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  print_vint128x ("BCD shift ", (vui128_t) s);
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdus:", (vui128_t) j, (vui128_t) e);
+
+  s = (vi8_t) CONST_VINT128_DW (2, 0);
+  e = CONST_VINT128_DW128 ( 0x1112131415161720UL,
+	                    0x2122232425262700UL );
+  j =  (vui128_t) vec_bcdus ((vBCD_t) i, s);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  print_vint128x ("BCD shift ", (vui128_t) s);
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdus:", (vui128_t) j, (vui128_t) e);
+
+  s = (vi8_t) CONST_VINT128_DW (15, 0);
+  e = CONST_VINT128_DW128 ( 0x7202122232425262UL,
+	                    0x7000000000000000UL );
+  j =  (vui128_t) vec_bcdus ((vBCD_t) i, s);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  print_vint128x ("BCD shift ", (vui128_t) s);
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdus:", (vui128_t) j, (vui128_t) e);
+
+  s = (vi8_t) CONST_VINT128_DW (31, 0);
+  e = CONST_VINT128_DW128 ( 0x7000000000000000UL,
+	                    0x0000000000000000UL );
+  j =  (vui128_t) vec_bcdus ((vBCD_t) i, s);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  print_vint128x ("BCD shift ", (vui128_t) s);
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdus:", (vui128_t) j, (vui128_t) e);
+
+  s = (vi8_t) CONST_VINT128_DW (-1, 0);
+  e = CONST_VINT128_DW128 ( 0x0101112131415161UL,
+	                    0x7202122232425262UL );
+  j =  (vui128_t) vec_bcdus ((vBCD_t) i, s);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  print_vint128x ("BCD shift ", (vui128_t) s);
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdus:", (vui128_t) j, (vui128_t) e);
+
+  s = (vi8_t) CONST_VINT128_DW (-2, 0);
+  e = CONST_VINT128_DW128 ( 0x0010111213141516UL,
+	                    0x1720212223242526UL );
+  j =  (vui128_t) vec_bcdus ((vBCD_t) i, s);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  print_vint128x ("BCD shift ", (vui128_t) s);
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdus:", (vui128_t) j, (vui128_t) e);
+
+  s = (vi8_t) CONST_VINT128_DW (-15, 0);
+  e = CONST_VINT128_DW128 ( 0x0000000000000001UL,
+	                    0x0111213141516172UL );
+  j =  (vui128_t) vec_bcdus ((vBCD_t) i, s);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  print_vint128x ("BCD shift ", (vui128_t) s);
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdus:", (vui128_t) j, (vui128_t) e);
+
+  s = (vi8_t) CONST_VINT128_DW (-31, 0);
+  e = CONST_VINT128_DW128 ( 0x0000000000000000UL,
+	                    0x0000000000000001UL );
+  j =  (vui128_t) vec_bcdus ((vBCD_t) i, s);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  print_vint128x ("BCD shift ", (vui128_t) s);
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdus:", (vui128_t) j, (vui128_t) e);
+
+ return rc;
+}
+//#undef __DEBUG_PRINT__
+
+//#define __DEBUG_PRINT__ 1
+int
+test_bcdslrqi (void)
+{
+  vui128_t i, j, e;
+  int rc = 0;
+
+  printf ("\n%s Vector Decimal Shift Immediate\n", __FUNCTION__);
+
+  i = CONST_VINT128_DW128 ( 0x1011121314151617UL,
+	                    0x202122232425262cUL );
+  e = CONST_VINT128_DW128 ( 0x0111213141516172UL,
+	                    0x021222324252620cUL );
+  j =  (vui128_t) vec_bcdslqi ((vBCD_t) i, 1);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  printf         ("BCD shift , 1)\n");
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdslqi:", (vui128_t) j, (vui128_t) e);
+
+  e = CONST_VINT128_DW128 ( 0x1112131415161720UL,
+	                    0x212223242526200cUL );
+  j =  (vui128_t) vec_bcdslqi ((vBCD_t) i, 2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  printf         ("BCD shift , 2)\n");
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdslqi:", (vui128_t) j, (vui128_t) e);
+
+  e = CONST_VINT128_DW128 ( 0x7202122232425262UL,
+	                    0x000000000000000cUL );
+  j =  (vui128_t) vec_bcdslqi ((vBCD_t) i, 15);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  printf         ("BCD shift , 15)\n");
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdslqi:", (vui128_t) j, (vui128_t) e);
+
+  e = CONST_VINT128_DW128 ( 0x0000000000000000UL,
+	                    0x000000000000000cUL );
+  j =  (vui128_t) vec_bcdslqi ((vBCD_t) i, 31);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  printf         ("BCD shift , 31)\n");
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdslqi:", (vui128_t) j, (vui128_t) e);
+
+  i = CONST_VINT128_DW128 ( 0x1011121314151617UL,
+	                    0x202122232425262dUL );
+  e = CONST_VINT128_DW128 ( 0x0101112131415161UL,
+	                    0x720212223242526dUL );
+  j =  (vui128_t) vec_bcdsrqi ((vBCD_t) i, 1);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  printf         ("BCD shift , 1)\n");
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdsrqi:", (vui128_t) j, (vui128_t) e);
+
+  e = CONST_VINT128_DW128 ( 0x0010111213141516UL,
+	                    0x172021222324252dUL );
+  j =  (vui128_t) vec_bcdsrqi ((vBCD_t) i, 2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  printf         ("BCD shift , 2)\n");
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdsrqi:", (vui128_t) j, (vui128_t) e);
+
+  e = CONST_VINT128_DW128 ( 0x0000000000000001UL,
+	                    0x011121314151617dUL );
+  j =  (vui128_t) vec_bcdsrqi ((vBCD_t) i, 15);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  printf         ("BCD shift , 15\n");
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdsrqi:", (vui128_t) j, (vui128_t) e);
+
+  e = CONST_VINT128_DW128 ( 0x0000000000000000UL,
+	                    0x000000000000000dUL );
+  j =  (vui128_t) vec_bcdsrqi ((vBCD_t) i, 31);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  printf         ("BCD shift , 31)\n");
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdsrqi:", (vui128_t) j, (vui128_t) e);
+
+ return rc;
+}
+//#undef __DEBUG_PRINT__
+
+//#define __DEBUG_PRINT__ 1
+int
+test_bcdslruqi (void)
+{
+  vui128_t i, j, e;
+  int rc = 0;
+
+  printf ("\n%s Vector Decimal Unsigned Shift Immediate\n", __FUNCTION__);
+
+  i = CONST_VINT128_DW128 ( 0x1011121314151617UL,
+	                    0x2021222324252627UL );
+  e = CONST_VINT128_DW128 ( 0x0111213141516172UL,
+	                    0x0212223242526270UL );
+  j =  (vui128_t) vec_bcdsluqi ((vBCD_t) i, 1);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  printf         ("BCD shift , 1)\n");
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdsluqi:", (vui128_t) j, (vui128_t) e);
+
+  e = CONST_VINT128_DW128 ( 0x1112131415161720UL,
+	                    0x2122232425262700UL );
+  j =  (vui128_t) vec_bcdsluqi ((vBCD_t) i, 2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  printf         ("BCD shift , 2)\n");
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdsluqi:", (vui128_t) j, (vui128_t) e);
+
+  e = CONST_VINT128_DW128 ( 0x7202122232425262UL,
+	                    0x7000000000000000UL );
+  j =  (vui128_t) vec_bcdsluqi ((vBCD_t) i, 15);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  printf         ("BCD shift , 15)\n");
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdsluqi:", (vui128_t) j, (vui128_t) e);
+
+  e = CONST_VINT128_DW128 ( 0x7000000000000000UL,
+	                    0x0000000000000000UL );
+  j =  (vui128_t) vec_bcdsluqi ((vBCD_t) i, 31);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  printf         ("BCD shift , 31)\n");
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdsluqi:", (vui128_t) j, (vui128_t) e);
+
+  e = CONST_VINT128_DW128 ( 0x0101112131415161UL,
+	                    0x7202122232425262UL );
+  j =  (vui128_t) vec_bcdsruqi ((vBCD_t) i, 1);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  printf         ("BCD shift , 1)\n");
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdsruqi:", (vui128_t) j, (vui128_t) e);
+
+  e = CONST_VINT128_DW128 ( 0x0010111213141516UL,
+	                    0x1720212223242526UL );
+  j =  (vui128_t) vec_bcdsruqi ((vBCD_t) i, 2);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  printf         ("BCD shift , 2)\n");
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdsruqi:", (vui128_t) j, (vui128_t) e);
+
+  e = CONST_VINT128_DW128 ( 0x0000000000000001UL,
+	                    0x0111213141516172UL );
+  j =  (vui128_t) vec_bcdsruqi ((vBCD_t) i, 15);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  printf         ("BCD shift , 15)\n");
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdsruqi:", (vui128_t) j, (vui128_t) e);
+
+  e = CONST_VINT128_DW128 ( 0x0000000000000000UL,
+	                    0x0000000000000001UL );
+  j =  (vui128_t) vec_bcdsruqi ((vBCD_t) i, 31);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("BCD qword ", i);
+  printf         ("BCD shift , 31)\n");
+  print_vint128x (" shifted  ", j);
+#endif
+  rc += check_vuint128x ("vec_bcdsruqi:", (vui128_t) j, (vui128_t) e);
+
+ return rc;
+}
+//#undef __DEBUG_PRINT__
+
+//#define __DEBUG_PRINT__ 1
+#ifdef __DEBUG_PRINT__
+#define test_vec_bcdmulh(_l, _k)	db_vec_bcdmulh(_l, _k)
+#else
+#define test_vec_bcdmulh(_l, _k)	vec_bcdmulh(_l, _k)
+#endif
+ int
+ test_bcd_mulh (void)
+ {
+   vBCD_t i, j, k;
+   vBCD_t e;
+  int rc = 0;
+
+  printf ("\n%s Vector BCD mulh\n", __FUNCTION__);
+
+  i = (vBCD_t) CONST_VINT128_W (0, 0, 0x99999999, 0x9999999c);
+  j = (vBCD_t) CONST_VINT128_W (0, 0, 0x99999999, 0x9999999c);
+  k = test_vec_bcdmulh (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd ((10**15-1)*(10**15-1))", k, i, j);
+#endif
+  e = (vBCD_t) CONST_VINT128_W (0, 0, 0, 0x0000000c);
+  rc += check_vuint128x ("vec_bcdmulh:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W (0, 0, 0x99999999, 0x9999999c);
+  j = (vBCD_t) CONST_VINT128_W (0, 0, 0x99999999, 0x9999999d);
+  k = test_vec_bcdmulh (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd ((10**15-1)*(10**15-1))", k, i, j);
+#endif
+  e = (vBCD_t) CONST_VINT128_W (0, 0, 0, 0x0000000c);
+  rc += check_vuint128x ("vec_bcdmulh:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W (0, 0, 0x99999999, 0x9999999d);
+  j = (vBCD_t) CONST_VINT128_W (0, 0, 0x99999999, 0x9999999c);
+  k = test_vec_bcdmulh (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd ((10**15-1)*(10**15-1))", k, i, j);
+#endif
+  e = (vBCD_t) CONST_VINT128_W (0, 0, 0, 0x0000000c);
+  rc += check_vuint128x ("vec_bcdmulh:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W (0, 0x9, 0x99999999, 0x9999999c);
+  j = (vBCD_t) CONST_VINT128_W (0, 0x9, 0x99999999, 0x9999999c);
+  k = test_vec_bcdmulh (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd ((10**16-1)*(10**16-1))", k, i, j);
+#endif
+  e = (vBCD_t) CONST_VINT128_W (0, 0, 0, 0x0000009c);
+  rc += check_vuint128x ("vec_bcdmulh:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W (0, 0x99, 0x99999999, 0x9999999c);
+  j = (vBCD_t) CONST_VINT128_W (0, 0x99, 0x99999999, 0x9999999c);
+  k = test_vec_bcdmulh (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd ((10**17-1)*(10**17-1))", k, i, j);
+#endif
+  e = (vBCD_t) CONST_VINT128_W (0, 0, 0, 0x0000999c);
+  rc += check_vuint128x ("vec_bcdmulh:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W (0, 0x999, 0x99999999, 0x9999999c);
+  j = (vBCD_t) CONST_VINT128_W (0, 0x999, 0x99999999, 0x9999999c);
+  k = test_vec_bcdmulh (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd ((10**18-1)*(10**18-1))", k, i, j);
+#endif
+  e = (vBCD_t) CONST_VINT128_W (0, 0, 0, 0x0099999c);
+  rc += check_vuint128x ("vec_bcdmulh:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W (0x99999999, 0x99999999, 0x99999999, 0x9999999c);
+  j = (vBCD_t) CONST_VINT128_W (0x99999999, 0x99999999, 0x99999999, 0x9999999c);
+  k = test_vec_bcdmulh (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd ((10**31-1)*(10**31-1))", k, i, j);
+#endif
+  e = (vBCD_t) CONST_VINT128_W (0x99999999, 0x99999999, 0x99999999, 0x9999998c);
+  rc += check_vuint128x ("vec_bcdmulh:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W (0x99999999, 0x99999999, 0x99999999, 0x9999999c);
+  j = (vBCD_t) CONST_VINT128_W (0x0, 0x1, 0x00000000, 0x0000000c);
+  k = test_vec_bcdmulh (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd ((10**31-1)*(10**15))", k, i, j);
+#endif
+  e = (vBCD_t) CONST_VINT128_W (0x0, 0x0, 0x99999999, 0x9999999c);
+  rc += check_vuint128x ("vec_bcdmulh:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W (0x99999999, 0x99999999, 0x99999999, 0x9999999c);
+  j = (vBCD_t) CONST_VINT128_W (0x0, 0x10, 0x00000000, 0x0000000c);
+  k = test_vec_bcdmulh (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd ((10**31-1)*(10**16))", k, i, j);
+#endif
+  e = (vBCD_t) CONST_VINT128_W (0x0, 0x9, 0x99999999, 0x9999999c);
+  rc += check_vuint128x ("vec_bcdmulh:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W (0x99999999, 0x99999999, 0x99999999, 0x9999999d);
+  j = (vBCD_t) CONST_VINT128_W (0x0, 0x10, 0x00000000, 0x0000000c);
+  k = test_vec_bcdmulh (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd ((10**31-1)*(10**16))", k, i, j);
+#endif
+  e = (vBCD_t) CONST_VINT128_W (0x0, 0x9, 0x99999999, 0x9999999d);
+  rc += check_vuint128x ("vec_bcdmulh:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W (0x99999999, 0x99999999, 0x99999999, 0x9999999c);
+  j = (vBCD_t) CONST_VINT128_W (0x0, 0x10, 0x00000000, 0x0000000d);
+  k = test_vec_bcdmulh (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd ((10**31-1)*(10**16))", k, i, j);
+#endif
+  e = (vBCD_t) CONST_VINT128_W (0x0, 0x9, 0x99999999, 0x9999999d);
+  rc += check_vuint128x ("vec_bcdmulh:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W (0x99999999, 0x99999999, 0x99999999, 0x9999999d);
+  j = (vBCD_t) CONST_VINT128_W (0x0, 0x10, 0x00000000, 0x0000000d);
+  k = test_vec_bcdmulh (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd ((10**31-1)*(10**16))", k, i, j);
+#endif
+  e = (vBCD_t) CONST_VINT128_W (0x0, 0x9, 0x99999999, 0x9999999c);
+  rc += check_vuint128x ("vec_bcdmulh:", (vui128_t) k, (vui128_t) e);
+
+  return rc;
+ }
+ //#undef __DEBUG_PRINT__
+
+ //#define __DEBUG_PRINT__ 1
+ #ifdef __DEBUG_PRINT__
+ #define test_vec_cbcdmul(_l, _j, _k)	db_vec_cbcdmul(_l, _j, _k)
+ #else
+ #define test_vec_cbcdmul(_l, _j, _k)	vec_cbcdmul(_l, _j, _k)
+ #endif
+int
+test_bcd_cmul (void)
+{
+  vBCD_t i, j, k, l;
+  vBCD_t e, eh;
+  int rc = 0;
+
+  printf ("\n%s Vector combined h/l BCD\n", __FUNCTION__);
+
+  i = (vBCD_t) CONST_VINT128_W(0x00000000, 0x00000009, 0x99999999, 0x9999999c);
+  j = (vBCD_t) CONST_VINT128_W(0x00000000, 0x00000009, 0x99999999, 0x9999999c);
+  k = test_vec_cbcdmul(&l, i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i * j ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("     = ", (vui128_t) l);
+  print_vint128x ("       ", (vui128_t) k);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W(0x00000000, 0x00000000, 0x00000000, 0x0000009c);
+  e = (vBCD_t) CONST_VINT128_W(0x99999999, 0x99999980, 0x00000000, 0x0000001c);
+  rc += check_vint256 ("vec_cbcdmul:", (vui128_t) l, (vui128_t) k,
+		       (vui128_t) eh, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W(0x99999999, 0x99999999, 0x99999999, 0x9999999c);
+  j = (vBCD_t) CONST_VINT128_W(0x99999999, 0x99999999, 0x99999999, 0x9999999c);
+  k = test_vec_cbcdmul(&l, i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i * j ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("     = ", (vui128_t) l);
+  print_vint128x ("       ", (vui128_t) k);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W(0x99999999, 0x99999999, 0x99999999, 0x9999998c);
+  e = (vBCD_t) CONST_VINT128_W(0x00000000, 0x00000000, 0x00000000, 0x0000001c);
+  rc += check_vint256 ("vec_cbcdmul:", (vui128_t) l, (vui128_t) k,
+		       (vui128_t) eh, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W(0x99999999, 0x99999999, 0x99999999, 0x9999999d);
+  j = (vBCD_t) CONST_VINT128_W(0x99999999, 0x99999999, 0x99999999, 0x9999999d);
+  k = test_vec_cbcdmul(&l, i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i * j ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("     = ", (vui128_t) l);
+  print_vint128x ("       ", (vui128_t) k);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W(0x99999999, 0x99999999, 0x99999999, 0x9999998c);
+  e = (vBCD_t) CONST_VINT128_W(0x00000000, 0x00000000, 0x00000000, 0x0000001c);
+  rc += check_vint256 ("vec_cbcdmul:", (vui128_t) l, (vui128_t) k,
+		       (vui128_t) eh, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W(0x99999999, 0x99999999, 0x99999999, 0x9999999d);
+  j = (vBCD_t) CONST_VINT128_W(0x99999999, 0x99999999, 0x99999999, 0x9999999c);
+  k = test_vec_cbcdmul(&l, i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i * j ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("     = ", (vui128_t) l);
+  print_vint128x ("       ", (vui128_t) k);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W(0x99999999, 0x99999999, 0x99999999, 0x9999998d);
+  e = (vBCD_t) CONST_VINT128_W(0x00000000, 0x00000000, 0x00000000, 0x0000001d);
+  rc += check_vint256 ("vec_cbcdmul:", (vui128_t) l, (vui128_t) k,
+		       (vui128_t) eh, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W(0x99999999, 0x99999999, 0x99999999, 0x9999999c);
+  j = (vBCD_t) CONST_VINT128_W(0x99999999, 0x99999999, 0x99999999, 0x9999999d);
+  k = test_vec_cbcdmul(&l, i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i * j ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("     = ", (vui128_t) l);
+  print_vint128x ("       ", (vui128_t) k);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W(0x99999999, 0x99999999, 0x99999999, 0x9999998d);
+  e = (vBCD_t) CONST_VINT128_W(0x00000000, 0x00000000, 0x00000000, 0x0000001d);
+  rc += check_vint256 ("vec_cbcdmul:", (vui128_t) l, (vui128_t) k,
+		       (vui128_t) eh, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W (0, 0, 0x99999999, 0x9999999c);
+  j = (vBCD_t) CONST_VINT128_W (0, 0, 0x99999999, 0x9999999c);
+  k = test_vec_cbcdmul(&l, i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i * j ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("     = ", (vui128_t) l);
+  print_vint128x ("       ", (vui128_t) k);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0, 0, 0, 0x0000000c);
+  e = (vBCD_t) CONST_VINT128_W(0x09999999, 0x99999998, 0x00000000, 0x0000001c);
+  rc += check_vint256 ("vec_cbcdmul:", (vui128_t) l, (vui128_t) k,
+		       (vui128_t) eh, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W (0, 0, 0x99999999, 0x9999999d);
+  j = (vBCD_t) CONST_VINT128_W (0, 0, 0x99999999, 0x9999999c);
+  k = test_vec_cbcdmul(&l, i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i * j ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("     = ", (vui128_t) l);
+  print_vint128x ("       ", (vui128_t) k);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0, 0, 0, 0x0000000c);
+  e = (vBCD_t) CONST_VINT128_W(0x09999999, 0x99999998, 0x00000000, 0x0000001d);
+  rc += check_vint256 ("vec_cbcdmul:", (vui128_t) l, (vui128_t) k,
+		       (vui128_t) eh, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W (0, 0, 0x99999999, 0x9999999c);
+  j = (vBCD_t) CONST_VINT128_W (0, 0, 0x99999999, 0x9999999d);
+  k = test_vec_cbcdmul(&l, i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i * j ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("     = ", (vui128_t) l);
+  print_vint128x ("       ", (vui128_t) k);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0, 0, 0, 0x0000000c);
+  e = (vBCD_t) CONST_VINT128_W(0x09999999, 0x99999998, 0x00000000, 0x0000001d);
+  rc += check_vint256 ("vec_cbcdmul:", (vui128_t) l, (vui128_t) k,
+		       (vui128_t) eh, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W (0, 0, 0x99999999, 0x9999999d);
+  j = (vBCD_t) CONST_VINT128_W (0, 0, 0x99999999, 0x9999999d);
+  k = test_vec_cbcdmul(&l, i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i * j ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("     = ", (vui128_t) l);
+  print_vint128x ("       ", (vui128_t) k);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0, 0, 0, 0x0000000c);
+  e = (vBCD_t) CONST_VINT128_W(0x09999999, 0x99999998, 0x00000000, 0x0000001c);
+  rc += check_vint256 ("vec_cbcdmul:", (vui128_t) l, (vui128_t) k,
+		       (vui128_t) eh, (vui128_t) e);
+
+  return rc;
+}
+
+//#define __DEBUG_PRINT__ 1
+#ifdef __DEBUG_PRINT__
+#define test_vec_bcdaddcsq(_l, _k)	db_vec_bcdaddcsq(_l, _k)
+#else
+#define test_vec_bcdaddcsq(_l, _k)	vec_bcdaddcsq(_l, _k)
+#endif
+int
+test_bcd_addcsq (void)
+{
+  vBCD_t i, j, k;
+  vBCD_t e;
+  int rc = 0;
+
+  printf ("\n%s Vector BCD add w/carry\n", __FUNCTION__);
+
+  i = (vBCD_t) CONST_VINT128_W(0, 0, 0, 0x0000001c);
+  j = (vBCD_t) CONST_VINT128_W(0, 0, 0, 0x0000001c);
+  k = test_vec_bcdaddcsq (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd 1", k, i, j);
+#endif
+  e = _BCD_CONST_ZERO;
+  rc += check_vuint128x ("vec_bcdaddcsq 1:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W(0, 0, 0, 0x0000001c);
+  j = (vBCD_t) CONST_VINT128_W(0, 0, 0, 0x0000001d);
+  k = test_vec_bcdaddcsq (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd 2", k, i, j);
+#endif
+  e = _BCD_CONST_ZERO;
+  rc += check_vuint128x ("vec_bcdaddcsq 2:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W(0x99999999, 0x99999999, 0x99999999, 0x9999999c);
+  j = (vBCD_t) CONST_VINT128_W(0, 0, 0, 0x0000001c);
+  k = test_vec_bcdaddcsq (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd 3", k, i, j);
+#endif
+  e = _BCD_CONST_PLUS_ONE;
+  rc += check_vuint128x ("vec_bcdaddcsq 3:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W(0x99999999, 0x99999999, 0x99999999, 0x9999999d);
+  j = (vBCD_t) CONST_VINT128_W(0, 0, 0, 0x0000001d);
+  k = test_vec_bcdaddcsq (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd 4", k, i, j);
+#endif
+  e = _BCD_CONST_MINUS_ONE;
+  rc += check_vuint128x ("vec_bcdaddcsq 4:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W(0x99999999, 0x99999999, 0x99999999, 0x9999999d);
+  j = (vBCD_t) CONST_VINT128_W(0, 0, 0, 0x0000001c);
+  k = test_vec_bcdaddcsq (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd 5", k, i, j);
+#endif
+  e = _BCD_CONST_ZERO;
+  rc += check_vuint128x ("vec_bcdaddcsq 5:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W(0x10000000, 0x00000000, 0x00000000, 0x0000008c);
+  j = (vBCD_t) CONST_VINT128_W(0x90000000, 0x00000000, 0x00000000, 0x0000008d);
+  k = test_vec_bcdaddcsq (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd 6", k, i, j);
+#endif
+  e = _BCD_CONST_ZERO;
+  rc += check_vuint128x ("vec_bcdaddcsq 6:", (vui128_t) k, (vui128_t) e);
+
+  return rc;
+}
+
+//#define __DEBUG_PRINT__ 1
+int
+test_bcd_subcsq (void)
+{
+  vBCD_t i, j, k;
+  vBCD_t e;
+  int rc = 0;
+
+  printf ("\n%s Vector BCD sub w/carry\n", __FUNCTION__);
+
+  i = (vBCD_t) CONST_VINT128_W(0, 0, 0, 0x0000001c);
+  j = (vBCD_t) CONST_VINT128_W(0, 0, 0, 0x0000001c);
+  k = vec_bcdsubcsq (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd 1", k, i, j);
+#endif
+  e = _BCD_CONST_ZERO;
+  rc += check_vuint128x ("vec_bcdsubcsq 1:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W(0, 0, 0, 0x0000001c);
+  j = (vBCD_t) CONST_VINT128_W(0, 0, 0, 0x0000001d);
+  k = vec_bcdsubcsq (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd 2", k, i, j);
+#endif
+  e = _BCD_CONST_ZERO;
+  rc += check_vuint128x ("vec_bcdsubcsq 2:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W(0x99999999, 0x99999999, 0x99999999, 0x9999999c);
+  j = (vBCD_t) CONST_VINT128_W(0, 0, 0, 0x0000001d);
+  k = vec_bcdsubcsq (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd 3", k, i, j);
+#endif
+  e = _BCD_CONST_PLUS_ONE;
+  rc += check_vuint128x ("vec_bcdsubcsq 3:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W(0x99999999, 0x99999999, 0x99999999, 0x9999999d);
+  j = (vBCD_t) CONST_VINT128_W(0, 0, 0, 0x0000001c);
+  k = vec_bcdsubcsq (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd 4", k, i, j);
+#endif
+  e = _BCD_CONST_MINUS_ONE;
+  rc += check_vuint128x ("vec_bcdsubcsq 4:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W(0x99999999, 0x99999999, 0x99999999, 0x9999999d);
+  j = (vBCD_t) CONST_VINT128_W(0, 0, 0, 0x0000001d);
+  k = vec_bcdsubcsq (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd 5", k, i, j);
+#endif
+  e = _BCD_CONST_ZERO;
+  rc += check_vuint128x ("vec_bcdsubcsq 5:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W(0x10000000, 0x00000000, 0x00000000, 0x0000008c);
+  j = (vBCD_t) CONST_VINT128_W(0x90000000, 0x00000000, 0x00000000, 0x0000008d);
+  k = vec_bcdsubcsq (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd 6", k, i, j);
+#endif
+  e = _BCD_CONST_PLUS_ONE;
+  rc += check_vuint128x ("vec_bcdsubcsq 6:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W(0x10000000, 0x00000000, 0x00000000, 0x0000008d);
+  j = (vBCD_t) CONST_VINT128_W(0x90000000, 0x00000000, 0x00000000, 0x0000008c);
+  k = vec_bcdsubcsq (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x_sum ("bcd 7", k, i, j);
+#endif
+  e = _BCD_CONST_MINUS_ONE;
+  rc += check_vuint128x ("vec_bcdsubcsq 7:", (vui128_t) k, (vui128_t) e);
+
+  return rc;
+}
+//#undef __DEBUG_PRINT__
+
+//#define __DEBUG_PRINT__ 1
+int
+test_bcd_addesqm (void)
+{
+  vBCD_t i, j, k, c;
+  vBCD_t e;
+  int rc = 0;
+
+  printf ("\n%s Vector BCD Add Extend\n", __FUNCTION__);
+
+  i = (vBCD_t) CONST_VINT128_W (0, 0, 0, 0x0000001c);
+  j = (vBCD_t) CONST_VINT128_W (0, 0, 0, 0x0000001c);
+  c = _BCD_CONST_ZERO;
+  k = vec_bcdaddesqm (i, j, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i+j+c ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("     = ", (vui128_t) c);
+  print_vint128x ("       ", (vui128_t) k);
+#endif
+  e = (vBCD_t) CONST_VINT128_W(0, 0, 0, 0x2c);
+  rc += check_vuint128x ("vec_bcdaddesqm:", (vui128_t) k, (vui128_t) e);
+
+  c = _BCD_CONST_PLUS_ONE;
+  k = vec_bcdaddesqm (i, j, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i+j+c ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("     = ", (vui128_t) c);
+  print_vint128x ("       ", (vui128_t) k);
+#endif
+  e = (vBCD_t) CONST_VINT128_W(0, 0, 0, 0x3c);
+  rc += check_vuint128x ("vec_bcdaddesqm:", (vui128_t) k, (vui128_t) e);
+
+  c = _BCD_CONST_MINUS_ONE;
+  k = vec_bcdaddesqm (i, j, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i+j+c ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("     = ", (vui128_t) c);
+  print_vint128x ("       ", (vui128_t) k);
+#endif
+  e = (vBCD_t) CONST_VINT128_W(0, 0, 0, 0x1c);
+  rc += check_vuint128x ("vec_bcdaddesqm:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W(0, 0, 0, 0x9999999c);
+  j = (vBCD_t) CONST_VINT128_W(0, 0, 0, 0x0000001c);
+  c = _BCD_CONST_ZERO;
+  k = vec_bcdaddesqm (i, j, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i+j+c ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("     = ", (vui128_t) c);
+  print_vint128x ("       ", (vui128_t) k);
+#endif
+  e = (vBCD_t) CONST_VINT128_W(0, 0, 0x1, 0x0000000c);
+  rc += check_vuint128x ("vec_bcdaddesqm:", (vui128_t) k, (vui128_t) e);
+
+  c = _BCD_CONST_PLUS_ONE;
+  k = vec_bcdaddesqm (i, j, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i+j+c ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("     = ", (vui128_t) c);
+  print_vint128x ("       ", (vui128_t) k);
+#endif
+  e = (vBCD_t) CONST_VINT128_W(0, 0, 0x1, 0x0000001c);
+  rc += check_vuint128x ("vec_bcdaddesqm:", (vui128_t) k, (vui128_t) e);
+
+  c = _BCD_CONST_MINUS_ONE;
+  k = vec_bcdaddesqm (i, j, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i+j+c ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("     = ", (vui128_t) c);
+  print_vint128x ("       ", (vui128_t) k);
+#endif
+  e = (vBCD_t) CONST_VINT128_W(0, 0, 0x0, 0x9999999c);
+  rc += check_vuint128x ("vec_bcdaddesqm:", (vui128_t) k, (vui128_t) e);
+
+  return rc;
+}
+//#undef __DEBUG_PRINT__
+
+//#define __DEBUG_PRINT__ 1
+int
+test_bcd_subesqm (void)
+{
+  vBCD_t i, j, k, c;
+  vBCD_t e;
+  int rc = 0;
+  const vBCD_t ex = (vBCD_t) CONST_VINT128_W(0, 0, 0, 0x0d);
+
+  printf ("\n%s Vector BCD subtract Extend\n", __FUNCTION__);
+
+  i = (vBCD_t) CONST_VINT128_W (0, 0, 0, 0x0000001c);
+  j = (vBCD_t) CONST_VINT128_W (0, 0, 0, 0x0000001c);
+  c = _BCD_CONST_ZERO;
+  k = vec_bcdsubesqm (i, j, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i+j+c ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("     = ", (vui128_t) c);
+  print_vint128x ("       ", (vui128_t) k);
+#endif
+  e = (vBCD_t) CONST_VINT128_W(0, 0, 0, 0x0c);
+#if 1
+  if (vec_all_eq (k, ex))
+    {
+      printf ("vec_bcdsubesqm: ignore negative zero. Likely QEMU artifact\n");
+      k = e;
+    }
+#endif
+  rc += check_vuint128x ("vec_bcdsubesqm 1:", (vui128_t) k, (vui128_t) e);
+
+  c = _BCD_CONST_PLUS_ONE;
+  k = vec_bcdsubesqm (i, j, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i+j+c ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("     = ", (vui128_t) c);
+  print_vint128x ("       ", (vui128_t) k);
+#endif
+  e = (vBCD_t) CONST_VINT128_W(0, 0, 0, 0x1d);
+  rc += check_vuint128x ("vec_bcdsubesqm 2:", (vui128_t) k, (vui128_t) e);
+
+  c = _BCD_CONST_MINUS_ONE;
+  k = vec_bcdsubesqm (i, j, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i+j+c ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("     = ", (vui128_t) c);
+  print_vint128x ("       ", (vui128_t) k);
+#endif
+  e = (vBCD_t) CONST_VINT128_W(0, 0, 0, 0x1c);
+  rc += check_vuint128x ("vec_bcdsubesqm 3:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W(0, 0, 0, 0x9999999c);
+  j = (vBCD_t) CONST_VINT128_W(0, 0, 0, 0x0000001c);
+  c = _BCD_CONST_ZERO;
+  k = vec_bcdsubesqm (i, j, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i+j+c ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("     = ", (vui128_t) c);
+  print_vint128x ("       ", (vui128_t) k);
+#endif
+  e = (vBCD_t) CONST_VINT128_W(0, 0, 0x0, 0x9999998c);
+  rc += check_vuint128x ("vec_bcdsubesqm 4:", (vui128_t) k, (vui128_t) e);
+
+  c = _BCD_CONST_PLUS_ONE;
+  k = vec_bcdsubesqm (i, j, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i+j+c ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("     = ", (vui128_t) c);
+  print_vint128x ("       ", (vui128_t) k);
+#endif
+  e = (vBCD_t) CONST_VINT128_W(0, 0,  0x0, 0x9999997c);
+  rc += check_vuint128x ("vec_bcdsubesqm 5:", (vui128_t) k, (vui128_t) e);
+
+  c = _BCD_CONST_MINUS_ONE;
+  k = vec_bcdsubesqm (i, j, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i+j+c ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("     = ", (vui128_t) c);
+  print_vint128x ("       ", (vui128_t) k);
+#endif
+  e = (vBCD_t) CONST_VINT128_W(0, 0, 0x0, 0x9999999c);
+  rc += check_vuint128x ("vec_bcdsubesqm 6:", (vui128_t) k, (vui128_t) e);
+
+  return rc;
+}
+
+//#define __DEBUG_PRINT__ 1
+int
+test_bcd_addecsq (void)
+{
+  vBCD_t i, j, k, c;
+  vBCD_t e;
+  int rc = 0;
+
+  printf ("\n%s Vector BCD Add Extended & Carry\n", __FUNCTION__);
+
+  i = (vBCD_t) CONST_VINT128_W (0x99999999, 0x99999999, 0x99999999, 0x9999998c);
+  j = _BCD_CONST_PLUS_ONE;
+  c = _BCD_CONST_ZERO;
+  k = vec_bcdaddecsq (i, j, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i+j+c ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("       ", (vui128_t) c);
+  print_vint128x ("     = ", (vui128_t) k);
+#endif
+  e = _BCD_CONST_ZERO;
+  rc += check_vuint128x ("vec_bcdaddecsq 1:", (vui128_t) k, (vui128_t) e);
+
+  j = _BCD_CONST_ZERO;
+  c = _BCD_CONST_PLUS_ONE;
+  k = vec_bcdaddecsq (i, j, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i+j+c ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("       ", (vui128_t) c);
+  print_vint128x ("     = ", (vui128_t) k);
+#endif
+  e = _BCD_CONST_ZERO;
+  rc += check_vuint128x ("vec_bcdaddecsq 2:", (vui128_t) k, (vui128_t) e);
+
+  j = _BCD_CONST_PLUS_ONE;
+  c = _BCD_CONST_PLUS_ONE;
+  k = vec_bcdaddecsq (i, j, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i+j+c ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("       ", (vui128_t) c);
+  print_vint128x ("     = ", (vui128_t) k);
+#endif
+  e = _BCD_CONST_PLUS_ONE;
+  rc += check_vuint128x ("vec_bcdaddecsq 3:", (vui128_t) k, (vui128_t) e);
+
+  j = _BCD_CONST_PLUS_ONE;
+  c = _BCD_CONST_MINUS_ONE;
+  k = vec_bcdaddecsq (i, j, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i+j+c ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("       ", (vui128_t) c);
+  print_vint128x ("     = ", (vui128_t) k);
+#endif
+  e = _BCD_CONST_ZERO;
+  rc += check_vuint128x ("vec_bcdaddecsq 4:", (vui128_t) k, (vui128_t) e);
+
+  j = _BCD_CONST_MINUS_ONE;
+  c = _BCD_CONST_PLUS_ONE;
+  k = vec_bcdaddecsq (i, j, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i+j+c ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("       ", (vui128_t) c);
+  print_vint128x ("     = ", (vui128_t) k);
+#endif
+  e = _BCD_CONST_ZERO;
+  rc += check_vuint128x ("vec_bcdaddecsq 5:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W (0x99999999, 0x99999999, 0x99999999, 0x9999998d);
+  j = _BCD_CONST_MINUS_ONE;
+  c = _BCD_CONST_PLUS_ONE;
+  k = vec_bcdaddecsq (i, j, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i+j+c ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("       ", (vui128_t) c);
+  print_vint128x ("     = ", (vui128_t) k);
+#endif
+  e = _BCD_CONST_ZERO;
+  rc += check_vuint128x ("vec_bcdaddecsq 6:", (vui128_t) k, (vui128_t) e);
+
+  j = _BCD_CONST_PLUS_ONE;
+  c = _BCD_CONST_MINUS_ONE;
+  k = vec_bcdaddecsq (i, j, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i+j+c ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("       ", (vui128_t) c);
+  print_vint128x ("     = ", (vui128_t) k);
+#endif
+  e = _BCD_CONST_ZERO;
+  rc += check_vuint128x ("vec_bcdaddecsq 7:", (vui128_t) k, (vui128_t) e);
+
+  j = _BCD_CONST_MINUS_ONE;
+  c = _BCD_CONST_MINUS_ONE;
+  k = vec_bcdaddecsq (i, j, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i+j+c ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("       ", (vui128_t) c);
+  print_vint128x ("     = ", (vui128_t) k);
+#endif
+  e = _BCD_CONST_MINUS_ONE;
+  rc += check_vuint128x ("vec_bcdaddecsq 8:", (vui128_t) k, (vui128_t) e);
+
+  return rc;
+}
+//#undef __DEBUG_PRINT__
+
+//#define __DEBUG_PRINT__ 1
+int
+test_bcd_subecsq (void)
+{
+  vBCD_t i, j, k, c;
+  vBCD_t e;
+  int rc = 0;
+
+  printf ("\n%s Vector BCD subtract Extended & Carry\n", __FUNCTION__);
+
+  i = (vBCD_t) CONST_VINT128_W (0x99999999, 0x99999999, 0x99999999, 0x9999998c);
+  j = _BCD_CONST_PLUS_ONE;
+  c = _BCD_CONST_ZERO;
+  k = vec_bcdsubecsq (i, j, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i+j+c ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("       ", (vui128_t) c);
+  print_vint128x ("     = ", (vui128_t) k);
+#endif
+  e = _BCD_CONST_ZERO;
+  rc += check_vuint128x ("vec_bcdsubecsq 1:", (vui128_t) k, (vui128_t) e);
+
+  j = _BCD_CONST_ZERO;
+  c = _BCD_CONST_PLUS_ONE;
+  k = vec_bcdsubecsq (i, j, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i+j+c ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("       ", (vui128_t) c);
+  print_vint128x ("     = ", (vui128_t) k);
+#endif
+  e = _BCD_CONST_ZERO;
+  rc += check_vuint128x ("vec_bcdsubecsq 2:", (vui128_t) k, (vui128_t) e);
+
+  j = _BCD_CONST_PLUS_ONE;
+  c = _BCD_CONST_PLUS_ONE;
+  k = vec_bcdsubecsq (i, j, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i+j+c ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("       ", (vui128_t) c);
+  print_vint128x ("     = ", (vui128_t) k);
+#endif
+  e = _BCD_CONST_ZERO;
+  rc += check_vuint128x ("vec_bcdsubecsq 3:", (vui128_t) k, (vui128_t) e);
+
+  j = _BCD_CONST_PLUS_ONE;
+  c = _BCD_CONST_MINUS_ONE;
+  k = vec_bcdsubecsq (i, j, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i+j+c ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("       ", (vui128_t) c);
+  print_vint128x ("     = ", (vui128_t) k);
+#endif
+  e = _BCD_CONST_ZERO;
+  rc += check_vuint128x ("vec_bcdsubecsq 4:", (vui128_t) k, (vui128_t) e);
+
+  j = _BCD_CONST_MINUS_ONE;
+  c = _BCD_CONST_PLUS_ONE;
+  k = vec_bcdsubecsq (i, j, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i+j+c ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("       ", (vui128_t) c);
+  print_vint128x ("     = ", (vui128_t) k);
+#endif
+  e = _BCD_CONST_ZERO;
+  rc += check_vuint128x ("vec_bcdsubecsq 5:", (vui128_t) k, (vui128_t) e);
+
+  i = (vBCD_t) CONST_VINT128_W (0x99999999, 0x99999999, 0x99999999, 0x9999998d);
+  j = _BCD_CONST_MINUS_ONE;
+  c = _BCD_CONST_PLUS_ONE;
+  k = vec_bcdsubecsq (i, j, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i+j+c ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("       ", (vui128_t) c);
+  print_vint128x ("     = ", (vui128_t) k);
+#endif
+  e = _BCD_CONST_ZERO;
+  rc += check_vuint128x ("vec_bcdsubecsq 6:", (vui128_t) k, (vui128_t) e);
+
+  j = _BCD_CONST_PLUS_ONE;
+  c = _BCD_CONST_MINUS_ONE;
+  k = vec_bcdsubecsq (i, j, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i+j+c ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("       ", (vui128_t) c);
+  print_vint128x ("     = ", (vui128_t) k);
+#endif
+  e = _BCD_CONST_ZERO;
+  rc += check_vuint128x ("vec_bcdsubecsq 7:", (vui128_t) k, (vui128_t) e);
+
+  j = _BCD_CONST_MINUS_ONE;
+  c = _BCD_CONST_MINUS_ONE;
+  k = vec_bcdsubecsq (i, j, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" i+j+c ", (vui128_t) i);
+  print_vint128x ("       ", (vui128_t) j);
+  print_vint128x ("       ", (vui128_t) c);
+  print_vint128x ("     = ", (vui128_t) k);
+#endif
+  e = _BCD_CONST_ZERO;
+  rc += check_vuint128x ("vec_bcdsubecsq 8:", (vui128_t) k, (vui128_t) e);
+
+  return rc;
+}
+#undef __DEBUG_PRINT__
+
+//#define __DEBUG_PRINT__ 1
+int
+test_bcd_adde256 (void)
+{
+  vBCD_t ih, il, jh, jl, kh, kl;
+  vBCD_t eh, el, ex, c;
+  int rc = 0;
+
+  printf ("\n%s Vector BCD Add Extended & Carry\n", __FUNCTION__);
+
+  ih = _BCD_CONST_PLUS_ONE;
+  il = (vBCD_t) CONST_VINT128_W (0x90000000, 0x00000000, 0x00000000, 0x0000008c);
+  jh = _BCD_CONST_PLUS_ONE;
+  jl = (vBCD_t) CONST_VINT128_W (0x10000000, 0x00000000, 0x00000000, 0x0000008c);
+  kl = vec_bcdadd (il, jl);
+  c  = vec_bcdaddcsq (il, jl);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000003c);;
+  el = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000016c);
+  rc += check_vint256 ("vec_bcdadde256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  jh = _BCD_CONST_MINUS_ONE;
+  jl = (vBCD_t) CONST_VINT128_W (0x10000000, 0x00000000, 0x00000000, 0x0000008d);
+  kl = vec_bcdadd (il, jl);
+  c  = vec_bcdaddcsq (il, jl);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000000c);;
+  el = (vBCD_t) CONST_VINT128_W (0x80000000, 0x00000000, 0x00000000, 0x0000000c);
+  rc += check_vint256 ("vec_bcdadde256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  ih = _BCD_CONST_MINUS_ONE;
+  il = (vBCD_t) CONST_VINT128_W (0x90000000, 0x00000000, 0x00000000, 0x0000008d);
+  jh = _BCD_CONST_PLUS_ONE;
+  jl = (vBCD_t) CONST_VINT128_W (0x10000000, 0x00000000, 0x00000000, 0x0000008c);
+  kl = vec_bcdadd (il, jl);
+  c  = vec_bcdaddcsq (il, jl);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000000c);;
+  el = (vBCD_t) CONST_VINT128_W (0x80000000, 0x00000000, 0x00000000, 0x0000000d);
+  rc += check_vint256 ("vec_bcdadde256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  jh = _BCD_CONST_MINUS_ONE;
+  jl = (vBCD_t) CONST_VINT128_W (0x10000000, 0x00000000, 0x00000000, 0x0000008d);
+  kl = vec_bcdadd (il, jl);
+  c  = vec_bcdaddcsq (il, jl);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000003d);;
+  el = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000016d);
+  rc += check_vint256 ("vec_bcdadde256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  ih = _BCD_CONST_PLUS_ONE;
+  il = (vBCD_t) CONST_VINT128_W (0x10000000, 0x00000000, 0x00000000, 0x0000008c);
+  jh = _BCD_CONST_PLUS_ONE;
+  jl = (vBCD_t) CONST_VINT128_W (0x90000000, 0x00000000, 0x00000000, 0x0000008c);
+  kl = vec_bcdadd (il, jl);
+  c  = vec_bcdaddcsq (il, jl);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000003c);;
+  el = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000016c);
+  rc += check_vint256 ("vec_bcdadde256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  jh = _BCD_CONST_ZERO;
+  jl = (vBCD_t) CONST_VINT128_W (0x90000000, 0x00000000, 0x00000000, 0x0000008d);
+  kl = vec_bcdadd (il, jl);
+  c  = vec_bcdaddcsq (il, jl);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000001c);;
+  el = (vBCD_t) CONST_VINT128_W (0x80000000, 0x00000000, 0x00000000, 0x0000000d);
+
+  ex = (vBCD_t) CONST_VINT128_W (0, 0, 0, 0x0000000d);
+  rc += check_vint256 ("vec_bcdadde256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  return rc;
+}
+
+#define __DEBUG_PRINT__ 1
+#ifdef __DEBUG_PRINT__
+#define test_vec_cbcdaddcsq(_j, _k, _l)	db_vec_cbcdaddcsq(_j, _k, _l)
+#else
+#define test_vec_cbcdaddcsq(_j, _k, _l)	vec_cbcdaddcsq(_j, _k, _l)
+#endif
+int
+test_bcd_cadde256 (void)
+{
+  vBCD_t ih, il, jh, jl, kh, kl;
+  vBCD_t eh, el, ex, c;
+  int rc = 0;
+
+  printf ("\n%s Vector BCD Add Extended & Carry\n", __FUNCTION__);
+
+  ih = _BCD_CONST_PLUS_ONE;
+  il = (vBCD_t) CONST_VINT128_W (0x90000000, 0x00000000, 0x00000000, 0x0000008c);
+  jh = _BCD_CONST_PLUS_ONE;
+  jl = (vBCD_t) CONST_VINT128_W (0x10000000, 0x00000000, 0x00000000, 0x0000008c);
+  kl = test_vec_cbcdaddcsq (&c, il, jl);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000003c);;
+  el = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000016c);
+  rc += check_vint256 ("vec_bcdadde256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  jh = _BCD_CONST_MINUS_ONE;
+  jl = (vBCD_t) CONST_VINT128_W (0x10000000, 0x00000000, 0x00000000, 0x0000008d);
+  kl = test_vec_cbcdaddcsq (&c, il, jl);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000000c);;
+  el = (vBCD_t) CONST_VINT128_W (0x80000000, 0x00000000, 0x00000000, 0x0000000c);
+  rc += check_vint256 ("vec_bcdadde256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  ih = _BCD_CONST_MINUS_ONE;
+  il = (vBCD_t) CONST_VINT128_W (0x90000000, 0x00000000, 0x00000000, 0x0000008d);
+  jh = _BCD_CONST_PLUS_ONE;
+  jl = (vBCD_t) CONST_VINT128_W (0x10000000, 0x00000000, 0x00000000, 0x0000008c);
+  kl = test_vec_cbcdaddcsq (&c, il, jl);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000000c);;
+  el = (vBCD_t) CONST_VINT128_W (0x80000000, 0x00000000, 0x00000000, 0x0000000d);
+  rc += check_vint256 ("vec_bcdadde256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  jh = _BCD_CONST_MINUS_ONE;
+  jl = (vBCD_t) CONST_VINT128_W (0x10000000, 0x00000000, 0x00000000, 0x0000008d);
+  kl = test_vec_cbcdaddcsq (&c, il, jl);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000003d);;
+  el = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000016d);
+  rc += check_vint256 ("vec_bcdadde256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  ih = _BCD_CONST_PLUS_ONE;
+  il = (vBCD_t) CONST_VINT128_W (0x10000000, 0x00000000, 0x00000000, 0x0000008c);
+  jh = _BCD_CONST_PLUS_ONE;
+  jl = (vBCD_t) CONST_VINT128_W (0x90000000, 0x00000000, 0x00000000, 0x0000008c);
+  kl = test_vec_cbcdaddcsq (&c, il, jl);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000003c);;
+  el = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000016c);
+  rc += check_vint256 ("vec_bcdadde256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  jh = _BCD_CONST_ZERO;
+  jl = (vBCD_t) CONST_VINT128_W (0x90000000, 0x00000000, 0x00000000, 0x0000008d);
+  kl = test_vec_cbcdaddcsq (&c, il, jl);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000000c);;
+  el = (vBCD_t) CONST_VINT128_W (0x20000000, 0x00000000, 0x00000000, 0x0000000c);
+
+  ex = (vBCD_t) CONST_VINT128_W (0, 0, 0, 0x0000000d);
+#if 1
+  if (vec_all_eq (kh, ex))
+    {
+      printf ("vec_bcdaddesqm: ignore negative zero. Likely QEMU artifact\n");
+      kh = eh;
+    }
+#endif
+  rc += check_vint256 ("vec_bcdadde256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  ih = _BCD_CONST_MINUS_ONE;
+  il = (vBCD_t) CONST_VINT128_W (0x10000000, 0x00000000, 0x00000000, 0x0000008d);
+  jh = _BCD_CONST_ZERO;
+  jl = (vBCD_t) CONST_VINT128_W (0x90000000, 0x00000000, 0x00000000, 0x0000008c);
+  kl = test_vec_cbcdaddcsq (&c, il, jl);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000000c);;
+  el = (vBCD_t) CONST_VINT128_W (0x20000000, 0x00000000, 0x00000000, 0x0000000d);
+
+  ex = (vBCD_t) CONST_VINT128_W (0, 0, 0, 0x0000000d);
+  rc += check_vint256 ("vec_bcdadde256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  return rc;
+}
+#undef __DEBUG_PRINT__
+//#define __DEBUG_PRINT__ 1
+#ifdef __DEBUG_PRINT__
+#define test_vec_cbcdaddecsq(_j, _k, _l, _m)	db_vec_cbcdaddecsq(_j, _k, _l, _m)
+#else
+#define test_vec_cbcdaddecsq(_j, _k, _l, _m)	vec_cbcdaddecsq(_j, _k, _l, _m)
+#endif
+int
+test_bcd_caddec256 (void)
+{
+  vBCD_t ih, il, jh, jl, kh, kl;
+  vBCD_t eh, el, ex, c, ci;
+  int rc = 0;
+
+  printf ("\n%s Vector BCD Add Extended 0 & Carry\n", __FUNCTION__);
+
+  ih = _BCD_CONST_PLUS_ONE;
+  il = (vBCD_t) CONST_VINT128_W (0x90000000, 0x00000000, 0x00000000, 0x0000008c);
+  jh = _BCD_CONST_PLUS_ONE;
+  jl = (vBCD_t) CONST_VINT128_W (0x10000000, 0x00000000, 0x00000000, 0x0000008c);
+  ci = _BCD_CONST_ZERO;
+  kl = test_vec_cbcdaddecsq (&c, il, jl, ci);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000003c);;
+  el = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000016c);
+  rc += check_vint256 ("vec_bcdaddec256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  jh = _BCD_CONST_MINUS_ONE;
+  jl = (vBCD_t) CONST_VINT128_W (0x10000000, 0x00000000, 0x00000000, 0x0000008d);
+  kl = test_vec_cbcdaddecsq (&c, il, jl, ci);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000000c);;
+  el = (vBCD_t) CONST_VINT128_W (0x80000000, 0x00000000, 0x00000000, 0x0000000c);
+  rc += check_vint256 ("vec_bcdaddec256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  ih = _BCD_CONST_MINUS_ONE;
+  il = (vBCD_t) CONST_VINT128_W (0x90000000, 0x00000000, 0x00000000, 0x0000008d);
+  jh = _BCD_CONST_PLUS_ONE;
+  jl = (vBCD_t) CONST_VINT128_W (0x10000000, 0x00000000, 0x00000000, 0x0000008c);
+  kl = test_vec_cbcdaddecsq (&c, il, jl, ci);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000000c);;
+  el = (vBCD_t) CONST_VINT128_W (0x80000000, 0x00000000, 0x00000000, 0x0000000d);
+  rc += check_vint256 ("vec_bcdaddec256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  jh = _BCD_CONST_MINUS_ONE;
+  jl = (vBCD_t) CONST_VINT128_W (0x10000000, 0x00000000, 0x00000000, 0x0000008d);
+  kl = test_vec_cbcdaddecsq (&c, il, jl, ci);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000003d);;
+  el = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000016d);
+  rc += check_vint256 ("vec_bcdaddec256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  ih = _BCD_CONST_PLUS_ONE;
+  il = (vBCD_t) CONST_VINT128_W (0x10000000, 0x00000000, 0x00000000, 0x0000008c);
+  jh = _BCD_CONST_PLUS_ONE;
+  jl = (vBCD_t) CONST_VINT128_W (0x90000000, 0x00000000, 0x00000000, 0x0000008c);
+  kl = test_vec_cbcdaddecsq (&c, il, jl, ci);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000003c);;
+  el = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000016c);
+  rc += check_vint256 ("vec_bcdaddec256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  jh = _BCD_CONST_ZERO;
+  jl = (vBCD_t) CONST_VINT128_W (0x90000000, 0x00000000, 0x00000000, 0x0000008d);
+  kl = test_vec_cbcdaddecsq (&c, il, jl, ci);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000000c);;
+  el = (vBCD_t) CONST_VINT128_W (0x20000000, 0x00000000, 0x00000000, 0x0000000c);
+
+  ex = (vBCD_t) CONST_VINT128_W (0, 0, 0, 0x0000000d);
+#if 1
+  if (vec_all_eq (kh, ex))
+    {
+      printf ("vec_bcdaddesqm: ignore negative zero. Likely QEMU artifact\n");
+      kh = eh;
+    }
+#endif
+  rc += check_vint256 ("vec_bcdaddec256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  ih = _BCD_CONST_MINUS_ONE;
+  il = (vBCD_t) CONST_VINT128_W (0x10000000, 0x00000000, 0x00000000, 0x0000008d);
+  jh = _BCD_CONST_ZERO;
+  jl = (vBCD_t) CONST_VINT128_W (0x90000000, 0x00000000, 0x00000000, 0x0000008c);
+  kl = test_vec_cbcdaddecsq (&c, il, jl, ci);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000000c);;
+  el = (vBCD_t) CONST_VINT128_W (0x20000000, 0x00000000, 0x00000000, 0x0000000d);
+
+  ex = (vBCD_t) CONST_VINT128_W (0, 0, 0, 0x0000000d);
+  rc += check_vint256 ("vec_bcdadde256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  printf ("\n%s Vector BCD Add Extended +1 & Carry\n", __FUNCTION__);
+  ih = _BCD_CONST_PLUS_ONE;
+  il = (vBCD_t) CONST_VINT128_W (0x90000000, 0x00000000, 0x00000000, 0x0000008c);
+  jh = _BCD_CONST_PLUS_ONE;
+  jl = (vBCD_t) CONST_VINT128_W (0x10000000, 0x00000000, 0x00000000, 0x0000008c);
+  ci = _BCD_CONST_PLUS_ONE;
+  kl = test_vec_cbcdaddecsq (&c, il, jl, ci);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000003c);;
+  el = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000017c);
+  rc += check_vint256 ("vec_bcdaddec256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  jh = _BCD_CONST_MINUS_ONE;
+  jl = (vBCD_t) CONST_VINT128_W (0x10000000, 0x00000000, 0x00000000, 0x0000008d);
+  kl = test_vec_cbcdaddecsq (&c, il, jl, ci);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000000c);
+  el = (vBCD_t) CONST_VINT128_W (0x80000000, 0x00000000, 0x00000000, 0x0000001c);
+  rc += check_vint256 ("vec_bcdaddec256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  ih = _BCD_CONST_MINUS_ONE;
+  il = (vBCD_t) CONST_VINT128_W (0x90000000, 0x00000000, 0x00000000, 0x0000008d);
+  jh = _BCD_CONST_PLUS_ONE;
+  jl = (vBCD_t) CONST_VINT128_W (0x10000000, 0x00000000, 0x00000000, 0x0000008c);
+  kl = test_vec_cbcdaddecsq (&c, il, jl, ci);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000000c);
+  el = (vBCD_t) CONST_VINT128_W (0x79999999, 0x99999999, 0x99999999, 0x9999999d);
+  rc += check_vint256 ("vec_bcdaddec256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  jh = _BCD_CONST_MINUS_ONE;
+  jl = (vBCD_t) CONST_VINT128_W (0x10000000, 0x00000000, 0x00000000, 0x0000008d);
+  kl = test_vec_cbcdaddecsq (&c, il, jl, ci);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000003d);;
+  el = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000015d);
+  rc += check_vint256 ("vec_bcdaddec256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  ih = _BCD_CONST_PLUS_ONE;
+  il = (vBCD_t) CONST_VINT128_W (0x10000000, 0x00000000, 0x00000000, 0x0000008c);
+  jh = _BCD_CONST_PLUS_ONE;
+  jl = (vBCD_t) CONST_VINT128_W (0x90000000, 0x00000000, 0x00000000, 0x0000008c);
+  kl = test_vec_cbcdaddecsq (&c, il, jl, ci);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000003c);;
+  el = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000017c);
+  rc += check_vint256 ("vec_bcdaddec256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  jh = _BCD_CONST_ZERO;
+  jl = (vBCD_t) CONST_VINT128_W (0x90000000, 0x00000000, 0x00000000, 0x0000008d);
+  kl = test_vec_cbcdaddecsq (&c, il, jl, ci);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000000c);
+  el = (vBCD_t) CONST_VINT128_W (0x20000000, 0x00000000, 0x00000000, 0x0000001c);
+
+  ex = (vBCD_t) CONST_VINT128_W (0, 0, 0, 0x0000000d);
+#if 1
+  if (vec_all_eq (kh, ex))
+    {
+      printf ("vec_bcdaddesqm: ignore negative zero. Likely QEMU artifact\n");
+      kh = eh;
+    }
+#endif
+  rc += check_vint256 ("vec_bcdaddec256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  ih = _BCD_CONST_MINUS_ONE;
+  il = (vBCD_t) CONST_VINT128_W (0x10000000, 0x00000000, 0x00000000, 0x0000008d);
+  jh = _BCD_CONST_ZERO;
+  jl = (vBCD_t) CONST_VINT128_W (0x90000000, 0x00000000, 0x00000000, 0x0000008c);
+  kl = test_vec_cbcdaddecsq (&c, il, jl, ci);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000000c);
+  el = (vBCD_t) CONST_VINT128_W (0x19999999, 0x99999999, 0x99999999, 0x9999999d);
+
+  ex = (vBCD_t) CONST_VINT128_W (0, 0, 0, 0x0000000d);
+  rc += check_vint256 ("vec_bcdadde256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  printf ("\n%s Vector BCD Add Extended -1 & Carry\n", __FUNCTION__);
+  ih = _BCD_CONST_PLUS_ONE;
+  il = (vBCD_t) CONST_VINT128_W (0x90000000, 0x00000000, 0x00000000, 0x0000008c);
+  jh = _BCD_CONST_PLUS_ONE;
+  jl = (vBCD_t) CONST_VINT128_W (0x10000000, 0x00000000, 0x00000000, 0x0000008c);
+  ci = _BCD_CONST_MINUS_ONE;
+  kl = test_vec_cbcdaddecsq (&c, il, jl, ci);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000003c);;
+  el = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000015c);
+  rc += check_vint256 ("vec_bcdaddec256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  jh = _BCD_CONST_MINUS_ONE;
+  jl = (vBCD_t) CONST_VINT128_W (0x10000000, 0x00000000, 0x00000000, 0x0000008d);
+  kl = test_vec_cbcdaddecsq (&c, il, jl, ci);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000000c);
+  el = (vBCD_t) CONST_VINT128_W (0x79999999, 0x99999999, 0x99999999, 0x9999999c);
+  rc += check_vint256 ("vec_bcdaddec256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  ih = _BCD_CONST_MINUS_ONE;
+  il = (vBCD_t) CONST_VINT128_W (0x90000000, 0x00000000, 0x00000000, 0x0000008d);
+  jh = _BCD_CONST_PLUS_ONE;
+  jl = (vBCD_t) CONST_VINT128_W (0x10000000, 0x00000000, 0x00000000, 0x0000008c);
+  kl = test_vec_cbcdaddecsq (&c, il, jl, ci);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000000c);
+  el = (vBCD_t) CONST_VINT128_W (0x80000000, 0x00000000, 0x00000000, 0x0000001d);
+  rc += check_vint256 ("vec_bcdaddec256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  jh = _BCD_CONST_MINUS_ONE;
+  jl = (vBCD_t) CONST_VINT128_W (0x10000000, 0x00000000, 0x00000000, 0x0000008d);
+  kl = test_vec_cbcdaddecsq (&c, il, jl, ci);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000003d);;
+  el = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000017d);
+  rc += check_vint256 ("vec_bcdaddec256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  ih = _BCD_CONST_PLUS_ONE;
+  il = (vBCD_t) CONST_VINT128_W (0x10000000, 0x00000000, 0x00000000, 0x0000008c);
+  jh = _BCD_CONST_PLUS_ONE;
+  jl = (vBCD_t) CONST_VINT128_W (0x90000000, 0x00000000, 0x00000000, 0x0000008c);
+  kl = test_vec_cbcdaddecsq (&c, il, jl, ci);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000003c);;
+  el = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000015c);
+  rc += check_vint256 ("vec_bcdaddec256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  jh = _BCD_CONST_ZERO;
+  jl = (vBCD_t) CONST_VINT128_W (0x90000000, 0x00000000, 0x00000000, 0x0000008d);
+  kl = test_vec_cbcdaddecsq (&c, il, jl, ci);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000000c);
+  el = (vBCD_t) CONST_VINT128_W (0x19999999, 0x99999999, 0x99999999, 0x9999999c);
+
+  ex = (vBCD_t) CONST_VINT128_W (0, 0, 0, 0x0000000d);
+#if 1
+  if (vec_all_eq (kh, ex))
+    {
+      printf ("vec_bcdaddesqm: ignore negative zero. Likely QEMU artifact\n");
+      kh = eh;
+    }
+#endif
+  rc += check_vint256 ("vec_bcdaddec256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  ih = _BCD_CONST_MINUS_ONE;
+  il = (vBCD_t) CONST_VINT128_W (0x10000000, 0x00000000, 0x00000000, 0x0000008d);
+  jh = _BCD_CONST_ZERO;
+  jl = (vBCD_t) CONST_VINT128_W (0x90000000, 0x00000000, 0x00000000, 0x0000008c);
+  kl = test_vec_cbcdaddecsq (&c, il, jl, ci);
+  kh = vec_bcdaddesqm (ih, jh, c);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" ih-il ", (vui128_t) ih);
+  print_vint128x ("       ", (vui128_t) il);
+  print_vint128x ("+jh-jl ", (vui128_t) jh);
+  print_vint128x ("       ", (vui128_t) jl);
+  print_vint128x ("=kh-kl ", (vui128_t) kh);
+  print_vint128x ("       ", (vui128_t) kl);
+  print_vint128x (" c     ", (vui128_t) c);
+#endif
+  eh = (vBCD_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0000000c);
+  el = (vBCD_t) CONST_VINT128_W (0x20000000, 0x00000000, 0x00000000, 0x0000001d);
+
+  ex = (vBCD_t) CONST_VINT128_W (0, 0, 0, 0x0000000d);
+  rc += check_vint256 ("vec_bcdadde256:", (vui128_t) kh, (vui128_t) kl,
+		       (vui128_t) eh, (vui128_t) el);
+
+  return rc;
+}
+
 
 int
 test_vec_bcd (void)
@@ -1226,8 +4302,31 @@ test_vec_bcd (void)
   rc += test_bcdctuq ();
 
   rc += test_zndctuq ();
+  rc += test_bcdctsq ();
 
-//  rc += test_48 ();
+  rc += test_setb_bcdsq ();
+  rc += test_setb_bcdinv ();
+  rc += test_signbit_bcdsq ();
+
+  rc += test_bcdcpsgn ();
+  rc += test_bcds ();
+  rc += test_bcdus ();
+  rc += test_bcdslrqi ();
+  rc += test_bcdslruqi ();
+
+  rc += test_bcd_mulh ();
+  rc += test_bcd_cmul ();
+
+  rc += test_bcd_addcsq ();
+  rc += test_bcd_subcsq ();
+  rc += test_bcd_addesqm ();
+  rc += test_bcd_subesqm ();
+  rc += test_bcd_addecsq ();
+  rc += test_bcd_subecsq ();
+
+  rc += test_bcd_cadde256 ();
+  rc += test_bcd_caddec256 ();
 
   return (rc);
 }
+

--- a/src/testsuite/vec_bcd_dummy.c
+++ b/src/testsuite/vec_bcd_dummy.c
@@ -14,10 +14,10 @@ test_pack_Decimal128 (_Decimal128 lval)
   return vec_pack_Decimal128 (lval);
 }
 
-vui32_t
+vBCD_t
 test_pack_Decimal128_cast (_Decimal128 lval)
 {
-  return (vui32_t) vec_pack_Decimal128 (lval);
+  return (vBCD_t) vec_pack_Decimal128 (lval);
 }
 
 _Decimal128
@@ -27,18 +27,18 @@ test_unpack_Decimal128 (vf64_t lval)
 }
 
 _Decimal128
-test_unpack_Decimal128_cast (vui32_t lval)
+test_unpack_Decimal128_cast (vBCD_t lval)
 {
   return vec_unpack_Decimal128 ((vf64_t) lval);
 }
 
 _Decimal128
-test_vec_BCD2DFP (vui32_t val)
+test_vec_BCD2DFP (vBCD_t val)
 {
   return vec_BCD2DFP (val);
 }
 
-vui32_t
+vBCD_t
 test_vec_DFP2BCD (_Decimal128 val)
 {
   return vec_DFP2BCD (val);
@@ -50,28 +50,115 @@ test_vec_bcdctb100s (vui8_t a)
   return (vec_rdxct100b (a));
 }
 
-vui32_t
-test_vec_bcdadd (vui32_t a, vui32_t b)
+vBCD_t
+test_vec_bcdadd (vBCD_t a, vBCD_t b)
 {
   return vec_bcdadd (a, b);
 }
 
-vui32_t
-test_vec_bcdsub (vui32_t a, vui32_t b)
+vBCD_t
+test_vec_bcdaddcsq (vBCD_t a, vBCD_t b)
+{
+  return vec_bcdaddcsq (a, b);
+}
+
+vBCD_t
+test_vec_cbcdaddcsq (vBCD_t *c, vBCD_t a, vBCD_t b)
+{
+  return vec_cbcdaddcsq (c, a, b);
+}
+
+vBCD_t
+test_vec_cbcdaddcsq_2 (vBCD_t *c, vBCD_t a, vBCD_t b)
+{
+  *c = vec_bcdaddcsq (a, b);
+  return vec_bcdadd (a, b);
+}
+
+vBCD_t
+test_vec_bcdaddesqm (vBCD_t a, vBCD_t b, vBCD_t c)
+{
+  return vec_bcdaddesqm (a, b, c);
+}
+
+vBCD_t
+test_vec_bcdaddecsq (vBCD_t a, vBCD_t b, vBCD_t c)
+{
+  return vec_bcdaddecsq (a, b, c);
+}
+
+vBCD_t
+test_vec_cbcdaddecsq (vBCD_t *co, vBCD_t a, vBCD_t b, vBCD_t c)
+{
+  return vec_cbcdaddecsq (co, a, b, c);
+}
+
+vBCD_t
+test_vec_cbcdaddecsq_2 (vBCD_t *co, vBCD_t a, vBCD_t b, vBCD_t c)
+{
+  *co = vec_bcdaddecsq (a, b, c);
+  return vec_bcdaddesqm (a, b, c);
+}
+
+vBCD_t
+test_vec_bcdsub (vBCD_t a, vBCD_t b)
 {
   return vec_bcdsub (a, b);
 }
 
-vui32_t
-test_vec_bcdmul (vui32_t a, vui32_t b)
+vBCD_t
+test_vec_bcdsubcsq (vBCD_t a, vBCD_t b)
+{
+  return vec_bcdaddcsq (a, b);
+}
+
+vBCD_t
+test_vec_bcdsubesqm (vBCD_t a, vBCD_t b, vBCD_t c)
+{
+  return vec_bcdsubesqm (a, b, c);
+}
+
+vBCD_t
+test_vec_bcdsubecsq (vBCD_t a, vBCD_t b, vBCD_t c)
+{
+  return vec_bcdsubecsq (a, b, c);
+}
+
+vBCD_t
+test_vec_cbcdsubecsq (vBCD_t *co, vBCD_t a, vBCD_t b, vBCD_t c)
+{
+  *co = vec_bcdsubecsq (a, b, c);
+  return vec_bcdsubesqm (a, b, c);
+}
+
+vBCD_t
+test_vec_bcdmulh (vBCD_t a, vBCD_t b)
+{
+  return vec_bcdmulh (a, b);
+}
+
+vBCD_t
+test_vec_bcdmul (vBCD_t a, vBCD_t b)
 {
   return vec_bcdmul (a, b);
 }
 
-vui32_t
-test_vec_bcddiv (vui32_t a, vui32_t b)
+vBCD_t
+test_vec_cbcdmul (vBCD_t *p, vBCD_t a, vBCD_t b)
+{
+  return vec_cbcdmul (p, a, b);
+}
+
+vBCD_t
+test_vec_bcddiv (vBCD_t a, vBCD_t b)
 {
   return vec_bcddiv (a, b);
+}
+
+vi128_t
+test_vec_bcdctsq (vBCD_t a)
+{
+  return (vec_bcdctsq (a));
 }
 
 vui128_t
@@ -104,6 +191,114 @@ test_vec_bcdctub (vBCD_t a)
   return (vec_bcdctub (a));
 }
 
+vBCD_t
+test_vec_bcdcpsgn (vBCD_t a, vBCD_t b)
+{
+  return vec_bcdcpsgn (a, b);
+}
+
+vBCD_t
+test_vec_bcds (vBCD_t vra, vi8_t vrb)
+{
+  return vec_bcds (vra, vrb);
+}
+
+vBCD_t
+test_vec_bcdus (vBCD_t vra, vi8_t vrb)
+{
+  return vec_bcdus (vra, vrb);
+}
+
+vBCD_t
+test_vec_bcdslqi_1 (vBCD_t vra, const int _N)
+{
+  return vec_bcdslqi (vra, 1);
+}
+
+vBCD_t
+test_vec_bcdslqi_2 (vBCD_t vra, const int _N)
+{
+  return vec_bcdslqi (vra, 2);
+}
+
+vBCD_t
+test_vec_bcdslqi_3 (vBCD_t vra, const int _N)
+{
+  return vec_bcdslqi (vra, 3);
+}
+
+vBCD_t
+test_vec_bcdslqi_15 (vBCD_t vra, const int _N)
+{
+  return vec_bcdslqi (vra, 15);
+}
+
+vBCD_t
+test_vec_bcdsrqi_1 (vBCD_t vra, const int _N)
+{
+  return vec_bcdsrqi (vra, 1);
+}
+
+vBCD_t
+test_vec_bcdsrqi_2 (vBCD_t vra, const int _N)
+{
+  return vec_bcdsrqi (vra, 2);
+}
+
+vBCD_t
+test_vec_bcdsrqi_3 (vBCD_t vra, const int _N)
+{
+  return vec_bcdsrqi (vra, 3);
+}
+
+vBCD_t
+test_vec_bcdsrqi_15 (vBCD_t vra, const int _N)
+{
+  return vec_bcdsrqi (vra, 15);
+}
+
+vBCD_t
+test_vec_bcdsruqi_1 (vBCD_t vra, const int _N)
+{
+  return vec_bcdsrqi (vra, 1);
+}
+
+vBCD_t
+test_vec_bcdsruqi_2 (vBCD_t vra, const int _N)
+{
+  return vec_bcdsruqi (vra, 2);
+}
+
+vBCD_t
+test_vec_bcdsruqi_3 (vBCD_t vra, const int _N)
+{
+  return vec_bcdsruqi (vra, 3);
+}
+
+vBCD_t
+test_vec_bcdsruqi_15 (vBCD_t vra, const int _N)
+{
+  return vec_bcdsruqi (vra, 15);
+}
+
+int
+test_vec_signgbit_bcdsq (vBCD_t a)
+{
+  return vec_signbit_bcdsq (a);
+}
+
+vb128_t
+test_vec_setbool_bcdsq (vBCD_t a)
+{
+  return vec_setbool_bcdsq (a);
+}
+
+vb128_t
+test_vec_setbool_bcdinv (vBCD_t a)
+{
+  return vec_setbool_bcdinv (a);
+}
+
 vui128_t
 example_vec_bcdctuq (vui8_t vra)
 {
@@ -123,14 +318,14 @@ example_vec_bcdctuq (vui8_t vra)
 }
 
 void
-example_vec_bcdctuq_loop (vui128_t *out, vui8_t* in, int cnt)
+example_vec_bcdctuq_loop (vui128_t *out, vui8_t* in, long cnt)
 {
   vui8_t d100;
   vui16_t d10k;
   vui32_t d100m;
   vui64_t d10e;
-  vui128_t result;
-  int i;
+//  vui128_t result;
+  long i;
 
   for (i = 0; i < cnt; i++)
     {
@@ -140,6 +335,22 @@ example_vec_bcdctuq_loop (vui128_t *out, vui8_t* in, int cnt)
       d10e = vec_rdxct10E16d (d100m);
       *out++ = vec_rdxct10e32q (d10e);
     }
+}
+
+void
+example_vec_cbcdecsq_loop (vBCD_t *cout, vBCD_t* out, vBCD_t* a, vBCD_t* b, long cnt)
+{
+  vBCD_t c, cn;
+  long i;
+
+  out[cnt-1] = vec_cbcdaddcsq (&c, a[cnt-1], b[cnt-1]);
+
+  for (i = (cnt-2); i >= 0; i--)
+    {
+      out[i] = vec_cbcdaddecsq (&cn, a[i], b[i], c);
+      c = cn;
+    }
+  *cout = cn;
 }
 
 #if (__GNUC__ > 4)
@@ -191,6 +402,19 @@ test__builtin_bcdmax (vi128_t vra, vi128_t vrb)
 }
 
 vi128_t
+test__vec_bcdaddcsq (vi128_t a, vi128_t b)
+{
+  vi128_t t, c;
+  c = (vi128_t) _BCD_CONST_ZERO;
+  t = __builtin_bcdadd (a, b, 0);
+  if (__builtin_expect (__builtin_bcdadd_ov ( a, b, 0), 0))
+    {
+      c = (vi128_t) vec_bcdcpsgn (_BCD_CONST_PLUS_ONE, (vBCD_t) t);
+    }
+  return (c);
+}
+
+vi128_t
 test__builtin_bcdabsd (vi128_t vra, vi128_t vrb)
 {
   vi128_t result;
@@ -198,6 +422,17 @@ test__builtin_bcdabsd (vi128_t vra, vi128_t vrb)
     result = __builtin_bcdsub (vra, vrb, 0);
   else
     result = __builtin_bcdsub (vrb, vra, 0);
+
+  return result;
+}
+
+vi128_t
+test__builtin_bcdabs (vi128_t vra)
+{
+  vi128_t result = vra;
+
+  if (__builtin_bcdadd_lt (vra, (vi128_t) _BCD_CONST_ZERO, 0))
+    result = __builtin_bcdsub ((vi128_t) _BCD_CONST_ZERO, vra, 0);
 
   return result;
 }

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -645,7 +645,7 @@ test_vec_cosf32_PWR9 (vf32_t value)
  * Otherwise compute and return sin(value).
  */
 __binary128
-test_sinf128 (__binary128 value)
+test_sinf128_PWR9 (__binary128 value)
   {
     __binary128 result;
 
@@ -672,7 +672,7 @@ test_sinf128 (__binary128 value)
  * Otherwise compute and return sin(value).
  */
 __binary128
-test_cosf128 (__binary128 value)
+test_cosf128_PWR9 (__binary128 value)
   {
     __binary128 result;
 
@@ -863,6 +863,124 @@ __test_vec_extract_sig_f32 (vf32_t val)
 }
 #endif
 
+vBCD_t
+test_vec_bcdmulh_PWR9 (vBCD_t a, vBCD_t b)
+{
+  return vec_bcdmulh (a, b);
+}
+
+vBCD_t
+test_vec_bcdmul_PWR9 (vBCD_t a, vBCD_t b)
+{
+  return vec_bcdmul (a, b);
+}
+
+vBCD_t
+test_vec_cbcdmul_PWR9 (vBCD_t *p, vBCD_t a, vBCD_t b)
+{
+  return vec_cbcdmul (p, a, b);
+}
+
+vi128_t
+test_vec_bcdctsq_PWR9 (vBCD_t a)
+{
+  return (vec_bcdctsq (a));
+}
+
+vBCD_t
+test_vec_bcdcpsgn_PWR9 (vBCD_t a, vBCD_t b)
+{
+  return vec_bcdcpsgn (a, b);
+}
+
+#if 1
+vBCD_t
+test_vec_bcds_PWR9 (vBCD_t vra, vi8_t vrb)
+{
+  return vec_bcds (vra, vrb);
+}
+vBCD_t
+test_vec_bcdus_PWR9 (vBCD_t vra, vi8_t vrb)
+{
+  return vec_bcdus (vra, vrb);
+}
+
+vBCD_t
+test_vec_bcdsrqi_1_PWR9 (vBCD_t vra)
+{
+  return vec_bcdsrqi (vra, 1);
+}
+
+vBCD_t
+test_vec_bcdsrqi_31_PWR9 (vBCD_t vra)
+{
+  return vec_bcdsrqi (vra, 31);
+}
+
+vBCD_t
+test_vec_bcdsruqi_1_PWR9 (vBCD_t vra)
+{
+  return vec_bcdsruqi (vra, 1);
+}
+
+vBCD_t
+test_vec_bcdsruqi_31_PWR9 (vBCD_t vra)
+{
+  return vec_bcdsruqi (vra, 31);
+}
+
+vBCD_t
+test_vec_bcdslqi_1_PWR9 (vBCD_t vra)
+{
+  return vec_bcdslqi (vra, 1);
+}
+
+vBCD_t
+test_vec_bcdslqi_31_PWR9 (vBCD_t vra)
+{
+  return vec_bcdslqi (vra, 31);
+}
+
+vBCD_t
+test_vec_bcdsluqi_1_PWR9 (vBCD_t vra)
+{
+  return vec_bcdsluqi (vra, 1);
+}
+
+vBCD_t
+test_vec_bcdsluqi_31_PWR9 (vBCD_t vra)
+{
+  return vec_bcdsluqi (vra, 31);
+}
+#endif
+
+
+vBCD_t
+test_vec_cbcdaddcsq_PWR9 (vBCD_t *c, vBCD_t a, vBCD_t b)
+{
+  return vec_cbcdaddcsq (c, a, b);
+}
+
+vBCD_t
+test_vec_cbcdaddcsq2_PWR9 (vBCD_t *c, vBCD_t a, vBCD_t b)
+{
+  *c = vec_bcdaddcsq (a, b);
+  return vec_bcdadd (a, b);
+}
+
+vBCD_t
+test_vec_cbcdaddecsq_PWR9 (vBCD_t *co, vBCD_t a, vBCD_t b, vBCD_t c)
+{
+  return vec_cbcdaddecsq (co, a, b, c);
+}
+
+vBCD_t
+test_vec_cbcdaddecsq2_PWR9 (vBCD_t *co, vBCD_t a, vBCD_t b, vBCD_t c)
+{
+  *co = vec_bcdaddecsq (a, b, c);
+  return vec_bcdaddesqm (a, b, c);
+}
+
 vui128_t
 example_vec_bcdctuq_PWR9 (vui8_t vra)
 {
@@ -879,6 +997,54 @@ example_vec_bcdctuq_PWR9 (vui8_t vra)
   return vec_rdxct10e32q (d10e);
 
   return result;
+}
+
+void
+example_vec_cbcdecsq_loop_PWR9 (vBCD_t *cout, vBCD_t* out, vBCD_t* a, vBCD_t* b,
+				long cnt)
+{
+  vBCD_t c, cn;
+  long i;
+
+  out[cnt - 1] = vec_cbcdaddcsq (&c, a[cnt - 1], b[cnt - 1]);
+
+  for (i = (cnt - 2); i >= 0; i--)
+    {
+      out[i] = vec_cbcdaddecsq (&cn, a[i], b[i], c);
+      c = cn;
+    }
+  *cout = cn;
+}
+
+vBCD_t
+test_vec_bcdaddcsq_PWR9 (vBCD_t a, vBCD_t b)
+{
+  return vec_bcdaddcsq (a, b);
+}
+
+vBCD_t
+test_vec_bcdaddesqm_PWR9 (vBCD_t a, vBCD_t b, vBCD_t c)
+{
+  return vec_bcdaddesqm (a, b, c);
+}
+
+vBCD_t
+test_vec_bcdaddecsq_PWR9 (vBCD_t a, vBCD_t b, vBCD_t c)
+{
+  return vec_bcdaddecsq (a, b, c);
+}
+
+vi128_t
+test__vec_bcdaddcsq_PWR9 (vi128_t a, vi128_t b)
+{
+  vi128_t t;
+  t = (vi128_t) _BCD_CONST_ZERO;
+  if (__builtin_expect (__builtin_bcdadd_ov ( a, b, 0), 0))
+    {
+      t = __builtin_bcdadd (a, b, 0);
+      t = (vi128_t) vec_bcdcpsgn (_BCD_CONST_PLUS_ONE, (vBCD_t) t);
+    }
+  return (t);
 }
 
 void


### PR DESCRIPTION
Added:
Signed BCD to vector __int128 conversion.
Extend/carry support for BCD add/sub.
BCD Multiply low/High combined (62-digit).
BCD Digit shifts.

	* src/testsuite/arith128_test_bcd.c (db_vec_ZN2i128,
	db_vec_BC10es2i128):
	Code clean up.
	(db_vec_bcddiv, db_vec_bcdmul, db_vec_bcdmulh, db_vec_cbcdmul):
	New Functions.
	(db_vec_bcdaddcsq, vec_copysign_Decimal128, db_vec_cbcdaddcsq,
	db_vec_cbcdaddecsq, db_vec_bcdsubcsq): New Functions.
	(test_bcd_muldiv): Update to use test_vec_bcddiv and
	test_vec_bcdmul to switch between vec_bcd_ppc.h and local db_
	implementations. Additional test cases.
	(test_setb_bcdsq, test_setb_bcdinv, test_signbit_bcdsq,
	test_bcdcpsgn, test_bcdctsq, test_bcds, test_bcdus,
	test_bcdslrqi, test_bcdslruqi, test_bcd_mulh, test_bcd_cmul,
	test_bcd_addcsq, test_bcd_subcsq, test_bcd_addesqm,
	test_bcd_subesqm, test_bcd_addecsq, test_bcd_subecsq,
	test_bcd_adde256, test_bcd_cadde256, test_bcd_caddec256:
	New Functions.
	(test_vec_bcd): Add calls to new test cases.

	* src/testsuite/vec_bcd_dummy.c (test_pack_Decimal128_cast,
	test_unpack_Decimal128_cast, test_vec_DFP2BCD, test_vec_bcdadd,
	test_vec_bcdsub, test_vec_bcdmul, test_vec_bcddiv,
	test_vec_bcdctuq):
	Used vBCD_t type.
	(test_vec_bcdaddcsq, test_vec_cbcdaddcsq, test_vec_cbcdaddcsq_2,
	test_vec_bcdaddesqm, test_vec_bcdaddecsq, test_vec_cbcdaddecsq,
	test_vec_cbcdaddecsq_2, test_vec_bcdsubcsq, test_vec_bcdsubesqm,
	test_vec_bcdsubecsq, test_vec_cbcdsubecsq, test_vec_bcdmulh,
	test_vec_cbcdmul, test_vec_bcdctsq, test_vec_bcdcpsgn,
	test_vec_bcds, test_vec_bcdus): New functions.
	(test_vec_bcdslqi_1, test_vec_bcdslqi_2, test_vec_bcdslqi_3,
	test_vec_bcdslqi_15, test_vec_bcdsrqi_1, test_vec_bcdsrqi_2,
	test_vec_bcdsrqi_3, test_vec_bcdsrqi_15, test_vec_bcdsruqi_1,
	test_vec_bcdsruqi_2, test_vec_bcdsruqi_3, test_vec_bcdsruqi_15):
	New functions.
	(test_vec_setbool_bcdsq, test_vec_setbool_bcdinv):
	New functions.
	(example_vec_bcdctuq_loop): Change int cnt to long
	(example_vec_cbcdecsq_loop, test__vec_bcdaddcsq,
	test__builtin_bcdabs): New functions.

	* src/testsuite/vec_pwr9_dummy.c (test_vec_bcdmulh_PWR9,
	test_vec_bcdmul_PWR9, test_vec_cbcdmul_PWR9,
	test_vec_bcdctsq_PWR9, test_vec_bcdcpsgn_PWR9,
	test_vec_bcds_PWR9, test_vec_bcdus_PWR9):
	New functions.
	(test_vec_bcdsrqi_1_PWR9, test_vec_bcdsrqi_31_PWR9,
	test_vec_bcdsruqi_1_PWR9, test_vec_bcdsruqi_31_PWR9,
	test_vec_bcdslqi_1_PWR9, test_vec_bcdslqi_31_PWR9,
	test_vec_bcdsluqi_1_PWR9, test_vec_bcdsluqi_31_PWR9):
	New functions.
	(test_vec_cbcdaddcsq_PWR9, test_vec_cbcdaddcsq2_PWR9,
	test_vec_cbcdaddecsq_PWR9, test_vec_cbcdaddecsq2_PWR9):
	New functions.
	(example_vec_cbcdecsq_loop_PWR9, test_vec_bcdaddcsq_PWR9,
	test_vec_bcdaddesqm_PWR9, test_vec_bcdaddecsq_PWR9,
	test__vec_bcdaddcsq_PWR9): New functions.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>