### PR TITLE
Test falures while testing Fedora 30 and GCC 9 compiler.

### DIFF
--- a/src/pveclib/vec_bcd_ppc.h
+++ b/src/pveclib/vec_bcd_ppc.h
@@ -1830,24 +1830,17 @@ vec_bcdaddcsq (vBCD_t a, vBCD_t b)
 {
   vBCD_t t;
 #if defined ( _ARCH_PWR8) && (__GNUC__ > 6)
-  vBCD_t a_b;
 #ifdef _ARCH_PWR9
   // Generate BCD zero from (a - a), which is 3 cycles on PWR9
   t = vec_bcdsub (a,  a);
 #else // Else load a BCD const 0.
   t = _BCD_CONST_ZERO;
 #endif
-  a_b = vec_bcdadd (a, b);
   if (__builtin_expect (__builtin_bcdadd_ov ((vi128_t) a, (vi128_t) b, 0), 0))
     {
-#ifdef _ARCH_PWR9
+      vBCD_t a_b;
+      a_b = vec_bcdadd (a, b);
       t = vec_bcdcpsgn (_BCD_CONST_PLUS_ONE, a_b);
-#else
-      if (__builtin_bcdadd_gt ((vi128_t) a, (vi128_t) b, 0))
-        t = _BCD_CONST_PLUS_ONE;
-      else
-        t = _BCD_CONST_MINUS_ONE;
-#endif
     }
 #else
   _Decimal128 d_a, d_b, d_s, d_t;
@@ -3504,17 +3497,10 @@ vec_bcdsubcsq (vBCD_t a, vBCD_t b)
 #else // Else load a BCD const 0.
   t = _BCD_CONST_ZERO;
 #endif
-  a_b = vec_bcdsub (a, b);
   if (__builtin_expect (__builtin_bcdsub_ov ((vi128_t) a, (vi128_t) b, 0), 0))
     {
-#ifdef _ARCH_PWR9
+      a_b = vec_bcdsub (a, b);
       t = vec_bcdcpsgn (_BCD_CONST_PLUS_ONE, a_b);
-#else
-      if (__builtin_bcdsub_gt ((vi128_t) a, (vi128_t) b, 0))
-        t = _BCD_CONST_PLUS_ONE;
-      else
-        t = _BCD_CONST_MINUS_ONE;
-#endif
     }
 #else
   const vui32_t mz = CONST_VINT128_W (0, 0, 0, 0x0000000d);

--- a/src/testsuite/arith128_print.c
+++ b/src/testsuite/arith128_print.c
@@ -707,9 +707,17 @@ print_vint384 (char *prefix, vui128_t val0_128, vui128_t val1_128,
   vui32_t val0 = (vui32_t) val0_128;
   vui32_t val1 = (vui32_t) val1_128;
   vui32_t val2 = (vui32_t) val2_128;
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   printf ("%s%08x%08x%08x%08x %08x%08x%08x%08x %08x%08x%08x%08x\n", prefix,
-          val0[0], val0[1], val0[2], val0[3], val1[0], val1[1], val1[2],
-          val1[3], val2[0], val2[1], val2[2], val2[3]);
+	  val0[3], val0[2], val0[1], val0[0],
+	  val1[3], val1[2], val1[1], val1[0],
+	  val2[3], val2[2], val2[1], val2[0]);
+#else
+  printf ("%s%08x%08x%08x%08x %08x%08x%08x%08x %08x%08x%08x%08x\n", prefix,
+	  val0[0], val0[1], val0[2], val0[3],
+	  val1[0], val1[1], val1[2], val1[3],
+	  val2[0], val2[1], val2[2], val2[3]);
+#endif
 }
 
 void


### PR DESCRIPTION
Traced back to bad code generation for if (__builtin_bcdsub_gt)
tests in vec_bcdaddcsq, vec_bcdsubcsq.
Found a worrk around by replacing the if test (which is setting
the carry sign code) with vec_bcdcpsgn()
Also found check_vint384 was not printing 128-bit values in
the correct high to low order. Corrected this.

	* src/pveclib/vec_bcd_ppc.h (vec_bcdaddcsq, vec_bcdsubcsq):
	Simplify logic to avoid GCC9 code gen bug.

	* src/testsuite/arith128_print.c
	(print_vint384 [__BYTE_ORDER__]):
	Print the 128-bit values in high to low order.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>