### PR TITLE
More vec_bcd_ppc.h add binary to BCD conversion:

### DIFF
--- a/src/testsuite/vec_bcd_dummy.c
+++ b/src/testsuite/vec_bcd_dummy.c
@@ -484,6 +484,7 @@ example_vec_cbcdecsq_loop (vBCD_t *cout, vBCD_t* out, vBCD_t* a, vBCD_t* b, long
 
   out[cnt-1] = vec_cbcdaddcsq (&c, a[cnt-1], b[cnt-1]);
 
+  cn = _BCD_CONST_ZERO;
   for (i = (cnt-2); i >= 0; i--)
     {
       out[i] = vec_cbcdaddecsq (&cn, a[i], b[i], c);
@@ -555,13 +556,13 @@ vui8_t
 test_vec_rdxct100b_0 (vui8_t vra)
 {
   vui8_t x10, c10, high_digit, low_digit;
-  // Isolated the low_digt
+  // Isolate the low_digit
   low_digit = vec_slbi (vra, 4);
   low_digit = vec_srbi (low_digit, 4);
   // Shift the high digit into the units position
   high_digit = vec_srbi (vra, 4);
   // multiply the high digit by 10
-  c10 = vec_splat_u8 ((unsigned char) 10);
+  c10 = vec_splats ((unsigned char) 10);
 #if (__GNUC__ > 7)
   x10 = vec_mul (high_digit, c10);
 #else
@@ -579,7 +580,7 @@ test_vec_rdxct100b_1 (vui8_t vra)
    * this is the isolated high digit multiplied by the radix difference
    * in binary.  For this stage we use 0x10 - 10 = 6.  */
   high_digit = vec_srbi (vra, 4);
-  c6 = vec_splat_u8 ((unsigned char) 0x06);
+  c6 = vec_splats ((unsigned char) (16-10));
 #if (__GNUC__ > 7)
   x6 = vec_mul (high_digit, c6);
 #else
@@ -615,19 +616,19 @@ test_vec_rdxct10e32q (vui64_t vra)
 }
 
 vBCD_t
-test_vec_bcdcfsq (vi128_t vra)
+__test_vec_bcdcfsq (vi128_t vra)
 {
   return vec_bcdcfsq (vra);
 }
 
 vBCD_t
-test_vec_bcdcfud (vui64_t vra)
+__test_vec_bcdcfud (vui64_t vra)
 {
   return vec_bcdcfud (vra);
 }
 
 vBCD_t
-test_vec_bcdcfuq (vui128_t vra)
+__test_vec_bcdcfuq (vui128_t vra)
 {
   return vec_bcdcfuq (vra);
 }

--- a/src/testsuite/vec_bcd_dummy.c
+++ b/src/testsuite/vec_bcd_dummy.c
@@ -32,6 +32,12 @@ test_unpack_Decimal128_cast (vBCD_t lval)
   return vec_unpack_Decimal128 ((vf64_t) lval);
 }
 
+vui64_t
+test_vec_BCD2BIN (vBCD_t val)
+{
+  return vec_BCD2BIN (val);
+}
+
 _Decimal128
 test_vec_BCD2DFP (vBCD_t val)
 {
@@ -513,6 +519,117 @@ example_bcdmul_2x2 (vBCD_t *__restrict__ mulu, vBCD_t m1h, vBCD_t m1l,
   mulu[1] = mplh;
   mulu[2] = mphl;
   mulu[3] = mphh;
+}
+
+vui8_t
+test_vec_rdxcf100b (vui8_t vra)
+{
+  return vec_rdxcf100b (vra);
+}
+
+vui8_t
+test_vec_rdxcf10kh (vui16_t vra)
+{
+  return vec_rdxcf10kh (vra);
+}
+
+vui16_t
+test_vec_rdxcf100mw (vui32_t vra)
+{
+  return vec_rdxcf100mw (vra);
+}
+
+vui32_t
+test_vec_rdxcf10E16d (vui64_t vra)
+{
+  return vec_rdxcf10E16d (vra);
+}
+
+vui64_t
+test_vec_rdxcf10e32q (vui128_t vra)
+{
+  return vec_rdxcf10e32q (vra);
+}
+
+vui8_t
+test_vec_rdxct100b_0 (vui8_t vra)
+{
+  vui8_t x10, c10, high_digit, low_digit;
+  // Isolated the low_digt
+  low_digit = vec_slbi (vra, 4);
+  low_digit = vec_srbi (low_digit, 4);
+  // Shift the high digit into the units position
+  high_digit = vec_srbi (vra, 4);
+  // multiply the high digit by 10
+  c10 = vec_splat_u8 ((unsigned char) 10);
+#if (__GNUC__ > 7)
+  x10 = vec_mul (high_digit, c10);
+#else
+  x10 = vec_mulubm (high_digit, c10);
+#endif
+  // add the low_digit to high_digit * 10.
+  return vec_add (x10, low_digit);
+}
+
+vui8_t
+test_vec_rdxct100b_1 (vui8_t vra)
+{
+  vui8_t x6, c6, high_digit;
+  /* Compute the high digit correction factor. For BCD to binary 100s
+   * this is the isolated high digit multiplied by the radix difference
+   * in binary.  For this stage we use 0x10 - 10 = 6.  */
+  high_digit = vec_srbi (vra, 4);
+  c6 = vec_splat_u8 ((unsigned char) 0x06);
+#if (__GNUC__ > 7)
+  x6 = vec_mul (high_digit, c6);
+#else
+  x6 = vec_mulubm (high_digit, c6);
+#endif
+  /* Subtract the high digit correction bytes from the original
+   * BCD bytes in binary.  This reduces byte range to 0-99. */
+  return vec_sub (vra, x6);
+}
+
+vui8_t
+test_vec_rdxct100b (vui8_t vra)
+{
+  return vec_rdxct100b (vra);
+}
+
+vui16_t
+test_vec_rdxct10kh (vui8_t vra)
+{
+  return vec_rdxct10kh (vra);
+}
+
+vui64_t
+test_vec_rdxct10E16d (vui32_t vra)
+{
+  return vec_rdxct10E16d (vra);
+}
+
+vui128_t
+test_vec_rdxct10e32q (vui64_t vra)
+{
+  return vec_rdxct10e32q (vra);
+}
+
+vBCD_t
+test_vec_bcdcfsq (vi128_t vra)
+{
+  return vec_bcdcfsq (vra);
+}
+
+vBCD_t
+test_vec_bcdcfud (vui64_t vra)
+{
+  return vec_bcdcfud (vra);
+}
+
+vBCD_t
+test_vec_bcdcfuq (vui128_t vra)
+{
+  return vec_bcdcfuq (vra);
 }
 
 #if (__GNUC__ > 4)

--- a/src/testsuite/vec_char_dummy.c
+++ b/src/testsuite/vec_char_dummy.c
@@ -12,8 +12,8 @@
 
 #include "vec_char_ppc.h"
 
-#if __GNUC__ >= 8
-/* Generic vec_mul not supported for vector char until GCC 8.  */
+#if __GNUC__ >= 7
+/* Generic vec_mul not supported for vector char until GCC 7.  */
 vui8_t
 __test_mulubm_gcc (vui8_t __A, vui8_t __B)
 {

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -1045,6 +1045,7 @@ example_vec_cbcdecsq_loop_PWR9 (vBCD_t *cout, vBCD_t* out, vBCD_t* a, vBCD_t* b,
 
   out[cnt - 1] = vec_cbcdaddcsq (&c, a[cnt - 1], b[cnt - 1]);
 
+  cn = _BCD_CONST_ZERO;
   for (i = (cnt - 2); i >= 0; i--)
     {
       out[i] = vec_cbcdaddecsq (&cn, a[i], b[i], c);

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -1090,6 +1090,42 @@ test__vec_bcdaddcsq2_PWR9 (vi128_t a, vi128_t b)
   return (t);
 }
 
+vui64_t
+test_vec_rdxct10E16d_PWR9 (vui32_t vra)
+{
+  return vec_rdxct10E16d (vra);
+}
+
+vui128_t
+test_vec_rdxct10e32q_PWR9 (vui64_t vra)
+{
+  return vec_rdxct10e32q (vra);
+}
+
+vui32_t
+test_vec_rdxcf10E16d_PWR9 (vui64_t vra)
+{
+  return vec_rdxcf10E16d (vra);
+}
+
+vui64_t
+test_vec_rdxcf10e32q_PWR9 (vui128_t vra)
+{
+  return vec_rdxcf10e32q (vra);
+}
+
+vBCD_t
+test_vec_bcdcfsq_PWR9 (vi128_t vra)
+{
+  return vec_bcdcfsq (vra);
+}
+
+vBCD_t
+test_vec_bcdcfuq_PWR9 (vui128_t vra)
+{
+  return vec_bcdcfuq (vra);
+}
+
 vi128_t
 __test_remsq_10e31_PWR9  (vi128_t a, vi128_t b)
 {

--- a/src/vec_char_ppc.h
+++ b/src/vec_char_ppc.h
@@ -589,10 +589,15 @@ vec_mulhub (vui8_t vra, vui8_t vrb)
 static inline vui8_t
 vec_mulubm (vui8_t vra, vui8_t vrb)
 {
+#if __GNUC__ >= 7
+/* Generic vec_mul not supported for vector char until GCC 7.  */
+  return vec_mul (vra, vrb);
+#else
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   return vec_mrgalb (vec_mulo (vra, vrb), vec_mule (vra, vrb));
 #else
   return vec_mrgalb (vec_mule (vra, vrb), vec_mulo (vra, vrb));
+#endif
 #endif
 }
 


### PR DESCRIPTION
Add compile tests for new operations.

	* src/testsuite/vec_bcd_dummy.c (test_vec_BCD2BIN):
	New function.
	(test_vec_rdxcf100b, test_vec_rdxcf10kh, test_vec_rdxcf100mw,
	test_vec_rdxcf10E16d, test_vec_rdxcf10e32q): New functions.
	(test_vec_rdxct100b_0, test_vec_rdxct100b_1): New functions.
	(test_vec_rdxct100b, test_vec_rdxct10kh, test_vec_rdxct10E16d,
	test_vec_rdxct10e32q, test_vec_bcdcfsq, test_vec_bcdcfud,
	test_vec_bcdcfuq): New functions.

	* src/testsuite/vec_char_dummy.c
	(__test_mulubm_gcc [__GNUC__ >= 7]): Compile vec_mul generic.

	* src/testsuite/vec_pwr9_dummy.c (test_vec_rdxct10E16d_PWR9,
	test_vec_rdxct10e32q_PWR9, test_vec_rdxcf10E16d_PWR9,
	test_vec_rdxcf10e32q_PWR9, test_vec_bcdcfsq_PWR9,
	test_vec_bcdcfuq_PWR9): New functions.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>