### PR TITLE
Fix vec_f128_ppc.h and dummmy for older compilers & without -mfloat128:

### DIFF
--- a/src/pveclib/vec_f128_ppc.h
+++ b/src/pveclib/vec_f128_ppc.h
@@ -517,7 +517,7 @@ vec_absf128 (__binary128 f128)
 static inline int
 vec_all_isfinitef128 (__binary128 f128)
 {
-#if defined (_ARCH_PWR9) && defined (scalar_test_data_class)
+#if defined (_ARCH_PWR9) && defined (scalar_test_data_class) && defined (__FLOAT128__) && (__GNUC__ > 7)
   return !scalar_test_data_class (f128, 0x70);
 #else
   vui32_t tmp, t128;
@@ -550,7 +550,7 @@ vec_all_isfinitef128 (__binary128 f128)
 static inline int
 vec_all_isinff128 (__binary128 f128)
 {
-#if defined (_ARCH_PWR9) && defined (scalar_test_data_class)
+#if defined (_ARCH_PWR9) && defined (scalar_test_data_class) && defined (__FLOAT128__) && (__GNUC__ > 7)
   return scalar_test_data_class (f128, 0x30);
 #else
   vui32_t tmp;
@@ -585,7 +585,7 @@ vec_all_isinff128 (__binary128 f128)
 static inline int
 vec_all_isnanf128 (__binary128 f128)
 {
-#if defined (_ARCH_PWR9) && defined (scalar_test_data_class)
+#if defined (_ARCH_PWR9) && defined (scalar_test_data_class) && defined (__FLOAT128__) && (__GNUC__ > 7)
   return scalar_test_data_class (f128, 0x40);
 #else
   vui32_t tmp, tmp2, t128;
@@ -623,7 +623,7 @@ vec_all_isnanf128 (__binary128 f128)
 static inline int
 vec_all_isnormalf128 (__binary128 f128)
 {
-#if defined (_ARCH_PWR9) && defined (scalar_test_data_class)
+#if defined (_ARCH_PWR9) && defined (scalar_test_data_class) && defined (__FLOAT128__) && (__GNUC__ > 7)
   return !scalar_test_data_class (f128, 0x7f);
 #else
   vui32_t tmp, t128;
@@ -659,7 +659,7 @@ vec_all_isnormalf128 (__binary128 f128)
 static inline int
 vec_all_issubnormalf128 (__binary128 f128)
 {
-#if defined (_ARCH_PWR9) && defined (scalar_test_data_class)
+#if defined (_ARCH_PWR9) && defined (scalar_test_data_class) && defined (__FLOAT128__) && (__GNUC__ > 7)
   return scalar_test_data_class (f128, 0x03);
 #else
   const vui64_t minnorm = CONST_VINT128_DW(0x0001000000000000UL, 0UL);
@@ -694,7 +694,7 @@ vec_all_issubnormalf128 (__binary128 f128)
 static inline int
 vec_all_iszerof128 (__binary128 f128)
 {
-#if defined (_ARCH_PWR9) && defined (scalar_test_data_class)
+#if defined (_ARCH_PWR9) && defined (scalar_test_data_class) && defined (__FLOAT128__) && (__GNUC__ > 7)
   return scalar_test_data_class (f128, 0x0c);
 #else
   vui64_t tmp2;
@@ -816,7 +816,7 @@ vec_const_nansf128 ()
 static inline vb128_t
 vec_isfinitef128 (__binary128 f128)
 {
-#if defined (_ARCH_PWR9) && defined (scalar_test_data_class)
+#if defined (_ARCH_PWR9) && defined (scalar_test_data_class) && defined (__FLOAT128__) && (__GNUC__ > 7)
   vui32_t result = CONST_VINT128_W(-1, -1, -1, -1);
 
   if (scalar_test_data_class (f128, 0x70))
@@ -863,7 +863,7 @@ static inline int
 vec_isinf_signf128 (__binary128 f128)
 {
   int result;
-#if defined (_ARCH_PWR9) && defined (scalar_test_data_class)
+#if defined (_ARCH_PWR9) && defined (scalar_test_data_class) && defined (__FLOAT128__) && (__GNUC__ > 7)
   if (scalar_test_data_class (f128, 0x20))
     result = 1;
   else if (scalar_test_data_class (f128, 0x10))
@@ -912,7 +912,7 @@ vec_isinf_signf128 (__binary128 f128)
 static inline vb128_t
 vec_isinff128 (__binary128 f128)
 {
-#if defined (_ARCH_PWR9) && defined (scalar_test_data_class)
+#if defined (_ARCH_PWR9) && defined (scalar_test_data_class) && defined (__FLOAT128__) && (__GNUC__ > 7)
   vui32_t result = CONST_VINT128_W(0, 0, 0, 0);
 
   if (scalar_test_data_class (f128, 0x30))
@@ -955,7 +955,7 @@ vec_isinff128 (__binary128 f128)
 static inline vb128_t
 vec_isnanf128 (__binary128 f128)
 {
-#if defined (_ARCH_PWR9) && defined (scalar_test_data_class)
+#if defined (_ARCH_PWR9) && defined (scalar_test_data_class) && defined (__FLOAT128__) && (__GNUC__ > 7)
   vui32_t result = CONST_VINT128_W(0, 0, 0, 0);
 
   if (scalar_test_data_class (f128, 0x40))
@@ -995,7 +995,7 @@ vec_isnanf128 (__binary128 f128)
 static inline vb128_t
 vec_isnormalf128 (__binary128 f128)
 {
-#if defined (_ARCH_PWR9) && defined (scalar_test_data_class)
+#if defined (_ARCH_PWR9) && defined (scalar_test_data_class) && defined (__FLOAT128__) && (__GNUC__ > 7)
   vui32_t result = CONST_VINT128_W(-1, -1, -1, -1);
 
   if (scalar_test_data_class (f128, 0x7f))
@@ -1040,7 +1040,7 @@ vec_isnormalf128 (__binary128 f128)
 static inline vb128_t
 vec_issubnormalf128 (__binary128 f128)
 {
-#if defined (_ARCH_PWR9) && defined (scalar_test_data_class)
+#if defined (_ARCH_PWR9) && defined (scalar_test_data_class) && defined (__FLOAT128__) && (__GNUC__ > 7)
   vui32_t result = CONST_VINT128_W(0, 0, 0, 0);
 
   if (scalar_test_data_class (f128, 0x03))
@@ -1083,7 +1083,7 @@ vec_issubnormalf128 (__binary128 f128)
 static inline vb128_t
 vec_iszerof128 (__binary128 f128)
 {
-#if defined (_ARCH_PWR9) && defined (scalar_test_data_class)
+#if defined (_ARCH_PWR9) && defined (scalar_test_data_class) && defined (__FLOAT128__) && (__GNUC__ > 7)
   vui32_t result = CONST_VINT128_W(0, 0, 0, 0);
 
   if (scalar_test_data_class (f128, 0x0c))

--- a/src/testsuite/vec_f128_dummy.c
+++ b/src/testsuite/vec_f128_dummy.c
@@ -153,11 +153,17 @@ __binary128
 test_sinf128 (__binary128 value)
   {
     __binary128 result;
+#ifdef __FLOAT128__
+    // requires -mfloat128 to use Q const
+    const __binary128 zeroF128 = 0.0Q;
+#else
+    const __binary128 zeroF128 = (__binary128)CONST_VINT128_W(0, 0, 0, 0);
+#endif
 
     if (vec_all_isnormalf128 (value))
       {
 	/* body of vec_sin() computation elided for this example.  */
-	result = 0.0q;
+	result = zeroF128;
       }
     else
       {
@@ -180,15 +186,23 @@ __binary128
 test_cosf128 (__binary128 value)
   {
     __binary128 result;
+#ifdef __FLOAT128__
+    // requires -mfloat128 to use Q const
+    const __binary128 zeroF128 = 0.0Q;
+    const __binary128 oneF128 = 1.0Q;
+#else
+    const __binary128 zeroF128 = (__binary128)CONST_VINT128_W(0, 0, 0, 0);
+    const __binary128 oneF128 = (__binary128)CONST_VINT128_W(0x3fff0000, 0, 0, 0);
+#endif
 
     if (vec_all_isfinitef128 (value))
       {
 	if (vec_all_iszerof128 (value))
-	  result = 1.0Q;
+	  result = oneF128;
 	else
 	  {
 	    /* body of vec_cos() computation elided for this example.  */
-	    result = 0.0q;
+            result = zeroF128;
 	  }
       }
     else
@@ -245,7 +259,7 @@ _test_xfer_bin128_2_vui16t (__binary128 f128)
   return vec_xfer_bin128_2_vui16t (f128);
 }
 
-#ifdef __FLOAT128_TYPE__
+#ifdef __FLOAT128__
 /* Mostly compiler and library tests follow to see what the various
  * compilers will do.  */
 

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -648,11 +648,17 @@ __binary128
 test_sinf128_PWR9 (__binary128 value)
   {
     __binary128 result;
+#ifdef __FLOAT128__
+    // requires -mfloat128 to use Q const
+    const __binary128 zeroF128 = 0.0Q;
+#else
+    const __binary128 zeroF128 = (__binary128)CONST_VINT128_W(0, 0, 0, 0);
+#endif
 
     if (vec_all_isnormalf128 (value))
       {
 	/* body of vec_sin() computation elided for this example.  */
-	result = 0.0q;
+	result = zeroF128;
       }
     else
       {
@@ -675,15 +681,23 @@ __binary128
 test_cosf128_PWR9 (__binary128 value)
   {
     __binary128 result;
+#ifdef __FLOAT128__
+    // requires -mfloat128 to use Q const
+    const __binary128 zeroF128 = 0.0Q;
+    const __binary128 oneF128 = 1.0Q;
+#else
+    const __binary128 zeroF128 = (__binary128)CONST_VINT128_W(0, 0, 0, 0);
+    const __binary128 oneF128 = (__binary128)CONST_VINT128_W(0x3fff0000, 0, 0, 0);
+#endif
 
     if (vec_all_isfinitef128 (value))
       {
 	if (vec_all_iszerof128 (value))
-	  result = 1.0q;
+	  result = oneF128;
 	else
 	  {
 	    /* body of vec_cos() computation elided for this example.  */
-	    result = 0.0q;
+            result = zeroF128;
 	  }
       }
     else
@@ -713,12 +727,13 @@ __test_cmpneud_PWR9 (vui64_t a, vui64_t b)
 #endif
 
 #ifdef scalar_test_data_class
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
 int
 __test_scalar_test_data_class_f128 (__binary128 val)
 {
   return scalar_test_data_class (val, 0x7f);
 }
-
+#endif
 int
 __test_scalar_test_data_class_f64 (double val)
 {
@@ -733,20 +748,23 @@ __test_scalar_test_data_class_f32 (float val)
 #endif
 
 #ifdef scalar_test_neg
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
 int
 __test_scalar_test_neg (__ieee128 val)
 {
   return scalar_test_neg (val);
 }
 #endif
+#endif
 
 #ifdef scalar_extract_exp
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
 long long int
 __test_scalar_extract_exp_f128 (__ieee128 val)
 {
   return scalar_extract_exp (val);
 }
-
+#endif
 int
 __test_scalar_extract_exp_f64 (double val)
 {
@@ -755,12 +773,13 @@ __test_scalar_extract_exp_f64 (double val)
 #endif
 
 #ifdef scalar_extract_sig
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
 __int128
 __test_scalar_extract_sig_f128 (__ieee128 val)
 {
   return scalar_extract_sig (val);
 }
-
+#endif
 long long int
 __test_scalar_extract_sig_f64 (double val)
 {
@@ -769,12 +788,13 @@ __test_scalar_extract_sig_f64 (double val)
 #endif
 
 #ifdef scalar_insert_exp
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
 __ieee128
 __test_scalar_insert_exp_f128 (__ieee128 sig, unsigned long long int exp)
 {
   return scalar_insert_exp (sig, exp);
 }
-
+#endif
 double
 __test_scalar_insert_exp_f64 (double sig, unsigned long long int exp)
 {


### PR DESCRIPTION
Float128 support is work in progress and Distro toolchains do not
include all Float128 backports provided by the Advance Toolchain.
So PVECLIB f128 operations that compile with AT may not compile with
the distro toolchain of the same GCC version.
This would be dissapointing for distros that claim power9 support.
This patch set insures that the Ubuntu 18.04 LTS toolchain can compile
and execute all pveclib vec_f128_ppc.h operations for -mcpu=power8/9.

	*src/vec_f128_ppc.h (vec_all_isfinitef128, vec_all_isinff128,
	vec_all_isnanf128, vec_all_isnormalf128,
	vec_all_issubnormalf128, vec_all_iszerof128, vec_isfinitef128,
	vec_isinf_signf128, vec_isinff128, vec_isnanf128,
	vec_isnormalf128, vec_issubnormalf128, vec_iszerof128):
	Add constrains "&& defined (__FLOAT128__) && (__GNUC__ > 7)"
	before using scalar builtins.

	* src/testsuite/vec_f128_dummy.c (test_sinf128 [__FLOAT128__]):
	Avoid 'Q' suffix floating-point constances if __FLOAT128__ is
	not defined. This requires compiler operation -mfloat128.
	(test_cosf128 [__FLOAT128__]):
	Avoid 'Q' suffix floating-point constances if __FLOAT128__ is
	not defined. This requires compiler operation -mfloat128.

	* src/testsuite/vec_pwr9_dummy.c
	(test_sinf128_PWR9 [__FLOAT128__]):
	Avoid 'Q' suffix floating-point constances if __FLOAT128__ is
	not defined. This requires compiler operation -mfloat128.
	(test_cosf128_PWR9 [__FLOAT128__]):
	Avoid 'Q' suffix floating-point constances if __FLOAT128__ is
	not defined. This requires compiler operation -mfloat128.

Signed-off-by: Steven Munroe <munroesj52.gmail.com>