### PR TITLE
Fix errors associaed with trying to use vector multiply word on P7.

### DIFF
--- a/src/pveclib/vec_f64_ppc.h
+++ b/src/pveclib/vec_f64_ppc.h
@@ -246,7 +246,7 @@ static inline int
 vec_all_isfinitef64 (vf64_t vf64)
 {
   vui64_t tmp;
-#if _ARCH_PWR9
+#if _ARCH_PWR9 && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   const vui64_t vec_zero = CONST_VINT128_DW (0, 0);
 #ifdef vec_test_data_class
   tmp = (vui64_t)vec_test_data_class (vf64, 0x70);
@@ -289,7 +289,7 @@ vec_all_isinff64 (vf64_t vf64)
 {
   vui64_t tmp;
 
-#if _ARCH_PWR9
+#if _ARCH_PWR9 && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   const vui64_t vec_ones = CONST_VINT128_DW (-1, -1);
 #ifdef vec_test_data_class
   tmp = (vui64_t)vec_test_data_class (vf64, 0x30);
@@ -335,7 +335,7 @@ vec_all_isnanf64 (vf64_t vf64)
 {
   vui64_t tmp;
 
-#if _ARCH_PWR9
+#if _ARCH_PWR9 && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   const vui64_t vec_ones = CONST_VINT128_DW (-1, -1);
 #ifdef vec_test_data_class
   tmp = (vui64_t)vec_test_data_class (vf64, 0x40);
@@ -382,7 +382,7 @@ vec_all_isnormalf64 (vf64_t vf64)
 {
   vui64_t tmp;
   const vui64_t vec_zero = CONST_VINT128_DW (0, 0);
-#if _ARCH_PWR9
+#if _ARCH_PWR9 && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
 #ifdef vec_test_data_class
   tmp = (vui64_t)vec_test_data_class (vf64, 0x7f);
 #else
@@ -426,7 +426,7 @@ vec_all_issubnormalf64 (vf64_t vf64)
 {
   vui64_t tmp;
 
-#if _ARCH_PWR9
+#if _ARCH_PWR9 && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   const vui64_t vec_ones = CONST_VINT128_DW (-1, -1);
 #ifdef vec_test_data_class
   tmp = (vui64_t)vec_test_data_class (vf64, 0x03);
@@ -474,7 +474,7 @@ vec_all_iszerof64 (vf64_t vf64)
 {
   vui64_t tmp;
 
-#if _ARCH_PWR9
+#if _ARCH_PWR9 && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   const vui64_t vec_ones = CONST_VINT128_DW (-1, -1);
 #ifdef vec_test_data_class
   tmp = (vui64_t)vec_test_data_class (vf64, 0x0c);

--- a/src/pveclib/vec_int128_ppc.h
+++ b/src/pveclib/vec_int128_ppc.h
@@ -2071,7 +2071,7 @@ int
 vec_cmpsq_all_eq (vi128_t vra, vi128_t vrb)
 {
   int result;
-#if defined (_ARCH_PWR8) && (__GNUC__ >= 6)
+#if defined (_ARCH_PWR8) && (__GNUC__ >= 6) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   result = vec_all_eq((vui64_t)vra, (vui64_t)vrb);
 #else
   result = vec_all_eq((vui32_t)vra, (vui32_t)vrb);
@@ -2225,7 +2225,7 @@ int
 vec_cmpsq_all_ne (vi128_t vra, vi128_t vrb)
 {
   int result;
-#if defined (_ARCH_PWR8) && (__GNUC__ >= 6)
+#if defined (_ARCH_PWR8) && (__GNUC__ >= 6) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   result = !vec_all_eq ((vui64_t) vra, (vui64_t) vrb);
 #else
   result = !vec_all_eq ((vui32_t) vra, (vui32_t) vrb);
@@ -2255,7 +2255,7 @@ int
 vec_cmpuq_all_eq (vui128_t vra, vui128_t vrb)
 {
   int result;
-#if defined (_ARCH_PWR8) && (__GNUC__ >= 6)
+#if defined (_ARCH_PWR8) && (__GNUC__ >= 6) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   result = vec_all_eq ((vui64_t) vra, (vui64_t) vrb);
 #else
   result = vec_all_eq ((vui32_t) vra, (vui32_t) vrb);
@@ -2393,7 +2393,7 @@ int
 vec_cmpuq_all_ne (vui128_t vra, vui128_t vrb)
 {
   int result;
-#if defined (_ARCH_PWR8) && (__GNUC__ >= 6)
+#if defined (_ARCH_PWR8) && (__GNUC__ >= 6) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   result = !vec_all_eq ((vui64_t) vra, (vui64_t) vrb);
 #else
   result = !vec_all_eq ((vui32_t) vra, (vui32_t) vrb);

--- a/src/pveclib/vec_int32_ppc.h
+++ b/src/pveclib/vec_int32_ppc.h
@@ -880,12 +880,13 @@ vec_mulosw (vi32_t a, vi32_t b)
  * But for POWER7 and earlier we have to construct word multiplies
  * from two halfword multiplies (vmuleuh and vmulouh). Then sum the
  * partial products for the final doubleword results. This is
- * complicated the fact that vector add doubleword is not available
+ * complicated by the fact that vector add doubleword is not available
  * for POWER7. So we need to construct the doubleword add from
  * Vector Add Unsigned Word Modulo (vadduwm) and
  * Vector Add and Write Carry-Out Unsigned Word (vaddcuw) with
  * shift double quadword to reposition the low word carry and
- * a final vadduwm to complete carry propagation the doubleword add.
+ * a final vadduwm to complete the carry propagation for the
+ * doubleword add.
  *
  * |processor|Latency|Throughput|
  * |--------:|:-----:|:---------|
@@ -982,12 +983,13 @@ vec_muleuw (vui32_t a, vui32_t b)
  * But for POWER7 and earlier we have to construct word multiplies
  * from two halfword multiplies (vmuleuh and vmulouh). Then sum the
  * partial products for the final doubleword results. This is
- * complicated the fact that vector add doubleword is not available
+ * complicated by the fact that vector add doubleword is not available
  * for POWER7. So we need to construct the doubleword add from
  * Vector Add Unsigned Word Modulo (vadduwm) and
  * Vector Add and Write Carry-Out Unsigned Word (vaddcuw) with
  * shift double quadword to reposition the low word carry and
- * a final vadduwm to complete carry propagation the doubleword add.
+ * a final vadduwm to complete the carry propagation for the doubleword
+ * add.
  *
  * |processor|Latency|Throughput|
  * |--------:|:-----:|:---------|

--- a/src/pveclib/vec_int64_ppc.h
+++ b/src/pveclib/vec_int64_ppc.h
@@ -1435,7 +1435,7 @@ int
 vec_cmpsd_all_eq (vi64_t a, vi64_t b)
 {
   int result;
-#if defined (_ARCH_PWR8) && (__GNUC__ >= 6)
+#if defined (_ARCH_PWR8) && (__GNUC__ >= 6) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   result = vec_all_eq(a, b);
 #else
   result = vec_all_eq((vui32_t)a, (vui32_t)b);
@@ -1465,7 +1465,7 @@ int
 vec_cmpsd_all_ge (vi64_t a, vi64_t b)
 {
   int result;
-#if defined (_ARCH_PWR8) && (__GNUC__ >= 6)
+#if defined (_ARCH_PWR8) && (__GNUC__ >= 6) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   result = vec_all_ge(a, b);
 #else
   vui32_t wt = { -1, -1, -1, -1};
@@ -1497,7 +1497,7 @@ int
 vec_cmpsd_all_gt (vi64_t a, vi64_t b)
 {
   int result;
-#if defined (_ARCH_PWR8) && (__GNUC__ >= 6)
+#if defined (_ARCH_PWR8) && (__GNUC__ >= 6) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   result = vec_all_gt(a, b);
 #else
   vui32_t wt = { -1, -1, -1, -1};
@@ -1576,7 +1576,7 @@ int
 vec_cmpsd_all_ne (vi64_t a, vi64_t b)
 {
   int result;
-#if defined (_ARCH_PWR8) && (__GNUC__ >= 6)
+#if defined (_ARCH_PWR8) && (__GNUC__ >= 6) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   result = vec_all_ne(a, b);
 #else
   vui32_t wt = { -1, -1, -1, -1};
@@ -1607,7 +1607,7 @@ int
 vec_cmpsd_any_eq (vi64_t a, vi64_t b)
 {
   int result;
-#if defined (_ARCH_PWR8) && (__GNUC__ >= 6)
+#if defined (_ARCH_PWR8) && (__GNUC__ >= 6) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   result = vec_any_eq(a, b);
 #else
   vui32_t wt = { -1, -1, -1, -1};
@@ -1639,7 +1639,7 @@ int
 vec_cmpsd_any_ge (vi64_t a, vi64_t b)
 {
   int result;
-#if defined (_ARCH_PWR8) && (__GNUC__ >= 6)
+#if defined (_ARCH_PWR8) && (__GNUC__ >= 6) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   result = vec_any_ge(a, b);
 #else
   vui32_t wt = { -1, -1, -1, -1};
@@ -1671,7 +1671,7 @@ int
 vec_cmpsd_any_gt (vi64_t a, vi64_t b)
 {
   int result;
-#if defined (_ARCH_PWR8) && (__GNUC__ >= 6)
+#if defined (_ARCH_PWR8) && (__GNUC__ >= 6) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   result = vec_any_gt(a, b);
 #else
   vui32_t wt = { -1, -1, -1, -1};
@@ -1750,7 +1750,7 @@ int
 vec_cmpsd_any_ne (vi64_t a, vi64_t b)
 {
   int result;
-#if defined (_ARCH_PWR8) && (__GNUC__ >= 6)
+#if defined (_ARCH_PWR8) && (__GNUC__ >= 6) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   result = vec_any_ne(a, b);
 #else
   vui32_t wt = { -1, -1, -1, -1};
@@ -1781,7 +1781,7 @@ int
 vec_cmpud_all_eq (vui64_t a, vui64_t b)
 {
   int result;
-#if defined (_ARCH_PWR8) && (__GNUC__ >= 6)
+#if defined (_ARCH_PWR8) && (__GNUC__ >= 6) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   result = vec_all_eq(a, b);
 #else
   result = vec_all_eq((vui32_t)a, (vui32_t)b);
@@ -1811,7 +1811,7 @@ int
 vec_cmpud_all_ge (vui64_t a, vui64_t b)
 {
   int result;
-#if defined (_ARCH_PWR8) && (__GNUC__ >= 6)
+#if defined (_ARCH_PWR8) && (__GNUC__ >= 6) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   result = vec_all_ge(a, b);
 #else
   vui32_t wt = { -1, -1, -1, -1};
@@ -1843,7 +1843,7 @@ int
 vec_cmpud_all_gt (vui64_t a, vui64_t b)
 {
   int result;
-#if defined (_ARCH_PWR8) && (__GNUC__ >= 6)
+#if defined (_ARCH_PWR8) && (__GNUC__ >= 6) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   result = vec_all_gt(a, b);
 #else
   vui32_t wt = { -1, -1, -1, -1};
@@ -1922,7 +1922,7 @@ int
 vec_cmpud_all_ne (vui64_t a, vui64_t b)
 {
   int result;
-#if defined (_ARCH_PWR8) && (__GNUC__ >= 6)
+#if defined (_ARCH_PWR8) && (__GNUC__ >= 6) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   result = vec_all_ne(a, b);
 #else
   vui32_t wt = { -1, -1, -1, -1};
@@ -1953,7 +1953,7 @@ int
 vec_cmpud_any_eq (vui64_t a, vui64_t b)
 {
   int result;
-#if defined (_ARCH_PWR8) && (__GNUC__ >= 6)
+#if defined (_ARCH_PWR8) && (__GNUC__ >= 6) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   result = vec_any_eq(a, b);
 #else
   vui32_t wt = { -1, -1, -1, -1};
@@ -1985,7 +1985,7 @@ int
 vec_cmpud_any_ge (vui64_t a, vui64_t b)
 {
   int result;
-#if defined (_ARCH_PWR8) && (__GNUC__ >= 6)
+#if defined (_ARCH_PWR8) && (__GNUC__ >= 6) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   result = vec_any_ge(a, b);
 #else
   vui32_t wt = { -1, -1, -1, -1};
@@ -2017,7 +2017,7 @@ int
 vec_cmpud_any_gt (vui64_t a, vui64_t b)
 {
   int result;
-#if defined (_ARCH_PWR8) && (__GNUC__ >= 6)
+#if defined (_ARCH_PWR8) && (__GNUC__ >= 6) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   result = vec_any_gt(a, b);
 #else
   vui32_t wt = { -1, -1, -1, -1};
@@ -2096,7 +2096,7 @@ int
 vec_cmpud_any_ne (vui64_t a, vui64_t b)
 {
   int result;
-#if defined (_ARCH_PWR8) && (__GNUC__ >= 6)
+#if defined (_ARCH_PWR8) && (__GNUC__ >= 6) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   result = vec_any_ne(a, b);
 #else
   vui32_t wt = { -1, -1, -1, -1};

--- a/src/testsuite/arith128_print.h
+++ b/src/testsuite/arith128_print.h
@@ -457,7 +457,7 @@ static inline int
 check_v2b64x (char *prefix, vb64_t val128, vb64_t shouldbe)
 {
   int rc = 0;
-  if (vec_any_ne((vui64_t )val128, (vui64_t )shouldbe))
+  if (vec_cmpud_any_ne((vui64_t )val128, (vui64_t )shouldbe))
     {
       rc = check_v2b64x_priv (prefix, val128, shouldbe);
     }
@@ -660,4 +660,5 @@ print_dfp128p2 (char *prefix, _Decimal128 val128, long exp);
 
 
 #endif /* TESTSUITE_ARITH128_PRINT_H_ */
+
 

--- a/src/testsuite/arith128_test_i32.c
+++ b/src/testsuite/arith128_test_i32.c
@@ -416,6 +416,336 @@ test_mrgeow (void)
 }
 //#undef __DEBUG_PRINT__
 
+//#define __DEBUG_PRINT__
+int
+test_mulesw (void)
+{
+  vi32_t i, j;
+  vi64_t k, e;
+  int rc = 0;
+
+  printf ("\ntest_mulesw Vector Multiply Even Signed words\n");
+
+  i = (vi32_t) {1, 2, 3, 4};
+  j = (vi32_t) {10, 20, 30, 40};
+  e = (vi64_t) {10, 90};
+  k = vec_mulesw (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint32d  ("mulesw  ( ", (vui32_t)i);
+  print_vint32d  ("         ,", (vui32_t)j);
+  print_v2xint64 ("        )=", (vui64_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulesw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vi32_t) {-1, -2, 3, 4};
+  j = (vi32_t) {10, -20, 30, -40};
+  e = (vi64_t) {-10, 90};
+  k = vec_mulesw (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint32d  ("mulesw  ( ", (vui32_t)i);
+  print_vint32d  ("         ,", (vui32_t)j);
+  print_v2xint64 ("        )=", (vui64_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulesw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vi32_t) {-1, -2, 3, 4};
+  j = (vi32_t) {-10, -20, -30, -40};
+  e = (vi64_t) {10, -90};
+  k = vec_mulesw (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint32d  ("mulesw  ( ", (vui32_t)i);
+  print_vint32d  ("         ,", (vui32_t)j);
+  print_v2xint64 ("        )=", (vui64_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulesw:", (vui128_t)k, (vui128_t) e);
+
+#ifdef __DEBUG_PRINT__
+  print_vint32d  ("mulesw  ( ", (vui32_t)i);
+  print_vint32d  ("         ,", (vui32_t)j);
+  print_v2xint64 ("        )=", (vui64_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulesw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vi32_t) {-1, -1, -1, -1};
+  j = (vi32_t) {-1, -1, -1, -1};
+  e = (vi64_t) {1, 1};
+  k = vec_mulesw (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint32d  ("mulesw  ( ", (vui32_t)i);
+  print_vint32d  ("         ,", (vui32_t)j);
+  print_v2xint64 ("        )=", (vui64_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulesw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vi32_t) {-1, -1, -1, -1};
+  j = (vi32_t) {-1,  1, -1,  1};
+  e = (vi64_t) {1, 1};
+  k = vec_mulesw (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint32d  ("mulesw  ( ", (vui32_t)i);
+  print_vint32d  ("         ,", (vui32_t)j);
+  print_v2xint64 ("        )=", (vui64_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulesw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vi32_t) {-1, -1, -1, -1};
+  j = (vi32_t) { 1, -1,  1, -1};
+  e = (vi64_t) {-1, -1};
+  k = vec_mulesw (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint32d  ("mulesw  ( ", (vui32_t)i);
+  print_vint32d  ("         ,", (vui32_t)j);
+  print_v2xint64 ("        )=", (vui64_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulesw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vi32_t) {99999999, 99999999, 99999999, 99999999};
+  j = (vi32_t) {99999999, -99999999, -99999999, 99999999};
+  e = (vi64_t) {9999999800000001LL, -9999999800000001LL};
+  k = vec_mulesw (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint32d  ("mulesw  ( ", (vui32_t)i);
+  print_vint32d  ("         ,", (vui32_t)j);
+  print_v2xint64 ("        )=", (vui64_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulesw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vi32_t) {88888888, 88888888, 88888888, 88888888};
+  j = (vi32_t) {88888888, -88888888, -88888888, 88888888};
+  e = (vi64_t) {7901234409876544LL, -7901234409876544LL};
+  k = vec_mulesw (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint32d  ("mulesw  ( ", (vui32_t)i);
+  print_vint32d  ("         ,", (vui32_t)j);
+  print_v2xint64 ("        )=", (vui64_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulesw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vi32_t) {99999999, 99999999, 99999999, 99999999};
+  j = (vi32_t) {88888888, -88888888, -88888888, 88888888};
+  e = (vi64_t) {8888888711111112LL, -8888888711111112LL};
+  k = vec_mulesw (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint32d  ("mulesw  ( ", (vui32_t)i);
+  print_vint32d  ("         ,", (vui32_t)j);
+  print_v2xint64 ("        )=", (vui64_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulesw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vi32_t) {99999999, 0, 99999999, 0};
+  j = (vi32_t) {0, 99999999, 0, 99999999};
+  e = (vi64_t) {0UL, 0UL};
+  k = vec_mulesw (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint32d  ("mulesw  ( ", (vui32_t)i);
+  print_vint32d  ("         ,", (vui32_t)j);
+  print_v2xint64 ("        )=", (vui64_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulesw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vi32_t) {__INT_MAX__, __INT_MAX__, __INT_MAX__, __INT_MAX__};
+  j = (vi32_t) {__INT_MAX__, __INT_MAX__, -__INT_MAX__, __INT_MAX__};
+  e = (vi64_t) {4611686014132420609LL, -4611686014132420609LL};
+  k = vec_mulesw (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint32d  ("mulesw  ( ", (vui32_t)i);
+  print_vint32d  ("         ,", (vui32_t)j);
+  print_v2xint64 ("        )=", (vui64_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulesw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vi32_t) { 0x80000000, 0x80000000, 0x80000000, 0x80000000};
+  j = (vi32_t) { 0x80000000, 0x80000000, __INT_MAX__, __INT_MAX__};
+  e = (vi64_t) { 0x4000000000000000LL, 0xc000000080000000LL};
+  k = vec_mulesw (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint32d  ("mulesw  ( ", (vui32_t)i);
+  print_vint32d  ("         ,", (vui32_t)j);
+  print_v2xint64 ("        )=", (vui64_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulesw:", (vui128_t)k, (vui128_t) e);
+
+  return (rc);
+}
+//#undef __DEBUG_PRINT__
+
+//#define __DEBUG_PRINT__
+int
+test_mulosw (void)
+{
+  vi32_t i, j;
+  vi64_t k, e;
+  int rc = 0;
+
+  printf ("\ntest_mulosw Vector Multiply Odd Signed words\n");
+
+  i = (vi32_t) {1, 2, 3, 4};
+  j = (vi32_t) {10, 20, 30, 40};
+  e = (vi64_t) {40, 160};
+  k = vec_mulosw (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint32d  ("mulosw  ( ", (vui32_t)i);
+  print_vint32d  ("         ,", (vui32_t)j);
+  print_v2xint64 ("        )=", (vui64_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulosw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vi32_t) {-1, -2, 3, 4};
+  j = (vi32_t) {10, -20, 30, -40};
+  e = (vi64_t) {40, -160};
+  k = vec_mulosw (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint32d  ("mulosw  ( ", (vui32_t)i);
+  print_vint32d  ("         ,", (vui32_t)j);
+  print_v2xint64 ("        )=", (vui64_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulosw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vi32_t) {-1, -2, 3, 4};
+  j = (vi32_t) {-10, -20, -30, -40};
+  e = (vi64_t) {40, -160};
+  k = vec_mulosw (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint32d  ("mulosw  ( ", (vui32_t)i);
+  print_vint32d  ("         ,", (vui32_t)j);
+  print_v2xint64 ("        )=", (vui64_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulosw:", (vui128_t)k, (vui128_t) e);
+
+#ifdef __DEBUG_PRINT__
+  print_vint32d  ("mulosw  ( ", (vui32_t)i);
+  print_vint32d  ("         ,", (vui32_t)j);
+  print_v2xint64 ("        )=", (vui64_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulosw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vi32_t) {-1, -1, -1, -1};
+  j = (vi32_t) {-1, -1, -1, -1};
+  e = (vi64_t) {1, 1};
+  k = vec_mulosw (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint32d  ("mulosw  ( ", (vui32_t)i);
+  print_vint32d  ("         ,", (vui32_t)j);
+  print_v2xint64 ("        )=", (vui64_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulosw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vi32_t) {-1, -1, -1, -1};
+  j = (vi32_t) {-1,  1, -1,  1};
+  e = (vi64_t) {-1, -1};
+  k = vec_mulosw (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint32d  ("mulosw  ( ", (vui32_t)i);
+  print_vint32d  ("         ,", (vui32_t)j);
+  print_v2xint64 ("        )=", (vui64_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulosw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vi32_t) {-1, -1, -1, -1};
+  j = (vi32_t) { 1, -1,  1, -1};
+  e = (vi64_t) {1, 1};
+  k = vec_mulosw (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint32d  ("mulosw  ( ", (vui32_t)i);
+  print_vint32d  ("         ,", (vui32_t)j);
+  print_v2xint64 ("        )=", (vui64_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulosw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vi32_t) {99999999, 99999999, 99999999, 99999999};
+  j = (vi32_t) {99999999, -99999999, -99999999, 99999999};
+  e = (vi64_t) {-9999999800000001LL, 9999999800000001LL};
+  k = vec_mulosw (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint32d  ("mulosw  ( ", (vui32_t)i);
+  print_vint32d  ("         ,", (vui32_t)j);
+  print_v2xint64 ("        )=", (vui64_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulosw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vi32_t) {88888888, 88888888, 88888888, 88888888};
+  j = (vi32_t) {88888888, -88888888, -88888888, 88888888};
+  e = (vi64_t) {-7901234409876544LL, 7901234409876544LL};
+  k = vec_mulosw (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint32d  ("mulosw  ( ", (vui32_t)i);
+  print_vint32d  ("         ,", (vui32_t)j);
+  print_v2xint64 ("        )=", (vui64_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulosw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vi32_t) {99999999, 99999999, 99999999, 99999999};
+  j = (vi32_t) {88888888, -88888888, -88888888, 88888888};
+  e = (vi64_t) {-8888888711111112LL, 8888888711111112LL};
+  k = vec_mulosw (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint32d  ("mulosw  ( ", (vui32_t)i);
+  print_vint32d  ("         ,", (vui32_t)j);
+  print_v2xint64 ("        )=", (vui64_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulosw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vi32_t) {99999999, 0, 99999999, 0};
+  j = (vi32_t) {0, 99999999, 0, 99999999};
+  e = (vi64_t) {0UL, 0UL};
+  k = vec_mulosw (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint32d  ("mulosw  ( ", (vui32_t)i);
+  print_vint32d  ("         ,", (vui32_t)j);
+  print_v2xint64 ("        )=", (vui64_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulosw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vi32_t) {__INT_MAX__, __INT_MAX__, __INT_MAX__, __INT_MAX__};
+  j = (vi32_t) {__INT_MAX__, -__INT_MAX__, -__INT_MAX__, __INT_MAX__};
+  e = (vi64_t) { -4611686014132420609LL, 4611686014132420609LL};
+  k = vec_mulosw (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint32d  ("mulosw  ( ", (vui32_t)i);
+  print_vint32d  ("         ,", (vui32_t)j);
+  print_v2xint64 ("        )=", (vui64_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulosw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vi32_t) { 0x80000000, 0x80000000, 0x80000000, 0x80000000};
+  j = (vi32_t) { 0x80000000, 0x80000000, __INT_MAX__, __INT_MAX__};
+  e = (vi64_t) { 0x4000000000000000LL, 0xc000000080000000LL};
+  k = vec_mulosw (i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint32d  ("mulosw  ( ", (vui32_t)i);
+  print_vint32d  ("         ,", (vui32_t)j);
+  print_v2xint64 ("        )=", (vui64_t)k);
+#endif
+  rc += check_vuint128x ("vec_mulosw:", (vui128_t)k, (vui128_t) e);
+
+  return (rc);
+}
+//#undef __DEBUG_PRINT__
+
 int
 test_muleuw (void)
 {
@@ -791,6 +1121,8 @@ test_vec_i32 (void)
   rc += test_revbw ();
   rc += test_clzw ();
   rc += test_popcntw();
+  rc += test_mulesw();
+  rc += test_mulosw();
   rc += test_muleuw();
   rc += test_mulouw();
   rc += test_muluwm();

--- a/src/testsuite/vec_f32_dummy.c
+++ b/src/testsuite/vec_f32_dummy.c
@@ -331,7 +331,7 @@ test_vec_float_uint (vui32_t __A)
     return vec_float (__A);
   }
 #endif
-#ifdef vec_float2
+#if defined vec_float2  && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
 vf32_t
 test_vec_float2_long (vi64_t __A, vi64_t __B)
   {

--- a/src/testsuite/vec_int32_dummy.c
+++ b/src/testsuite/vec_int32_dummy.c
@@ -91,6 +91,18 @@ __test_mulouw (vui32_t a, vui32_t b)
   return vec_mulouw (a, b);
 }
 
+vi64_t
+__test_mulesw (vi32_t a, vi32_t b)
+{
+  return vec_mulesw (a, b);
+}
+
+vi64_t
+__test_mulosw (vi32_t a, vi32_t b)
+{
+  return vec_mulosw (a, b);
+}
+
 vi32_t
 __test_mulhsw (vi32_t a, vi32_t b)
 {
@@ -296,8 +308,20 @@ __test_mulow (vui32_t vra, vui32_t vrb)
 #endif
 
 #if defined _ARCH_PWR7 && (__GNUC__ > 6)
+vi32_t
+__test_abssw (vi32_t vra)
+{
+  return vec_abs (vra);
+}
+
 vui32_t
 __test_mulluw (vui32_t vra, vui32_t vrb)
+{
+  return vec_mul (vra, vrb);
+}
+
+vi32_t
+__test_mullsw (vi32_t vra, vi32_t vrb)
 {
   return vec_mul (vra, vrb);
 }

--- a/src/testsuite/vec_int64_dummy.c
+++ b/src/testsuite/vec_int64_dummy.c
@@ -661,7 +661,7 @@ __test_splatd1 (vui64_t a)
   return vec_splat (a, 1);
 }
 
-#if (__GNUC__ > 7)
+#if (__GNUC__ > 7)  && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
 
 vui64_t
 __test_mergee (vui64_t a, vui64_t b)

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -314,6 +314,8 @@ test_vec_iszerof32_PWR9 (vf32_t value)
 {
   return (vec_iszerof32 (value));
 }
+
+#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
 int
 test_vec_all_finitef64_PWR9 (vf64_t value)
 {
@@ -420,6 +422,7 @@ test_vec_iszerof64_PWR9 (vf64_t value)
 {
   return (vec_iszerof64 (value));
 }
+#endif
 
 vb128_t
 test_vec_isfinitef128_PWR9 (__binary128 f128)
@@ -1437,3 +1440,4 @@ test_mul4uq_PWR9 (vui128_t *__restrict__ mulu, vui128_t m1h, vui128_t m1l, vui12
 }
 
 //#pragma GCC pop target
+


### PR DESCRIPTION
Fixes #82
Initially this was from missing multiply signed word implementation
for P7. But also hit a compiler bug where some built-ins where disabled
when I mixed -mcpu= and #pragma GCC target with different targets.
Specifically -mcpu=power7 and #pragma GCC target ("cpu=power8").
This seems to be Endian specific as P7 is BE only while P8 can be
either. Anyway. compiler folks are busy and will not spend cycles on a
bug that only impacts P7. So I added not conditionals to avoid this.
This should resolve issue #82.

	* src/pveclib/vec_f64_ppc.h (vec_all_isfinitef64,
	vec_all_isinff64, vec_all_isnanf64, vec_all_isnormalf64,
	vec_all_issubnormalf64, vec_all_iszerof64
	[__ORDER_LITTLE_ENDIAN__]): Test data built-ins only available
	for LE.

	* src/pveclib/vec_int128_ppc.h (vec_cmpsq_all_eq,
	vec_cmpsq_all_ne, vec_cmpuq_all_eq, vec_cmpuq_all_ne
	[__ORDER_LITTLE_ENDIAN__]):
	Generic vec_all_eq() for vector long only available for LE.

	* src/pveclib/vec_int32_ppc.h
	(vec_muleuw, vec_mulouw, vec_srawi): Forward reference.
	(vec_mulesw, vec_mulosw):
	Additional doxygent text.
	(vec_mulesw, vec_mulosw[! _ARCH_PWR8]):
	New implementation for POWER7
	(vec_muleuw, vec_mulouw):
	Additional doxygent text.

	* src/pveclib/vec_int64_ppc.h
	(vec_cmpsd_all_eq, vec_cmpsd_all_gt, vec_cmpsd_all_ne,
	vec_cmpsd_any_eq, vec_cmpsd_any_ge, vec_cmpsd_any_gt,
	vec_cmpsd_any_ne, vec_cmpud_all_eq, vec_cmpud_all_ge,
	vec_cmpud_all_gt, vec_cmpud_all_ne, vec_cmpud_any_eq,
	vec_cmpud_any_ge, vec_cmpud_any_gt, vec_cmpud_any_ne
	[__ORDER_LITTLE_ENDIAN__]):
	Generic vec_[all|any]_[eq|gt|ge|ne]() for vector long only
	available for LE.

	* src/testsuite/arith128_print.h (check_v2b64x):
	Use vec_cmpud_any_ne.
	* src/testsuite/arith128_test_i32.c (test_mulesw, test_mulosw):
	New functions.
	(test_muleuw): Add calls to test_mulesw and test_mulosw.

	* src/testsuite/vec_f32_dummy.c [defined vec_float2  &&
	(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)]:
	Restrict float* built-in compile tests to LE.

	* src/testsuite/vec_int32_dummy.c (__test_mulesw,
	__test_mulosw, __test_abssw, __test_mullsw): New functions.

	* src/testsuite/vec_int64_dummy.c
	[(__GNUC__ > 7)  && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)]:
	Restrict merge even/odd built-in compile tests to LE.

	* src/testsuite/vec_pwr9_dummy.c (vec_all_isfinitef64,
	vec_all_isinff64, vec_all_isnanf64, vec_all_isnormalf64,
	vec_all_issubnormalf64, vec_all_iszerof64
	[__ORDER_LITTLE_ENDIAN__]): Test data built-ins only available
	for LE.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>