### PR TITLE
Add long division factoring support to vec_int128_ppc.h:

### DIFF
--- a/src/testsuite/vec_bcd_dummy.c
+++ b/src/testsuite/vec_bcd_dummy.c
@@ -522,6 +522,31 @@ example_bcdmul_2x2 (vBCD_t *__restrict__ mulu, vBCD_t m1h, vBCD_t m1l,
   mulu[3] = mphh;
 }
 
+// Convert extended quadword binary to BCD 32-digits at a time.
+vBCD_t
+example_longbcdcf_10e32 (vui128_t *q, vui128_t *d, long int _N)
+{
+  vui128_t dn, qh, ql, rh;
+  long int i;
+
+  // init step for the top digits
+  dn = d[0];
+  qh = vec_divuq_10e32 (dn);
+  rh = vec_moduq_10e32 (dn, qh);
+  q[0] = qh;
+
+  // now we know the remainder is less than the divisor.
+  for (i=1; i<_N; i++)
+    {
+      dn = d[i];
+      ql = vec_divudq_10e32 (&qh, rh, dn);
+      rh = vec_modudq_10e32 (rh, dn, &ql);
+      q[i] = ql;
+    }
+  // convert to BCD and return the remainder for this step
+  return vec_bcdcfuq (rh);
+}
+
 vui8_t
 test_vec_rdxcf100b (vui8_t vra)
 {

--- a/src/testsuite/vec_int128_dummy.c
+++ b/src/testsuite/vec_int128_dummy.c
@@ -865,6 +865,34 @@ __test_remuq_10e32  (vui128_t a, vui128_t b)
   return vec_moduq_10e32 (a, q);
 }
 
+vui128_t
+__test_divudq_10e31  (vui128_t *qh, vui128_t a, vui128_t b)
+{
+  return vec_divudq_10e31 (qh, a, b);
+}
+
+vui128_t
+__test_divudq_10e32  (vui128_t *qh, vui128_t a, vui128_t b)
+{
+  return vec_divudq_10e32 (qh, a, b);
+}
+
+vui128_t
+__test_remudq_10e31  (vui128_t a, vui128_t b)
+{
+  vui128_t q, qh;
+  q = vec_divudq_10e31 (&qh, a, b);
+  return vec_modudq_10e31 (a, b, &q);
+}
+
+vui128_t
+__test_remudq_10e32  (vui128_t a, vui128_t b)
+{
+  vui128_t q, qh;
+  q = vec_divudq_10e32 (&qh, a, b);
+  return vec_modudq_10e32 (a, b, &q);
+}
+
 #ifdef _ARCH_PWR8
 vui128_t
 test_vec_subq (vui128_t a, vui128_t b)
@@ -1049,6 +1077,54 @@ example_dw_convert_timebase (vui64_t *tb, vui32_t *timespec, int n)
        * So pack results and store the timespec.  */
       *timespec++ = vec_vpkudum (timespec1, timespec2);
     }
+}
+
+vui128_t
+example_longdiv_10e31 (vui128_t *q, vui128_t *d, long int _N)
+{
+  vui128_t dn, qh, ql, rh;
+  long int i;
+
+  // init step for the top digits
+  dn = d[0];
+  qh = vec_divuq_10e31 (dn);
+  rh = vec_moduq_10e31 (dn, qh);
+  q[0] = qh;
+
+  // now we know the remainder is less than the divisor.
+  for (i=1; i<_N; i++)
+    {
+      dn = d[i];
+      ql = vec_divudq_10e31 (&qh, rh, dn);
+      rh = vec_modudq_10e31 (rh, dn, &ql);
+      q[i] = ql;
+    }
+  // return the final remainder
+  return rh;
+}
+
+vui128_t
+example_longdiv_10e32 (vui128_t *q, vui128_t *d, long int _N)
+{
+  vui128_t dn, qh, ql, rh;
+  long int i;
+
+  // init step for the top digits
+  dn = d[0];
+  qh = vec_divuq_10e32 (dn);
+  rh = vec_moduq_10e32 (dn, qh);
+  q[0] = qh;
+
+  // now we know the remainder is less than the divisor.
+  for (i=1; i<_N; i++)
+    {
+      dn = d[i];
+      ql = vec_divudq_10e32 (&qh, rh, dn);
+      rh = vec_modudq_10e32 (rh, dn, &ql);
+      q[i] = ql;
+    }
+  // return the final remainder
+  return rh;
 }
 
 /* alternative algorithms tested and not selected due to code size

--- a/src/testsuite/vec_int16_dummy.c
+++ b/src/testsuite/vec_int16_dummy.c
@@ -123,7 +123,7 @@ __test_mod10 (vui16_t n)
   vui16_t magic = vec_splats ((unsigned short) 52429);
   vui16_t c_10 = vec_splats ((unsigned short) 10);
   const int s = 3;
-  vui16_t tmp, rem, q_10;
+  vui16_t tmp, q_10;
 
   q = vec_mulhuh (magic, n);
   q_10 = vec_srhi (q, s);
@@ -139,7 +139,6 @@ __test_div10000 (vui16_t n)
   /* M= 41839, a=1, s=14 */
   vui16_t magic = vec_splats ((unsigned short) 41839);
   const int s = 14;
-  vui16_t tmp, rem;
 
   q = vec_mulhuh (magic, n);
     {

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -1019,6 +1019,12 @@ test_vec_cbcdaddecsq2_PWR9 (vBCD_t *co, vBCD_t a, vBCD_t b, vBCD_t c)
 }
 
 vui128_t
+test_vec_bcdctuq_PWR9 (vBCD_t vra)
+{
+  return vec_bcdctuq (vra);
+}
+
+vui128_t
 example_vec_bcdctuq_PWR9 (vui8_t vra)
 {
   vui8_t d100;
@@ -1258,6 +1264,114 @@ example_longdiv_10e31_PWR9 (vui128_t *q, vui128_t *d, long int _N)
     }
 
   return rh;
+}
+
+long int
+example_longbcdct_10e32_PWR9 (vui128_t *d, vBCD_t decimal, long int _C , long int _N)
+{
+  /* ten32  = +100000000000000000000000000000000UQ  */
+  const vui128_t ten32 = (vui128_t)
+	  { (__int128) 10000000000000000UL * (__int128) 10000000000000000UL };
+  const vui128_t zero = (vui128_t) { (__int128) 0UL };
+  vui128_t dn, ph, pl, cn, c;
+  long int i, cnt;
+
+  cnt = _C;
+
+  dn = zero;
+  cn  = zero;
+  if ( cnt == 0 )
+    {
+      if (vec_cmpuq_all_ne ((vui128_t) decimal, zero))
+	{
+	  cnt++;
+	  dn = vec_bcdctuq (decimal);
+	}
+
+      for ( i = 0; i < (_N - 1); i++ )
+	{
+	  d[i] = zero;
+	}
+      d[_N - cnt] = dn;
+    }
+  else
+    {
+      if (vec_cmpuq_all_ne ((vui128_t) decimal, zero))
+	{
+	  dn = vec_bcdctuq (decimal);
+	}
+      for ( i = (_N - 1); i >= (_N - cnt); i--)
+	{
+	  pl = vec_muludq (&ph, d[i], ten32);
+
+	  c = vec_addecuq (pl, dn, cn);
+	  d[i] = vec_addeuqm (pl, dn, cn);
+	  cn = c;
+	  dn = ph;
+	}
+      if (vec_cmpuq_all_ne (dn, zero) || vec_cmpuq_all_ne (cn, zero))
+	{
+	  cnt++;
+	  dn = vec_adduqm (dn, cn);
+	  d[_N - cnt] = dn;
+	}
+    }
+
+  return cnt;
+}
+
+long int
+example_longbcdct_10e31_PWR9 (vui128_t *d, vBCD_t decimal, long int _C,
+			      long int _N)
+{
+  const vui128_t ten31 = (vui128_t)
+	  { (__int128) 1000000000000000UL * (__int128) 10000000000000000UL };
+  const vui128_t zero = (vui128_t) { (__int128) 0UL };
+  vui128_t dn, ph, pl, cn, c;
+  long int i, cnt;
+
+  cnt = _C;
+
+  dn = zero;
+  cn = zero;
+  if (cnt == 0)
+    {
+      if (vec_cmpuq_all_ne ((vui128_t) decimal, zero))
+	{
+	  cnt++;
+	  dn = (vui128_t) vec_bcdctsq (decimal);
+	}
+
+      for (i = 0; i < (_N - 1); i++)
+	{
+	  d[i] = zero;
+	}
+      d[_N - cnt] = dn;
+    }
+  else
+    {
+      if (vec_cmpuq_all_ne ((vui128_t) decimal, zero))
+	{
+	  dn = (vui128_t) vec_bcdctsq (decimal);
+	}
+      for ( i = (_N - 1); i >= (_N - cnt); i--)
+	{
+	  pl = vec_muludq (&ph, d[i], ten31);
+
+	  c = vec_addecuq (pl, dn, cn);
+	  d[i] = vec_addeuqm (pl, dn, cn);
+	  cn = c;
+	  dn = ph;
+	}
+      if (vec_cmpuq_all_ne (dn, zero) || vec_cmpuq_all_ne (cn, zero))
+	{
+	  cnt++;
+	  dn = vec_adduqm (dn, cn);
+	  d[_N - cnt] = dn;
+	}
+    }
+
+  return cnt;
 }
 
 void

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -1151,6 +1151,34 @@ __test_remuq_10e32_PWR9  (vui128_t a, vui128_t b)
   return vec_moduq_10e32 (a, q);
 }
 
+vui128_t
+__test_divudq_10e31_PWR9  (vui128_t *qh, vui128_t a, vui128_t b)
+{
+  return vec_divudq_10e31 (qh, a, b);
+}
+
+vui128_t
+__test_divudq_10e32_PWR9  (vui128_t *qh, vui128_t a, vui128_t b)
+{
+  return vec_divudq_10e32 (qh, a, b);
+}
+
+vui128_t
+__test_remudq_10e31_PWR9  (vui128_t a, vui128_t b)
+{
+  vui128_t q, qh;
+  q = vec_divudq_10e31 (&qh, a, b);
+  return vec_modudq_10e31 (a, b, &q);
+}
+
+vui128_t
+__test_remudq_10e32_PWR9  (vui128_t a, vui128_t b)
+{
+  vui128_t q, qh;
+  q = vec_divudq_10e32 (&qh, a, b);
+  return vec_modudq_10e32 (a, b, &q);
+}
+
 void
 example_qw_convert_decimal_PWR9 (vui64_t *ten_16, vui128_t value)
 {
@@ -1206,6 +1234,30 @@ example_qw_convert_decimal_PWR9 (vui64_t *ten_16, vui128_t value)
   ten_16[1] = (vui64_t) tmpq[VEC_DW_L];
   // return low 16 digits
   ten_16[2] = (vui64_t) tmpr[VEC_DW_L];
+}
+
+vui128_t
+example_longdiv_10e31_PWR9 (vui128_t *q, vui128_t *d, long int _N)
+{
+  vui128_t dn, qh, ql, rh;
+  long int i;
+
+  // init step for the top digits
+  dn = d[0];
+  qh = vec_divuq_10e31 (dn);
+  rh = vec_moduq_10e31 (dn, qh);
+  q[0] = qh;
+
+  // now we know the remainder is less than the divisor.
+  for (i=1; i<_N; i++)
+    {
+      dn = d[i];
+      ql = vec_divudq_10e31 (&qh, rh, dn);
+      rh = vec_modudq_10e31 (rh, dn, &ql);
+      q[i] = ql;
+    }
+
+  return rh;
 }
 
 void


### PR DESCRIPTION
Enable extended quadword long division by constant powers of 10.
Addition compile tests and examples. Some examples are used as
performance tests.

	* src/testsuite/vec_bcd_dummy.c (example_longbcdcf_10e32):
	New function.

	* src/testsuite/vec_int128_dummy.c (__test_divudq_10e31,
	__test_divudq_10e32, __test_remudq_10e31, __test_remudq_10e32):
	New function.
	(example_longdiv_10e31, example_longdiv_10e32):
	New example functions.

	* src/testsuite/vec_pwr9_dummy.c (__test_divudq_10e31_PWR9,
	__test_divudq_10e32_PWR9, __test_remudq_10e31_PWR9,
	__test_remudq_10e32_PWR9): New functions.
	(example_longdiv_10e31_PWR9): New example functions.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>