### PR TITLE
Add long division factoring support to vec_int128_ppv.h:

### DIFF
--- a/src/testsuite/arith128_test_i128.c
+++ b/src/testsuite/arith128_test_i128.c
@@ -783,7 +783,6 @@ db_vec_divudq_10e31 (vui128_t *qh, vui128_t vra, vui128_t vrb)
 #endif
       c = vec_addcuq (q1, q);
       q = vec_adduqm (q1, q);
-//  c2 = vec_addcuq (q2, c);
       q1 = vec_adduqm (t, c);
 #ifdef __DEBUG_PRINT__
       print_vint128x (" q         ", (vui128_t) q1);

--- a/src/testsuite/arith128_test_i128.c
+++ b/src/testsuite/arith128_test_i128.c
@@ -6041,18 +6041,46 @@ test_time_i128 (void)
   printf ("\n%s longbcdcf_10e32 tb delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
 	  delta_sec);
 
-  printf ("\n%s maxdouble_10e32 start, ...\n", __FUNCTION__);
+  printf ("\n%s longbcdct_10e32 start, ...\n", __FUNCTION__);
   t_start = __builtin_ppc_get_timebase ();
   for (i = 0; i < TIME_10_ITERATION; i++)
     {
-      rc += timed_maxdouble_10e32 ();
+      rc += timed_longbcdct_10e32 ();
     }
   t_end = __builtin_ppc_get_timebase ();
   t_delta = t_end - t_start;
   delta_sec = TimeDeltaSec (t_delta);
 
-  printf ("\n%s maxdouble_10e32 end", __FUNCTION__);
-  printf ("\n%s maxdouble_10e32 delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
+  printf ("\n%s longbcdct_10e32 end", __FUNCTION__);
+  printf ("\n%s longbcdct_10e32 tb delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
+	  delta_sec);
+
+  printf ("\n%s cfmaxdouble_10e32 start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIME_10_ITERATION; i++)
+    {
+      rc += timed_cfmaxdouble_10e32 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s cfmaxdouble_10e32 end", __FUNCTION__);
+  printf ("\n%s cfmaxdouble_10e32 delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
+	  delta_sec);
+
+  printf ("\n%s ctmaxdouble_10e32 start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIME_10_ITERATION; i++)
+    {
+      rc += timed_ctmaxdouble_10e32 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s ctmaxdouble_10e32 end", __FUNCTION__);
+  printf ("\n%s ctmaxdouble_10e32 delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
 	  delta_sec);
 
   return (rc);

--- a/src/testsuite/pveclib_test.c
+++ b/src/testsuite/pveclib_test.c
@@ -69,7 +69,9 @@ main (void)
 #if 1
   rc += test_vec_f64 ();
 #endif
+#if 1
   rc += test_vec_f128 ();
+#endif
 
   if (rc > 0)
     printf ("%d failures reported\n", rc);


### PR DESCRIPTION
Enable extended quadword long division by constant powers of 10.
Additional unit tests.

	* src/testsuite/arith128_test_i128.c (db_vec_divudq_10e31,
	db_vec_modudq_10e31, db_example_longdiv_10e31):
	New debug functions.
	(test_time_i128): Add timed tests; timed_longdiv_e32,
	timed_longbcdcf_10e32, timed_maxdouble_10e32.
	(test_div_moduq_e32, test_div_modsq_e31) remove unused
	variables.
	(test_div_modudq_e31, test_longdiv_e31, test_longdiv_e32):
	New unit test functions.
	(test_vec_i128): Add calls to new units tests above.

	* src/testsuite/pveclib_test.c: Minor update.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>