### PR TITLE
Add vec_int512 files for multiple precision quadword integer support.

### DIFF
--- a/src/testsuite/arith128_print.c
+++ b/src/testsuite/arith128_print.c
@@ -22,6 +22,7 @@
 
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 #include <float.h>
 #define __DEBUG_PRINT__
 #include <pveclib/vec_f128_ppc.h>
@@ -678,6 +679,41 @@ print_vint256 (char *prefix, vui128_t val0_128, vui128_t val1_128)
 }
 
 void
+print_vuint512x (char *prefix, vui128_t val0_128, vui128_t val1_128, vui128_t val2_128, vui128_t val3_128)
+{
+  vui32_t val0 = (vui32_t) val0_128;
+  vui32_t val1 = (vui32_t) val1_128;
+  vui32_t val2 = (vui32_t) val2_128;
+  vui32_t val3 = (vui32_t) val3_128;
+  int i;
+  int len = strlen (prefix);
+  char pad[64];
+
+  len = (len < 64) ? len : 63;
+  for (i=0; i < len; i++)
+    pad [i] = ' ';
+
+  pad [len] = 0;
+
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  printf ("%s%08x%08x%08x%08x %08x%08x%08x%08x\n", prefix,
+	  val0[3], val0[2], val0[1], val0[0],
+	  val1[3], val1[2], val1[1], val1[0]);
+  printf ("%s%08x%08x%08x%08x %08x%08x%08x%08x\n", pad,
+	  val2[3], val2[2], val2[1], val2[0],
+	  val3[3], val3[2], val3[1], val3[0]);
+#else
+  printf ("%s%08x%08x%08x%08x %08x%08x%08x%08x\n", prefix,
+	  val0[0], val0[1], val0[2], val0[3],
+	  val1[0], val1[1], val1[2], val1[3]);
+  printf ("%s%08x%08x%08x%08x %08x%08x%08x%08x\n", pad,
+	  val2[3], val2[2], val2[1], val2[0],
+	  val3[3], val3[2], val3[1], val3[0]);
+#endif
+}
+
+void
 print_vb128c (char *prefix, vb128_t val)
 {
   const vui64_t true = { 'T', 'T' };
@@ -766,6 +802,88 @@ print_vint128_prod (char *prefix, vui32_t r, vui32_t a, vui32_t b, vui32_t c)
   print_vint128 ("  b = ", (vui128_t) b);
   print_vint128 (" *u = ", (vui128_t) c);
   print_vint128 (" *l = ", (vui128_t) r);
+}
+
+void
+print_vint512x (char *prefix, __VEC_U_512 r)
+{
+  printf ("vec %s\n", prefix);
+
+  vui32_t val0 = (vui32_t) r.vx3;
+  vui32_t val1 = (vui32_t) r.vx2;
+  vui32_t val2 = (vui32_t) r.vx1;
+  vui32_t val3 = (vui32_t) r.vx0;
+  int i;
+  int len = strlen (prefix);
+  char pad[64];
+
+  len = (len < 64) ? len : 63;
+  for (i=0; i < len; i++)
+    pad [i] = ' ';
+
+  pad [len] = 0;
+
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  printf ("%s%08x%08x%08x%08x %08x%08x%08x%08x\n", prefix,
+	  val0[3], val0[2], val0[1], val0[0],
+	  val1[3], val1[2], val1[1], val1[0]);
+  printf ("%s%08x%08x%08x%08x %08x%08x%08x%08x\n", pad,
+	  val2[3], val2[2], val2[1], val2[0],
+	  val3[3], val3[2], val3[1], val3[0]);
+#else
+  printf ("%s%08x%08x%08x%08x %08x%08x%08x%08x\n", prefix,
+	  val0[0], val0[1], val0[2], val0[3],
+	  val1[0], val1[1], val1[2], val1[3]);
+  printf ("%s%08x%08x%08x%08x %08x%08x%08x%08x\n", pad,
+	  val2[3], val2[2], val2[1], val2[0],
+	  val3[3], val3[2], val3[1], val3[0]);
+#endif
+}
+
+void
+print_vint640x (char *prefix, __VEC_U_640 r)
+{
+  printf ("vec %s\n", prefix);
+  print_vint128x ("  =rh ", (vui128_t) r.vx4);
+  print_vint128x ("      ", (vui128_t) r.vx3);
+  print_vint128x ("      ", (vui128_t) r.vx2);
+  print_vint128x ("      ", (vui128_t) r.vx1);
+  print_vint128x ("   rl ", (vui128_t) r.vx0);
+}
+
+void
+print_vint512x_prod (char *prefix, __VEC_U_512 r, __VEC_U_256 a, __VEC_U_256 b)
+{
+  printf ("vec %s\n", prefix);
+  print_vint128x ("  a   ", (vui128_t) a.vx1);
+  print_vint128x ("      ", (vui128_t) a.vx0);
+  print_vint128x (" *b   ", (vui128_t) b.vx1);
+  print_vint128x ("      ", (vui128_t) b.vx0);
+  print_vint128x ("  =rh ", (vui128_t) r.vx3);
+  print_vint128x ("      ", (vui128_t) r.vx2);
+  print_vint128x ("      ", (vui128_t) r.vx1);
+  print_vint128x ("   rl ", (vui128_t) r.vx0);
+}
+
+void
+print_vint256x_prod (char *prefix, __VEC_U_256 r, vui128_t a, vui128_t b)
+{
+  printf ("vec %s\n", prefix);
+  print_vint128x ("  a * ", (vui128_t) a);
+  print_vint128x ("  b = ", (vui128_t) b);
+  print_vint128x (" *rh= ", (vui128_t) r.vx1);
+  print_vint128x (" *rl= ", (vui128_t) r.vx0);
+}
+
+void
+print_vint256_prod (char *prefix, __VEC_U_256 r, vui128_t a, vui128_t b)
+{
+  printf ("vec %s\n", prefix);
+  print_vint128 ("  a * ", (vui128_t) a);
+  print_vint128 ("  b = ", (vui128_t) b);
+  print_vint128 (" *rh= ", (vui128_t) r.vx1);
+  print_vint128 (" *rl= ", (vui128_t) r.vx0);
 }
 
 void
@@ -932,6 +1050,26 @@ check_vint384_priv (char *prefix, vui128_t val0_128, vui128_t val1_128,
       printf ("%s\n", prefix);
       print_vint384 ("\tshould be: ", sb0_128, sb1_128, sb2_128);
       print_vint384 ("\t       is: ", val0_128, val1_128, val2_128);
+    }
+
+  return (rc);
+}
+
+int
+check_vint512_priv (char *prefix, __VEC_U_512 val_is, __VEC_U_512 val_sb)
+{
+  int rc = 0;
+  if (vec_any_ne ((vui32_t) val_is.vx0, (vui32_t) val_sb.vx0)
+   || vec_any_ne ((vui32_t) val_is.vx1, (vui32_t) val_sb.vx1)
+   || vec_any_ne ((vui32_t) val_is.vx2, (vui32_t) val_sb.vx2)
+   || vec_any_ne ((vui32_t) val_is.vx3, (vui32_t) val_sb.vx3))
+    {
+      rc = 1;
+      printf ("%s\n", prefix);
+      print_vuint512x ("    should be: ", val_sb.vx3, val_sb.vx2, val_sb.vx1,
+		       val_sb.vx0);
+      print_vuint512x ("           is: ", val_is.vx3, val_is.vx2, val_is.vx1,
+		       val_is.vx0);
     }
 
   return (rc);

--- a/src/testsuite/arith128_print.h
+++ b/src/testsuite/arith128_print.h
@@ -25,6 +25,7 @@
 
 #include "arith128.h"
 #include <pveclib/vec_f128_ppc.h>
+#include <pveclib/vec_int512_ppc.h>
 
 static inline
 double
@@ -182,6 +183,21 @@ print_vint128_prod (char *prefix,
     vui32_t r, vui32_t a, vui32_t b, vui32_t c);
 
 extern void
+print_vint512x (char *prefix, __VEC_U_512 r);
+
+extern void
+print_vint640x (char *prefix, __VEC_U_640 r);
+
+extern void
+print_vint512x_prod (char *prefix, __VEC_U_512 r, __VEC_U_256 a, __VEC_U_256 b);
+
+extern void
+print_vint256x_prod (char *prefix, __VEC_U_256 r, vui128_t a, vui128_t b);
+
+extern void
+print_vint256_prod (char *prefix, __VEC_U_256 r, vui128_t a, vui128_t b);
+
+extern void
 print_vint128_extend (char *prefix,
     vui32_t r, vui32_t co, vui32_t a, vui32_t b, vui32_t c);
 
@@ -331,6 +347,9 @@ check_vint384_priv (char *prefix, vui128_t val0_128, vui128_t val1_128,
                     vui128_t val2_128, vui128_t sb0_128, vui128_t sb1_128,
                     vui128_t sb2_128);
 
+extern int
+check_vint512_priv (char *prefix, __VEC_U_512 val_is, __VEC_U_512 val_sb);
+
 static inline int
 check_vint384 (char *prefix, vui128_t val0_128, vui128_t val1_128,
                vui128_t val2_128, vui128_t sb0_128, vui128_t sb1_128,
@@ -357,6 +376,21 @@ check_vint256 (char *prefix, vui128_t val0_128, vui128_t val1_128,
   ||  vec_any_ne ((vui32_t)val1_128, (vui32_t)sb1_128))
     {
       rc = check_vint256_priv (prefix, val0_128, val1_128, sb0_128, sb1_128);
+    }
+
+  return (rc);
+}
+
+static inline int
+check_vint512 (char *prefix, __VEC_U_512 val_is, __VEC_U_512 val_sb)
+{
+  int rc = 0;
+  if (vec_any_ne ((vui32_t) val_is.vx0, (vui32_t) val_sb.vx0)
+   || vec_any_ne ((vui32_t) val_is.vx1, (vui32_t) val_sb.vx1)
+   || vec_any_ne ((vui32_t) val_is.vx2, (vui32_t) val_sb.vx2)
+   || vec_any_ne ((vui32_t) val_is.vx3, (vui32_t) val_sb.vx3))
+    {
+      rc = check_vint512_priv (prefix, val_is, val_sb);
     }
 
   return (rc);

--- a/src/testsuite/arith128_test_i512.c
+++ b/src/testsuite/arith128_test_i512.c
@@ -1,0 +1,1639 @@
+/*
+ Copyright (c) [2019] Steven Munroe.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ arith128_test_i512.c
+
+ Contributors:
+      Steven Munroe
+      Created on: Sep 9, 2019
+ */
+
+#define __STDC_WANT_DEC_FP__    1
+
+#include <stdint.h>
+#include <stdio.h>
+#if 0
+#include <fenv.h>
+#include <float.h>
+#include <math.h>
+#endif
+
+//#define __DEBUG_PRINT__
+#include <pveclib/vec_common_ppc.h>
+#include <pveclib/vec_int128_ppc.h>
+#include <pveclib/vec_int512_ppc.h>
+
+#include "arith128.h"
+#include <testsuite/arith128_print.h>
+
+#include <testsuite/arith128_test_i512.h>
+#include <testsuite/vec_perf_i512.h>
+
+
+const __VEC_U_512 vec512_zeros = {
+    (vui128_t) ((unsigned __int128) 0),
+    (vui128_t) ((unsigned __int128) 0),
+    (vui128_t) ((unsigned __int128) 0),
+    (vui128_t) ((unsigned __int128) 0)
+};
+
+const __VEC_U_512 vec512_one = CONST_VINT512_Q
+    (
+      (vui128_t) ((unsigned __int128) 0x00000000),
+      (vui128_t) ((unsigned __int128) 0x00000000),
+      (vui128_t) ((unsigned __int128) 0x00000000),
+      (vui128_t) ((unsigned __int128) 0x00000001)
+    );
+
+const __VEC_U_512 vec512_foxes = CONST_VINT512_Q
+    (
+      // FFFF...FFFF
+      (vui128_t) ((__int128) -1),
+      (vui128_t) ((__int128) -1),
+      (vui128_t) ((__int128) -1),
+      (vui128_t) ((__int128) -1)
+    );
+
+const __VEC_U_512 vec512_foxeasy = CONST_VINT512_Q
+    (
+	// FFFF...FFFE
+	(vui128_t) ((__int128) -1),
+	(vui128_t) ((__int128) -1),
+	(vui128_t) ((__int128) -1),
+	(vui128_t) ((__int128) -2)
+    );
+
+const __VEC_U_512  vec512_ten128th = CONST_VINT512_Q
+    (
+      CONST_VUINT128_QxW (0x00000000, 0x00000000, 0x0000024e, 0xe91f2603),
+      CONST_VUINT128_QxW (0xa6337f19, 0xbccdb0da, 0xc404dc08, 0xd3cff5ec),
+      CONST_VUINT128_QxW (0x2374e42f, 0x0f1538fd, 0x03df9909, 0x2e953e01),
+      CONST_VUINT128_QxW (0x00000000, 0x00000000, 0x00000000, 0x00000000)
+    );
+
+const __VEC_U_512 vec512_ten256_h = CONST_VINT512_Q
+    (
+	CONST_VUINT128_QxW (0x00000000, 0x00000000, 0x00000000, 0x00000000),
+	CONST_VUINT128_QxW (0x00000000, 0x000553f7, 0x5fdcefce, 0xf46eeddc),
+	CONST_VUINT128_QxW (0x80dcc7f7, 0x55bc28f2, 0x65f9ef17, 0xcc5573c0),
+	CONST_VUINT128_QxW (0x63ff540e, 0x3c42d35a, 0x1d153624, 0xadc666b0)
+    );
+
+const __VEC_U_512 vec512_ten256_l = CONST_VINT512_Q
+    (
+	CONST_VUINT128_QxW (0x26b2716e, 0xd595d80f, 0xcf4a6e70, 0x6bde50c6),
+	CONST_VUINT128_QxW (0x12152f87, 0xd8d99f72, 0xbed3875b, 0x982e7c01),
+	CONST_VUINT128_QxW (0x00000000, 0x00000000, 0x00000000, 0x00000000),
+	CONST_VUINT128_QxW (0x00000000, 0x00000000, 0x00000000, 0x00000000)
+    );
+
+const __VEC_U_512 vec512_ten384_h = CONST_VINT512_Q
+    (
+        CONST_VUINT128_QxW (0x00000000, 0x00000000, 0x00000000, 0x00000000),
+	CONST_VUINT128_QxW (0x00000000, 0x00000000, 0x00000000, 0x00000000),
+	CONST_VUINT128_QxW (0x0c4c5e31, 0x0aef8aa1, 0x71027fff, 0x56784f44),
+	CONST_VUINT128_QxW (0x4e117bef, 0xa6fab7d1, 0x99c34cce, 0x922010ba)
+    );
+
+const __VEC_U_512 vec512_ten384_m = CONST_VINT512_Q
+    (
+	CONST_VUINT128_QxW (0xcba53571, 0xac20aee4, 0xe9cd9bd7, 0xf1b92377),
+	CONST_VUINT128_QxW( 0xfc363385, 0x867b782d, 0x6e921a29, 0x949e1b66),
+	CONST_VUINT128_QxW( 0x23303863, 0xb92d6f55, 0x34a8e6d6, 0x997d980d),
+	CONST_VUINT128_QxW( 0x61c2dbb1, 0x09169857, 0x4cff3c6c, 0x0892aa8f)
+    );
+
+const __VEC_U_512 vec512_ten384_l = CONST_VINT512_Q
+    (
+	CONST_VUINT128_QxW (0x3347f75d, 0xe297de35, 0x60e19896, 0x34cbba01),
+	CONST_VUINT128_QxW( 0x00000000, 0x00000000, 0x00000000, 0x00000000),
+	CONST_VUINT128_QxW( 0x00000000, 0x00000000, 0x00000000, 0x00000000),
+	CONST_VUINT128_QxW( 0x00000000, 0x00000000, 0x00000000, 0x00000000)
+    );
+
+
+const __VEC_U_512 vec512_ten512_3 = CONST_VINT512_Q
+    (
+	CONST_VUINT128_QxW (0x00000000, 0x00000000, 0x00000000, 0x00000000),
+	CONST_VUINT128_QxW (0x00000000, 0x00000000, 0x00000000, 0x00000000),
+	CONST_VUINT128_QxW (0x00000000, 0x00000000, 0x0000001C, 0x633415D4),
+	CONST_VUINT128_QxW (0xC1D238D9, 0x8CAB8A97, 0x8A0B1F13, 0x8CB07303)
+    );
+
+const __VEC_U_512 vec512_ten512_2 = CONST_VINT512_Q
+    (
+	CONST_VUINT128_QxW (0xA2699748, 0x45A71D46, 0xB099BC81, 0x7343AFAC),
+	CONST_VUINT128_QxW (0x69BE5B0E, 0x9449775C, 0x1366732A, 0x93ABADE4),
+	CONST_VUINT128_QxW (0xB2908EE0, 0xF95F635E, 0x85A91924, 0xC3FC0695),
+	CONST_VUINT128_QxW (0xE7FC7153, 0x329C57AE, 0xBFA3EDAC, 0x96E14F5D)
+    );
+
+const __VEC_U_512 vec512_ten512_1 = CONST_VINT512_Q
+    (
+	CONST_VUINT128_QxW (0xBC51FB2E, 0xB21A2F22, 0x1E25CFEA, 0x703ED321),
+	CONST_VUINT128_QxW (0xAA1DA1BF, 0x28F8733B, 0x4475B579, 0xC88976C1),
+	CONST_VUINT128_QxW (0x94E65747, 0x46C40513, 0xC31E1AD9, 0xB83A8A97),
+	CONST_VUINT128_QxW (0x5D96976F, 0x8F9546DC, 0x77F27267, 0xFC6CF801)
+    );
+
+const __VEC_U_512 vec512_ten512_0 = CONST_VINT512_Q
+    (
+      (vui128_t) ((unsigned __int128) 0),
+      (vui128_t) ((unsigned __int128) 0),
+      (vui128_t) ((unsigned __int128) 0),
+      (vui128_t) ((unsigned __int128) 0)
+    );
+
+const __VEC_U_512 vec512_ten1024_6 = CONST_VINT512_Q
+    (
+	CONST_VUINT128_QxW (0x00000000, 0x00000000, 0x00000000, 0x00000000),
+	CONST_VUINT128_QxW (0x00000000, 0x00000325, 0xD9D61A05, 0xD4305D94),
+	CONST_VUINT128_QxW (0x34F4A3C6, 0x2D433949, 0xAE6209D4, 0x926C3F5B),
+	CONST_VUINT128_QxW (0xD2DB49EF, 0x47187094, 0xC1A6970C, 0xA7E6BD2A)
+);
+
+const __VEC_U_512 vec512_ten1024_5 = CONST_VINT512_Q
+    (
+	CONST_VUINT128_QxW (0x73C55349, 0x36A8DE06, 0x1E8D4649, 0xF4F3235E),
+	CONST_VUINT128_QxW (0x005B8041, 0x1640114A, 0x88BC491B, 0x9FC4ED52),
+	CONST_VUINT128_QxW (0x0190FBA0, 0x35FAABA6, 0xC356E38A, 0x31B5653F),
+	CONST_VUINT128_QxW (0x44597583, 0x6CB0B6C9, 0x75A351A2, 0x8E4262CE)
+);
+
+const __VEC_U_512 vec512_ten1024_4 = CONST_VINT512_Q
+    (
+	CONST_VUINT128_QxW (0x3CE3A0B8, 0xDF68368A, 0xE26A7B7E, 0x976A3310),
+	CONST_VUINT128_QxW (0xFC8F1F90, 0x31EB0F66, 0x9A202882, 0x80BDA5A5),
+	CONST_VUINT128_QxW (0x80D98089, 0xDC1A47FE, 0x6B7595FB, 0x101A3616),
+	CONST_VUINT128_QxW (0xB6F4654B, 0x31FB6BFD, 0xF56DEEEC, 0xB1B896BC)
+);
+
+const __VEC_U_512 vec512_ten1024_3 = CONST_VINT512_Q
+    (
+	CONST_VUINT128_QxW (0x8FC51A16, 0xBF3FDEB3, 0xD814B505, 0xBA34C411),
+	CONST_VUINT128_QxW (0x8AD822A5, 0x1ABE1DE3, 0x045B7A74, 0x8E1042C4),
+	CONST_VUINT128_QxW (0x62BE695A, 0x9F9F2A07, 0xA7E89431, 0x922BBB9F),
+	CONST_VUINT128_QxW (0xC9635986, 0x1C5CD134, 0xF451218B, 0x65DC60D7)
+);
+
+const __VEC_U_512 vec512_ten1024_2 = CONST_VINT512_Q
+    (
+	CONST_VUINT128_QxW (0x233E55C7, 0x231D2B9C, 0x9FCE837D, 0x1E43F61F),
+	CONST_VUINT128_QxW (0x7DE16CFB, 0x896634EE, 0x0ED1440E, 0xCC2CD819),
+	CONST_VUINT128_QxW (0x4C7D1E1A, 0x140AC535, 0x15C51A88, 0x991C4E87),
+	CONST_VUINT128_QxW (0x1EC29F86, 0x6E7C215B, 0xF55B2B72, 0x2919F001)
+);
+
+const __VEC_U_512 vec512_ten1024_1 = CONST_VINT512_Q
+    (
+      (vui128_t) ((unsigned __int128) 0),
+      (vui128_t) ((unsigned __int128) 0),
+      (vui128_t) ((unsigned __int128) 0),
+      (vui128_t) ((unsigned __int128) 0)
+    );
+
+const __VEC_U_512 vec512_ten1024_0 = CONST_VINT512_Q
+    (
+      (vui128_t) ((unsigned __int128) 0),
+      (vui128_t) ((unsigned __int128) 0),
+      (vui128_t) ((unsigned __int128) 0),
+      (vui128_t) ((unsigned __int128) 0)
+    );
+
+#define TIME_10_ITERATION 10
+
+int
+test_time_i512 (void)
+{
+  long i;
+  uint64_t t_start, t_end, t_delta;
+  double delta_sec;
+  int rc = 0;
+
+  printf ("\n%s mul512x512 start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIME_10_ITERATION; i++)
+    {
+      rc += timed_mul512x512 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s mul512x512 end", __FUNCTION__);
+  printf ("\n%s mul512x512 delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
+	  delta_sec);
+
+  printf ("\n%s mul1024x1024 start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIME_10_ITERATION; i++)
+    {
+      rc += timed_mul1024x1024 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s mul1024x1024 end", __FUNCTION__);
+  printf ("\n%s mul1024x1024 delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
+	  delta_sec);
+
+  printf ("\n%s mul2048x2048 start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIME_10_ITERATION; i++)
+    {
+      rc += timed_mul2048x2048 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s mul2048x2048 end", __FUNCTION__);
+  printf ("\n%s mul2048x2048 delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
+	  delta_sec);
+
+  return (rc);
+}
+
+//#define __DEBUG_PRINT__ 1
+int
+test_mul128x128 (void)
+{
+  __VEC_U_256 k, e;
+  vui128_t i, j;
+  int rc = 0;
+
+  printf ("\ntest_mul128x128 vector multiply quadword, 256-bit product\n");
+
+  i = (vui128_t) CONST_VINT128_W (0, 0xffffffff, 0xffffffff, 0xffffffff);
+  j = (vui128_t) CONST_VINT128_W (0, 0xffffffff, 0xffffffff, 0xffffffff);
+  k = __VEC_PWR_IMP (vec_mul128x128)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint256_prod ("2**96-1 * 2**96-1 ", k, i, j);
+#endif
+  e.vx0 = (vui128_t) CONST_VINT128_W (0xfffffffe, 0x00000000, 0x00000000, 0x00000001);
+  e.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0xffffffff, 0xffffffff);
+  rc += check_vint256 ("vec_mul128x128 1:", k.vx1, k.vx0, e.vx1, e.vx0);
+
+  i = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  k = __VEC_PWR_IMP (vec_mul128x128)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint256_prod ("2**128-1 * 2**128-1 ", k, i, j);
+#endif
+  e.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  e.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  rc += check_vint256 ("vec_mul128x128 2:", k.vx1, k.vx0, e.vx1, e.vx0);
+
+  i = (vui128_t) CONST_VINT128_W (0, 0, 0, 100000000);
+  j = (vui128_t) CONST_VINT128_W (0, 0, 0, 100000000);
+  k = __VEC_PWR_IMP (vec_mul128x128)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint256_prod ("10**8 * 10**8 ", k, i, j);
+#endif
+  e.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x002386f2, 0x6fc10000);
+  e.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint256 ("vec_mul128x128 3:", k.vx1, k.vx0, e.vx1, e.vx0);
+
+  i = k.vx0;
+  j = k.vx0;
+  k = __VEC_PWR_IMP (vec_mul128x128)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint256_prod ("10**16 * 10**16 ", k, i, j);
+#endif
+  e.vx0 = (vui128_t) CONST_VINT128_W (0x000004ee, 0x2d6d415b, 0x85acef81, 0x00000000);
+  e.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint256 ("vec_mul128x128 4:", k.vx1, k.vx0, e.vx1, e.vx0);
+
+  i = k.vx0;
+  j = k.vx0;
+  k = __VEC_PWR_IMP (vec_mul128x128)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint256_prod ("10**32 * 10**32 ", k, i, j);
+#endif
+  e.vx0 = (vui128_t) CONST_VINT128_W (0x6e38ed64, 0xbf6a1f01, 0x00000000, 0x00000000);
+  e.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00184f03, 0xe93ff9f4, 0xdaa797ed);
+  rc += check_vint256 ("vec_mul128x128 5:", k.vx1, k.vx0, e.vx1, e.vx0);
+
+  return (rc);
+}
+
+int
+test_mul256x256 (void)
+{
+  __VEC_U_512 k, e;
+  __VEC_U_256 i, j;
+  int rc = 0;
+
+  printf ("\ntest_mul256x256 vector multiply quadword, 512-bit product\n");
+
+  i.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  k = __VEC_PWR_IMP (vec_mul256x256)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x_prod ("2**256-1 * 2**256-1 ", k, i, j);
+#endif
+  e.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  e.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  e.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  e.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint512 ("vec_mul256x256 1:", k, e);
+
+  i.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  k = __VEC_PWR_IMP (vec_mul256x256)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x_prod ("2**256-1 * 2**256-1 ", k, i, j);
+#endif
+  e.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  e.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  e.vx2 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  e.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint512 ("vec_mul256x256 2:", k, e);
+
+  i.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  k = __VEC_PWR_IMP (vec_mul256x256)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x_prod ("2**256-1 * 2**256-1 ", k, i, j);
+#endif
+  e.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  e.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  e.vx2 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  e.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint512 ("vec_mul256x256 3:", k, e);
+
+  i.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  k = __VEC_PWR_IMP (vec_mul256x256)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x_prod ("2**256-1 * 2**256-1 ", k, i, j);
+#endif
+  e.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  e.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  e.vx2 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  e.vx3 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  rc += check_vint512 ("vec_mul256x256 4:", k, e);
+
+  i.vx0 = (vui128_t) CONST_VINT128_W (0x000004ee, 0x2d6d415b, 0x85acef81, 0x00000000);
+  i.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx0 = (vui128_t) CONST_VINT128_W (0x000004ee, 0x2d6d415b, 0x85acef81, 0x00000000);
+  j.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  k = __VEC_PWR_IMP (vec_mul256x256)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x_prod ("10**32 * 10**32 ", k, i, j);
+#endif
+  e.vx0 = (vui128_t) CONST_VINT128_W (0x6e38ed64, 0xbf6a1f01, 0x00000000, 0x00000000);
+  e.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00184f03, 0xe93ff9f4, 0xdaa797ed);
+  e.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  e.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint512 ("vec_mul256x256 5:", k, e);
+
+  i.vx0 = e.vx0;
+  i.vx1 = e.vx1;
+  j.vx0 = e.vx0;
+  j.vx1 = e.vx1;
+  k = __VEC_PWR_IMP (vec_mul256x256)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x_prod ("10**64 * 10**64 ", k, i, j);
+#endif
+  e.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  e.vx1 = (vui128_t) CONST_VINT128_W (0x2374e42f, 0x0f1538fd, 0x03df9909, 0x2e953e01);
+  e.vx2 = (vui128_t) CONST_VINT128_W (0xa6337f19, 0xbccdb0da, 0xc404dc08, 0xd3cff5ec);
+  e.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x0000024e, 0xe91f2603);
+  rc += check_vint512 ("vec_mul256x256 6:", k, e);
+
+  return (rc);
+}
+
+int
+test_mul512x128 (void)
+{
+  __VEC_U_640 k, e;
+  __VEC_U_512x1 kp, ep;
+  __VEC_U_512 i;
+  vui128_t j;
+  int rc = 0;
+
+  printf ("\ntest_mul512x128 vector multiply quadword, 512-bit product\n");
+
+  i.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j     = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  k = __VEC_PWR_IMP (vec_mul512x128)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" 2**128-1   ", i);
+  print_vint128x (" * 2**128-1 ", j);
+  print_vint640x ("          = ", k);
+#endif
+  kp.x640 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x128 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vuint128x ("vec_mul512x128 1a:", kp.x2.v1x128, ep.x2.v1x128);
+  rc += check_vint512   ("vec_mul512x128 1b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  i.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j     = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  k = __VEC_PWR_IMP (vec_mul512x128)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" 2**256-2**128-1 ", i);
+  print_vint128x ("      * 2**128-1 ", j);
+  print_vint640x ("               = ", k);
+#endif
+  kp.x640 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x128 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vuint128x ("vec_mul512x128 2a:", kp.x2.v1x128, ep.x2.v1x128);
+  rc += check_vint512   ("vec_mul512x128 2b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  i.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx2 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j     = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  k = __VEC_PWR_IMP (vec_mul512x128)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" 2**396-2**256-1 ", i);
+  print_vint128x ("      * 2**128-1 ", j);
+  print_vint640x ("               = ", k);
+#endif
+  kp.x640 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  ep.x2.v1x128 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vuint128x ("vec_mul512x128 3a:", kp.x2.v1x128, ep.x2.v1x128);
+  rc += check_vint512   ("vec_mul512x128 3b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  i.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx3 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j     = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  k = __VEC_PWR_IMP (vec_mul512x128)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  kp.x640 = k;
+  print_vint512x (" 2**512-2**396-1 ", i);
+  print_vint128x ("      * 2**128-1 ", j);
+  print_vint640x ("               = ", k);
+#endif
+  kp.x640 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ep.x2.v1x128 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  rc += check_vuint128x ("vec_mul512x128 4a:", kp.x2.v1x128, ep.x2.v1x128);
+  rc += check_vint512   ("vec_mul512x128 4b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  i.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx2 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx3 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j     = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  k = __VEC_PWR_IMP (vec_mul512x128)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x ("  2**512-1 ", i);
+  print_vint128x ("* 2**128-1 ", j);
+  print_vint640x ("         = ", k);
+#endif
+  kp.x640 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  ep.x2.v1x128 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  rc += check_vuint128x ("vec_mul512x128 5a:", kp.x2.v1x128, ep.x2.v1x128);
+  rc += check_vint512   ("vec_mul512x128 5b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  return (rc);
+}
+
+//#define __DEBUG_PRINT__ 1
+int
+test_mul512x512 (void)
+{
+  __VEC_U_1024 k, e;
+  __VEC_U_1024x512 kp, ep;
+  __VEC_U_512 i, j;
+  int rc = 0;
+
+  printf ("\ntest_mul512x512 vector multiply quadword, 1024-bit product\n");
+
+  i.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  k = __VEC_PWR_IMP (vec_mul512x512)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  kp.x1024 = k;
+  print_vint512x (" 2**128-1   ", i);
+  print_vint512x (" * 2**128-1 ", j);
+  print_vint512x ("     = h512 ", kp.x2.v1x512);
+  print_vint512x ("       l512 ", kp.x2.v0x512);
+#endif
+  kp.x1024 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint512 ("vec_mul512x128 1a:", kp.x2.v1x512, ep.x2.v1x512);
+  rc += check_vint512 ("vec_mul512x128 1b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  j.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  k = __VEC_PWR_IMP (vec_mul512x512)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  kp.x1024 = k;
+  print_vint512x (" 2**256-2**128-1 ", i);
+  print_vint512x (" * 2**128-1      ", j);
+  print_vint512x ("     = h512 ", kp.x2.v1x512);
+  print_vint512x ("       l512 ", kp.x2.v0x512);
+#endif
+  kp.x1024 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint512 ("vec_mul512x128 2a:", kp.x2.v1x512, ep.x2.v1x512);
+  rc += check_vint512 ("vec_mul512x128 2b:", kp.x2.v0x512, ep.x2.v0x512);
+  k = __VEC_PWR_IMP (vec_mul512x512)(j, i);
+
+#ifdef __DEBUG_PRINT__
+  kp.x1024 = k;
+  print_vint512x (" 2**256-2**128-1 ", j);
+  print_vint512x (" * 2**128-1      ", i);
+  print_vint512x ("     = h512 ", kp.x2.v1x512);
+  print_vint512x ("       l512 ", kp.x2.v0x512);
+#endif
+  kp.x1024 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint512 ("vec_mul512x128 2a:", kp.x2.v1x512, ep.x2.v1x512);
+  rc += check_vint512 ("vec_mul512x128 2b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  j.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx2 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  k = __VEC_PWR_IMP (vec_mul512x512)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  kp.x1024 = k;
+  print_vint512x (" 2**396-2**256-1 ", i);
+  print_vint512x (" * 2**128-1      ", j);
+  print_vint512x ("     = h512 ", kp.x2.v1x512);
+  print_vint512x ("       l512 ", kp.x2.v0x512);
+#endif
+  kp.x1024 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  ep.x2.v1x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint512 ("vec_mul512x128 3a:", kp.x2.v1x512, ep.x2.v1x512);
+  rc += check_vint512 ("vec_mul512x128 3b:", kp.x2.v0x512, ep.x2.v0x512);
+  k = __VEC_PWR_IMP (vec_mul512x512)(j, i);
+
+#ifdef __DEBUG_PRINT__
+  kp.x1024 = k;
+  print_vint512x (" 2**396-2**256-1 ", j);
+  print_vint512x (" * 2**128-1      ", i);
+  print_vint512x ("     = h512 ", kp.x2.v1x512);
+  print_vint512x ("       l512 ", kp.x2.v0x512);
+#endif
+  kp.x1024 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  ep.x2.v1x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint512 ("vec_mul512x128 4a:", kp.x2.v1x512, ep.x2.v1x512);
+  rc += check_vint512 ("vec_mul512x128 4b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  j.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx3 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  k = __VEC_PWR_IMP (vec_mul512x512)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  kp.x1024 = k;
+  print_vint512x (" 2**512-2**396-1 ", i);
+  print_vint512x (" * 2**128-1      ", j);
+  print_vint512x ("     = h512 ", kp.x2.v1x512);
+  print_vint512x ("       l512 ", kp.x2.v0x512);
+#endif
+  kp.x1024 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ep.x2.v1x512.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint512 ("vec_mul512x128 5a:", kp.x2.v1x512, ep.x2.v1x512);
+  rc += check_vint512 ("vec_mul512x128 5b:", kp.x2.v0x512, ep.x2.v0x512);
+  k = __VEC_PWR_IMP (vec_mul512x512)(j, i);
+
+#ifdef __DEBUG_PRINT__
+  kp.x1024 = k;
+  print_vint512x (" 2**512-2**396-1 ", j);
+  print_vint512x (" * 2**128-1      ", i);
+  print_vint512x ("     = h512 ", kp.x2.v1x512);
+  print_vint512x ("       l512 ", kp.x2.v0x512);
+#endif
+  kp.x1024 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ep.x2.v1x512.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint512 ("vec_mul512x128 6a:", kp.x2.v1x512, ep.x2.v1x512);
+  rc += check_vint512 ("vec_mul512x128 6b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  i.vx0 = (vui128_t) CONST_VINT128_W (0x000004ee, 0x2d6d415b, 0x85acef81, 0x00000000);
+  i.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx0 = (vui128_t) CONST_VINT128_W (0x000004ee, 0x2d6d415b, 0x85acef81, 0x00000000);
+  j.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  k = __VEC_PWR_IMP (vec_mul512x512)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  kp.x1024 = k;
+  print_vint512x (" 10**32   ", i);
+  print_vint512x (" * 10**32 ", j);
+  print_vint512x ("   = h512 ", kp.x2.v1x512);
+  print_vint512x ("     l512 ", kp.x2.v0x512);
+#endif
+  kp.x1024 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x6e38ed64, 0xbf6a1f01, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00184f03, 0xe93ff9f4, 0xdaa797ed);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint512 ("vec_mul512x128 7a:", kp.x2.v1x512, ep.x2.v1x512);
+  rc += check_vint512 ("vec_mul512x128 7b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  kp.x1024 = k;
+  i = kp.x2.v0x512;
+  j = kp.x2.v0x512;
+  k = __VEC_PWR_IMP (vec_mul512x512)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  kp.x1024 = k;
+  print_vint512x (" 10**64   ", i);
+  print_vint512x (" * 10**64 ", j);
+  print_vint512x ("   = h512 ", kp.x2.v1x512);
+  print_vint512x ("     l512 ", kp.x2.v0x512);
+#endif
+  kp.x1024 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x2374e42f, 0x0f1538fd, 0x03df9909, 0x2e953e01);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0xa6337f19, 0xbccdb0da, 0xc404dc08, 0xd3cff5ec);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x0000024e, 0xe91f2603);
+  ep.x2.v1x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint512 ("vec_mul512x128 8a:", kp.x2.v1x512, ep.x2.v1x512);
+  rc += check_vint512 ("vec_mul512x128 8b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  kp.x1024 = k;
+  i = kp.x2.v0x512;
+  j = kp.x2.v0x512;
+  k = __VEC_PWR_IMP (vec_mul512x512)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  kp.x1024 = k;
+  print_vint512x (" 10**128  ", i);
+  print_vint512x (" *10**128 ", j);
+  print_vint512x ("   = h512 ", kp.x2.v1x512);
+  print_vint512x ("     l512 ", kp.x2.v0x512);
+#endif
+  kp.x1024 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0x12152f87, 0xd8d99f72, 0xbed3875b, 0x982e7c01);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x26b2716e, 0xd595d80f, 0xcf4a6e70, 0x6bde50c6);
+  ep.x2.v1x512.vx0 = (vui128_t) CONST_VINT128_W (0x63ff540e, 0x3c42d35a, 0x1d153624, 0xadc666b0);
+  ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x80dcc7f7, 0x55bc28f2, 0x65f9ef17, 0xcc5573c0);
+  ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x000553f7, 0x5fdcefce, 0xf46eeddc);
+  ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint512 ("vec_mul512x128 8a:", kp.x2.v1x512, ep.x2.v1x512);
+  rc += check_vint512 ("vec_mul512x128 8b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  return (rc);
+}
+
+
+//#define __DEBUG_PRINT__ 1
+int
+test_mul1024x1024 (void)
+{
+  __VEC_U_2048x512 k, e;
+  __VEC_U_1024x512 m1, m2;
+  __VEC_U_512 i, j;
+
+  int rc = 0;
+
+  printf ("\ntest_mul1024x1024 vector multiply quadword, 2048-bit product\n");
+
+  m1.x2.v1x512 = vec512_zeros;
+  m1.x2.v0x512 = vec512_foxes;
+  m2.x2.v1x512 = vec512_zeros;
+  m2.x2.v0x512 = vec512_foxes;
+  __VEC_PWR_IMP (vec_mul1024x1024)(&k.x2048, &m1.x1024, &m2.x1024);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[1]   ", m1.x2.v1x512);
+  print_vint512x (" m1[0] * ", m1.x2.v0x512);
+  print_vint512x (" m2[1]   ", m2.x2.v1x512);
+  print_vint512x (" m2[0] = ", m2.x2.v0x512);
+  print_vint512x (" k [3]   ", k.x4.v3x512);
+  print_vint512x (" k [2]   ", k.x4.v2x512);
+  print_vint512x (" k [1]   ", k.x4.v1x512);
+  print_vint512x (" k [0] = ", k.x4.v0x512);
+#endif
+  e.x4.v0x512 = vec512_one;
+  e.x4.v1x512 = vec512_foxeasy;
+  e.x4.v2x512 = vec512_zeros;
+  e.x4.v3x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul1024x1024 1a:", k.x4.v3x512, e.x4.v3x512);
+  rc += check_vint512 ("vec_mul1024x1024 1b:", k.x4.v2x512, e.x4.v2x512);
+  rc += check_vint512 ("vec_mul1024x1024 1c:", k.x4.v1x512, e.x4.v1x512);
+  rc += check_vint512 ("vec_mul1024x1024 1d:", k.x4.v0x512, e.x4.v0x512);
+
+  m1.x2.v1x512 = vec512_foxes;
+  m1.x2.v0x512 = vec512_zeros;
+  m2.x2.v1x512 = vec512_zeros;
+  m2.x2.v0x512 = vec512_foxes;
+  __VEC_PWR_IMP (vec_mul1024x1024)(&k.x2048, &m1.x1024, &m2.x1024);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[1]   ", m1.x2.v1x512);
+  print_vint512x (" m1[0] * ", m1.x2.v0x512);
+  print_vint512x (" m2[1]   ", m2.x2.v1x512);
+  print_vint512x (" m2[0] = ", m2.x2.v0x512);
+  print_vint512x (" k [3]   ", k.x4.v3x512);
+  print_vint512x (" k [2]   ", k.x4.v2x512);
+  print_vint512x (" k [1]   ", k.x4.v1x512);
+  print_vint512x (" k [0]   ", k.x4.v0x512);
+#endif
+  e.x4.v0x512 = vec512_zeros;
+  e.x4.v1x512 = vec512_one;
+  e.x4.v2x512 = vec512_foxeasy;
+  e.x4.v3x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul1024x1024 2a:", k.x4.v3x512, e.x4.v3x512);
+  rc += check_vint512 ("vec_mul1024x1024 2b:", k.x4.v2x512, e.x4.v2x512);
+  rc += check_vint512 ("vec_mul1024x1024 2c:", k.x4.v1x512, e.x4.v1x512);
+  rc += check_vint512 ("vec_mul1024x1024 2d:", k.x4.v0x512, e.x4.v0x512);
+
+  __VEC_PWR_IMP (vec_mul1024x1024)(&k.x2048, &m1.x1024, &m2.x1024);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[1]   ", m2.x2.v1x512);
+  print_vint512x (" m1[0] * ", m2.x2.v0x512);
+  print_vint512x (" m2[1]   ", m1.x2.v1x512);
+  print_vint512x (" m2[0] = ", m1.x2.v0x512);
+  print_vint512x (" k [3]   ", k.x4.v3x512);
+  print_vint512x (" k [2]   ", k.x4.v2x512);
+  print_vint512x (" k [1]   ", k.x4.v1x512);
+  print_vint512x (" k [0]   ", k.x4.v0x512);
+#endif
+  rc += check_vint512 ("vec_mul1024x1024 3a:", k.x4.v3x512, e.x4.v3x512);
+  rc += check_vint512 ("vec_mul1024x1024 3b:", k.x4.v2x512, e.x4.v2x512);
+  rc += check_vint512 ("vec_mul1024x1024 3c:", k.x4.v1x512, e.x4.v1x512);
+  rc += check_vint512 ("vec_mul1024x1024 3d:", k.x4.v0x512, e.x4.v0x512);
+
+  m1.x2.v1x512 = vec512_foxes;
+  m1.x2.v0x512 = vec512_zeros;
+  m2.x2.v1x512 = vec512_foxes;
+  m2.x2.v0x512 = vec512_zeros;
+  __VEC_PWR_IMP (vec_mul1024x1024)(&k.x2048, &m1.x1024, &m2.x1024);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[1]   ", m1.x2.v1x512);
+  print_vint512x (" m1[0] * ", m1.x2.v0x512);
+  print_vint512x (" m2[1]   ", m2.x2.v1x512);
+  print_vint512x (" m2[0] = ", m2.x2.v0x512);
+  print_vint512x (" k [3]   ", k.x4.v3x512);
+  print_vint512x (" k [2]   ", k.x4.v2x512);
+  print_vint512x (" k [1]   ", k.x4.v1x512);
+  print_vint512x (" k [0]   ", k.x4.v0x512);
+#endif
+  e.x4.v0x512 = vec512_zeros;
+  e.x4.v1x512 = vec512_zeros;
+  e.x4.v2x512 = vec512_one;
+  e.x4.v3x512 = vec512_foxeasy;
+  rc += check_vint512 ("vec_mul1024x1024 4a:", k.x4.v3x512, e.x4.v3x512);
+  rc += check_vint512 ("vec_mul1024x1024 4b:", k.x4.v2x512, e.x4.v2x512);
+  rc += check_vint512 ("vec_mul1024x1024 4c:", k.x4.v1x512, e.x4.v1x512);
+  rc += check_vint512 ("vec_mul1024x1024 4d:", k.x4.v0x512, e.x4.v0x512);
+
+  m1.x2.v1x512 = vec512_foxes;
+  m1.x2.v0x512 = vec512_foxes;
+  m2.x2.v1x512 = vec512_foxes;
+  m2.x2.v0x512 = vec512_foxes;
+  __VEC_PWR_IMP (vec_mul1024x1024)(&k.x2048, &m1.x1024, &m2.x1024);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[1]   ", m1.x2.v1x512);
+  print_vint512x (" m1[0] * ", m1.x2.v0x512);
+  print_vint512x (" m2[1]   ", m2.x2.v1x512);
+  print_vint512x (" m2[0] = ", m2.x2.v0x512);
+  print_vint512x (" k [3]   ", k.x4.v3x512);
+  print_vint512x (" k [2]   ", k.x4.v2x512);
+  print_vint512x (" k [1]   ", k.x4.v1x512);
+  print_vint512x (" k [0]   ", k.x4.v0x512);
+#endif
+  e.x4.v0x512 = vec512_one;
+  e.x4.v1x512 = vec512_zeros;
+  e.x4.v2x512 = vec512_foxeasy;
+  e.x4.v3x512 = vec512_foxes;
+  rc += check_vint512 ("vec_mul1024x1024 5a:", k.x4.v3x512, e.x4.v3x512);
+  rc += check_vint512 ("vec_mul1024x1024 5b:", k.x4.v2x512, e.x4.v2x512);
+  rc += check_vint512 ("vec_mul1024x1024 5c:", k.x4.v1x512, e.x4.v1x512);
+  rc += check_vint512 ("vec_mul1024x1024 5d:", k.x4.v0x512, e.x4.v0x512);
+
+  m1.x2.v1x512 = vec512_zeros;
+  m1.x2.v0x512 = vec512_ten128th;
+  m2.x2.v1x512 = vec512_zeros;
+  m2.x2.v0x512 = vec512_ten128th;
+  __VEC_PWR_IMP (vec_mul1024x1024)(&k.x2048, &m1.x1024, &m2.x1024);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[1]   ", m1.x2.v1x512);
+  print_vint512x (" m1[0] * ", m1.x2.v0x512);
+  print_vint512x (" m2[1]   ", m2.x2.v1x512);
+  print_vint512x (" m2[0] = ", m2.x2.v0x512);
+  print_vint512x (" k [3]   ", k.x4.v3x512);
+  print_vint512x (" k [2]   ", k.x4.v2x512);
+  print_vint512x (" k [1]   ", k.x4.v1x512);
+  print_vint512x (" k [0]   ", k.x4.v0x512);
+#endif
+  e.x4.v0x512 = vec512_ten256_l;
+  e.x4.v1x512 = vec512_ten256_h;
+  e.x4.v2x512 = vec512_zeros;
+  e.x4.v3x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul1024x1024 6a:", k.x4.v3x512, e.x4.v3x512);
+  rc += check_vint512 ("vec_mul1024x1024 6b:", k.x4.v2x512, e.x4.v2x512);
+  rc += check_vint512 ("vec_mul1024x1024 6c:", k.x4.v1x512, e.x4.v1x512);
+  rc += check_vint512 ("vec_mul1024x1024 6d:", k.x4.v0x512, e.x4.v0x512);
+
+  m1.x2.v1x512 = e.x4.v1x512;
+  m1.x2.v0x512 = e.x4.v0x512;
+  m2.x2.v1x512 = e.x4.v1x512;
+  m2.x2.v0x512 = e.x4.v0x512;
+  __VEC_PWR_IMP (vec_mul1024x1024)(&k.x2048, &m1.x1024, &m2.x1024);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[1]   ", m1.x2.v1x512);
+  print_vint512x (" m1[0] * ", m1.x2.v0x512);
+  print_vint512x (" m2[1]   ", m2.x2.v1x512);
+  print_vint512x (" m2[0] = ", m2.x2.v0x512);
+  print_vint512x (" k [3]   ", k.x4.v3x512);
+  print_vint512x (" k [2]   ", k.x4.v2x512);
+  print_vint512x (" k [1]   ", k.x4.v1x512);
+  print_vint512x (" k [0]   ", k.x4.v0x512);
+#endif
+  e.x4.v0x512 = vec512_zeros;
+  e.x4.v1x512 = vec512_ten512_1;
+  e.x4.v2x512 = vec512_ten512_2;
+  e.x4.v3x512 = vec512_ten512_3;
+  rc += check_vint512 ("vec_mul1024x1024 7a:", k.x4.v3x512, e.x4.v3x512);
+  rc += check_vint512 ("vec_mul1024x1024 7b:", k.x4.v2x512, e.x4.v2x512);
+  rc += check_vint512 ("vec_mul1024x1024 7c:", k.x4.v1x512, e.x4.v1x512);
+  rc += check_vint512 ("vec_mul1024x1024 7d:", k.x4.v0x512, e.x4.v0x512);
+
+  m1.x2.v1x512 = vec512_zeros;
+  m1.x2.v0x512 = vec512_ten128th;
+  m2.x2.v1x512 = vec512_ten256_h;
+  m2.x2.v0x512 = vec512_ten256_l;
+  __VEC_PWR_IMP (vec_mul1024x1024)(&k.x2048, &m1.x1024, &m2.x1024);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[1]   ", m1.x2.v1x512);
+  print_vint512x (" m1[0] * ", m1.x2.v0x512);
+  print_vint512x (" m2[1]   ", m2.x2.v1x512);
+  print_vint512x (" m2[0] = ", m2.x2.v0x512);
+  print_vint512x (" k [3]   ", k.x4.v3x512);
+  print_vint512x (" k [2]   ", k.x4.v2x512);
+  print_vint512x (" k [1]   ", k.x4.v1x512);
+  print_vint512x (" k [0]   ", k.x4.v0x512);
+#endif
+  e.x4.v0x512 = vec512_ten384_l;
+  e.x4.v1x512 = vec512_ten384_m;
+  e.x4.v2x512 = vec512_ten384_h;
+  e.x4.v3x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul1024x1024 8a:", k.x4.v3x512, e.x4.v3x512);
+  rc += check_vint512 ("vec_mul1024x1024 8b:", k.x4.v2x512, e.x4.v2x512);
+  rc += check_vint512 ("vec_mul1024x1024 8c:", k.x4.v1x512, e.x4.v1x512);
+  rc += check_vint512 ("vec_mul1024x1024 8d:", k.x4.v0x512, e.x4.v0x512);
+
+  __VEC_PWR_IMP (vec_mul1024x1024)(&k.x2048, &m1.x1024, &m2.x1024);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[1]   ", m2.x2.v1x512);
+  print_vint512x (" m1[0] * ", m2.x2.v0x512);
+  print_vint512x (" m2[1]   ", m1.x2.v1x512);
+  print_vint512x (" m2[0] = ", m1.x2.v0x512);
+  print_vint512x (" k [3]   ", k.x4.v3x512);
+  print_vint512x (" k [2]   ", k.x4.v2x512);
+  print_vint512x (" k [1]   ", k.x4.v1x512);
+  print_vint512x (" k [0]   ", k.x4.v0x512);
+#endif
+  rc += check_vint512 ("vec_mul1024x1024 9a:", k.x4.v3x512, e.x4.v3x512);
+  rc += check_vint512 ("vec_mul1024x1024 9b:", k.x4.v2x512, e.x4.v2x512);
+  rc += check_vint512 ("vec_mul1024x1024 9c:", k.x4.v1x512, e.x4.v1x512);
+  rc += check_vint512 ("vec_mul1024x1024 9d:", k.x4.v0x512, e.x4.v0x512);
+
+  m1.x2.v1x512 = vec512_foxes;
+  m1.x2.v0x512 = vec512_foxes;
+  m2.x2.v1x512 = vec512_foxes;
+  m2.x2.v0x512 = vec512_zeros;
+  __VEC_PWR_IMP (vec_mul1024x1024)(&k.x2048, &m1.x1024, &m2.x1024);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[1]   ", m1.x2.v1x512);
+  print_vint512x (" m1[0] * ", m1.x2.v0x512);
+  print_vint512x (" m2[1]   ", m2.x2.v1x512);
+  print_vint512x (" m2[0] = ", m2.x2.v0x512);
+  print_vint512x (" k [3]   ", k.x4.v3x512);
+  print_vint512x (" k [2]   ", k.x4.v2x512);
+  print_vint512x (" k [1]   ", k.x4.v1x512);
+  print_vint512x (" k [0]   ", k.x4.v0x512);
+#endif
+  e.x4.v0x512 = vec512_zeros;
+  e.x4.v1x512 = vec512_one;
+  e.x4.v2x512 = vec512_foxes;
+  e.x4.v3x512 = vec512_foxeasy;
+  rc += check_vint512 ("vec_mul1024x1024 10a:", k.x4.v3x512, e.x4.v3x512);
+  rc += check_vint512 ("vec_mul1024x1024 10b:", k.x4.v2x512, e.x4.v2x512);
+  rc += check_vint512 ("vec_mul1024x1024 10c:", k.x4.v1x512, e.x4.v1x512);
+  rc += check_vint512 ("vec_mul1024x1024 10d:", k.x4.v0x512, e.x4.v0x512);
+
+  return (rc);
+}
+//#undef __DEBUG_PRINT__
+
+//#define __DEBUG_PRINT__ 1
+int
+test_mul2048x2048 (void)
+{
+  __VEC_U_4096x512 k, e;
+  __VEC_U_2048x512 m1, m2;
+  __VEC_U_512 i, j;
+
+  int rc = 0;
+
+  printf ("\ntest_mul2048x2048 vector multiply quadword, 1024-bit product\n");
+
+  m1.x4.v3x512 = vec512_zeros;
+  m1.x4.v2x512 = vec512_zeros;
+  m1.x4.v1x512 = vec512_zeros;
+  m1.x4.v0x512 = vec512_foxes;
+  m2.x4.v3x512 = vec512_zeros;
+  m2.x4.v2x512 = vec512_zeros;
+  m2.x4.v1x512 = vec512_zeros;
+  m2.x4.v0x512 = vec512_foxes;
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k.x4096, &m1.x2048, &m2.x2048);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[3]   ", m1.x4.v3x512);
+  print_vint512x (" m1[2]   ", m1.x4.v2x512);
+  print_vint512x (" m1[1]   ", m1.x4.v1x512);
+  print_vint512x (" m1[0] * ", m1.x4.v0x512);
+  print_vint512x (" m2[3]   ", m2.x4.v3x512);
+  print_vint512x (" m2[2]   ", m2.x4.v2x512);
+  print_vint512x (" m2[1]   ", m2.x4.v1x512);
+  print_vint512x (" m2[0] = ", m2.x4.v0x512);
+  print_vint512x (" k [7]   ", k.x8.v7x512);
+  print_vint512x (" k [6]   ", k.x8.v6x512);
+  print_vint512x (" k [5]   ", k.x8.v5x512);
+  print_vint512x (" k [4] = ", k.x8.v4x512);
+  print_vint512x (" k [3]   ", k.x8.v3x512);
+  print_vint512x (" k [2]   ", k.x8.v2x512);
+  print_vint512x (" k [1]   ", k.x8.v1x512);
+  print_vint512x (" k [0] = ", k.x8.v0x512);
+#endif
+  e.x8.v0x512 = vec512_one;
+  e.x8.v1x512 = vec512_foxeasy;
+  e.x8.v2x512 = vec512_zeros;
+  e.x8.v3x512 = vec512_zeros;
+  e.x8.v4x512 = vec512_zeros;
+  e.x8.v5x512 = vec512_zeros;
+  e.x8.v6x512 = vec512_zeros;
+  e.x8.v7x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul2048x2048 1a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul2048x2048 1b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul2048x2048 1c:", k.x8.v5x512, e.x8.v5x512);
+  rc += check_vint512 ("vec_mul2048x2048 1d:", k.x8.v4x512, e.x8.v4x512);
+  rc += check_vint512 ("vec_mul2048x2048 1e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul2048x2048 1f:", k.x8.v2x512, e.x8.v2x512);
+  rc += check_vint512 ("vec_mul2048x2048 1g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul2048x2048 1h:", k.x8.v0x512, e.x8.v0x512);
+
+  m1.x4.v3x512 = vec512_zeros;
+  m1.x4.v2x512 = vec512_zeros;
+  m1.x4.v1x512 = vec512_foxes;
+  m1.x4.v0x512 = vec512_zeros;
+  m2.x4.v3x512 = vec512_zeros;
+  m2.x4.v2x512 = vec512_zeros;
+  m2.x4.v1x512 = vec512_zeros;
+  m2.x4.v0x512 = vec512_foxes;
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k.x4096, &m1.x2048, &m2.x2048);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[3]   ", m1.x4.v3x512);
+  print_vint512x (" m1[2]   ", m1.x4.v2x512);
+  print_vint512x (" m1[1]   ", m1.x4.v1x512);
+  print_vint512x (" m1[0] * ", m1.x4.v0x512);
+  print_vint512x (" m2[3]   ", m2.x4.v3x512);
+  print_vint512x (" m2[2]   ", m2.x4.v2x512);
+  print_vint512x (" m2[1]   ", m2.x4.v1x512);
+  print_vint512x (" m2[0] = ", m2.x4.v0x512);
+  print_vint512x (" k [7]   ", k.x8.v7x512);
+  print_vint512x (" k [6]   ", k.x8.v6x512);
+  print_vint512x (" k [5]   ", k.x8.v5x512);
+  print_vint512x (" k [4]   ", k.x8.v4x512);
+  print_vint512x (" k [3]   ", k.x8.v3x512);
+  print_vint512x (" k [2]   ", k.x8.v2x512);
+  print_vint512x (" k [1]   ", k.x8.v1x512);
+  print_vint512x (" k [0]   ", k.x8.v0x512);
+#endif
+  e.x8.v0x512 = vec512_zeros;
+  e.x8.v1x512 = vec512_one;
+  e.x8.v2x512 = vec512_foxeasy;
+  e.x8.v3x512 = vec512_zeros;
+  e.x8.v4x512 = vec512_zeros;
+  e.x8.v5x512 = vec512_zeros;
+  e.x8.v6x512 = vec512_zeros;
+  e.x8.v7x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul2048x2048 2a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul2048x2048 2b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul2048x2048 2c:", k.x8.v5x512, e.x8.v5x512);
+  rc += check_vint512 ("vec_mul2048x2048 2d:", k.x8.v4x512, e.x8.v4x512);
+  rc += check_vint512 ("vec_mul2048x2048 2e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul2048x2048 2f:", k.x8.v2x512, e.x8.v2x512);
+  rc += check_vint512 ("vec_mul2048x2048 2g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul2048x2048 2h:", k.x8.v0x512, e.x8.v0x512);
+
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k.x4096, &m1.x2048, &m2.x2048);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[3]   ", m2.x4.v3x512);
+  print_vint512x (" m1[2]   ", m2.x4.v2x512);
+  print_vint512x (" m1[1]   ", m2.x4.v1x512);
+  print_vint512x (" m1[0] * ", m2.x4.v0x512);
+  print_vint512x (" m2[3]   ", m1.x4.v3x512);
+  print_vint512x (" m2[2]   ", m1.x4.v2x512);
+  print_vint512x (" m2[1]   ", m1.x4.v1x512);
+  print_vint512x (" m2[0] = ", m1.x4.v0x512);
+  print_vint512x (" k [7]   ", k.x8.v7x512);
+  print_vint512x (" k [6]   ", k.x8.v6x512);
+  print_vint512x (" k [5]   ", k.x8.v5x512);
+  print_vint512x (" k [4]   ", k.x8.v4x512);
+  print_vint512x (" k [3]   ", k.x8.v3x512);
+  print_vint512x (" k [2]   ", k.x8.v2x512);
+  print_vint512x (" k [1]   ", k.x8.v1x512);
+  print_vint512x (" k [0]   ", k.x8.v0x512);
+#endif
+  rc += check_vint512 ("vec_mul2048x2048 3a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul2048x2048 3b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul2048x2048 3c:", k.x8.v5x512, e.x8.v5x512);
+  rc += check_vint512 ("vec_mul2048x2048 3d:", k.x8.v4x512, e.x8.v4x512);
+  rc += check_vint512 ("vec_mul2048x2048 3e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul2048x2048 3f:", k.x8.v2x512, e.x8.v2x512);
+  rc += check_vint512 ("vec_mul2048x2048 3g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul2048x2048 3h:", k.x8.v0x512, e.x8.v0x512);
+
+  m1.x4.v3x512 = vec512_zeros;
+  m1.x4.v2x512 = vec512_foxes;
+  m1.x4.v1x512 = vec512_zeros;
+  m1.x4.v0x512 = vec512_zeros;
+  m2.x4.v3x512 = vec512_zeros;
+  m2.x4.v2x512 = vec512_zeros;
+  m2.x4.v1x512 = vec512_zeros;
+  m2.x4.v0x512 = vec512_foxes;
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k.x4096, &m1.x2048, &m2.x2048);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[3]   ", m1.x4.v3x512);
+  print_vint512x (" m1[2]   ", m1.x4.v2x512);
+  print_vint512x (" m1[1]   ", m1.x4.v1x512);
+  print_vint512x (" m1[0] * ", m1.x4.v0x512);
+  print_vint512x (" m2[3]   ", m2.x4.v3x512);
+  print_vint512x (" m2[2]   ", m2.x4.v2x512);
+  print_vint512x (" m2[1]   ", m2.x4.v1x512);
+  print_vint512x (" m2[0] = ", m2.x4.v0x512);
+  print_vint512x (" k [7]   ", k.x8.v7x512);
+  print_vint512x (" k [6]   ", k.x8.v6x512);
+  print_vint512x (" k [5]   ", k.x8.v5x512);
+  print_vint512x (" k [4]   ", k.x8.v4x512);
+  print_vint512x (" k [3]   ", k.x8.v3x512);
+  print_vint512x (" k [2]   ", k.x8.v2x512);
+  print_vint512x (" k [1]   ", k.x8.v1x512);
+  print_vint512x (" k [0]   ", k.x8.v0x512);
+#endif
+  e.x8.v0x512 = vec512_zeros;
+  e.x8.v1x512 = vec512_zeros;
+  e.x8.v2x512 = vec512_one;
+  e.x8.v3x512 = vec512_foxeasy;
+  e.x8.v4x512 = vec512_zeros;
+  e.x8.v5x512 = vec512_zeros;
+  e.x8.v6x512 = vec512_zeros;
+  e.x8.v7x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul2048x2048 4a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul2048x2048 4b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul2048x2048 4c:", k.x8.v5x512, e.x8.v5x512);
+  rc += check_vint512 ("vec_mul2048x2048 4d:", k.x8.v4x512, e.x8.v4x512);
+  rc += check_vint512 ("vec_mul2048x2048 4e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul2048x2048 4f:", k.x8.v2x512, e.x8.v2x512);
+  rc += check_vint512 ("vec_mul2048x2048 4g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul2048x2048 4h:", k.x8.v0x512, e.x8.v0x512);
+
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k.x4096, &m1.x2048, &m2.x2048);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[3]   ", m2.x4.v3x512);
+  print_vint512x (" m1[2]   ", m2.x4.v2x512);
+  print_vint512x (" m1[1]   ", m2.x4.v1x512);
+  print_vint512x (" m1[0] * ", m2.x4.v0x512);
+  print_vint512x (" m2[3]   ", m1.x4.v3x512);
+  print_vint512x (" m2[2]   ", m1.x4.v2x512);
+  print_vint512x (" m2[1]   ", m1.x4.v1x512);
+  print_vint512x (" m2[0] = ", m1.x4.v0x512);
+  print_vint512x (" k [7]   ", k.x8.v7x512);
+  print_vint512x (" k [6]   ", k.x8.v6x512);
+  print_vint512x (" k [5]   ", k.x8.v5x512);
+  print_vint512x (" k [4]   ", k.x8.v4x512);
+  print_vint512x (" k [3]   ", k.x8.v3x512);
+  print_vint512x (" k [2]   ", k.x8.v2x512);
+  print_vint512x (" k [1]   ", k.x8.v1x512);
+  print_vint512x (" k [0]   ", k.x8.v0x512);
+#endif
+  rc += check_vint512 ("vec_mul2048x2048 5a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul2048x2048 5b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul2048x2048 5c:", k.x8.v5x512, e.x8.v5x512);
+  rc += check_vint512 ("vec_mul2048x2048 5d:", k.x8.v4x512, e.x8.v4x512);
+  rc += check_vint512 ("vec_mul2048x2048 5e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul2048x2048 5f:", k.x8.v2x512, e.x8.v2x512);
+  rc += check_vint512 ("vec_mul2048x2048 5g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul2048x2048 5h:", k.x8.v0x512, e.x8.v0x512);
+
+  m1.x4.v3x512 = vec512_foxes;
+  m1.x4.v2x512 = vec512_zeros;
+  m1.x4.v1x512 = vec512_zeros;
+  m1.x4.v0x512 = vec512_zeros;
+  m2.x4.v3x512 = vec512_zeros;
+  m2.x4.v2x512 = vec512_zeros;
+  m2.x4.v1x512 = vec512_zeros;
+  m2.x4.v0x512 = vec512_foxes;
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k.x4096, &m1.x2048, &m2.x2048);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[3]   ", m1.x4.v3x512);
+  print_vint512x (" m1[2]   ", m1.x4.v2x512);
+  print_vint512x (" m1[1]   ", m1.x4.v1x512);
+  print_vint512x (" m1[0] * ", m1.x4.v0x512);
+  print_vint512x (" m2[3]   ", m2.x4.v3x512);
+  print_vint512x (" m2[2]   ", m2.x4.v2x512);
+  print_vint512x (" m2[1]   ", m2.x4.v1x512);
+  print_vint512x (" m2[0] = ", m2.x4.v0x512);
+  print_vint512x (" k [7]   ", k.x8.v7x512);
+  print_vint512x (" k [6]   ", k.x8.v6x512);
+  print_vint512x (" k [5]   ", k.x8.v5x512);
+  print_vint512x (" k [4]   ", k.x8.v4x512);
+  print_vint512x (" k [3]   ", k.x8.v3x512);
+  print_vint512x (" k [2]   ", k.x8.v2x512);
+  print_vint512x (" k [1]   ", k.x8.v1x512);
+  print_vint512x (" k [0]   ", k.x8.v0x512);
+#endif
+  e.x8.v0x512 = vec512_zeros;
+  e.x8.v1x512 = vec512_zeros;
+  e.x8.v2x512 = vec512_zeros;
+  e.x8.v3x512 = vec512_one;
+  e.x8.v4x512 = vec512_foxeasy;
+  e.x8.v5x512 = vec512_zeros;
+  e.x8.v6x512 = vec512_zeros;
+  e.x8.v7x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul2048x2048 6a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul2048x2048 6b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul2048x2048 6c:", k.x8.v5x512, e.x8.v5x512);
+  rc += check_vint512 ("vec_mul2048x2048 6d:", k.x8.v4x512, e.x8.v4x512);
+  rc += check_vint512 ("vec_mul2048x2048 6e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul2048x2048 6f:", k.x8.v2x512, e.x8.v2x512);
+  rc += check_vint512 ("vec_mul2048x2048 6g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul2048x2048 6h:", k.x8.v0x512, e.x8.v0x512);
+
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k.x4096, &m1.x2048, &m2.x2048);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[3]   ", m2.x4.v3x512);
+  print_vint512x (" m1[2]   ", m2.x4.v2x512);
+  print_vint512x (" m1[1]   ", m2.x4.v1x512);
+  print_vint512x (" m1[0] * ", m2.x4.v0x512);
+  print_vint512x (" m2[3]   ", m1.x4.v3x512);
+  print_vint512x (" m2[2]   ", m1.x4.v2x512);
+  print_vint512x (" m2[1]   ", m1.x4.v1x512);
+  print_vint512x (" m2[0] = ", m1.x4.v0x512);
+  print_vint512x (" k [7]   ", k.x8.v7x512);
+  print_vint512x (" k [6]   ", k.x8.v6x512);
+  print_vint512x (" k [5]   ", k.x8.v5x512);
+  print_vint512x (" k [4]   ", k.x8.v4x512);
+  print_vint512x (" k [3]   ", k.x8.v3x512);
+  print_vint512x (" k [2]   ", k.x8.v2x512);
+  print_vint512x (" k [1]   ", k.x8.v1x512);
+  print_vint512x (" k [0]   ", k.x8.v0x512);
+#endif
+  rc += check_vint512 ("vec_mul2048x2048 7a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul2048x2048 7b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul2048x2048 7c:", k.x8.v5x512, e.x8.v5x512);
+  rc += check_vint512 ("vec_mul2048x2048 7d:", k.x8.v4x512, e.x8.v4x512);
+  rc += check_vint512 ("vec_mul2048x2048 7e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul2048x2048 7f:", k.x8.v2x512, e.x8.v2x512);
+  rc += check_vint512 ("vec_mul2048x2048 7g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul2048x2048 7h:", k.x8.v0x512, e.x8.v0x512);
+
+  m1.x4.v3x512 = vec512_foxes;
+  m1.x4.v2x512 = vec512_foxes;
+  m1.x4.v1x512 = vec512_foxes;
+  m1.x4.v0x512 = vec512_foxes;
+  m2.x4.v3x512 = vec512_foxes;
+  m2.x4.v2x512 = vec512_foxes;
+  m2.x4.v1x512 = vec512_foxes;
+  m2.x4.v0x512 = vec512_foxes;
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k.x4096, &m1.x2048, &m2.x2048);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[3]   ", m1.x4.v3x512);
+  print_vint512x (" m1[2]   ", m1.x4.v2x512);
+  print_vint512x (" m1[1]   ", m1.x4.v1x512);
+  print_vint512x (" m1[0] * ", m1.x4.v0x512);
+  print_vint512x (" m2[3]   ", m2.x4.v3x512);
+  print_vint512x (" m2[2]   ", m2.x4.v2x512);
+  print_vint512x (" m2[1]   ", m2.x4.v1x512);
+  print_vint512x (" m2[0] = ", m2.x4.v0x512);
+  print_vint512x (" k [7]   ", k.x8.v7x512);
+  print_vint512x (" k [6]   ", k.x8.v6x512);
+  print_vint512x (" k [5]   ", k.x8.v5x512);
+  print_vint512x (" k [4]   ", k.x8.v4x512);
+  print_vint512x (" k [3]   ", k.x8.v3x512);
+  print_vint512x (" k [2]   ", k.x8.v2x512);
+  print_vint512x (" k [1]   ", k.x8.v1x512);
+  print_vint512x (" k [0]   ", k.x8.v0x512);
+#endif
+  e.x8.v0x512 = vec512_one;
+  e.x8.v1x512 = vec512_zeros;
+  e.x8.v2x512 = vec512_zeros;
+  e.x8.v3x512 = vec512_zeros;
+  e.x8.v4x512 = vec512_foxeasy;
+  e.x8.v5x512 = vec512_foxes;
+  e.x8.v6x512 = vec512_foxes;
+  e.x8.v7x512 = vec512_foxes;
+  rc += check_vint512 ("vec_mul2048x2048 8a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul2048x2048 8b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul2048x2048 8c:", k.x8.v5x512, e.x8.v5x512);
+  rc += check_vint512 ("vec_mul2048x2048 8d:", k.x8.v4x512, e.x8.v4x512);
+  rc += check_vint512 ("vec_mul2048x2048 8e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul2048x2048 8f:", k.x8.v2x512, e.x8.v2x512);
+  rc += check_vint512 ("vec_mul2048x2048 8g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul2048x2048 8h:", k.x8.v0x512, e.x8.v0x512);
+
+  m1.x4.v3x512 = vec512_zeros;
+  m1.x4.v2x512 = vec512_zeros;
+  m1.x4.v1x512 = vec512_foxes;
+  m1.x4.v0x512 = vec512_foxes;
+  m2.x4.v3x512 = vec512_zeros;
+  m2.x4.v2x512 = vec512_zeros;
+  m2.x4.v1x512 = vec512_foxes;
+  m2.x4.v0x512 = vec512_foxes;
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k.x4096, &m1.x2048, &m2.x2048);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[3]   ", m1.x4.v3x512);
+  print_vint512x (" m1[2]   ", m1.x4.v2x512);
+  print_vint512x (" m1[1]   ", m1.x4.v1x512);
+  print_vint512x (" m1[0] * ", m1.x4.v0x512);
+  print_vint512x (" m2[3]   ", m2.x4.v3x512);
+  print_vint512x (" m2[2]   ", m2.x4.v2x512);
+  print_vint512x (" m2[1]   ", m2.x4.v1x512);
+  print_vint512x (" m2[0] = ", m2.x4.v0x512);
+  print_vint512x (" k [7]   ", k.x8.v7x512);
+  print_vint512x (" k [6]   ", k.x8.v6x512);
+  print_vint512x (" k [5]   ", k.x8.v5x512);
+  print_vint512x (" k [4]   ", k.x8.v4x512);
+  print_vint512x (" k [3]   ", k.x8.v3x512);
+  print_vint512x (" k [2]   ", k.x8.v2x512);
+  print_vint512x (" k [1]   ", k.x8.v1x512);
+  print_vint512x (" k [0]   ", k.x8.v0x512);
+#endif
+  e.x8.v0x512 = vec512_one;
+  e.x8.v1x512 = vec512_zeros;
+  e.x8.v2x512 = vec512_foxeasy;
+  e.x8.v3x512 = vec512_foxes;
+  e.x8.v4x512 = vec512_zeros;
+  e.x8.v5x512 = vec512_zeros;
+  e.x8.v6x512 = vec512_zeros;
+  e.x8.v7x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul2048x2048 9a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul2048x2048 9b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul2048x2048 9c:", k.x8.v5x512, e.x8.v5x512);
+  rc += check_vint512 ("vec_mul2048x2048 9d:", k.x8.v4x512, e.x8.v4x512);
+  rc += check_vint512 ("vec_mul2048x2048 9e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul2048x2048 9f:", k.x8.v2x512, e.x8.v2x512);
+  rc += check_vint512 ("vec_mul2048x2048 9g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul2048x2048 9h:", k.x8.v0x512, e.x8.v0x512);
+
+  m1.x4.v3x512 = vec512_foxes;
+  m1.x4.v2x512 = vec512_foxes;
+  m1.x4.v1x512 = vec512_foxes;
+  m1.x4.v0x512 = vec512_foxes;
+  m2.x4.v3x512 = vec512_zeros;
+  m2.x4.v2x512 = vec512_zeros;
+  m2.x4.v1x512 = vec512_zeros;
+  m2.x4.v0x512 = vec512_foxes;
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k.x4096, &m1.x2048, &m2.x2048);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[3]   ", m1.x4.v3x512);
+  print_vint512x (" m1[2]   ", m1.x4.v2x512);
+  print_vint512x (" m1[1]   ", m1.x4.v1x512);
+  print_vint512x (" m1[0] * ", m1.x4.v0x512);
+  print_vint512x (" m2[3]   ", m2.x4.v3x512);
+  print_vint512x (" m2[2]   ", m2.x4.v2x512);
+  print_vint512x (" m2[1]   ", m2.x4.v1x512);
+  print_vint512x (" m2[0] = ", m2.x4.v0x512);
+  print_vint512x (" k [7]   ", k.x8.v7x512);
+  print_vint512x (" k [6]   ", k.x8.v6x512);
+  print_vint512x (" k [5]   ", k.x8.v5x512);
+  print_vint512x (" k [4]   ", k.x8.v4x512);
+  print_vint512x (" k [3]   ", k.x8.v3x512);
+  print_vint512x (" k [2]   ", k.x8.v2x512);
+  print_vint512x (" k [1]   ", k.x8.v1x512);
+  print_vint512x (" k [0]   ", k.x8.v0x512);
+#endif
+  e.x8.v0x512 = vec512_one;
+  e.x8.v1x512 = vec512_foxes;
+  e.x8.v2x512 = vec512_foxes;
+  e.x8.v3x512 = vec512_foxes;
+  e.x8.v4x512 = vec512_foxeasy;
+  e.x8.v5x512 = vec512_zeros;
+  e.x8.v6x512 = vec512_zeros;
+  e.x8.v7x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul2048x2048 10a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul2048x2048 10b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul2048x2048 10c:", k.x8.v5x512, e.x8.v5x512);
+  rc += check_vint512 ("vec_mul2048x2048 10d:", k.x8.v4x512, e.x8.v4x512);
+  rc += check_vint512 ("vec_mul2048x2048 10e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul2048x2048 10f:", k.x8.v2x512, e.x8.v2x512);
+  rc += check_vint512 ("vec_mul2048x2048 10g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul2048x2048 10h:", k.x8.v0x512, e.x8.v0x512);
+
+  m1.x4.v3x512 = vec512_zeros;
+  m1.x4.v2x512 = vec512_zeros;
+  m1.x4.v1x512 = vec512_zeros;
+  m1.x4.v0x512 = vec512_ten128th;
+  m2.x4.v3x512 = vec512_zeros;
+  m2.x4.v2x512 = vec512_zeros;
+  m2.x4.v1x512 = vec512_zeros;
+  m2.x4.v0x512 = vec512_ten128th;
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k.x4096, &m1.x2048, &m2.x2048);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[3]   ", m1.x4.v3x512);
+  print_vint512x (" m1[2]   ", m1.x4.v2x512);
+  print_vint512x (" m1[1]   ", m1.x4.v1x512);
+  print_vint512x (" m1[0] * ", m1.x4.v0x512);
+  print_vint512x (" m2[3]   ", m2.x4.v3x512);
+  print_vint512x (" m2[2]   ", m2.x4.v2x512);
+  print_vint512x (" m2[1]   ", m2.x4.v1x512);
+  print_vint512x (" m2[0] = ", m2.x4.v0x512);
+  print_vint512x (" k [7]   ", k.x8.v7x512);
+  print_vint512x (" k [6]   ", k.x8.v6x512);
+  print_vint512x (" k [5]   ", k.x8.v5x512);
+  print_vint512x (" k [4]   ", k.x8.v4x512);
+  print_vint512x (" k [3]   ", k.x8.v3x512);
+  print_vint512x (" k [2]   ", k.x8.v2x512);
+  print_vint512x (" k [1]   ", k.x8.v1x512);
+  print_vint512x (" k [0]   ", k.x8.v0x512);
+#endif
+  e.x8.v0x512 = vec512_ten256_l;
+  e.x8.v1x512 = vec512_ten256_h;
+  e.x8.v2x512 = vec512_zeros;
+  e.x8.v3x512 = vec512_zeros;
+  e.x8.v4x512 = vec512_zeros;
+  e.x8.v5x512 = vec512_zeros;
+  e.x8.v6x512 = vec512_zeros;
+  e.x8.v7x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul2048x2048 11a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul2048x2048 11b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul2048x2048 11c:", k.x8.v5x512, e.x8.v5x512);
+  rc += check_vint512 ("vec_mul2048x2048 11d:", k.x8.v4x512, e.x8.v4x512);
+  rc += check_vint512 ("vec_mul2048x2048 11e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul2048x2048 11f:", k.x8.v2x512, e.x8.v2x512);
+  rc += check_vint512 ("vec_mul2048x2048 11g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul2048x2048 11h:", k.x8.v0x512, e.x8.v0x512);
+
+  m1.x4.v3x512 = vec512_zeros;
+  m1.x4.v2x512 = vec512_zeros;
+  m1.x4.v1x512 = e.x8.v1x512;
+  m1.x4.v0x512 = e.x8.v0x512;
+  m2.x4.v3x512 = vec512_zeros;
+  m2.x4.v2x512 = vec512_zeros;
+  m2.x4.v1x512 = e.x8.v1x512;
+  m2.x4.v0x512 = e.x8.v0x512;
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k.x4096, &m1.x2048, &m2.x2048);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[3]   ", m1.x4.v3x512);
+  print_vint512x (" m1[2]   ", m1.x4.v2x512);
+  print_vint512x (" m1[1]   ", m1.x4.v1x512);
+  print_vint512x (" m1[0] * ", m1.x4.v0x512);
+  print_vint512x (" m2[3]   ", m2.x4.v3x512);
+  print_vint512x (" m2[2]   ", m2.x4.v2x512);
+  print_vint512x (" m2[1]   ", m2.x4.v1x512);
+  print_vint512x (" m2[0] = ", m2.x4.v0x512);
+  print_vint512x (" k [7]   ", k.x8.v7x512);
+  print_vint512x (" k [6]   ", k.x8.v6x512);
+  print_vint512x (" k [5]   ", k.x8.v5x512);
+  print_vint512x (" k [4]   ", k.x8.v4x512);
+  print_vint512x (" k [3]   ", k.x8.v3x512);
+  print_vint512x (" k [2]   ", k.x8.v2x512);
+  print_vint512x (" k [1]   ", k.x8.v1x512);
+  print_vint512x (" k [0]   ", k.x8.v0x512);
+#endif
+  e.x8.v0x512 = vec512_zeros;
+  e.x8.v1x512 = vec512_ten512_1;
+  e.x8.v2x512 = vec512_ten512_2;
+  e.x8.v3x512 = vec512_ten512_3;
+  e.x8.v4x512 = vec512_zeros;
+  e.x8.v5x512 = vec512_zeros;
+  e.x8.v6x512 = vec512_zeros;
+  e.x8.v7x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul2048x2048 12a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul2048x2048 12b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul2048x2048 12c:", k.x8.v5x512, e.x8.v5x512);
+  rc += check_vint512 ("vec_mul2048x2048 12d:", k.x8.v4x512, e.x8.v4x512);
+  rc += check_vint512 ("vec_mul2048x2048 12e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul2048x2048 12f:", k.x8.v2x512, e.x8.v2x512);
+  rc += check_vint512 ("vec_mul2048x2048 12g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul2048x2048 12h:", k.x8.v0x512, e.x8.v0x512);
+
+  m1.x4.v3x512 = e.x8.v3x512;
+  m1.x4.v2x512 = e.x8.v2x512;
+  m1.x4.v1x512 = e.x8.v1x512;
+  m1.x4.v0x512 = e.x8.v0x512;
+  m2.x4.v3x512 = e.x8.v3x512;
+  m2.x4.v2x512 = e.x8.v2x512;
+  m2.x4.v1x512 = e.x8.v1x512;
+  m2.x4.v0x512 = e.x8.v0x512;
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k.x4096, &m1.x2048, &m2.x2048);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[3]   ", m1.x4.v3x512);
+  print_vint512x (" m1[2]   ", m1.x4.v2x512);
+  print_vint512x (" m1[1]   ", m1.x4.v1x512);
+  print_vint512x (" m1[0] * ", m1.x4.v0x512);
+  print_vint512x (" m2[3]   ", m2.x4.v3x512);
+  print_vint512x (" m2[2]   ", m2.x4.v2x512);
+  print_vint512x (" m2[1]   ", m2.x4.v1x512);
+  print_vint512x (" m2[0] = ", m2.x4.v0x512);
+  print_vint512x (" k [7]   ", k.x8.v7x512);
+  print_vint512x (" k [6]   ", k.x8.v6x512);
+  print_vint512x (" k [5]   ", k.x8.v5x512);
+  print_vint512x (" k [4]   ", k.x8.v4x512);
+  print_vint512x (" k [3]   ", k.x8.v3x512);
+  print_vint512x (" k [2]   ", k.x8.v2x512);
+  print_vint512x (" k [1]   ", k.x8.v1x512);
+  print_vint512x (" k [0]   ", k.x8.v0x512);
+#endif
+  e.x8.v0x512 = vec512_zeros;
+  e.x8.v1x512 = vec512_zeros;
+  e.x8.v2x512 = vec512_ten1024_2;
+  e.x8.v3x512 = vec512_ten1024_3;
+  e.x8.v4x512 = vec512_ten1024_4;
+  e.x8.v5x512 = vec512_ten1024_5;
+  e.x8.v6x512 = vec512_ten1024_6;
+  e.x8.v7x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul2048x2048 13a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul2048x2048 13b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul2048x2048 13c:", k.x8.v5x512, e.x8.v5x512);
+  rc += check_vint512 ("vec_mul2048x2048 13d:", k.x8.v4x512, e.x8.v4x512);
+  rc += check_vint512 ("vec_mul2048x2048 13e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul2048x2048 13f:", k.x8.v2x512, e.x8.v2x512);
+  rc += check_vint512 ("vec_mul2048x2048 13g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul2048x2048 13h:", k.x8.v0x512, e.x8.v0x512);
+
+
+  return (rc);
+}
+#undef __DEBUG_PRINT__
+
+int
+test_vec_i512 (void)
+{
+  int rc = 0;
+
+  printf ("\n%s\n", __FUNCTION__);
+#if 1
+  rc += test_mul128x128 ();
+  rc += test_mul256x256 ();
+  rc += test_mul512x128 ();
+  rc += test_mul512x512 ();
+  rc += test_mul1024x1024 ();
+  rc += test_mul2048x2048 ();
+#endif
+#if 1
+  rc += test_time_i512();
+#endif
+  return (rc);
+}
+

--- a/src/testsuite/arith128_test_i512.c
+++ b/src/testsuite/arith128_test_i512.c
@@ -24,11 +24,6 @@
 
 #include <stdint.h>
 #include <stdio.h>
-#if 0
-#include <fenv.h>
-#include <float.h>
-#include <math.h>
-#endif
 
 //#define __DEBUG_PRINT__
 #include <pveclib/vec_common_ppc.h>
@@ -42,12 +37,13 @@
 #include <testsuite/vec_perf_i512.h>
 
 
-const __VEC_U_512 vec512_zeros = {
-    (vui128_t) ((unsigned __int128) 0),
-    (vui128_t) ((unsigned __int128) 0),
-    (vui128_t) ((unsigned __int128) 0),
-    (vui128_t) ((unsigned __int128) 0)
-};
+const __VEC_U_512 vec512_zeros =
+    {
+	(vui128_t) ((unsigned __int128) 0),
+	(vui128_t) ((unsigned __int128) 0),
+	(vui128_t) ((unsigned __int128) 0),
+	(vui128_t) ((unsigned __int128) 0)
+    };
 
 const __VEC_U_512 vec512_one = CONST_VINT512_Q
     (
@@ -162,7 +158,7 @@ const __VEC_U_512 vec512_ten1024_6 = CONST_VINT512_Q
 	CONST_VUINT128_QxW (0x00000000, 0x00000325, 0xD9D61A05, 0xD4305D94),
 	CONST_VUINT128_QxW (0x34F4A3C6, 0x2D433949, 0xAE6209D4, 0x926C3F5B),
 	CONST_VUINT128_QxW (0xD2DB49EF, 0x47187094, 0xC1A6970C, 0xA7E6BD2A)
-);
+    );
 
 const __VEC_U_512 vec512_ten1024_5 = CONST_VINT512_Q
     (
@@ -170,7 +166,7 @@ const __VEC_U_512 vec512_ten1024_5 = CONST_VINT512_Q
 	CONST_VUINT128_QxW (0x005B8041, 0x1640114A, 0x88BC491B, 0x9FC4ED52),
 	CONST_VUINT128_QxW (0x0190FBA0, 0x35FAABA6, 0xC356E38A, 0x31B5653F),
 	CONST_VUINT128_QxW (0x44597583, 0x6CB0B6C9, 0x75A351A2, 0x8E4262CE)
-);
+    );
 
 const __VEC_U_512 vec512_ten1024_4 = CONST_VINT512_Q
     (
@@ -178,7 +174,7 @@ const __VEC_U_512 vec512_ten1024_4 = CONST_VINT512_Q
 	CONST_VUINT128_QxW (0xFC8F1F90, 0x31EB0F66, 0x9A202882, 0x80BDA5A5),
 	CONST_VUINT128_QxW (0x80D98089, 0xDC1A47FE, 0x6B7595FB, 0x101A3616),
 	CONST_VUINT128_QxW (0xB6F4654B, 0x31FB6BFD, 0xF56DEEEC, 0xB1B896BC)
-);
+    );
 
 const __VEC_U_512 vec512_ten1024_3 = CONST_VINT512_Q
     (
@@ -186,7 +182,7 @@ const __VEC_U_512 vec512_ten1024_3 = CONST_VINT512_Q
 	CONST_VUINT128_QxW (0x8AD822A5, 0x1ABE1DE3, 0x045B7A74, 0x8E1042C4),
 	CONST_VUINT128_QxW (0x62BE695A, 0x9F9F2A07, 0xA7E89431, 0x922BBB9F),
 	CONST_VUINT128_QxW (0xC9635986, 0x1C5CD134, 0xF451218B, 0x65DC60D7)
-);
+    );
 
 const __VEC_U_512 vec512_ten1024_2 = CONST_VINT512_Q
     (
@@ -194,7 +190,7 @@ const __VEC_U_512 vec512_ten1024_2 = CONST_VINT512_Q
 	CONST_VUINT128_QxW (0x7DE16CFB, 0x896634EE, 0x0ED1440E, 0xCC2CD819),
 	CONST_VUINT128_QxW (0x4C7D1E1A, 0x140AC535, 0x15C51A88, 0x991C4E87),
 	CONST_VUINT128_QxW (0x1EC29F86, 0x6E7C215B, 0xF55B2B72, 0x2919F001)
-);
+    );
 
 const __VEC_U_512 vec512_ten1024_1 = CONST_VINT512_Q
     (

--- a/src/testsuite/arith128_test_i512.h
+++ b/src/testsuite/arith128_test_i512.h
@@ -1,0 +1,63 @@
+/*
+ Copyright (c) [2019] Steven Munroe.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ arith128_test_i512.h
+
+ Contributors:
+      Steven Munroe
+      Created on: Sep 9, 2019
+ */
+
+#ifndef SRC_TESTSUITE_ARITH128_TEST_I512_H_
+#define SRC_TESTSUITE_ARITH128_TEST_I512_H_
+#include <pveclib/vec_int512_ppc.h>
+
+extern const __VEC_U_512 vec512_zeros;
+extern const __VEC_U_512 vec512_one;
+extern const __VEC_U_512 vec512_foxes;
+extern const __VEC_U_512 vec512_foxeasy;
+
+extern const __VEC_U_512 vec512_ten128th;
+
+extern const __VEC_U_512 vec512_ten256_h;
+extern const __VEC_U_512 vec512_ten256_l;
+
+extern const __VEC_U_512 vec512_ten384_h;
+extern const __VEC_U_512 vec512_ten384_m;
+extern const __VEC_U_512 vec512_ten384_l;
+
+extern const __VEC_U_512 vec512_ten512_3;
+extern const __VEC_U_512 vec512_ten512_2;
+extern const __VEC_U_512 vec512_ten512_1;
+extern const __VEC_U_512 vec512_ten512_0;
+
+extern const __VEC_U_512 vec512_ten1024_6;
+extern const __VEC_U_512 vec512_ten1024_5;
+extern const __VEC_U_512 vec512_ten1024_4;
+extern const __VEC_U_512 vec512_ten1024_3;
+extern const __VEC_U_512 vec512_ten1024_2;
+extern const __VEC_U_512 vec512_ten1024_1;
+extern const __VEC_U_512 vec512_ten1024_0;
+
+extern int test_mul128x128 (void);
+extern int test_mul256x256 (void);
+extern int test_mul512x128 (void);
+extern int test_mul512x512 (void);
+extern int test_mul2048x2048 (void);
+
+extern int test_vec_i512 (void);
+
+
+#endif /* SRC_TESTSUITE_ARITH128_TEST_I512_H_ */

--- a/src/testsuite/vec_int512_dummy.c
+++ b/src/testsuite/vec_int512_dummy.c
@@ -1,0 +1,743 @@
+/*
+ Copyright (c) [2019] Steven Munroe.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ vec_int512_dummy.c
+
+ Contributors:
+      Steven Munroe
+      Created on: Aug 20, 2019
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <pveclib/vec_int512_ppc.h>
+
+__VEC_U_640
+__VEC_PWR_IMP (test_add512cu) (__VEC_U_512 a, __VEC_U_512 b)
+{
+  return vec_add512cu (a, b);
+}
+
+__VEC_U_640
+__VEC_PWR_IMP (test_add512ecu) (__VEC_U_512 a, __VEC_U_512 b, vui128_t c)
+{
+  return vec_add512ecu (a, b, c);
+}
+
+__VEC_U_512
+__VEC_PWR_IMP (test_add512eum) (__VEC_U_512 a, __VEC_U_512 b, vui128_t c)
+{
+  return vec_add512eum (a, b, c);
+}
+
+__VEC_U_512
+__VEC_PWR_IMP (test_add512ze) (__VEC_U_512 a, vui128_t c)
+{
+  return vec_add512ze (a, c);
+}
+
+__VEC_U_512
+__VEC_PWR_IMP (test_add512ze2) (__VEC_U_512 a, vui128_t c1, vui128_t c2)
+{
+  return vec_add512ze2 (a, c1, c2);
+}
+
+__VEC_U_256 /* __attribute__((__target__("cpu=power8"))) */
+__VEC_PWR_IMP (test_mul128x128) (vui128_t m1l, vui128_t m2l)
+{
+  return vec_mul128x128_inline (m1l, m2l);
+}
+
+__VEC_U_512
+__VEC_PWR_IMP (test_mul256x256) (__VEC_U_256 m1, __VEC_U_256 m2)
+{
+  return vec_mul256x256_inline (m1, m2);
+}
+
+__VEC_U_640
+__VEC_PWR_IMP (test_mul512x128) (__VEC_U_512 m1, vui128_t m2)
+{
+  return vec_mul512x128_inline (m1, m2);
+}
+
+__VEC_U_512
+__VEC_PWR_IMP (test_add512um) (__VEC_U_512 a, __VEC_U_512 b)
+{
+  return vec_add512um (a, b);
+}
+
+__VEC_U_640
+__VEC_PWR_IMP (test_mulu512x128) (__VEC_U_512 m1, vui128_t m2)
+{
+  __VEC_U_640 result;
+  vui128_t mq3, mq2, mq1, mq0, mq, mc;
+  vui128_t mpx0, mpx1, mpx2, mpx3;
+
+  mpx0 = vec_muludq (&mq0, m1.vx0, m2);
+  COMPILE_FENCE;
+  mpx1 = vec_muludq (&mq1, m1.vx1, m2);
+  mpx1 = vec_addcq (&mc, mpx1, mq0);
+  COMPILE_FENCE;
+  mpx2 = vec_muludq (&mq2, m1.vx2, m2);
+  mpx2 = vec_addeq (&mq, mpx2, mq1, mc);
+  COMPILE_FENCE;
+  mpx3 = vec_muludq (&mq3, m1.vx3, m2);
+  mpx3 = vec_addeq (&mc, mpx3, mq2, mq);
+  mq3 = vec_adduqm (mc, mq3);
+  COMPILE_FENCE;
+
+  result.vx0 = mpx0;
+  result.vx1 = mpx1;
+  result.vx2 = mpx2;
+  result.vx3 = mpx3;
+  result.vx4 = mq3;
+  return result;
+}
+
+__VEC_U_1152
+__VEC_PWR_IMP (test_mulu1024x128) (__VEC_U_1024 m1, vui128_t m2)
+{
+  __VEC_U_1152 result;
+  vui128_t mq7, mq6, mq5, mq4, mq3, mq2, mq1, mq0;
+  vui128_t mq, mc;
+  vui128_t mpx0, mpx1, mpx2, mpx3;
+  vui128_t mpx4, mpx5, mpx6, mpx7;
+  mpx0 = vec_muludq (&mq0, m1.vx0, m2);
+  COMPILE_FENCE;
+  mpx1 = vec_muludq (&mq1, m1.vx1, m2);
+  mpx1 = vec_addcq (&mc, mpx1, mq0);
+  COMPILE_FENCE;
+  mpx2 = vec_muludq (&mq2, m1.vx2, m2);
+  mpx2 = vec_addeq (&mq, mpx2, mq1, mc);
+  COMPILE_FENCE;
+  mpx3 = vec_muludq (&mq3, m1.vx3, m2);
+  mpx3 = vec_addeq (&mc, mpx3, mq2, mq);
+  COMPILE_FENCE;
+
+  mpx4 = vec_muludq (&mq4, m1.vx4, m2);
+  mpx4 = vec_addeq (&mq, mpx4, mq3, mc);
+  COMPILE_FENCE;
+  mpx5 = vec_muludq (&mq5, m1.vx5, m2);
+  mpx5 = vec_addeq (&mc, mpx5, mq4, mq);
+  COMPILE_FENCE;
+  mpx6 = vec_muludq (&mq6, m1.vx6, m2);
+  mpx6 = vec_addeq (&mq, mpx6, mq5, mc);
+  COMPILE_FENCE;
+  mpx7 = vec_muludq (&mq7, m1.vx7, m2);
+  mpx7 = vec_addeq (&mc, mpx7, mq6, mq);
+  mq7 = vec_adduqm (mc, mq7);
+  COMPILE_FENCE;
+
+  result.vx0 = mpx0;
+  result.vx1 = mpx1;
+  result.vx2 = mpx2;
+  result.vx3 = mpx3;
+  result.vx4 = mpx4;
+  result.vx5 = mpx5;
+  result.vx6 = mpx6;
+  result.vx7 = mpx7;
+  result.vx8 = mq7;
+  return result;
+}
+
+__VEC_U_2176
+__VEC_PWR_IMP (test_mulu2048x128) (__VEC_U_2048 m1, vui128_t m2)
+{
+  __VEC_U_2176 result;
+  vui128_t mq7, mq6, mq5, mq4, mq3, mq2, mq1, mq0;
+  vui128_t mq15, mq14, mq13, mq12, mq11, mq10, mq9, mq8;
+  vui128_t mq, mc;
+  vui128_t mpx0, mpx1, mpx2, mpx3;
+  vui128_t mpx4, mpx5, mpx6, mpx7;
+  vui128_t mpx8, mpx9, mpx10, mpx11;
+  vui128_t mpx12, mpx13, mpx14, mpx15;
+  mpx0 = vec_muludq (&mq0, m1.vx0, m2);
+  COMPILE_FENCE;
+  mpx1 = vec_muludq (&mq1, m1.vx1, m2);
+  mpx1 = vec_addcq (&mc, mpx1, mq0);
+  COMPILE_FENCE;
+  mpx2 = vec_muludq (&mq2, m1.vx2, m2);
+  mpx2 = vec_addeq (&mq, mpx2, mq1, mc);
+  COMPILE_FENCE;
+  mpx3 = vec_muludq (&mq3, m1.vx3, m2);
+  mpx3 = vec_addeq (&mc, mpx3, mq2, mq);
+  COMPILE_FENCE;
+
+  mpx4 = vec_muludq (&mq4, m1.vx4, m2);
+  mpx4 = vec_addeq (&mq, mpx4, mq3, mc);
+  COMPILE_FENCE;
+  mpx5 = vec_muludq (&mq5, m1.vx5, m2);
+  mpx5 = vec_addeq (&mc, mpx5, mq4, mq);
+  COMPILE_FENCE;
+  mpx6 = vec_muludq (&mq6, m1.vx6, m2);
+  mpx6 = vec_addeq (&mq, mpx6, mq5, mc);
+  COMPILE_FENCE;
+  mpx7 = vec_muludq (&mq7, m1.vx7, m2);
+  mpx7 = vec_addeq (&mc, mpx7, mq6, mq);
+  COMPILE_FENCE;
+
+  mpx8 = vec_muludq (&mq8, m1.vx8, m2);
+  mpx8 = vec_addeq (&mq, mpx8, mq7, mc);
+  COMPILE_FENCE;
+  mpx9 = vec_muludq (&mq9, m1.vx9, m2);
+  mpx9 = vec_addeq (&mc, mpx9, mq8, mq);
+  COMPILE_FENCE;
+  mpx10 = vec_muludq (&mq10, m1.vx10, m2);
+  mpx10 = vec_addeq (&mq, mpx10, mq9, mc);
+  COMPILE_FENCE;
+  mpx11 = vec_muludq (&mq11, m1.vx11, m2);
+  mpx11 = vec_addeq (&mc, mpx11, mq10, mq);
+  COMPILE_FENCE;
+
+  mpx12 = vec_muludq (&mq12, m1.vx12, m2);
+  mpx12 = vec_addeq (&mq, mpx12, mq11, mc);
+  COMPILE_FENCE;
+  mpx13 = vec_muludq (&mq13, m1.vx13, m2);
+  mpx13 = vec_addeq (&mc, mpx13, mq12, mq);
+  COMPILE_FENCE;
+  mpx14 = vec_muludq (&mq14, m1.vx14, m2);
+  mpx14 = vec_addeq (&mq, mpx14, mq13, mc);
+  COMPILE_FENCE;
+  mpx15 = vec_muludq (&mq15, m1.vx15, m2);
+  mpx15 = vec_addeq (&mc, mpx15, mq14, mq);
+  mq15 = vec_adduqm (mc, mq15);
+  COMPILE_FENCE;
+
+  result.vx0 = mpx0;
+  result.vx1 = mpx1;
+  result.vx2 = mpx2;
+  result.vx3 = mpx3;
+  result.vx4 = mpx4;
+  result.vx5 = mpx5;
+  result.vx6 = mpx6;
+  result.vx7 = mpx7;
+  result.vx8 = mpx8;
+  result.vx9 = mpx9;
+  result.vx10 = mpx10;
+  result.vx11 = mpx11;
+  result.vx12 = mpx12;
+  result.vx13 = mpx13;
+  result.vx14 = mpx14;
+  result.vx15 = mpx15;
+  result.vx16 = mq15;
+  return result;
+}
+
+__VEC_U_1024
+__VEC_PWR_IMP (test_mulu512x512) (__VEC_U_512 m1, __VEC_U_512 m2)
+{
+#if 1
+  return vec_mul512x512_inline (m1, m2);
+#else
+  __VEC_U_1024 result;
+  vui128_t mc, mp, mq;
+  __VEC_U_640 mp3, mp2, mp1, mp0;
+#if 1
+
+  mp0 = test_mul512x128_inline (m1, m2.vx0);
+  result.vx0 = mp0.vx0;
+  result.vx1 = mp0.vx1;
+  result.vx2 = mp0.vx2;
+  result.vx3 = mp0.vx3;
+  result.vx4 = mp0.vx4;
+  COMPILE_FENCE;
+  mp1 = test_mul512x128_inline (m1, m2.vx1);
+  result.vx1 = vec_addcq (&mq, mp1.vx0, result.vx1);
+  result.vx2 = vec_addeq (&mp, mp1.vx1, result.vx2, mq);
+  result.vx3 = vec_addeq (&mq, mp1.vx2, result.vx3, mp);
+  result.vx4 = vec_addeq (&mp, mp1.vx3, result.vx4, mq);
+  result.vx5 = vec_addcq (&result.vx6, mp1.vx4, mp);
+  COMPILE_FENCE;
+  mp2 = test_mul512x128_inline (m1, m2.vx2);
+  result.vx2 = vec_addcq (&mq, mp2.vx0, result.vx2);
+  result.vx3 = vec_addeq (&mp, mp2.vx1, result.vx3, mq);
+  result.vx4 = vec_addeq (&mq, mp2.vx2, result.vx4, mp);
+  result.vx5 = vec_addeq (&mp, mp2.vx3, result.vx5, mq);
+  result.vx6 = vec_addeq (&result.vx7, mp2.vx4, result.vx6, mp);
+  COMPILE_FENCE;
+  mp3 = test_mul512x128_inline (m1, m2.vx3);
+  result.vx3 = vec_addcq (&mq, mp3.vx0, result.vx3);
+  result.vx4 = vec_addeq (&mp, mp3.vx1, result.vx4, mq);
+  result.vx5 = vec_addeq (&mq, mp3.vx2, result.vx5, mp);
+  result.vx6 = vec_addeq (&mp, mp3.vx3, result.vx6, mq);
+  result.vx7 = vec_addeuqm (result.vx7, mp3.vx4, mp);
+#else
+  mp0 = test_muluq512x128_inline_PWR9 (m1, m2.vx0);
+  result.vx0 = mp0.vx0;
+  result.vx1 = mp0.vx1;
+  result.vx2 = mp0.vx2;
+  result.vx3 = mp0.vx3;
+  result.vx4 = mp0.vx4;
+  mp1 = test_muluq512x128_inline_PWR9 (m1, m2.vx1);
+  result.vx1 = vec_addcq (&mq, mp1.vx0, result.vx1);
+  result.vx2 = vec_addeq (&mp, mp1.vx1, result.vx2, mq);
+  result.vx3 = vec_addeq (&mq, mp1.vx2, result.vx3, mp);
+  result.vx4 = vec_addeq (&mp, mp1.vx3, result.vx4, mq);
+  result.vx5 = vec_addcq (&result.vx6, mp1.vx4, mp);
+  mp2 = test_muluq512x128_inline_PWR9 (m1, m2.vx2);
+  result.vx2 = vec_addcq (&mq, mp2.vx0, result.vx2);
+  result.vx3 = vec_addeq (&mp, mp2.vx1, result.vx3, mq);
+  result.vx4 = vec_addeq (&mq, mp2.vx2, result.vx4, mp);
+  result.vx5 = vec_addeq (&mp, mp2.vx3, result.vx5, mq);
+  result.vx6 = vec_addeq (&result.vx7, mp2.vx4, result.vx6, mp);
+  mp3 = test_muluq512x128_inline_PWR9 (m1, m2.vx3);
+  result.vx3 = vec_addcq (&mq, mp3.vx0, result.vx3);
+  result.vx4 = vec_addeq (&mp, mp3.vx1, result.vx4, mq);
+  result.vx5 = vec_addeq (&mq, mp3.vx2, result.vx5, mp);
+  result.vx6 = vec_addeq (&mp, mp3.vx3, result.vx6, mq);
+  result.vx7 = vec_addeuqm (mp3.vx4, result.vx7, mp);
+#endif
+  return result;
+#endif
+}
+
+void __attribute__((flatten))
+__VEC_PWR_IMP (test_mulu2048x512) (__VEC_U_512 p2560[5], __VEC_U_512 m1[4], __VEC_U_512 m2)
+{
+  __VEC_U_1024x512 subp0, subp1, subp2, subp3;
+  __VEC_U_512x1 sum0, sum1, sum2, sum3, sumx;
+  __VEC_U_512 temp[4];
+
+  subp0.x1024 = vec_mul512x512_inline (m1[0], m2);
+  p2560[0] = subp0.x2.v0x512;
+
+  subp1.x1024 = vec_mul512x512_inline (m1[1], m2);
+  sum0.x640 = vec_add512cu (subp1.x2.v0x512, subp0.x2.v1x512);
+
+  p2560[1] = sum0.x2.v0x512;
+  COMPILE_FENCE;
+
+  subp2.x1024 = vec_mul512x512_inline (m1[2], m2);
+  sum1.x640 = vec_add512ecu (subp2.x2.v0x512, subp1.x2.v1x512, sum0.x2.v1x128);
+
+  p2560[2] = sum1.x2.v0x512;
+  COMPILE_FENCE;
+
+  subp3.x1024 = vec_mul512x512_inline (m1[3], m2);
+  sum2.x640 = vec_add512ecu (subp3.x2.v0x512, subp2.x2.v1x512, sum1.x2.v1x128);
+
+  p2560[3] = sum2.x2.v0x512;
+  p2560[4] = vec_add512ze  (subp3.x2.v1x512, sum2.x2.v1x128);
+  COMPILE_FENCE;
+
+}
+
+void  __attribute__((flatten ))
+__VEC_PWR_IMP (test_mul1024x1024) (__VEC_U_2048 r2048, __VEC_U_1024 m1_1024, __VEC_U_1024 m2_1024)
+{
+  __VEC_U_2048x512 *p2048;
+  __VEC_U_1024x512 *m1, *m2;
+  __VEC_U_1024x512 subp0, subp1, subp2, subp3;
+  __VEC_U_512x1 sum0, sum1, sum2, sum3, sumx;
+  __VEC_U_512 temp[3];
+
+  p2048 = (__VEC_U_2048x512 *) &r2048;
+  m1 = (__VEC_U_1024x512 *) &m1_1024;
+  m2 = (__VEC_U_1024x512 *) &m2_1024;
+
+  subp0.x1024 = vec_mul512x512_inline (m1->x2.v0x512, m2->x2.v0x512);
+  p2048->x4.v0x512 = subp0.x2.v0x512;
+
+  subp1.x1024 = vec_mul512x512_inline (m1->x2.v1x512, m2->x2.v0x512);
+  sum1.x640 = vec_add512cu (subp1.x2.v0x512, subp0.x2.v1x512);
+
+  temp[0] = sum1.x2.v0x512;
+  temp[1] = vec_add512ze  (subp1.x2.v1x512, sum1.x2.v1x128);
+  COMPILE_FENCE;
+
+  subp2.x1024 = vec_mul512x512_inline (m1->x2.v0x512, m2->x2.v1x512);
+  sum2.x640 = vec_add512cu (temp[0], subp2.x2.v0x512);
+  temp[2] = sum2.x2.v0x512;
+  p2048->x4.v1x512 = temp[2];
+  sumx.x640 = vec_add512ecu (temp[1], subp2.x2.v1x512, sum2.x2.v1x128);
+  temp[1] = sumx.x2.v0x512;
+  COMPILE_FENCE;
+
+  subp3.x1024 = vec_mul512x512_inline (m1->x2.v1x512, m2->x2.v1x512);
+  sum3.x640 = vec_add512cu (sumx.x2.v0x512, subp3.x2.v0x512);
+  p2048->x4.v2x512 = sum3.x2.v0x512;
+  p2048->x4.v3x512 = vec_add512ze2 (subp3.x2.v1x512, sumx.x2.v1x128, sum3.x2.v1x128);
+
+}
+
+void  __attribute__((flatten ))
+__VEC_PWR_IMP (test_mul1024x1024x) (__VEC_U_2048 *r2048, __VEC_U_1024 *m1_1024, __VEC_U_1024 *m2_1024)
+{
+  __VEC_U_512 *p2048, *m1, *m2;
+  __VEC_U_1024x512 subp0, subp1, subp2, subp3;
+  __VEC_U_512x1 sum0, sum1, sum2, sum3, sumx;
+  __VEC_U_512 temp[3];
+
+  p2048 = (__VEC_U_512 *)r2048;
+  m1 = (__VEC_U_512 *) m1_1024;
+  m2 = (__VEC_U_512 *) m2_1024;
+
+  subp0.x1024 = vec_mul512x512_inline (m1[0], m2[0]);
+  p2048[0] = subp0.x2.v0x512;
+
+  subp1.x1024 = vec_mul512x512_inline (m1[1], m2[0]);
+  sum1.x640 = vec_add512cu (subp1.x2.v0x512, subp0.x2.v1x512);
+
+  temp[0] = sum1.x2.v0x512;
+  temp[1] = vec_add512ze  (subp1.x2.v1x512, sum1.x2.v1x128);
+  COMPILE_FENCE;
+
+  subp2.x1024 = vec_mul512x512_inline (m1[0], m2[1]);
+  sum2.x640 = vec_add512cu (temp[0], subp2.x2.v0x512);
+  temp[2] = sum2.x2.v0x512;
+  p2048[1] = temp[2];
+  sumx.x640 = vec_add512ecu (temp[1], subp2.x2.v1x512, sum2.x2.v1x128);
+  temp[1] = sumx.x2.v0x512;
+  COMPILE_FENCE;
+
+  subp3.x1024 = vec_mul512x512_inline (m1[1], m2[1]);
+  sum3.x640 = vec_add512cu (sumx.x2.v0x512, subp3.x2.v0x512);
+  p2048[2] = sum3.x2.v0x512;
+  p2048[3] = vec_add512ze2 (subp3.x2.v1x512, sumx.x2.v1x128, sum3.x2.v1x128);
+
+}
+
+void  __attribute__((flatten ))
+__VEC_PWR_IMP (test_mul1024x1024y) (__VEC_U_2048 *r2048, __VEC_U_1024 *m1_1024, __VEC_U_1024 *m2_1024)
+{
+  __VEC_U_2048x512 *p2048;
+  __VEC_U_1024x512 *m1, *m2;
+  __VEC_U_1024x512 subp0, subp1, subp2, subp3;
+  __VEC_U_512x1 sum0, sum1, sum2, sum3, sumx;
+  __VEC_U_512 temp[3];
+
+  p2048 = (__VEC_U_2048x512 *)r2048;
+  m1 = (__VEC_U_1024x512 *) m1_1024;
+  m2 = (__VEC_U_1024x512 *) m2_1024;
+
+  subp0.x1024 = vec_mul512x512_inline (m1->x2.v0x512, m2->x2.v0x512);
+  p2048->x4.v0x512 = subp0.x2.v0x512;
+
+  subp1.x1024 = vec_mul512x512_inline (m1->x2.v1x512, m2->x2.v0x512);
+  sum1.x640 = vec_add512cu (subp1.x2.v0x512, subp0.x2.v1x512);
+
+  temp[0] = sum1.x2.v0x512;
+  temp[1] = vec_add512ze  (subp1.x2.v1x512, sum1.x2.v1x128);
+  COMPILE_FENCE;
+
+  subp2.x1024 = vec_mul512x512_inline (m1->x2.v0x512, m2->x2.v1x512);
+  sum2.x640 = vec_add512cu (temp[0], subp2.x2.v0x512);
+  temp[2] = sum2.x2.v0x512;
+  p2048->x4.v1x512 = temp[2];
+  sumx.x640 = vec_add512ecu (temp[1], subp2.x2.v1x512, sum2.x2.v1x128);
+  temp[1] = sumx.x2.v0x512;
+  COMPILE_FENCE;
+
+  subp3.x1024 = vec_mul512x512_inline (m1->x2.v1x512, m2->x2.v1x512);
+  sum3.x640 = vec_add512cu (sumx.x2.v0x512, subp3.x2.v0x512);
+  p2048->x4.v2x512 = sum3.x2.v0x512;
+  p2048->x4.v3x512 = vec_add512ze2 (subp3.x2.v1x512, sumx.x2.v1x128, sum3.x2.v1x128);
+
+}
+
+void  __attribute__((flatten ))
+__VEC_PWR_IMP (test_mul1024x1024z) (__VEC_U_2048x512 p2048, __VEC_U_1024x512 m1, __VEC_U_1024x512 m2)
+{
+  //__VEC_U_2048x512 *p2048;
+  //__VEC_U_1024x512 *m1, *m2;
+  __VEC_U_1024x512 subp0, subp1, subp2, subp3;
+  __VEC_U_512x1 sum0, sum1, sum2, sum3, sumx;
+  __VEC_U_512 temp[3];
+
+  //p2048 = (__VEC_U_2048x512 *)r2048;
+  //m1 = (__VEC_U_1024x512 *) m1_1024;
+  //m2 = (__VEC_U_1024x512 *) m2_1024;
+
+  subp0.x1024 = vec_mul512x512_inline (m1.x2.v0x512, m2.x2.v0x512);
+  p2048.x4.v0x512 = subp0.x2.v0x512;
+
+  subp1.x1024 = vec_mul512x512_inline (m1.x2.v1x512, m2.x2.v0x512);
+  sum1.x640 = vec_add512cu (subp1.x2.v0x512, subp0.x2.v1x512);
+
+  temp[0] = sum1.x2.v0x512;
+  temp[1] = vec_add512ze  (subp1.x2.v1x512, sum1.x2.v1x128);
+  COMPILE_FENCE;
+
+  subp2.x1024 = vec_mul512x512_inline (m1.x2.v0x512, m2.x2.v1x512);
+  sum2.x640 = vec_add512cu (temp[0], subp2.x2.v0x512);
+  temp[2] = sum2.x2.v0x512;
+  p2048.x4.v1x512 = temp[2];
+  sumx.x640 = vec_add512ecu (temp[1], subp2.x2.v1x512, sum2.x2.v1x128);
+  temp[1] = sumx.x2.v0x512;
+  COMPILE_FENCE;
+
+  subp3.x1024 = vec_mul512x512_inline (m1.x2.v1x512, m2.x2.v1x512);
+  sum3.x640 = vec_add512cu (sumx.x2.v0x512, subp3.x2.v0x512);
+  p2048.x4.v2x512 = sum3.x2.v0x512;
+  p2048.x4.v3x512 = vec_add512ze2 (subp3.x2.v1x512, sumx.x2.v1x128, sum3.x2.v1x128);
+
+}
+
+void  __attribute__((flatten /*, target_clones("cpu=power9,default") */))
+__VEC_PWR_IMP (test_mulu2048x2048) (__VEC_U_512 p4096[8], __VEC_U_512 m1[4], __VEC_U_512 m2[4])
+{
+  __VEC_U_1024x512 subp0, subp1, subp2, subp3;
+  __VEC_U_512x1 sum0, sum1, sum2, sum3, sumx;
+  __VEC_U_512 temp[4];
+
+  subp0.x1024 = vec_mul512x512_inline (m1[0], m2[0]);
+  p4096[0] = subp0.x2.v0x512;
+
+  subp1.x1024 = vec_mul512x512_inline (m1[1], m2[0]);
+  sum0.x640 = vec_add512cu (subp1.x2.v0x512, subp0.x2.v1x512);
+
+  temp[0] = sum0.x2.v0x512;
+  COMPILE_FENCE;
+
+  subp2.x1024 = vec_mul512x512_inline (m1[2], m2[0]);
+  sum1.x640 = vec_add512ecu (subp2.x2.v0x512, subp1.x2.v1x512, sum0.x2.v1x128);
+
+  temp[1] = sum1.x2.v0x512;
+  COMPILE_FENCE;
+
+  subp3.x1024 = vec_mul512x512_inline (m1[3], m2[0]);
+  sum2.x640 = vec_add512ecu (subp3.x2.v0x512, subp2.x2.v1x512, sum1.x2.v1x128);
+
+  temp[2] = sum2.x2.v0x512;
+  temp[3] = vec_add512ze  (subp3.x2.v1x512, sum2.x2.v1x128);
+  COMPILE_FENCE;
+
+
+
+  subp0.x1024 = vec_mul512x512_inline (m1[0], m2[1]);
+  sumx.x640 = vec_add512cu (subp0.x2.v0x512, temp[0]);
+  p4096[1] = sumx.x2.v0x512;
+  COMPILE_FENCE;
+
+  subp1.x1024 = vec_mul512x512_inline (m1[1], m2[1]);
+  sum0.x640 = vec_add512cu (subp1.x2.v0x512, subp0.x2.v1x512);
+  sumx.x640 = vec_add512ecu (sum0.x2.v0x512, temp[1], sum0.x2.v1x128);
+  sumx.x2.v1x128 = vec_adduqm (sumx.x2.v1x128, sum0.x2.v1x128);
+
+  temp[0] = sumx.x2.v0x512;
+  COMPILE_FENCE;
+
+  subp2.x1024 = vec_mul512x512_inline (m1[2], m2[1]);
+  sum1.x640 = vec_add512cu (subp2.x2.v0x512, subp1.x2.v1x512);
+  sumx.x640 = vec_add512ecu (sum1.x2.v0x512, temp[2], sum1.x2.v1x128);
+  sumx.x2.v1x128 = vec_adduqm (sumx.x2.v1x128, sum0.x2.v1x128);
+
+  temp[1] = sumx.x2.v0x512;
+  COMPILE_FENCE;
+
+  subp3.x1024 = vec_mul512x512_inline (m1[3], m2[1]);
+  sum2.x640 = vec_add512cu (subp3.x2.v0x512, subp2.x2.v1x512);
+  sumx.x640 = vec_add512ecu (sum2.x2.v0x512, temp[3], sum1.x2.v1x128);
+  sumx.x2.v1x128 = vec_adduqm (sumx.x2.v1x128, sum0.x2.v1x128);
+
+  temp[2] = sumx.x2.v0x512;
+  temp[3] = vec_add512ze  (subp3.x2.v1x512, sumx.x2.v1x128);
+  COMPILE_FENCE;
+
+
+  subp0.x1024 = vec_mul512x512_inline (m1[0], m2[2]);
+  sumx.x640 = vec_add512cu (subp0.x2.v0x512, temp[0]);
+  p4096[2] = sumx.x2.v0x512;
+  COMPILE_FENCE;
+
+  subp1.x1024 = vec_mul512x512_inline (m1[1], m2[2]);
+  sum0.x640 = vec_add512cu (subp1.x2.v0x512, subp0.x2.v1x512);
+  sumx.x640 = vec_add512ecu (sum0.x2.v0x512, temp[1], sum0.x2.v1x128);
+  sumx.x2.v1x128 = vec_adduqm (sumx.x2.v1x128, sum0.x2.v1x128);
+
+  temp[0] = sumx.x2.v0x512;
+  COMPILE_FENCE;
+
+  subp2.x1024 = vec_mul512x512_inline (m1[2], m2[2]);
+  sum1.x640 = vec_add512cu (subp2.x2.v0x512, subp1.x2.v1x512);
+  sumx.x640 = vec_add512ecu (sum1.x2.v0x512, temp[2], sum1.x2.v1x128);
+  sumx.x2.v1x128 = vec_adduqm (sumx.x2.v1x128, sum0.x2.v1x128);
+
+  temp[1] = sumx.x2.v0x512;
+  COMPILE_FENCE;
+
+  subp3.x1024 = vec_mul512x512_inline (m1[3], m2[2]);
+  sum2.x640 = vec_add512cu (subp3.x2.v0x512, subp2.x2.v1x512);
+  sumx.x640 = vec_add512ecu (sum2.x2.v0x512, temp[3], sum1.x2.v1x128);
+  sumx.x2.v1x128 = vec_adduqm (sumx.x2.v1x128, sum0.x2.v1x128);
+
+  temp[2] = sumx.x2.v0x512;
+  temp[3] = vec_add512ze  (subp3.x2.v1x512, sumx.x2.v1x128);
+  COMPILE_FENCE;
+
+
+
+  subp0.x1024 = vec_mul512x512_inline (m1[0], m2[3]);
+  sumx.x640 = vec_add512cu (subp0.x2.v0x512, temp[0]);
+  p4096[3] = sumx.x2.v0x512;
+  COMPILE_FENCE;
+
+  subp1.x1024 = vec_mul512x512_inline (m1[1], m2[3]);
+  sum0.x640 = vec_add512cu (subp1.x2.v0x512, subp0.x2.v1x512);
+  sumx.x640 = vec_add512ecu (sum0.x2.v0x512, temp[1], sum0.x2.v1x128);
+  sumx.x2.v1x128 = vec_adduqm (sumx.x2.v1x128, sum0.x2.v1x128);
+
+  p4096[4] = sumx.x2.v0x512;
+  COMPILE_FENCE;
+
+  subp2.x1024 = vec_mul512x512_inline (m1[2], m2[3]);
+  sum1.x640 = vec_add512cu (subp2.x2.v0x512, subp1.x2.v1x512);
+  sumx.x640 = vec_add512ecu (sum1.x2.v0x512, temp[2], sum1.x2.v1x128);
+  sumx.x2.v1x128 = vec_adduqm (sumx.x2.v1x128, sum0.x2.v1x128);
+
+  p4096[5] = sumx.x2.v0x512;
+  COMPILE_FENCE;
+
+  subp3.x1024 = vec_mul512x512_inline (m1[3], m2[3]);
+  sum2.x640 = vec_add512cu (subp3.x2.v0x512, subp2.x2.v1x512);
+  sumx.x640 = vec_add512ecu (sum2.x2.v0x512, temp[3], sum1.x2.v1x128);
+  sumx.x2.v1x128 = vec_adduqm (sumx.x2.v1x128, sum0.x2.v1x128);
+
+  p4096[6] = sumx.x2.v0x512;
+  p4096[7] = vec_add512ze  (subp3.x2.v1x512, sumx.x2.v1x128);
+
+}
+
+void  __attribute__((flatten))
+__VEC_PWR_IMP (test_mulu2048x2048z) (__VEC_U_4096 *r4096,
+              __VEC_U_2048 *m1_2048, __VEC_U_2048 *m2_2048)
+{
+  __VEC_U_512 *p4096, *m1, *m2;
+  __VEC_U_1024x512 subp0, subp1, subp2, subp3;
+  __VEC_U_512x1 sum0, sum1, sum2, sum3, sumx;
+  __VEC_U_512 temp[4];
+
+  p4096 = (__VEC_U_512 *)r4096;
+  m1 = (__VEC_U_512 *) m1_2048;
+  m2 = (__VEC_U_512 *) m2_2048;
+
+  subp0.x1024 = vec_mul512x512_inline (m1[0], m2[0]);
+  p4096[0] = subp0.x2.v0x512;
+
+  subp1.x1024 = vec_mul512x512_inline (m1[1], m2[0]);
+  sum0.x640 = vec_add512cu (subp1.x2.v0x512, subp0.x2.v1x512);
+
+  temp[0] = sum0.x2.v0x512;
+  COMPILE_FENCE;
+
+  subp2.x1024 = vec_mul512x512_inline (m1[2], m2[0]);
+  sum1.x640 = vec_add512ecu (subp2.x2.v0x512, subp1.x2.v1x512, sum0.x2.v1x128);
+
+  temp[1] = sum1.x2.v0x512;
+  COMPILE_FENCE;
+
+  subp3.x1024 = vec_mul512x512_inline (m1[3], m2[0]);
+  sum2.x640 = vec_add512ecu (subp3.x2.v0x512, subp2.x2.v1x512, sum1.x2.v1x128);
+
+  temp[2] = sum2.x2.v0x512;
+  temp[3] = vec_add512ze  (subp3.x2.v1x512, sum2.x2.v1x128);
+  COMPILE_FENCE;
+
+
+
+  subp0.x1024 = vec_mul512x512_inline (m1[0], m2[1]);
+  sumx.x640 = vec_add512cu (subp0.x2.v0x512, temp[0]);
+  p4096[1] = sumx.x2.v0x512;
+  COMPILE_FENCE;
+
+  subp1.x1024 = vec_mul512x512_inline (m1[1], m2[1]);
+  sum0.x640 = vec_add512cu (subp1.x2.v0x512, subp0.x2.v1x512);
+  sumx.x640 = vec_add512ecu (sum0.x2.v0x512, temp[1], sum0.x2.v1x128);
+  sumx.x2.v1x128 = vec_adduqm (sumx.x2.v1x128, sum0.x2.v1x128);
+
+  temp[0] = sumx.x2.v0x512;
+  COMPILE_FENCE;
+
+  subp2.x1024 = vec_mul512x512_inline (m1[2], m2[1]);
+  sum1.x640 = vec_add512cu (subp2.x2.v0x512, subp1.x2.v1x512);
+  sumx.x640 = vec_add512ecu (sum1.x2.v0x512, temp[2], sum1.x2.v1x128);
+  sumx.x2.v1x128 = vec_adduqm (sumx.x2.v1x128, sum0.x2.v1x128);
+
+  temp[1] = sumx.x2.v0x512;
+  COMPILE_FENCE;
+
+  subp3.x1024 = vec_mul512x512_inline (m1[3], m2[1]);
+  sum2.x640 = vec_add512cu (subp3.x2.v0x512, subp2.x2.v1x512);
+  sumx.x640 = vec_add512ecu (sum2.x2.v0x512, temp[3], sum1.x2.v1x128);
+  sumx.x2.v1x128 = vec_adduqm (sumx.x2.v1x128, sum0.x2.v1x128);
+
+  temp[2] = sumx.x2.v0x512;
+  temp[3] = vec_add512ze  (subp3.x2.v1x512, sumx.x2.v1x128);
+  COMPILE_FENCE;
+
+
+  subp0.x1024 = vec_mul512x512_inline (m1[0], m2[2]);
+  sumx.x640 = vec_add512cu (subp0.x2.v0x512, temp[0]);
+  p4096[2] = sumx.x2.v0x512;
+  COMPILE_FENCE;
+
+  subp1.x1024 = vec_mul512x512_inline (m1[1], m2[2]);
+  sum0.x640 = vec_add512cu (subp1.x2.v0x512, subp0.x2.v1x512);
+  sumx.x640 = vec_add512ecu (sum0.x2.v0x512, temp[1], sum0.x2.v1x128);
+  sumx.x2.v1x128 = vec_adduqm (sumx.x2.v1x128, sum0.x2.v1x128);
+
+  temp[0] = sumx.x2.v0x512;
+  COMPILE_FENCE;
+
+  subp2.x1024 = vec_mul512x512_inline (m1[2], m2[2]);
+  sum1.x640 = vec_add512cu (subp2.x2.v0x512, subp1.x2.v1x512);
+  sumx.x640 = vec_add512ecu (sum1.x2.v0x512, temp[2], sum1.x2.v1x128);
+  sumx.x2.v1x128 = vec_adduqm (sumx.x2.v1x128, sum0.x2.v1x128);
+
+  temp[1] = sumx.x2.v0x512;
+  COMPILE_FENCE;
+
+  subp3.x1024 = vec_mul512x512_inline (m1[3], m2[2]);
+  sum2.x640 = vec_add512cu (subp3.x2.v0x512, subp2.x2.v1x512);
+  sumx.x640 = vec_add512ecu (sum2.x2.v0x512, temp[3], sum1.x2.v1x128);
+  sumx.x2.v1x128 = vec_adduqm (sumx.x2.v1x128, sum0.x2.v1x128);
+
+  temp[2] = sumx.x2.v0x512;
+  temp[3] = vec_add512ze  (subp3.x2.v1x512, sumx.x2.v1x128);
+  COMPILE_FENCE;
+
+
+
+  subp0.x1024 = vec_mul512x512_inline (m1[0], m2[3]);
+  sumx.x640 = vec_add512cu (subp0.x2.v0x512, temp[0]);
+  p4096[3] = sumx.x2.v0x512;
+  COMPILE_FENCE;
+
+  subp1.x1024 = vec_mul512x512_inline (m1[1], m2[3]);
+  sum0.x640 = vec_add512cu (subp1.x2.v0x512, subp0.x2.v1x512);
+  sumx.x640 = vec_add512ecu (sum0.x2.v0x512, temp[1], sum0.x2.v1x128);
+  sumx.x2.v1x128 = vec_adduqm (sumx.x2.v1x128, sum0.x2.v1x128);
+
+  p4096[4] = sumx.x2.v0x512;
+  COMPILE_FENCE;
+
+  subp2.x1024 = vec_mul512x512_inline (m1[2], m2[3]);
+  sum1.x640 = vec_add512cu (subp2.x2.v0x512, subp1.x2.v1x512);
+  sumx.x640 = vec_add512ecu (sum1.x2.v0x512, temp[2], sum1.x2.v1x128);
+  sumx.x2.v1x128 = vec_adduqm (sumx.x2.v1x128, sum0.x2.v1x128);
+
+  p4096[5] = sumx.x2.v0x512;
+  COMPILE_FENCE;
+
+  subp3.x1024 = vec_mul512x512_inline (m1[3], m2[3]);
+  sum2.x640 = vec_add512cu (subp3.x2.v0x512, subp2.x2.v1x512);
+  sumx.x640 = vec_add512ecu (sum2.x2.v0x512, temp[3], sum1.x2.v1x128);
+  sumx.x2.v1x128 = vec_adduqm (sumx.x2.v1x128, sum0.x2.v1x128);
+
+  p4096[6] = sumx.x2.v0x512;
+  p4096[7] = vec_add512ze  (subp3.x2.v1x512, sumx.x2.v1x128);
+
+}
+

--- a/src/testsuite/vec_int512_dummy.c
+++ b/src/testsuite/vec_int512_dummy.c
@@ -244,7 +244,6 @@ __VEC_PWR_IMP (test_mulu512x512) (__VEC_U_512 m1, __VEC_U_512 m2)
   __VEC_U_1024 result;
   vui128_t mc, mp, mq;
   __VEC_U_640 mp3, mp2, mp1, mp0;
-#if 1
 
   mp0 = test_mul512x128_inline (m1, m2.vx0);
   result.vx0 = mp0.vx0;
@@ -273,32 +272,6 @@ __VEC_PWR_IMP (test_mulu512x512) (__VEC_U_512 m1, __VEC_U_512 m2)
   result.vx5 = vec_addeq (&mq, mp3.vx2, result.vx5, mp);
   result.vx6 = vec_addeq (&mp, mp3.vx3, result.vx6, mq);
   result.vx7 = vec_addeuqm (result.vx7, mp3.vx4, mp);
-#else
-  mp0 = test_muluq512x128_inline_PWR9 (m1, m2.vx0);
-  result.vx0 = mp0.vx0;
-  result.vx1 = mp0.vx1;
-  result.vx2 = mp0.vx2;
-  result.vx3 = mp0.vx3;
-  result.vx4 = mp0.vx4;
-  mp1 = test_muluq512x128_inline_PWR9 (m1, m2.vx1);
-  result.vx1 = vec_addcq (&mq, mp1.vx0, result.vx1);
-  result.vx2 = vec_addeq (&mp, mp1.vx1, result.vx2, mq);
-  result.vx3 = vec_addeq (&mq, mp1.vx2, result.vx3, mp);
-  result.vx4 = vec_addeq (&mp, mp1.vx3, result.vx4, mq);
-  result.vx5 = vec_addcq (&result.vx6, mp1.vx4, mp);
-  mp2 = test_muluq512x128_inline_PWR9 (m1, m2.vx2);
-  result.vx2 = vec_addcq (&mq, mp2.vx0, result.vx2);
-  result.vx3 = vec_addeq (&mp, mp2.vx1, result.vx3, mq);
-  result.vx4 = vec_addeq (&mq, mp2.vx2, result.vx4, mp);
-  result.vx5 = vec_addeq (&mp, mp2.vx3, result.vx5, mq);
-  result.vx6 = vec_addeq (&result.vx7, mp2.vx4, result.vx6, mp);
-  mp3 = test_muluq512x128_inline_PWR9 (m1, m2.vx3);
-  result.vx3 = vec_addcq (&mq, mp3.vx0, result.vx3);
-  result.vx4 = vec_addeq (&mp, mp3.vx1, result.vx4, mq);
-  result.vx5 = vec_addeq (&mq, mp3.vx2, result.vx5, mp);
-  result.vx6 = vec_addeq (&mp, mp3.vx3, result.vx6, mq);
-  result.vx7 = vec_addeuqm (mp3.vx4, result.vx7, mp);
-#endif
   return result;
 #endif
 }

--- a/src/testsuite/vec_perf_i512.c
+++ b/src/testsuite/vec_perf_i512.c
@@ -1,0 +1,826 @@
+/*
+ Copyright (c) [2019] Steven Munroe.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ vec_perf_i512.c
+
+ Contributors:
+      Steven Munroe
+      Created on: Sep 9, 2019
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <fenv.h>
+#include <float.h>
+#include <math.h>
+
+//#define __DEBUG_PRINT__
+#include <pveclib/vec_int128_ppc.h>
+#include <pveclib/vec_int512_ppc.h>
+
+//#include "arith128.h"
+#include <testsuite/arith128_print.h>
+#include <testsuite/arith128_test_i512.h>
+#include <testsuite/vec_perf_i512.h>
+
+//#define __DEBUG_PRINT__ 1
+int
+timed_mul1024x1024 (void)
+{
+  __VEC_U_2048x512 k, e;
+  __VEC_U_1024x512 m1, m2;
+  __VEC_U_512 i, j;
+  int rc = 0;
+
+#ifdef __DEBUG_PRINT__
+  printf ("\ntest_mul1024x1024 vector multiply quadword, 2048-bit product\n");
+#endif
+
+  m1.x2.v1x512 = vec512_zeros;
+  m1.x2.v0x512 = vec512_foxes;
+  m2.x2.v1x512 = vec512_zeros;
+  m2.x2.v0x512 = vec512_foxes;
+  __VEC_PWR_IMP (vec_mul1024x1024)(&k.x2048, &m1.x1024, &m2.x1024);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[1]   ", m1.x2.v1x512);
+  print_vint512x (" m1[0] * ", m1.x2.v0x512);
+  print_vint512x (" m2[1]   ", m2.x2.v1x512);
+  print_vint512x (" m2[0] = ", m2.x2.v0x512);
+  print_vint512x (" k [3]   ", k.x4.v3x512);
+  print_vint512x (" k [2]   ", k.x4.v2x512);
+  print_vint512x (" k [1]   ", k.x4.v1x512);
+  print_vint512x (" k [0] = ", k.x4.v0x512);
+#endif
+  e.x4.v0x512 = vec512_one;
+  e.x4.v1x512 = vec512_foxeasy;
+#ifdef __DEBUG_PRINT__
+  e.x4.v2x512 = vec512_zeros;
+  e.x4.v3x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul1024x1024 1a:", k.x4.v3x512, e.x4.v3x512);
+  rc += check_vint512 ("vec_mul1024x1024 1b:", k.x4.v2x512, e.x4.v2x512);
+#endif
+  rc += check_vint512 ("vec_mul1024x1024 1c:", k.x4.v1x512, e.x4.v1x512);
+  rc += check_vint512 ("vec_mul1024x1024 1d:", k.x4.v0x512, e.x4.v0x512);
+
+  m1.x2.v1x512 = vec512_foxes;
+  m1.x2.v0x512 = vec512_zeros;
+  m2.x2.v1x512 = vec512_zeros;
+  m2.x2.v0x512 = vec512_foxes;
+  __VEC_PWR_IMP (vec_mul1024x1024)(&k.x2048, &m1.x1024, &m2.x1024);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[1]   ", m1.x2.v1x512);
+  print_vint512x (" m1[0] * ", m1.x2.v0x512);
+  print_vint512x (" m2[1]   ", m2.x2.v1x512);
+  print_vint512x (" m2[0] = ", m2.x2.v0x512);
+  print_vint512x (" k [3]   ", k.x4.v3x512);
+  print_vint512x (" k [2]   ", k.x4.v2x512);
+  print_vint512x (" k [1]   ", k.x4.v1x512);
+  print_vint512x (" k [0]   ", k.x4.v0x512);
+#endif
+  e.x4.v0x512 = vec512_zeros;
+  e.x4.v1x512 = vec512_one;
+  e.x4.v2x512 = vec512_foxeasy;
+#ifdef __DEBUG_PRINT__
+  e.x4.v3x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul1024x1024 2a:", k.x4.v3x512, e.x4.v3x512);
+#endif
+  rc += check_vint512 ("vec_mul1024x1024 2b:", k.x4.v2x512, e.x4.v2x512);
+  rc += check_vint512 ("vec_mul1024x1024 2c:", k.x4.v1x512, e.x4.v1x512);
+  rc += check_vint512 ("vec_mul1024x1024 2d:", k.x4.v0x512, e.x4.v0x512);
+
+  __VEC_PWR_IMP (vec_mul1024x1024)(&k.x2048, &m1.x1024, &m2.x1024);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[1]   ", m2.x2.v1x512);
+  print_vint512x (" m1[0] * ", m2.x2.v0x512);
+  print_vint512x (" m2[1]   ", m1.x2.v1x512);
+  print_vint512x (" m2[0] = ", m1.x2.v0x512);
+  print_vint512x (" k [3]   ", k.x4.v3x512);
+  print_vint512x (" k [2]   ", k.x4.v2x512);
+  print_vint512x (" k [1]   ", k.x4.v1x512);
+  print_vint512x (" k [0]   ", k.x4.v0x512);
+#endif
+#ifdef __DEBUG_PRINT__
+  rc += check_vint512 ("vec_mul1024x1024 3a:", k.x4.v3x512, e.x4.v3x512);
+#endif
+  rc += check_vint512 ("vec_mul1024x1024 3b:", k.x4.v2x512, e.x4.v2x512);
+  rc += check_vint512 ("vec_mul1024x1024 3c:", k.x4.v1x512, e.x4.v1x512);
+  rc += check_vint512 ("vec_mul1024x1024 3d:", k.x4.v0x512, e.x4.v0x512);
+
+  m1.x2.v1x512 = vec512_foxes;
+  m1.x2.v0x512 = vec512_zeros;
+  m2.x2.v1x512 = vec512_foxes;
+  m2.x2.v0x512 = vec512_zeros;
+  __VEC_PWR_IMP (vec_mul1024x1024)(&k.x2048, &m1.x1024, &m2.x1024);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[1]   ", m1.x2.v1x512);
+  print_vint512x (" m1[0] * ", m1.x2.v0x512);
+  print_vint512x (" m2[1]   ", m2.x2.v1x512);
+  print_vint512x (" m2[0] = ", m2.x2.v0x512);
+  print_vint512x (" k [3]   ", k.x4.v3x512);
+  print_vint512x (" k [2]   ", k.x4.v2x512);
+  print_vint512x (" k [1]   ", k.x4.v1x512);
+  print_vint512x (" k [0]   ", k.x4.v0x512);
+#endif
+#ifdef __DEBUG_PRINT__
+  e.x4.v0x512 = vec512_zeros;
+  e.x4.v1x512 = vec512_zeros;
+#endif
+  e.x4.v2x512 = vec512_one;
+  e.x4.v3x512 = vec512_foxeasy;
+  rc += check_vint512 ("vec_mul1024x1024 4a:", k.x4.v3x512, e.x4.v3x512);
+  rc += check_vint512 ("vec_mul1024x1024 4b:", k.x4.v2x512, e.x4.v2x512);
+#ifdef __DEBUG_PRINT__
+  rc += check_vint512 ("vec_mul1024x1024 4c:", k.x4.v1x512, e.x4.v1x512);
+  rc += check_vint512 ("vec_mul1024x1024 4d:", k.x4.v0x512, e.x4.v0x512);
+#endif
+
+  m1.x2.v1x512 = vec512_foxes;
+  m1.x2.v0x512 = vec512_foxes;
+  m2.x2.v1x512 = vec512_foxes;
+  m2.x2.v0x512 = vec512_foxes;
+  __VEC_PWR_IMP (vec_mul1024x1024)(&k.x2048, &m1.x1024, &m2.x1024);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[1]   ", m1.x2.v1x512);
+  print_vint512x (" m1[0] * ", m1.x2.v0x512);
+  print_vint512x (" m2[1]   ", m2.x2.v1x512);
+  print_vint512x (" m2[0] = ", m2.x2.v0x512);
+  print_vint512x (" k [3]   ", k.x4.v3x512);
+  print_vint512x (" k [2]   ", k.x4.v2x512);
+  print_vint512x (" k [1]   ", k.x4.v1x512);
+  print_vint512x (" k [0]   ", k.x4.v0x512);
+#endif
+  e.x4.v0x512 = vec512_one;
+  e.x4.v1x512 = vec512_zeros;
+  e.x4.v2x512 = vec512_foxeasy;
+  e.x4.v3x512 = vec512_foxes;
+  rc += check_vint512 ("vec_mul1024x1024 5a:", k.x4.v3x512, e.x4.v3x512);
+  rc += check_vint512 ("vec_mul1024x1024 5b:", k.x4.v2x512, e.x4.v2x512);
+  rc += check_vint512 ("vec_mul1024x1024 5c:", k.x4.v1x512, e.x4.v1x512);
+  rc += check_vint512 ("vec_mul1024x1024 5d:", k.x4.v0x512, e.x4.v0x512);
+
+  m1.x2.v1x512 = vec512_zeros;
+  m1.x2.v0x512 = vec512_ten128th;
+  m2.x2.v1x512 = vec512_zeros;
+  m2.x2.v0x512 = vec512_ten128th;
+  __VEC_PWR_IMP (vec_mul1024x1024)(&k.x2048, &m1.x1024, &m2.x1024);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[1]   ", m1.x2.v1x512);
+  print_vint512x (" m1[0] * ", m1.x2.v0x512);
+  print_vint512x (" m2[1]   ", m2.x2.v1x512);
+  print_vint512x (" m2[0] = ", m2.x2.v0x512);
+  print_vint512x (" k [3]   ", k.x4.v3x512);
+  print_vint512x (" k [2]   ", k.x4.v2x512);
+  print_vint512x (" k [1]   ", k.x4.v1x512);
+  print_vint512x (" k [0]   ", k.x4.v0x512);
+#endif
+  e.x4.v0x512 = vec512_ten256_l;
+  e.x4.v1x512 = vec512_ten256_h;
+#ifdef __DEBUG_PRINT__
+  e.x4.v2x512 = vec512_zeros;
+  e.x4.v3x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul1024x1024 6a:", k.x4.v3x512, e.x4.v3x512);
+  rc += check_vint512 ("vec_mul1024x1024 6b:", k.x4.v2x512, e.x4.v2x512);
+#endif
+  rc += check_vint512 ("vec_mul1024x1024 6c:", k.x4.v1x512, e.x4.v1x512);
+  rc += check_vint512 ("vec_mul1024x1024 6d:", k.x4.v0x512, e.x4.v0x512);
+
+  m1.x2.v1x512 = e.x4.v1x512;
+  m1.x2.v0x512 = e.x4.v0x512;
+  m2.x2.v1x512 = e.x4.v1x512;
+  m2.x2.v0x512 = e.x4.v0x512;
+  __VEC_PWR_IMP (vec_mul1024x1024)(&k.x2048, &m1.x1024, &m2.x1024);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[1]   ", m1.x2.v1x512);
+  print_vint512x (" m1[0] * ", m1.x2.v0x512);
+  print_vint512x (" m2[1]   ", m2.x2.v1x512);
+  print_vint512x (" m2[0] = ", m2.x2.v0x512);
+  print_vint512x (" k [3]   ", k.x4.v3x512);
+  print_vint512x (" k [2]   ", k.x4.v2x512);
+  print_vint512x (" k [1]   ", k.x4.v1x512);
+  print_vint512x (" k [0]   ", k.x4.v0x512);
+#endif
+  e.x4.v0x512 = vec512_zeros;
+  e.x4.v1x512 = vec512_ten512_1;
+  e.x4.v2x512 = vec512_ten512_2;
+  e.x4.v3x512 = vec512_ten512_3;
+  rc += check_vint512 ("vec_mul1024x1024 7a:", k.x4.v3x512, e.x4.v3x512);
+  rc += check_vint512 ("vec_mul1024x1024 7b:", k.x4.v2x512, e.x4.v2x512);
+  rc += check_vint512 ("vec_mul1024x1024 7c:", k.x4.v1x512, e.x4.v1x512);
+  rc += check_vint512 ("vec_mul1024x1024 7d:", k.x4.v0x512, e.x4.v0x512);
+
+  m1.x2.v1x512 = vec512_zeros;
+  m1.x2.v0x512 = vec512_ten128th;
+  m2.x2.v1x512 = vec512_ten256_h;
+  m2.x2.v0x512 = vec512_ten256_l;
+  __VEC_PWR_IMP (vec_mul1024x1024)(&k.x2048, &m1.x1024, &m2.x1024);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[1]   ", m1.x2.v1x512);
+  print_vint512x (" m1[0] * ", m1.x2.v0x512);
+  print_vint512x (" m2[1]   ", m2.x2.v1x512);
+  print_vint512x (" m2[0] = ", m2.x2.v0x512);
+  print_vint512x (" k [3]   ", k.x4.v3x512);
+  print_vint512x (" k [2]   ", k.x4.v2x512);
+  print_vint512x (" k [1]   ", k.x4.v1x512);
+  print_vint512x (" k [0]   ", k.x4.v0x512);
+#endif
+  e.x4.v0x512 = vec512_ten384_l;
+  e.x4.v1x512 = vec512_ten384_m;
+  e.x4.v2x512 = vec512_ten384_h;
+#ifdef __DEBUG_PRINT__
+  e.x4.v3x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul1024x1024 8a:", k.x4.v3x512, e.x4.v3x512);
+#endif
+  rc += check_vint512 ("vec_mul1024x1024 8b:", k.x4.v2x512, e.x4.v2x512);
+  rc += check_vint512 ("vec_mul1024x1024 8c:", k.x4.v1x512, e.x4.v1x512);
+  rc += check_vint512 ("vec_mul1024x1024 8d:", k.x4.v0x512, e.x4.v0x512);
+
+  __VEC_PWR_IMP (vec_mul1024x1024)(&k.x2048, &m1.x1024, &m2.x1024);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[1]   ", m2.x2.v1x512);
+  print_vint512x (" m1[0] * ", m2.x2.v0x512);
+  print_vint512x (" m2[1]   ", m1.x2.v1x512);
+  print_vint512x (" m2[0] = ", m1.x2.v0x512);
+  print_vint512x (" k [3]   ", k.x4.v3x512);
+  print_vint512x (" k [2]   ", k.x4.v2x512);
+  print_vint512x (" k [1]   ", k.x4.v1x512);
+  print_vint512x (" k [0]   ", k.x4.v0x512);
+#endif
+#ifdef __DEBUG_PRINT__
+  rc += check_vint512 ("vec_mul1024x1024 9a:", k.x4.v3x512, e.x4.v3x512);
+#endif
+  rc += check_vint512 ("vec_mul1024x1024 9b:", k.x4.v2x512, e.x4.v2x512);
+  rc += check_vint512 ("vec_mul1024x1024 9c:", k.x4.v1x512, e.x4.v1x512);
+  rc += check_vint512 ("vec_mul1024x1024 9d:", k.x4.v0x512, e.x4.v0x512);
+
+  m1.x2.v1x512 = vec512_foxes;
+  m1.x2.v0x512 = vec512_foxes;
+  m2.x2.v1x512 = vec512_foxes;
+  m2.x2.v0x512 = vec512_zeros;
+  __VEC_PWR_IMP (vec_mul1024x1024)(&k.x2048, &m1.x1024, &m2.x1024);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[1]   ", m1.x2.v1x512);
+  print_vint512x (" m1[0] * ", m1.x2.v0x512);
+  print_vint512x (" m2[1]   ", m2.x2.v1x512);
+  print_vint512x (" m2[0] = ", m2.x2.v0x512);
+  print_vint512x (" k [3]   ", k.x4.v3x512);
+  print_vint512x (" k [2]   ", k.x4.v2x512);
+  print_vint512x (" k [1]   ", k.x4.v1x512);
+  print_vint512x (" k [0]   ", k.x4.v0x512);
+#endif
+  e.x4.v0x512 = vec512_zeros;
+  e.x4.v1x512 = vec512_one;
+  e.x4.v2x512 = vec512_foxes;
+  e.x4.v3x512 = vec512_foxeasy;
+  rc += check_vint512 ("vec_mul1024x1024 10a:", k.x4.v3x512, e.x4.v3x512);
+  rc += check_vint512 ("vec_mul1024x1024 10b:", k.x4.v2x512, e.x4.v2x512);
+  rc += check_vint512 ("vec_mul1024x1024 10c:", k.x4.v1x512, e.x4.v1x512);
+  rc += check_vint512 ("vec_mul1024x1024 10d:", k.x4.v0x512, e.x4.v0x512);
+
+  return (rc);
+}
+
+//#define __DEBUG_PRINT__ 1
+int
+timed_mul2048x2048 (void)
+{
+  __VEC_U_4096x512 k, e;
+  __VEC_U_2048x512 m1, m2;
+  __VEC_U_512 i, j;
+
+  int rc = 0;
+
+#ifdef __DEBUG_PRINT__
+  printf ("\ntimed_mul2048x2048 vector multiply quadword, 4096-bit product\n");
+#endif
+
+  m1.x4.v3x512 = vec512_zeros;
+  m1.x4.v2x512 = vec512_zeros;
+  m1.x4.v1x512 = vec512_zeros;
+  m1.x4.v0x512 = vec512_foxes;
+  m2.x4.v3x512 = vec512_zeros;
+  m2.x4.v2x512 = vec512_zeros;
+  m2.x4.v1x512 = vec512_zeros;
+  m2.x4.v0x512 = vec512_foxes;
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k.x4096, &m1.x2048, &m2.x2048);
+
+  e.x8.v0x512 = vec512_one;
+  e.x8.v1x512 = vec512_foxeasy;
+#ifdef __DEBUG_PRINT__
+  e.x8.v2x512 = vec512_zeros;
+  e.x8.v3x512 = vec512_zeros;
+  e.x8.v4x512 = vec512_zeros;
+  e.x8.v5x512 = vec512_zeros;
+  e.x8.v6x512 = vec512_zeros;
+  e.x8.v7x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul2048x2048 1a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul2048x2048 1b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul2048x2048 1c:", k.x8.v5x512, e.x8.v5x512);
+  rc += check_vint512 ("vec_mul2048x2048 1d:", k.x8.v4x512, e.x8.v4x512);
+  rc += check_vint512 ("vec_mul2048x2048 1e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul2048x2048 1f:", k.x8.v2x512, e.x8.v2x512);
+#endif
+  rc += check_vint512 ("vec_mul2048x2048 1g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul2048x2048 1h:", k.x8.v0x512, e.x8.v0x512);
+
+  m1.x4.v3x512 = vec512_zeros;
+  m1.x4.v2x512 = vec512_zeros;
+  m1.x4.v1x512 = vec512_foxes;
+  m1.x4.v0x512 = vec512_zeros;
+  m2.x4.v3x512 = vec512_zeros;
+  m2.x4.v2x512 = vec512_zeros;
+  m2.x4.v1x512 = vec512_zeros;
+  m2.x4.v0x512 = vec512_foxes;
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k.x4096, &m1.x2048, &m2.x2048);
+
+  e.x8.v0x512 = vec512_zeros;
+  e.x8.v1x512 = vec512_one;
+  e.x8.v2x512 = vec512_foxeasy;
+#ifdef __DEBUG_PRINT__
+  e.x8.v3x512 = vec512_zeros;
+  e.x8.v4x512 = vec512_zeros;
+  e.x8.v5x512 = vec512_zeros;
+  e.x8.v6x512 = vec512_zeros;
+  e.x8.v7x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul2048x2048 2a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul2048x2048 2b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul2048x2048 2c:", k.x8.v5x512, e.x8.v5x512);
+  rc += check_vint512 ("vec_mul2048x2048 2d:", k.x8.v4x512, e.x8.v4x512);
+  rc += check_vint512 ("vec_mul2048x2048 2e:", k.x8.v3x512, e.x8.v3x512);
+#endif
+  rc += check_vint512 ("vec_mul2048x2048 2f:", k.x8.v2x512, e.x8.v2x512);
+  rc += check_vint512 ("vec_mul2048x2048 2g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul2048x2048 2h:", k.x8.v0x512, e.x8.v0x512);
+
+  m1.x4.v3x512 = vec512_zeros;
+  m1.x4.v2x512 = vec512_foxes;
+  m1.x4.v1x512 = vec512_zeros;
+  m1.x4.v0x512 = vec512_zeros;
+  m2.x4.v3x512 = vec512_zeros;
+  m2.x4.v2x512 = vec512_zeros;
+  m2.x4.v1x512 = vec512_zeros;
+  m2.x4.v0x512 = vec512_foxes;
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k.x4096, &m1.x2048, &m2.x2048);
+
+  e.x8.v0x512 = vec512_zeros;
+  e.x8.v1x512 = vec512_zeros;
+  e.x8.v2x512 = vec512_one;
+  e.x8.v3x512 = vec512_foxeasy;
+#ifdef __DEBUG_PRINT__
+  e.x8.v4x512 = vec512_zeros;
+  e.x8.v5x512 = vec512_zeros;
+  e.x8.v6x512 = vec512_zeros;
+  e.x8.v7x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul2048x2048 4a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul2048x2048 4b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul2048x2048 4c:", k.x8.v5x512, e.x8.v5x512);
+  rc += check_vint512 ("vec_mul2048x2048 4d:", k.x8.v4x512, e.x8.v4x512);
+#endif
+  rc += check_vint512 ("vec_mul2048x2048 4e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul2048x2048 4f:", k.x8.v2x512, e.x8.v2x512);
+#ifdef __DEBUG_PRINT__
+  rc += check_vint512 ("vec_mul2048x2048 4g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul2048x2048 4h:", k.x8.v0x512, e.x8.v0x512);
+#endif
+
+  m1.x4.v3x512 = vec512_foxes;
+  m1.x4.v2x512 = vec512_zeros;
+  m1.x4.v1x512 = vec512_zeros;
+  m1.x4.v0x512 = vec512_zeros;
+  m2.x4.v3x512 = vec512_zeros;
+  m2.x4.v2x512 = vec512_zeros;
+  m2.x4.v1x512 = vec512_zeros;
+  m2.x4.v0x512 = vec512_foxes;
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k.x4096, &m1.x2048, &m2.x2048);
+
+  e.x8.v0x512 = vec512_zeros;
+  e.x8.v1x512 = vec512_zeros;
+  e.x8.v2x512 = vec512_zeros;
+  e.x8.v3x512 = vec512_one;
+  e.x8.v4x512 = vec512_foxeasy;
+#ifdef __DEBUG_PRINT__
+  e.x8.v5x512 = vec512_zeros;
+  e.x8.v6x512 = vec512_zeros;
+  e.x8.v7x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul2048x2048 6a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul2048x2048 6b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul2048x2048 6c:", k.x8.v5x512, e.x8.v5x512);
+#endif
+  rc += check_vint512 ("vec_mul2048x2048 6d:", k.x8.v4x512, e.x8.v4x512);
+  rc += check_vint512 ("vec_mul2048x2048 6e:", k.x8.v3x512, e.x8.v3x512);
+#ifdef __DEBUG_PRINT__
+  rc += check_vint512 ("vec_mul2048x2048 6f:", k.x8.v2x512, e.x8.v2x512);
+  rc += check_vint512 ("vec_mul2048x2048 6g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul2048x2048 6h:", k.x8.v0x512, e.x8.v0x512);
+#endif
+
+  m1.x4.v3x512 = vec512_foxes;
+  m1.x4.v2x512 = vec512_foxes;
+  m1.x4.v1x512 = vec512_foxes;
+  m1.x4.v0x512 = vec512_foxes;
+  m2.x4.v3x512 = vec512_foxes;
+  m2.x4.v2x512 = vec512_foxes;
+  m2.x4.v1x512 = vec512_foxes;
+  m2.x4.v0x512 = vec512_foxes;
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k.x4096, &m1.x2048, &m2.x2048);
+
+  e.x8.v0x512 = vec512_one;
+  e.x8.v1x512 = vec512_zeros;
+  e.x8.v2x512 = vec512_zeros;
+  e.x8.v3x512 = vec512_zeros;
+  e.x8.v4x512 = vec512_foxeasy;
+  e.x8.v5x512 = vec512_foxes;
+  e.x8.v6x512 = vec512_foxes;
+  e.x8.v7x512 = vec512_foxes;
+  rc += check_vint512 ("vec_mul2048x2048 8a:", k.x8.v7x512, e.x8.v7x512);
+#ifdef __DEBUG_PRINT__
+  rc += check_vint512 ("vec_mul2048x2048 8b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul2048x2048 8c:", k.x8.v5x512, e.x8.v5x512);
+#endif
+  rc += check_vint512 ("vec_mul2048x2048 8d:", k.x8.v4x512, e.x8.v4x512);
+#ifdef __DEBUG_PRINT__
+  rc += check_vint512 ("vec_mul2048x2048 8e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul2048x2048 8f:", k.x8.v2x512, e.x8.v2x512);
+  rc += check_vint512 ("vec_mul2048x2048 8g:", k.x8.v1x512, e.x8.v1x512);
+#endif
+  rc += check_vint512 ("vec_mul2048x2048 8h:", k.x8.v0x512, e.x8.v0x512);
+
+  m1.x4.v3x512 = vec512_zeros;
+  m1.x4.v2x512 = vec512_zeros;
+  m1.x4.v1x512 = vec512_foxes;
+  m1.x4.v0x512 = vec512_foxes;
+  m2.x4.v3x512 = vec512_zeros;
+  m2.x4.v2x512 = vec512_zeros;
+  m2.x4.v1x512 = vec512_foxes;
+  m2.x4.v0x512 = vec512_foxes;
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k.x4096, &m1.x2048, &m2.x2048);
+
+  e.x8.v0x512 = vec512_one;
+  e.x8.v1x512 = vec512_zeros;
+  e.x8.v2x512 = vec512_foxeasy;
+  e.x8.v3x512 = vec512_foxes;
+#ifdef __DEBUG_PRINT__
+  e.x8.v4x512 = vec512_zeros;
+  e.x8.v5x512 = vec512_zeros;
+  e.x8.v6x512 = vec512_zeros;
+  e.x8.v7x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul2048x2048 9a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul2048x2048 9b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul2048x2048 9c:", k.x8.v5x512, e.x8.v5x512);
+  rc += check_vint512 ("vec_mul2048x2048 9d:", k.x8.v4x512, e.x8.v4x512);
+#endif
+  rc += check_vint512 ("vec_mul2048x2048 9e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul2048x2048 9f:", k.x8.v2x512, e.x8.v2x512);
+  rc += check_vint512 ("vec_mul2048x2048 9g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul2048x2048 9h:", k.x8.v0x512, e.x8.v0x512);
+
+  m1.x4.v3x512 = vec512_foxes;
+  m1.x4.v2x512 = vec512_foxes;
+  m1.x4.v1x512 = vec512_foxes;
+  m1.x4.v0x512 = vec512_foxes;
+  m2.x4.v3x512 = vec512_zeros;
+  m2.x4.v2x512 = vec512_zeros;
+  m2.x4.v1x512 = vec512_zeros;
+  m2.x4.v0x512 = vec512_foxes;
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k.x4096, &m1.x2048, &m2.x2048);
+
+  e.x8.v0x512 = vec512_one;
+  e.x8.v1x512 = vec512_foxes;
+  e.x8.v2x512 = vec512_foxes;
+  e.x8.v3x512 = vec512_foxes;
+  e.x8.v4x512 = vec512_foxeasy;
+#ifdef __DEBUG_PRINT__
+  e.x8.v5x512 = vec512_zeros;
+  e.x8.v6x512 = vec512_zeros;
+  e.x8.v7x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul2048x2048 10a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul2048x2048 10b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul2048x2048 10c:", k.x8.v5x512, e.x8.v5x512);
+#endif
+  rc += check_vint512 ("vec_mul2048x2048 10d:", k.x8.v4x512, e.x8.v4x512);
+  rc += check_vint512 ("vec_mul2048x2048 10e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul2048x2048 10f:", k.x8.v2x512, e.x8.v2x512);
+  rc += check_vint512 ("vec_mul2048x2048 10g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul2048x2048 10h:", k.x8.v0x512, e.x8.v0x512);
+
+  m1.x4.v3x512 = vec512_zeros;
+  m1.x4.v2x512 = vec512_zeros;
+  m1.x4.v1x512 = vec512_zeros;
+  m1.x4.v0x512 = vec512_ten128th;
+  m2.x4.v3x512 = vec512_zeros;
+  m2.x4.v2x512 = vec512_zeros;
+  m2.x4.v1x512 = vec512_zeros;
+  m2.x4.v0x512 = vec512_ten128th;
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k.x4096, &m1.x2048, &m2.x2048);
+
+  e.x8.v0x512 = vec512_ten256_l;
+  e.x8.v1x512 = vec512_ten256_h;
+#ifdef __DEBUG_PRINT__
+  e.x8.v2x512 = vec512_zeros;
+  e.x8.v3x512 = vec512_zeros;
+  e.x8.v4x512 = vec512_zeros;
+  e.x8.v5x512 = vec512_zeros;
+  e.x8.v6x512 = vec512_zeros;
+  e.x8.v7x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul2048x2048 11a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul2048x2048 11b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul2048x2048 11c:", k.x8.v5x512, e.x8.v5x512);
+  rc += check_vint512 ("vec_mul2048x2048 11d:", k.x8.v4x512, e.x8.v4x512);
+  rc += check_vint512 ("vec_mul2048x2048 11e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul2048x2048 11f:", k.x8.v2x512, e.x8.v2x512);
+#endif
+  rc += check_vint512 ("vec_mul2048x2048 11g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul2048x2048 11h:", k.x8.v0x512, e.x8.v0x512);
+
+  m1.x4.v3x512 = vec512_zeros;
+  m1.x4.v2x512 = vec512_zeros;
+  m1.x4.v1x512 = e.x8.v1x512;
+  m1.x4.v0x512 = e.x8.v0x512;
+  m2.x4.v3x512 = vec512_zeros;
+  m2.x4.v2x512 = vec512_zeros;
+  m2.x4.v1x512 = e.x8.v1x512;
+  m2.x4.v0x512 = e.x8.v0x512;
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k.x4096, &m1.x2048, &m2.x2048);
+
+  e.x8.v0x512 = vec512_zeros;
+  e.x8.v1x512 = vec512_ten512_1;
+  e.x8.v2x512 = vec512_ten512_2;
+  e.x8.v3x512 = vec512_ten512_3;
+#ifdef __DEBUG_PRINT__
+  e.x8.v4x512 = vec512_zeros;
+  e.x8.v5x512 = vec512_zeros;
+  e.x8.v6x512 = vec512_zeros;
+  e.x8.v7x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul2048x2048 12a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul2048x2048 12b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul2048x2048 12c:", k.x8.v5x512, e.x8.v5x512);
+  rc += check_vint512 ("vec_mul2048x2048 12d:", k.x8.v4x512, e.x8.v4x512);
+#endif
+  rc += check_vint512 ("vec_mul2048x2048 12e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul2048x2048 12f:", k.x8.v2x512, e.x8.v2x512);
+  rc += check_vint512 ("vec_mul2048x2048 12g:", k.x8.v1x512, e.x8.v1x512);
+#ifdef __DEBUG_PRINT__
+  rc += check_vint512 ("vec_mul2048x2048 12h:", k.x8.v0x512, e.x8.v0x512);
+#endif
+
+  m1.x4.v3x512 = e.x8.v3x512;
+  m1.x4.v2x512 = e.x8.v2x512;
+  m1.x4.v1x512 = e.x8.v1x512;
+  m1.x4.v0x512 = e.x8.v0x512;
+  m2.x4.v3x512 = e.x8.v3x512;
+  m2.x4.v2x512 = e.x8.v2x512;
+  m2.x4.v1x512 = e.x8.v1x512;
+  m2.x4.v0x512 = e.x8.v0x512;
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k.x4096, &m1.x2048, &m2.x2048);
+
+  e.x8.v0x512 = vec512_zeros;
+  e.x8.v1x512 = vec512_zeros;
+  e.x8.v2x512 = vec512_ten1024_2;
+  e.x8.v3x512 = vec512_ten1024_3;
+  e.x8.v4x512 = vec512_ten1024_4;
+  e.x8.v5x512 = vec512_ten1024_5;
+  e.x8.v6x512 = vec512_ten1024_6;
+#ifdef __DEBUG_PRINT__
+  e.x8.v7x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul2048x2048 13a:", k.x8.v7x512, e.x8.v7x512);
+#endif
+  rc += check_vint512 ("vec_mul2048x2048 13b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul2048x2048 13c:", k.x8.v5x512, e.x8.v5x512);
+  rc += check_vint512 ("vec_mul2048x2048 13d:", k.x8.v4x512, e.x8.v4x512);
+  rc += check_vint512 ("vec_mul2048x2048 13e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul2048x2048 13f:", k.x8.v2x512, e.x8.v2x512);
+#ifdef __DEBUG_PRINT__
+  rc += check_vint512 ("vec_mul2048x2048 13g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul2048x2048 13h:", k.x8.v0x512, e.x8.v0x512);
+#endif
+
+
+  return (rc);
+}
+
+int
+timed_mul512x512 (void)
+{
+  __VEC_U_1024 k, e;
+  __VEC_U_1024x512 kp, ep;
+  __VEC_U_512 i, j;
+  int rc = 0;
+
+#ifdef __DEBUG_PRINT__
+  printf ("\ntest_mul512x512 vector multiply quadword, 1024-bit product\n");
+#endif
+
+  i.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  k = __VEC_PWR_IMP (vec_mul512x512)(i, j);
+
+  kp.x1024 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+#ifdef __DEBUG_PRINT__
+  ep.x2.v1x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint512 ("vec_mul512x128 1a:", kp.x2.v1x512, ep.x2.v1x512);
+#endif
+  rc += check_vint512 ("vec_mul512x128 1b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  j.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  k = __VEC_PWR_IMP (vec_mul512x512)(i, j);
+
+  kp.x1024 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+#ifdef __DEBUG_PRINT__
+  ep.x2.v1x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint512 ("vec_mul512x128 2a:", kp.x2.v1x512, ep.x2.v1x512);
+#endif
+  rc += check_vint512 ("vec_mul512x128 2b:", kp.x2.v0x512, ep.x2.v0x512);
+  k = __VEC_PWR_IMP (vec_mul512x512)(j, i);
+
+  kp.x1024 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+#ifdef __DEBUG_PRINT__
+  ep.x2.v1x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint512 ("vec_mul512x128 2a:", kp.x2.v1x512, ep.x2.v1x512);
+#endif
+  rc += check_vint512 ("vec_mul512x128 2b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  j.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx2 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  k = __VEC_PWR_IMP (vec_mul512x512)(i, j);
+
+  kp.x1024 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+#ifdef __DEBUG_PRINT__
+  ep.x2.v1x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint512 ("vec_mul512x128 3a:", kp.x2.v1x512, ep.x2.v1x512);
+#endif
+  rc += check_vint512 ("vec_mul512x128 3b:", kp.x2.v0x512, ep.x2.v0x512);
+  k = __VEC_PWR_IMP (vec_mul512x512)(j, i);
+
+  kp.x1024 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+#ifdef __DEBUG_PRINT__
+  ep.x2.v1x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint512 ("vec_mul512x128 4a:", kp.x2.v1x512, ep.x2.v1x512);
+#endif
+  rc += check_vint512 ("vec_mul512x128 4b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  j.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx3 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  k = __VEC_PWR_IMP (vec_mul512x512)(i, j);
+
+#ifdef __DEBUG_PRINT__
+#endif
+  kp.x1024 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ep.x2.v1x512.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint512 ("vec_mul512x128 5a:", kp.x2.v1x512, ep.x2.v1x512);
+  rc += check_vint512 ("vec_mul512x128 5b:", kp.x2.v0x512, ep.x2.v0x512);
+  k = __VEC_PWR_IMP (vec_mul512x512)(j, i);
+
+#ifdef __DEBUG_PRINT__
+#endif
+  kp.x1024 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ep.x2.v1x512.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint512 ("vec_mul512x128 6a:", kp.x2.v1x512, ep.x2.v1x512);
+  rc += check_vint512 ("vec_mul512x128 6b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  i.vx0 = (vui128_t) CONST_VINT128_W (0x000004ee, 0x2d6d415b, 0x85acef81, 0x00000000);
+  i.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx0 = (vui128_t) CONST_VINT128_W (0x000004ee, 0x2d6d415b, 0x85acef81, 0x00000000);
+  j.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  k = __VEC_PWR_IMP (vec_mul512x512)(i, j);
+
+  kp.x1024 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x6e38ed64, 0xbf6a1f01, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00184f03, 0xe93ff9f4, 0xdaa797ed);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+#ifdef __DEBUG_PRINT__
+  ep.x2.v1x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint512 ("vec_mul512x128 7a:", kp.x2.v1x512, ep.x2.v1x512);
+#endif
+  rc += check_vint512 ("vec_mul512x128 7b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  kp.x1024 = k;
+  i = kp.x2.v0x512;
+  j = kp.x2.v0x512;
+  k = __VEC_PWR_IMP (vec_mul512x512)(i, j);
+
+  kp.x1024 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x2374e42f, 0x0f1538fd, 0x03df9909, 0x2e953e01);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0xa6337f19, 0xbccdb0da, 0xc404dc08, 0xd3cff5ec);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x0000024e, 0xe91f2603);
+#ifdef __DEBUG_PRINT__
+  ep.x2.v1x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint512 ("vec_mul512x128 8a:", kp.x2.v1x512, ep.x2.v1x512);
+#endif
+  rc += check_vint512 ("vec_mul512x128 8b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  kp.x1024 = k;
+  i = kp.x2.v0x512;
+  j = kp.x2.v0x512;
+  k = __VEC_PWR_IMP (vec_mul512x512)(i, j);
+
+  kp.x1024 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0x12152f87, 0xd8d99f72, 0xbed3875b, 0x982e7c01);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x26b2716e, 0xd595d80f, 0xcf4a6e70, 0x6bde50c6);
+  ep.x2.v1x512.vx0 = (vui128_t) CONST_VINT128_W (0x63ff540e, 0x3c42d35a, 0x1d153624, 0xadc666b0);
+  ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x80dcc7f7, 0x55bc28f2, 0x65f9ef17, 0xcc5573c0);
+  ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x000553f7, 0x5fdcefce, 0xf46eeddc);
+  ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint512 ("vec_mul512x128 8a:", kp.x2.v1x512, ep.x2.v1x512);
+  rc += check_vint512 ("vec_mul512x128 8b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  return (rc);
+}

--- a/src/testsuite/vec_perf_i512.h
+++ b/src/testsuite/vec_perf_i512.h
@@ -1,0 +1,30 @@
+/*
+ Copyright (c) [2019] Steven Munroe.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ vec_perf_i512.h
+
+ Contributors:
+      Steven Munroe
+      Created on: Sep 9, 2019
+ */
+
+#ifndef SRC_TESTSUITE_VEC_PERF_I512_H_
+#define SRC_TESTSUITE_VEC_PERF_I512_H_
+
+extern int timed_mul512x512 (void);
+extern int timed_mul1024x1024 (void);
+extern int timed_mul2048x2048 (void);
+
+#endif /* SRC_TESTSUITE_VEC_PERF_I512_H_ */


### PR DESCRIPTION
Add compile and unit tests for int512.
Correct some compile only examples that turned out to be incorrect.
Add new print/check functions to support int512 unit test.

	* src/testsuite/arith128_test_i512.c: New File.
	* src/testsuite/arith128_test_i512.h: Ditto.
	* src/testsuite/vec_int512_dummy.c: Ditto.
	* src/testsuite/vec_perf_i512.c: Ditto.
	* src/testsuite/vec_perf_i512.h: Ditto.

	* src/testsuite/vec_int128_dummy.c
	(test_vec_mul10uq): Attribute target power9.
	(test_mul4uq): Correct implementation.
	(example_qw_convert_decimal [CONST_VUINT128_Qx19d]):
	Replace use of CONST_VINT128_DW.
	[CONST_VUINT128_Qx16d]: replace use of CONST_VINT128_DW.

	* src/testsuite/vec_pwr9_dummy.c:
	Include <pveclib/vec_int512_ppc.h>
	(test_mul4uq_PWR9): Correct implementation.
	(test_vec_mul1024x1024_PWR9: New function.
.
	* src/testsuite/arith128_print.h: Include
	<pveclib/vec_int512_ppc.h>
	(print_vint512x, print_vint640x, print_vint512x_prod,
	print_vint256x_prod, print_vint256_prod, check_vint512_priv):
	Define extern.
	(check_vint512): New inline function.
	* src/testsuite/arith128_print.c: Include <string.h>.
	(print_vuint512x, print_vint512x, print_vint640x,
	print_vint512x_prod, print_vint256x_prod, print_vint256_prod,
	check_vint512_priv): New functions.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>