### PR TITLE
More vec_bcd_ppc.h compile and unit tests:

### DIFF
--- a/src/testsuite/arith128_test_bcd.c
+++ b/src/testsuite/arith128_test_bcd.c
@@ -510,7 +510,7 @@ db_vec_cbcdaddcsq (vBCD_t *c, vBCD_t a, vBCD_t b)
 	  vBCD_t c10s = vec_bcdcpsgn (_BCD_CONST_PLUS_ONE, a);
 	  t = vec_bcdcpsgn (_BCD_CONST_PLUS_ONE, sum_ab);
 	  sum_ab = vec_bcdaddesqm (nines, sum_ab, c10s);
-	  print_vint128x (" barrow   c  ) =", (vui128_t) t);
+	  print_vint128x (" borrow   c  ) =", (vui128_t) t);
 	  print_vint128x (" invert sum  ) =", (vui128_t) sum_ab);
 	}
     }

--- a/src/testsuite/arith128_test_bcd.c
+++ b/src/testsuite/arith128_test_bcd.c
@@ -3850,7 +3850,9 @@ test_bcd_cadde256 (void)
   rc += check_vint256 ("vec_bcdadde256:", (vui128_t) kh, (vui128_t) kl,
 		       (vui128_t) eh, (vui128_t) el);
 #if 0
-  // This case does not work with the general code
+  // This case does not work with the general code.
+  // Difference where the left operand has a smaller magnitude.
+  // Will renable this when I figure out borrows completely.
   ih = _BCD_CONST_PLUS_ONE;
   il = (vBCD_t) CONST_VINT128_W (0x10000000, 0x00000000, 0x00000000, 0x0000008c);
   jh = _BCD_CONST_MINUS_ONE;
@@ -6395,7 +6397,7 @@ test_bcdutrunc (void)
 
 #ifdef __DEBUG_PRINT__
   print_vint128x ("BCD qword ", i);
-  print_vint128x ("BCD trunc ", (vui128_t) s);
+  print_vint128x ("BCDutrunc ", (vui128_t) s);
   print_vint128x ("truncated ", j);
 #endif
   rc += check_vuint128x ("vec_bcdutrunc:", (vui128_t) j, (vui128_t) e);
@@ -6409,7 +6411,7 @@ test_bcdutrunc (void)
 
 #ifdef __DEBUG_PRINT__
   print_vint128x ("BCD qword ", i);
-  print_vint128x ("BCD trunc ", (vui128_t) s);
+  print_vint128x ("BCDutrunc ", (vui128_t) s);
   print_vint128x ("truncated ", j);
 #endif
   rc += check_vuint128x ("vec_bcdutrunc:", (vui128_t) j, (vui128_t) e);
@@ -6421,7 +6423,7 @@ test_bcdutrunc (void)
 
 #ifdef __DEBUG_PRINT__
   print_vint128x ("BCD qword ", i);
-  print_vint128x ("BCD trunc ", (vui128_t) s);
+  print_vint128x ("BCDutrunc ", (vui128_t) s);
   print_vint128x ("truncated ", j);
 #endif
   rc += check_vuint128x ("vec_bcdutrunc:", (vui128_t) j, (vui128_t) e);
@@ -6433,7 +6435,7 @@ test_bcdutrunc (void)
 
 #ifdef __DEBUG_PRINT__
   print_vint128x ("BCD qword ", i);
-  print_vint128x ("BCD trunc ", (vui128_t) s);
+  print_vint128x ("BCDutrunc ", (vui128_t) s);
   print_vint128x ("truncated ", j);
 #endif
   rc += check_vuint128x ("vec_bcdutrunc:", (vui128_t) j, (vui128_t) e);
@@ -6445,7 +6447,7 @@ test_bcdutrunc (void)
 
 #ifdef __DEBUG_PRINT__
   print_vint128x ("BCD qword ", i);
-  print_vint128x ("BCD trunc ", (vui128_t) s);
+  print_vint128x ("BCDutrunc ", (vui128_t) s);
   print_vint128x ("truncated ", j);
 #endif
   rc += check_vuint128x ("vec_bcdutrunc:", (vui128_t) j, (vui128_t) e);
@@ -6457,7 +6459,7 @@ test_bcdutrunc (void)
 
 #ifdef __DEBUG_PRINT__
   print_vint128x ("BCD qword ", i);
-  print_vint128x ("BCD trunc ", (vui128_t) s);
+  print_vint128x ("BCDutrunc ", (vui128_t) s);
   print_vint128x ("truncated ", j);
 #endif
   rc += check_vuint128x ("vec_bcdutrunc:", (vui128_t) j, (vui128_t) e);

--- a/src/testsuite/vec_bcd_dummy.c
+++ b/src/testsuite/vec_bcd_dummy.c
@@ -150,6 +150,13 @@ test_vec_cbcdmul (vBCD_t *p, vBCD_t a, vBCD_t b)
 }
 
 vBCD_t
+test_vec_cbcdmul_2 (vBCD_t *p, vBCD_t a, vBCD_t b)
+{
+  *p = vec_bcdmulh (a, b);
+  return vec_bcdmul (a, b);
+}
+
+vBCD_t
 test_vec_bcddiv (vBCD_t a, vBCD_t b)
 {
   return vec_bcddiv (a, b);
@@ -198,9 +205,63 @@ test_vec_bcdcpsgn (vBCD_t a, vBCD_t b)
 }
 
 vBCD_t
+test_vec_bcdsetsgn (vBCD_t a)
+{
+  return vec_bcdsetsgn (a);
+}
+
+vBCD_t
+test_vec_bcdcfz (vui8_t vrb)
+{
+  return vec_bcdcfz (vrb);
+}
+
+vui8_t
+test_vec_bcdctz (vBCD_t vrb)
+{
+  return vec_bcdctz (vrb);
+}
+
+vBCD_t
 test_vec_bcds (vBCD_t vra, vi8_t vrb)
 {
   return vec_bcds (vra, vrb);
+}
+
+vBCD_t
+test_vec_bcdsr (vBCD_t vra, vi8_t vrb)
+{
+  return vec_bcdsr (vra, vrb);
+}
+
+vBCD_t
+test_vec_bcdsrrqi (vBCD_t vra)
+{
+  return vec_bcdsrrqi (vra, 15);
+}
+
+vBCD_t
+test_vec_bcdtrunc (vBCD_t vra, vui16_t vrb)
+{
+  return vec_bcdtrunc (vra, vrb);
+}
+
+vBCD_t
+test_vec_bcdtruncqi (vBCD_t vra)
+{
+  return vec_bcdtruncqi (vra, 15);
+}
+
+vBCD_t
+test_vec_bcdutrunc (vBCD_t vra, vui16_t vrb)
+{
+  return vec_bcdutrunc (vra, vrb);
+}
+
+vBCD_t
+test_vec_bcdutruncqi (vBCD_t vra)
+{
+  return vec_bcdutruncqi (vra, 15);
 }
 
 vBCD_t
@@ -299,6 +360,78 @@ test_vec_setbool_bcdinv (vBCD_t a)
   return vec_setbool_bcdinv (a);
 }
 
+vbBCD_t
+test_vec_bcdcmp_eqsq (vBCD_t vra, vBCD_t vrb)
+{
+  return vec_bcdcmp_eqsq (vra, vrb);
+}
+
+vbBCD_t
+test_vec_bcdcmp_nesq (vBCD_t vra, vBCD_t vrb)
+{
+  return vec_bcdcmp_nesq (vra, vrb);
+}
+
+vbBCD_t
+test_vec_bcdcmp_gtsq (vBCD_t vra, vBCD_t vrb)
+{
+  return vec_bcdcmp_gtsq (vra, vrb);
+}
+
+vbBCD_t
+test_vec_bcdcmp_gesq (vBCD_t vra, vBCD_t vrb)
+{
+  return vec_bcdcmp_gesq (vra, vrb);
+}
+
+vbBCD_t
+test_vec_bcdcmp_ltsq (vBCD_t vra, vBCD_t vrb)
+{
+  return vec_bcdcmp_ltsq (vra, vrb);
+}
+
+vbBCD_t
+test_vec_bcdcmp_lesq (vBCD_t vra, vBCD_t vrb)
+{
+  return vec_bcdcmp_lesq (vra, vrb);
+}
+
+int
+test_vec_bcdcmpeq (vBCD_t vra, vBCD_t vrb)
+{
+  return vec_bcdcmpeq (vra, vrb);
+}
+
+int
+test_vec_bcdcmpne (vBCD_t vra, vBCD_t vrb)
+{
+  return vec_bcdcmpne (vra, vrb);
+}
+
+int
+test_vec_bcdcmpgt (vBCD_t vra, vBCD_t vrb)
+{
+  return vec_bcdcmpgt (vra, vrb);
+}
+
+int
+test_vec_bcdcmpge (vBCD_t vra, vBCD_t vrb)
+{
+  return vec_bcdcmpge (vra, vrb);
+}
+
+int
+test_vec_bcdcmplt (vBCD_t vra, vBCD_t vrb)
+{
+  return vec_bcdcmplt (vra, vrb);
+}
+
+int
+test_vec_bcdcmple (vBCD_t vra, vBCD_t vrb)
+{
+  return vec_bcdcmple (vra, vrb);
+}
+
 vui128_t
 example_vec_bcdctuq (vui8_t vra)
 {
@@ -353,6 +486,35 @@ example_vec_cbcdecsq_loop (vBCD_t *cout, vBCD_t* out, vBCD_t* a, vBCD_t* b, long
   *cout = cn;
 }
 
+
+void
+example_bcdmul_2x2 (vBCD_t *__restrict__ mulu, vBCD_t m1h, vBCD_t m1l,
+		    vBCD_t m2h, vBCD_t m2l)
+{
+  vBCD_t mc, mp, mq;
+  vBCD_t mphh, mphl, mplh, mpll;
+  mpll = vec_cbcdmul (&mplh, m1l, m2l);
+  mp = vec_cbcdmul (&mphl, m1h, m2l);
+  mplh = vec_bcdadd (mplh, mp);
+  mc   = vec_bcdaddcsq (mplh, mp);
+  mphl   = vec_bcdadd (mphl, mp);
+  mp = vec_cbcdmul (&mc, m2h, m1l);
+  mplh = vec_bcdadd (mplh, mp);
+  mq   = vec_bcdaddcsq (mplh, mp);
+  mphl = vec_bcdadd (mphl, mq);
+  mc   = vec_bcdaddcsq (mplh, mq);
+  mp = vec_cbcdmul (&mphh, m2h, m1h);
+  mphl = vec_bcdadd (mphl, mp);
+  mp   = vec_bcdaddcsq (mplh, mp);
+  mphh = vec_bcdadd (mphh, mp);
+  mphh = vec_bcdadd (mphh, mc);
+
+  mulu[0] = mpll;
+  mulu[1] = mplh;
+  mulu[2] = mphl;
+  mulu[3] = mphh;
+}
+
 #if (__GNUC__ > 4)
 _Decimal128
 test__builtin_ddedpdq ( _Decimal128 value)
@@ -389,6 +551,12 @@ int
 test__builtin_bcdsub_eq (vi128_t vra, vi128_t vrb)
 {
   return __builtin_bcdsub_eq (vra, vrb, 0);
+}
+
+int
+test__builtin_bcdsub_lt (vi128_t vra, vi128_t vrb)
+{
+  return __builtin_bcdsub_lt (vra, vrb, 0);
 }
 
 vi128_t

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -899,6 +899,43 @@ test_vec_bcds_PWR9 (vBCD_t vra, vi8_t vrb)
 {
   return vec_bcds (vra, vrb);
 }
+
+vBCD_t
+test_vec_bcdsr_PWR9 (vBCD_t vra, vi8_t vrb)
+{
+  return vec_bcdsr (vra, vrb);
+}
+
+vBCD_t
+test_vec_bcdsrrqi_PWR9 (vBCD_t vra)
+{
+  return vec_bcdsrrqi (vra, 15);
+}
+
+vBCD_t
+test_vec_bcdtrunc_PWR9 (vBCD_t vra, vui16_t vrb)
+{
+  return vec_bcdtrunc (vra, vrb);
+}
+
+vBCD_t
+test_vec_bcdtruncqi_PWR9 (vBCD_t vra)
+{
+  return vec_bcdtruncqi (vra, 15);
+}
+
+vBCD_t
+test_vec_bcdutrunc_PWR9 (vBCD_t vra, vui16_t vrb)
+{
+  return vec_bcdutrunc (vra, vrb);
+}
+
+vBCD_t
+test_vec_bcdutruncqi_PWR9 (vBCD_t vra)
+{
+  return vec_bcdutruncqi (vra, 15);
+}
+
 vBCD_t
 test_vec_bcdus_PWR9 (vBCD_t vra, vi8_t vrb)
 {
@@ -1034,8 +1071,14 @@ test_vec_bcdaddecsq_PWR9 (vBCD_t a, vBCD_t b, vBCD_t c)
   return vec_bcdaddecsq (a, b, c);
 }
 
+vBCD_t
+test__vec_bcdaddcsq_PWR9 (vBCD_t a, vBCD_t b)
+{
+  return vec_bcdaddcsq (a, b);
+}
+
 vi128_t
-test__vec_bcdaddcsq_PWR9 (vi128_t a, vi128_t b)
+test__vec_bcdaddcsq2_PWR9 (vi128_t a, vi128_t b)
 {
   vi128_t t;
   t = (vi128_t) _BCD_CONST_ZERO;


### PR DESCRIPTION
Update unit tests after change to bcdsub and related functions.
Added unit tests for new operations.
Added compile tests for new operations.
Added power9 target tests for new operations.

	* src/testsuite/arith128_test_bcd.c (vec_copysign_Decimal128):
	Prototype, disable for now.
	(db_vec_cbcdaddcsq): Add debug printf. Update "borrow" test to
	check for != BCD 0. Ditto for _ARCH_PWR7.
	(db_vec_cbcdsubcsq): New function.
	(test_bcd_subesqm): Correct unit tests results after changes.
	(test_bcd_subecsq): Ditto.
	(test_bcd_cadde256): Add unit tests.
	(test_bcdcmpsq_p2, test_bcdcmpsq, test_bcdcmp_p2, test_bcdcmp,
	test_bcdsetsgn, test_bcdcfz, test_bcdctz, test_bcdsr,
	test_bcdtrunc, test_bcdutrunc, test_bcdtruncqi,
	test_bcdutruncqi, test_bcdsrrqi, test_bcd_csube256):
	New function.
	(test_vec_bcd): Update to call new unit test functions.

	* src/testsuite/vec_bcd_dummy.c (test_vec_cbcdmul_2,
	test_vec_bcdsetsgn, test_vec_bcdcfz, test_vec_bcdctz,
	test_vec_bcdsr, test_vec_bcdtrunc, test_vec_bcdtruncqi,
	test_vec_bcdutrunc, test_vec_bcdutruncqi): New functions.
	(test_vec_bcdcmp_eqsq, test_vec_bcdcmp_nesq,
	test_vec_bcdcmp_gtsq, test_vec_bcdcmp_gesq,
	test_vec_bcdcmp_ltsq, test_vec_bcdcmp_lesq,
	test_vec_bcdcmpeq, test_vec_bcdcmpne, test_vec_bcdcmpgt,
`	test_vec_bcdcmpge, test_vec_bcdcmplt, test_vec_bcdcmple):
	New functions.
	(example_bcdmul_2x2): New function.
	(test__builtin_bcdsub_lt): New function.

	* src/testsuite/vec_pwr9_dummy.c (test_vec_bcdsr_PWR9,
	test_vec_bcdsrrqi_PWR9, test_vec_bcdtrunc_PWR9,
	test_vec_bcdtruncqi_PWR9, test_vec_bcdutrunc_PWR9,
	test_vec_bcdutruncq): New functions.
	(test__vec_bcdaddcsq_PWR9): New function.
	(test__vec_bcdaddcsq2_PWR9): Renamed from
	test__vec_bcdaddcsq_PWR9.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>