### PR TITLE
More vec_bcd_ppc.h add factoring support to vec_int128_ppv.h:

### DIFF
--- a/src/testsuite/arith128_print.c
+++ b/src/testsuite/arith128_print.c
@@ -642,6 +642,16 @@ print_vint128 (char *prefix, vui128_t val128)
 }
 
 void
+print_vint128s (char *prefix, vi128_t val128)
+{
+  __VEC_U_128 val;
+  signed __int128 val_x;
+  val.vx1 = (vui128_t) val128;
+  val_x = (signed __int128)val.i128;
+  print_int128 (prefix, val_x);
+}
+
+void
 print_vint128x (char *prefix, vui128_t val128)
 {
   vui32_t val = (vui32_t) val128;

--- a/src/testsuite/arith128_print.h
+++ b/src/testsuite/arith128_print.h
@@ -149,6 +149,9 @@ extern void
 print_vint128 (char *prefix, vui128_t val);
 
 extern void
+print_vint128s (char *prefix, vi128_t val128);
+
+extern void
 print_vint128x (char *prefix, vui128_t val);
 
 extern void

--- a/src/testsuite/arith128_test_i128.c
+++ b/src/testsuite/arith128_test_i128.c
@@ -8668,6 +8668,360 @@ test_cmpsq_all (void)
   return (rc);
 }
 
+//#define __DEBUG_PRINT__ 1
+int
+test_div_moduq_e32 (void)
+{
+  vui128_t i, j;
+  vui128_t k, l, e;
+  int rc = 0;
+
+  printf ("\ntest Vector divide/modulo Unsigned Quadword\n");
+
+  i = (vui128_t)CONST_VINT128_DW128(__UINT64_MAX__, __UINT64_MAX__);
+  e = (vui128_t)CONST_VINT128_DW128(0, 3402823);
+
+  k = vec_divuq_10e32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 (" divuq_10e32 ", (vui128_t)i);
+  print_vint128 ("           = ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_divuq_10e32:", (vui128_t)k, (vui128_t) e);
+
+  e = (vui128_t) CONST_VINT128_DW128 ( 0x0000034ca936deeeUL,
+				       0xc98ba738ffffffffUL );
+  l = vec_moduq_10e32 (i, k);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 (" moduq_10e32 ", (vui128_t)i);
+  print_vint128 ("           q ", (vui128_t)k);
+  print_vint128 ("           = ", (vui128_t)l);
+  print_vint128x("           = 0x", (vui128_t)l);
+#endif
+  rc += check_vuint128x ("vec_moduq_10e32:", (vui128_t)l, (vui128_t) e);
+
+  i = (vui128_t) { (__int128 ) 10000000000000000UL
+                 * (__int128 ) 10000000000000000UL };;
+  e = (vui128_t)CONST_VINT128_DW128(0, 1);
+
+  k = vec_divuq_10e32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 (" divuq_10e32 ", (vui128_t)i);
+  print_vint128 ("           = ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_divuq_10e32:", (vui128_t)k, (vui128_t) e);
+
+  e = (vui128_t) CONST_VINT128_DW128 ( 0UL,
+				       0UL );
+  l = vec_moduq_10e32 (i, k);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 (" moduq_10e32 ", (vui128_t)i);
+  print_vint128 ("           q ", (vui128_t)k);
+  print_vint128 ("           = ", (vui128_t)l);
+  print_vint128x("           = 0x", (vui128_t)l);
+#endif
+  rc += check_vuint128x ("vec_moduq_10e32:", (vui128_t)l, (vui128_t) e);
+
+  i = (vui128_t) { (__int128 )  9999999999999999UL
+                 * (__int128 ) 10000000000000000UL
+		 + (__int128 )  9999999999999999UL};
+  e = (vui128_t)CONST_VINT128_DW128(0, 0);
+
+  k = vec_divuq_10e32 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 (" divuq_10e32 ", (vui128_t)i);
+  print_vint128 ("           = ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_divuq_10e32:", (vui128_t)k, (vui128_t) e);
+
+  e = (vui128_t) { (__int128 )  9999999999999999UL
+                 * (__int128 ) 10000000000000000UL
+		 + (__int128 )  9999999999999999UL};
+  l = vec_moduq_10e32 (i, k);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 (" moduq_10e32 ", (vui128_t)i);
+  print_vint128 ("           q ", (vui128_t)k);
+  print_vint128 ("           = ", (vui128_t)l);
+  print_vint128x("           = 0x", (vui128_t)l);
+#endif
+  rc += check_vuint128x ("vec_moduq_10e32:", (vui128_t)l, (vui128_t) e);
+
+  return (rc);
+}
+
+//#define __DEBUG_PRINT__ 1
+int
+test_div_moduq_e31 (void)
+{
+  vui128_t i, j;
+  vui128_t k, l, e;
+  int rc = 0;
+
+  printf ("\ntest Vector divide/modulo Unsigned Quadword\n");
+
+  i = (vui128_t)CONST_VINT128_DW128(__UINT64_MAX__, __UINT64_MAX__);
+  e = (vui128_t)CONST_VINT128_DW128(0, 34028236);
+
+  k = vec_divuq_10e31 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 (" divuq_10e31 ", (vui128_t)i);
+  print_vint128 ("           = ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_divuq_10e31:", (vui128_t)k, (vui128_t) e);
+
+  e = (vui128_t) CONST_VINT128_DW128 ( 0x000000575ac21e1eUL,
+				       0x4623e451ffffffffUL );
+  l = vec_moduq_10e31 (i, k);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 (" moduq_10e31 ", (vui128_t)i);
+  print_vint128 ("           q ", (vui128_t)k);
+  print_vint128 ("           = ", (vui128_t)l);
+  print_vint128x("           = 0x", (vui128_t)l);
+#endif
+  rc += check_vuint128x ("vec_moduq_10e31:", (vui128_t)l, (vui128_t) e);
+
+  i = (vui128_t) { (__int128 ) 1000000000000000UL
+                 * (__int128 ) 10000000000000000UL };;
+  e = (vui128_t)CONST_VINT128_DW128(0, 1);
+
+  k = vec_divuq_10e31 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 (" divuq_10e31 ", (vui128_t)i);
+  print_vint128 ("           = ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_divuq_10e31:", (vui128_t)k, (vui128_t) e);
+
+  e = (vui128_t) CONST_VINT128_DW128 ( 0UL,
+				       0UL );
+  l = vec_moduq_10e31 (i, k);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 (" moduq_10e31 ", (vui128_t)i);
+  print_vint128 ("           q ", (vui128_t)k);
+  print_vint128 ("           = ", (vui128_t)l);
+  print_vint128x("           = 0x", (vui128_t)l);
+#endif
+  rc += check_vuint128x ("vec_moduq_10e31:", (vui128_t)l, (vui128_t) e);
+
+  i = (vui128_t) { (__int128 )   999999999999999UL
+                 * (__int128 ) 10000000000000000UL
+		 + (__int128 )  9999999999999999UL};
+  e = (vui128_t)CONST_VINT128_DW128(0, 0);
+
+  k = vec_divuq_10e31 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 (" divuq_10e31 ", (vui128_t)i);
+  print_vint128 ("           = ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_divuq_10e31:", (vui128_t)k, (vui128_t) e);
+
+  e = (vui128_t) { (__int128 )   999999999999999UL
+                 * (__int128 ) 10000000000000000UL
+		 + (__int128 )  9999999999999999UL};
+  l = vec_moduq_10e31 (i, k);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 (" moduq_10e31 ", (vui128_t)i);
+  print_vint128 ("           q ", (vui128_t)k);
+  print_vint128 ("           = ", (vui128_t)l);
+  print_vint128x("           = 0x", (vui128_t)l);
+#endif
+  rc += check_vuint128x ("vec_moduq_10e31:", (vui128_t)l, (vui128_t) e);
+
+  return (rc);
+}
+
+#define __DEBUG_PRINT__ 1
+int
+test_div_modsq_e31 (void)
+{
+  vi128_t i, j;
+  vi128_t k, l, e;
+  int rc = 0;
+
+  printf ("\ntest Vector divide/modulo Unsigned Quadword\n");
+
+  i = (vi128_t)CONST_VINT128_DW128(__INT64_MAX__, __UINT64_MAX__);
+  e = (vi128_t)CONST_VINT128_DW128(0, 17014118);
+
+  k = vec_divsq_10e31 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128s(" divsq_10e31 ", (vi128_t)i);
+  print_vint128s("           = ", (vi128_t)k);
+#endif
+  rc += check_vuint128x ("vec_divsq_10e31:", (vui128_t)k, (vui128_t) e);
+
+  e = (vi128_t) CONST_VINT128_DW128 ( 0x0000002bad610f0fUL,
+				      0x2311f228ffffffffUL );
+  l = vec_modsq_10e31 (i, k);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128s(" modsq_10e31 ", (vi128_t)i);
+  print_vint128s("           q ", (vi128_t)k);
+  print_vint128s("           = ", (vi128_t)l);
+  print_vint128x("           = 0x", (vui128_t)l);
+#endif
+  rc += check_vuint128x ("vec_modsq_10e31:", (vui128_t)l, (vui128_t) e);
+
+  i = (vi128_t) { (__int128 ) 1000000000000000UL
+                 * (__int128 ) 10000000000000000UL };
+  e = (vi128_t)CONST_VINT128_DW128(0, 1);
+
+  k = vec_divsq_10e31 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128s(" divsq_10e31 ", (vi128_t)i);
+  print_vint128s("           = ", (vi128_t)k);
+#endif
+  rc += check_vuint128x ("vec_divsq_10e31:", (vui128_t)k, (vui128_t) e);
+
+  e = (vi128_t) CONST_VINT128_DW128 ( 0UL,
+				       0UL );
+  l = vec_modsq_10e31 (i, k);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128s(" modsq_10e31 ", (vi128_t)i);
+  print_vint128s("           q ", (vi128_t)k);
+  print_vint128s("           = ", (vi128_t)l);
+  print_vint128x("           = 0x", (vui128_t)l);
+#endif
+  rc += check_vuint128x ("vec_modsq_10e31:", (vui128_t)l, (vui128_t) e);
+
+  i = (vi128_t) { (__int128 )   999999999999999UL
+                 * (__int128 ) 10000000000000000UL
+		 + (__int128 )  9999999999999999UL};
+  e = (vi128_t)CONST_VINT128_DW128(0, 0);
+
+  k = vec_divsq_10e31 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128s(" divsq_10e31 ", (vi128_t)i);
+  print_vint128s("           = ", (vi128_t)k);
+#endif
+  rc += check_vuint128x ("vec_divsq_10e31:", (vui128_t)k, (vui128_t) e);
+
+  e = (vi128_t) { (__int128 )   999999999999999UL
+                 * (__int128 ) 10000000000000000UL
+		 + (__int128 )  9999999999999999UL};
+  l = vec_modsq_10e31 (i, k);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128s(" modsq_10e31 ", (vi128_t)i);
+  print_vint128s("           q ", (vi128_t)k);
+  print_vint128s("           = ", (vi128_t)l);
+  print_vint128x("           = 0x", (vui128_t)l);
+#endif
+  rc += check_vuint128x ("vec_modsq_10e31:", (vui128_t)l, (vui128_t) e);
+
+  i = (vi128_t)CONST_VINT128_DW128(0x8000000000000000UL, 0);
+  e = (vi128_t)CONST_VINT128_DW128(__UINT64_MAX__, -17014118);
+
+  k = vec_divsq_10e31 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128s(" divsq_10e31 ", (vi128_t)i);
+  print_vint128s("           = ", (vi128_t)k);
+#endif
+  rc += check_vuint128x ("vec_divsq_10e31:", (vui128_t)k, (vui128_t) e);
+
+  e = (vi128_t) CONST_VINT128_DW128 ( 0xffffffd4529ef0f0UL,
+				      0xdcee0dd700000000UL );
+  l = vec_modsq_10e31 (i, k);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128s(" modsq_10e31 ", (vi128_t)i);
+  print_vint128s("           q ", (vi128_t)k);
+  print_vint128s("           = ", (vi128_t)l);
+  print_vint128x("           = 0x", (vui128_t)l);
+#endif
+  rc += check_vuint128x ("vec_modsq_10e31:", (vui128_t)l, (vui128_t) e);
+
+  i = (vi128_t)CONST_VINT128_DW128(0x8000000000000000UL, 1);
+  e = (vi128_t)CONST_VINT128_DW128(__UINT64_MAX__, -17014118);
+
+  k = vec_divsq_10e31 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128s(" divsq_10e31 ", (vi128_t)i);
+  print_vint128s("           = ", (vi128_t)k);
+#endif
+  rc += check_vuint128x ("vec_divsq_10e31:", (vui128_t)k, (vui128_t) e);
+
+  e = (vi128_t) CONST_VINT128_DW128 ( 0xffffffd4529ef0f0UL,
+				      0xdcee0dd700000001UL );
+  l = vec_modsq_10e31 (i, k);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128s(" modsq_10e31 ", (vi128_t)i);
+  print_vint128s("           q ", (vi128_t)k);
+  print_vint128s("           = ", (vi128_t)l);
+  print_vint128x("           = 0x", (vui128_t)l);
+#endif
+  rc += check_vuint128x ("vec_modsq_10e31:", (vui128_t)l, (vui128_t) e);
+
+  i = (vi128_t) { -((__int128 )  1000000000000000UL
+                 * (__int128 ) 10000000000000000UL) };
+  e = (vi128_t) { -((__int128 ) 1UL) };
+
+  k = vec_divsq_10e31 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128s(" divsq_10e31 ", (vi128_t)i);
+  print_vint128s("           = ", (vi128_t)k);
+#endif
+  rc += check_vuint128x ("vec_divsq_10e31:", (vui128_t)k, (vui128_t) e);
+
+  e = (vi128_t) CONST_VINT128_DW128 ( 0UL,
+				       0UL );
+  l = vec_modsq_10e31 (i, k);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128s(" modsq_10e31 ", (vi128_t)i);
+  print_vint128s("           q ", (vi128_t)k);
+  print_vint128s("           = ", (vi128_t)l);
+  print_vint128x("           = 0x", (vui128_t)l);
+#endif
+  rc += check_vuint128x ("vec_modsq_10e31:", (vui128_t)l, (vui128_t) e);
+
+  i = (vi128_t) { -((__int128 )   999999999999999UL
+                  * (__int128 ) 10000000000000000UL
+		  + (__int128 )  9999999999999999UL)};
+  e = (vi128_t)CONST_VINT128_DW128(0, 0);
+
+  k = vec_divsq_10e31 (i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128s(" divsq_10e31 ", (vi128_t)i);
+  print_vint128s("           = ", (vi128_t)k);
+#endif
+  rc += check_vuint128x ("vec_divsq_10e31:", (vui128_t)k, (vui128_t) e);
+
+  e = (vi128_t) { -((__int128 )   999999999999999UL
+                  * (__int128 ) 10000000000000000UL
+		  + (__int128 )  9999999999999999UL)};
+  l = vec_modsq_10e31 (i, k);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128s(" modsq_10e31 ", (vi128_t)i);
+  print_vint128s("           q ", (vi128_t)k);
+  print_vint128s("           = ", (vi128_t)l);
+  print_vint128x("           = 0x", (vui128_t)l);
+#endif
+  rc += check_vuint128x ("vec_modsq_10e31:", (vui128_t)l, (vui128_t) e);
+
+  return (rc);
+}
+
 int
 test_vec_i128 (void)
 {
@@ -8716,6 +9070,10 @@ test_vec_i128 (void)
   rc += test_minsq ();
   rc += test_absduq ();
   rc += test_avguq ();
+
+  rc = test_div_moduq_e32 ();
+  rc = test_div_moduq_e31 ();
+  rc = test_div_modsq_e31 ();
 #if 0
   rc += test_time_i128();
 #endif

--- a/src/testsuite/vec_int128_dummy.c
+++ b/src/testsuite/vec_int128_dummy.c
@@ -649,7 +649,7 @@ test_cmul100ecuq (vui128_t *cout, vui128_t a, vui128_t cin)
 vui128_t
 test_vec_mul10uq_c (vui128_t *p, vui128_t a)
 {
-  *p = vec_mul10uq (a);
+  *p = vec_mul10cuq (a);
   return vec_mul10uq (a);
 }
 
@@ -833,6 +833,36 @@ __test_mulhuq2 (vui128_t a, vui128_t b)
   vui128_t mq, r;
   r = vec_muludq (&mq, a, b);
   return mq;
+}
+
+vi128_t
+__test_modsq_10e31  (vi128_t a, vi128_t b)
+{
+  return vec_modsq_10e31 (a, b);
+}
+
+vi128_t
+__test_remsq_10e31  (vi128_t a, vi128_t b)
+{
+  vi128_t q;
+  q = vec_divsq_10e31 (a);
+  return vec_modsq_10e31 (a, q);
+}
+
+vui128_t
+__test_remuq_10e31  (vui128_t a, vui128_t b)
+{
+  vui128_t q;
+  q = vec_divuq_10e31 (a);
+  return vec_moduq_10e31 (a, q);
+}
+
+vui128_t
+__test_remuq_10e32  (vui128_t a, vui128_t b)
+{
+  vui128_t q;
+  q = vec_divuq_10e32 (a);
+  return vec_moduq_10e32 (a, q);
 }
 
 #ifdef _ARCH_PWR8

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -1047,6 +1047,30 @@ test__vec_bcdaddcsq_PWR9 (vi128_t a, vi128_t b)
   return (t);
 }
 
+vi128_t
+__test_remsq_10e31_PWR9  (vi128_t a, vi128_t b)
+{
+  vi128_t q;
+  q = vec_divsq_10e31 (a);
+  return vec_modsq_10e31 (a, q);
+}
+
+vui128_t
+__test_remuq_10e31_PWR9  (vui128_t a, vui128_t b)
+{
+  vui128_t q;
+  q = vec_divuq_10e31 (a);
+  return vec_moduq_10e31 (a, q);
+}
+
+vui128_t
+__test_remuq_10e32_PWR9  (vui128_t a, vui128_t b)
+{
+  vui128_t q;
+  q = vec_divuq_10e32 (a);
+  return vec_moduq_10e32 (a, q);
+}
+
 void
 example_qw_convert_decimal_PWR9 (vui64_t *ten_16, vui128_t value)
 {


### PR DESCRIPTION
Added divide/modulo operations to to factor signed/unsigned vector
__int128 values to convert to BCD. The __int128 type can represent
integers up to 39 decimal digits while vector BCD can represent 31 (signed)
or 32 (unsigned) digits. The operations use the multiplicative inverse
to divide by 10**31 or 10*32) for the quotient. Then multiply and
subtract to isolate the remainder.

	*src/vec_int128_ppc.h (\subsection int128_examples_0_1_2):
	New Doxygen for "Converting Vector __int128 values to BCD".
	(\subsection int128_examples_0_1_3): Renumbered from
	\subsection int128_examples_0_1_2.
	(vec_divsq_10e31, vec_divuq_10e31, vec_divuq_10e32,
	vec_modsq_10e31, vec_moduq_10e31, vec_moduq_10e32):
	New Functions.

	* src/testsuite/arith128_test_i128.c (test_div_moduq_e32,
	test_div_moduq_e31, test_div_modsq_e31): New functions.
	(test_vec_i128): Add calls to the above new functions.

	* src/testsuite/arith128_print.h (print_vint128s): New extern.
	* src/testsuite/arith128_print.c (print_vint128s): New function
	to print vi128_t.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>