### PR TITLE
Optimizations for multiple quadword precision integer support (doubleword).

### DIFF
--- a/src/pveclib/vec_int64_ppc.h
+++ b/src/pveclib/vec_int64_ppc.h
@@ -2452,6 +2452,51 @@ vec_mrgod (vui64_t __VA, vui64_t __VB)
   return (result);
 }
 
+/** \brief \copybrief vec_int128_ppc.h::vec_msumudm()
+ *
+ * \note this implementation exists in
+ * \ref vec_int128_ppc.h::vec_msumudm()
+ * as it requires vec_adduqm().
+ */
+static inline vui128_t
+vec_msumudm (vui64_t a, vui64_t b, vui128_t c);
+
+/** \brief \copybrief vec_int128_ppc.h::vec_muleud()
+ *
+ * \note this implementation exists in
+ * \ref vec_int128_ppc.h::vec_muleud()
+ * as it requires vec_vmuleud and vec_adduqm().
+ */
+static inline vui128_t
+vec_muleud (vui64_t a, vui64_t b);
+
+/** \brief \copybrief vec_int128_ppc.h::vec_mulhud()
+ *
+ * \note this implementation exists in
+ * \ref vec_int128_ppc.h::vec_mulhud()
+ * as it requires vec_vmuleud() and vec_vmuloud().
+ */
+static inline vui64_t
+vec_mulhud (vui64_t vra, vui64_t vrb);
+
+/** \brief \copybrief vec_int128_ppc.h::vec_muloud()
+ *
+ * \note this implementation exists in
+ * \ref vec_int128_ppc.h::vec_muloud()
+ * as it requires vec_vmuloud() and vec_adduqm().
+ */
+static inline vui128_t
+vec_muloud (vui64_t a, vui64_t b);
+
+/** \brief \copybrief vec_int128_ppc.h::vec_muludm()
+ *
+ * \note this implementation exists in
+ * \ref vec_int128_ppc.h::vec_muludm()
+ * as it requires vec_vmuleud() and vec_vmuloud().
+ */
+static inline vui64_t
+vec_muludm (vui64_t vra, vui64_t vrb);
+
 /** \brief Vector doubleword paste.
  *  Concatenate the high doubleword of the 1st vector with the
  *  low double word of the 2nd vector.
@@ -3037,6 +3082,78 @@ vec_swapd (vui64_t vra)
   return (result);
 }
 
+/** \brief \copybrief vec_int128_ppc.h::vec_vmadd2eud()
+ *
+ * \note this implementation exists in
+ * \ref vec_int128_ppc.h::vec_vmadd2eud()
+ * as it requires vec_msumudm() and vec_adduqm().
+ */
+static inline vui128_t
+vec_vmadd2eud (vui64_t a, vui64_t b, vui64_t c, vui64_t d);
+
+/** \brief \copybrief vec_int128_ppc.h::vec_vmaddeud()
+ *
+ * \note this implementation exists in
+ * \ref vec_int128_ppc.h::vec_vmaddeud()
+ * as it requires vec_msumudm() and vec_adduqm().
+ */
+static inline vui128_t
+vec_vmaddeud (vui64_t a, vui64_t b, vui64_t c);
+
+/** \brief \copybrief vec_int128_ppc.h::vec_vmadd2oud()
+ *
+ * \note this implementation exists in
+ * \ref vec_int128_ppc.h::vec_vmadd2oud()
+ * as it requires vec_msumudm() and vec_adduqm().
+ */
+static inline vui128_t
+vec_vmadd2oud (vui64_t a, vui64_t b, vui64_t c, vui64_t d);
+
+/** \brief \copybrief vec_int128_ppc.h::vec_vmaddoud()
+ *
+ * \note this implementation exists in
+ * \ref vec_int128_ppc.h::vec_vmaddoud()
+ * as it requires vec_msumudm() and vec_adduqm().
+ */
+static inline vui128_t
+vec_vmaddoud (vui64_t a, vui64_t b, vui64_t c);
+
+/** \brief \copybrief vec_int128_ppc.h::vec_vmuleud()
+ *
+ * \note this implementation exists in
+ * \ref vec_int128_ppc.h::vec_vmuleud()
+ * as it requires vec_msumudm() and vec_adduqm().
+ */
+static inline vui128_t
+vec_vmuleud (vui64_t a, vui64_t b);
+
+/** \brief \copybrief vec_int128_ppc.h::vec_vmuloud()
+ *
+ * \note this implementation exists in
+ * \ref vec_int128_ppc.h::vec_vmuloud()
+ * as it requires vec_msumudm() and vec_adduqm().
+ */
+static inline vui128_t
+vec_vmuloud (vui64_t a, vui64_t b);
+
+/** \brief \copybrief vec_int128_ppc.h::vec_vmsumeud()
+ *
+ * \note this implementation exists in
+ * \ref vec_int128_ppc.h::vec_vmsumeud()
+ * as it requires vec_msumudm() and vec_adduqm().
+ */
+static inline vui128_t
+vec_vmsumeud (vui64_t a, vui64_t b, vui128_t c);
+
+/** \brief \copybrief vec_int128_ppc.h::vec_vmsumoud()
+ *
+ * \note this implementation exists in
+ * \ref vec_int128_ppc.h::vec_vmsumoud()
+ * as it requires vec_msumudm() and vec_adduqm().
+ */
+static inline vui128_t
+vec_vmsumoud (vui64_t a, vui64_t b, vui128_t c);
+
 /** \brief Vector Pack Unsigned Doubleword Unsigned Modulo.
  *
  *  The doubleword source is the concatination of vra and vrb.
@@ -3364,6 +3481,144 @@ vec_xxspltd (vui64_t vra, const int ctl)
   return (result);
 }
 
+/** \brief Vector Multiply-Add Even Unsigned Words.
+ *
+ *  Multiply the even 32-bit Words of vector unsigned int
+ *  values (a * b) and return sums of the unsigned 64-bit product and
+ *  the even 32-bit words of c
+ *  (a<SUB>even</SUB> * b<SUB>even</SUB>) + EXTZ(c<SUB>even</SUB>).
+ *
+ *  \note The advantage of this form (versus Multiply-Sum) is that
+ *  the final 64 bit sums can not overflow.
+ *  \note This implementation is NOT endian sensitive and the function is
+ *  stable across BE/LE implementations.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   |   9   | 2/cycle  |
+ *  |power9   |   9   | 2/cycle  |
+ *
+ *  @param a 128-bit vector unsigned int.
+ *  @param b 128-bit vector unsigned int.
+ *  @param c 128-bit vector unsigned int.
+ *  @return vector unsigned long int sum (a<SUB>even</SUB> * b<SUB>even</SUB>) + EXTZ(c<SUB>even</SUB>).
+ */
+static inline vui64_t
+vec_vmaddeuw (vui32_t a, vui32_t b, vui32_t c)
+{
+  const vui32_t zero = { 0, 0, 0, 0 };
+  vui64_t res;
+  vui32_t c_euw = vec_mrgahw ((vui64_t) zero, (vui64_t) c);
+  res = vec_vmuleuw (a, b);
+  return vec_addudm (res, (vui64_t) c_euw);
+}
+
+/** \brief Vector Multiply-Add2 Even Unsigned Words.
+ *
+ *  Multiply the even 32-bit Words of vector unsigned int
+ *  values (a * b) and return sums of the unsigned 64-bit product and
+ *  the even 32-bit words of c and d
+ *  (a<SUB>even</SUB> * b<SUB>even</SUB>) +
+ *  EXTZ(c<SUB>even</SUB> + EXTZ(d<SUB>even</SUB>).
+ *
+ *  \note The advantage of this form (versus Multiply-Sum) is that
+ *  the final 64 bit sums can not overflow.
+ *  \note This implementation is NOT endian sensitive and the function is
+ *  stable across BE/LE implementations.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   |   9   | 1/cycle  |
+ *  |power9   |   9   | 1/cycle  |
+ *
+ *  @param a 128-bit vector unsigned int.
+ *  @param b 128-bit vector unsigned int.
+ *  @param c 128-bit vector unsigned int.
+ *  @param d 128-bit vector unsigned int.
+ *  @return vector unsigned long int sum (a<SUB>even</SUB> * b<SUB>even</SUB>) +
+ *  EXTZ(c<SUB>even</SUB>) + EXTZ(d<SUB>even</SUB>).
+ */
+static inline vui64_t
+vec_vmadd2euw (vui32_t a, vui32_t b, vui32_t c, vui32_t d)
+{
+  const vui32_t zero = { 0, 0, 0, 0 };
+  vui64_t res, sum;
+  vui32_t c_euw = vec_mrgahw ((vui64_t) zero, (vui64_t) c);
+  vui32_t d_euw = vec_mrgahw ((vui64_t) zero, (vui64_t) d);
+  res = vec_vmuleuw (a, b);
+  sum = vec_addudm ( (vui64_t) c_euw, (vui64_t) d_euw);
+  return vec_addudm (res, sum);
+}
+
+/** \brief Vector Multiply-Add Odd Unsigned Words.
+ *
+ *  Multiply the odd 32-bit Words of vector unsigned int
+ *  values (a * b) and return sums of the unsigned 64-bit product and
+ *  the odd 32-bit words of c
+ *  (a<SUB>odd</SUB> * b<SUB>odd</SUB>) + EXTZ(c<SUB>odd</SUB>).
+ *
+ *  \note The advantage of this form (versus Multiply-Sum) is that
+ *  the final 64 bit sums can not overflow.
+ *  \note This implementation is NOT endian sensitive and the function is
+ *  stable across BE/LE implementations.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   |   9   | 2/cycle  |
+ *  |power9   |   9   | 2/cycle  |
+ *
+ *  @param a 128-bit vector unsigned int.
+ *  @param b 128-bit vector unsigned int.
+ *  @param c 128-bit vector unsigned int.
+ *  @return vector unsigned long int sum (a<SUB>odd</SUB> * b<SUB>odd</SUB>) + EXTZ(c<SUB>odd</SUB>).
+ */
+static inline vui64_t
+vec_vmaddouw (vui32_t a, vui32_t b, vui32_t c)
+{
+  const vui32_t zero = { 0, 0, 0, 0 };
+  vui64_t res;
+  vui32_t c_ouw = vec_mrgalw ((vui64_t) zero, (vui64_t) c);
+  res = vec_vmulouw (a, b);
+  return vec_addudm (res, (vui64_t) c_ouw);
+}
+
+/** \brief Vector Multiply-Add2 Odd Unsigned Words.
+ *
+ *  Multiply the odd 32-bit Words of vector unsigned int
+ *  values (a * b) and return sums of the unsigned 64-bit product and
+ *  the odd 32-bit words of c and d
+ *  (a<SUB>odd</SUB> * b<SUB>odd</SUB>) +
+ *  EXTZ(c<SUB>odd</SUB> + EXTZ(d<SUB>odd</SUB>).
+ *
+ *  \note The advantage of this form (versus Multiply-Sum) is that
+ *  the final 64 bit sums can not overflow.
+ *  \note This implementation is NOT endian sensitive and the function is
+ *  stable across BE/LE implementations.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   |   9   | 1/cycle  |
+ *  |power9   |   9   | 1/cycle  |
+ *
+ *  @param a 128-bit vector unsigned int.
+ *  @param b 128-bit vector unsigned int.
+ *  @param c 128-bit vector unsigned int.
+ *  @param d 128-bit vector unsigned int.
+ *  @return vector unsigned long int sum (a<SUB>odd</SUB> * b<SUB>odd</SUB>) +
+ *  EXTZ(c<SUB>odd</SUB> + EXTZ(d<SUB>odd</SUB>).
+ */
+static inline vui64_t
+vec_vmadd2ouw (vui32_t a, vui32_t b, vui32_t c, vui32_t d)
+{
+  const vui32_t zero = { 0, 0, 0, 0 };
+  vui64_t res, sum;
+  vui32_t c_ouw = vec_mrgalw ((vui64_t) zero, (vui64_t) c);
+  vui32_t d_ouw = vec_mrgalw ((vui64_t) zero, (vui64_t) d);
+  res = vec_vmulouw (a, b);
+  sum = vec_addudm ((vui64_t) c_ouw, (vui64_t) d_ouw);
+  return vec_addudm (res, sum);
+}
+
 /** \brief Vector Multiply-Sum Unsigned Word Modulo
  *
  *  Multiply the unsigned word elements of vra and vrb, internally
@@ -3386,8 +3641,8 @@ vec_xxspltd (vui64_t vra, const int ctl)
  *  @param vrb 128-bit vector unsigned int.
  *  @param vrc 128-bit vector unsigned long.
  *  @return vector of doubleword elements where each is the sum of
- *  the even and odd product of the vra and vrb,
- *  plus the doubleword elements of vrc.
+ *  the even and odd adjacent products of the vra and vrb,
+ *  plus the corresponding doubleword element of vrc.
  */
 static inline vui64_t
 vec_vmsumuwm (vui32_t vra, vui32_t vrb, vui64_t vrc)

--- a/src/testsuite/arith128_test_i64.c
+++ b/src/testsuite/arith128_test_i64.c
@@ -1974,6 +1974,321 @@ test_muludm (void)
   return (rc);
 }
 
+
+//#define __DEBUG_PRINT__ 1
+int
+test_vmaddeud (void)
+{
+  vui64_t i, j, m, n;
+  vui128_t k, e;
+  int rc = 0;
+
+  printf ("\ntest_vmaddeud Vector Multiply-Add Even Unsigned Doublewords\n");
+  i = (vui64_t) CONST_VINT64_DW (1, 2);
+  j = (vui64_t) CONST_VINT64_DW (101, 102);
+  m = (vui64_t) CONST_VINT64_DW (10, 20);
+  e = (vui128_t) CONST_VINT128_DW128(0, 111);
+  k = vec_vmaddeud (i, j, m);
+
+#ifdef __DEBUG_PRINT__
+  print_v2int64 ("vmaddeud ( ", i);
+  print_v2int64 ("          ,", j);
+  print_v2int64 ("          ,", m);
+  print_vint128 ("         )=", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_vmaddeud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW (1000000000, 1000000000 );
+  j = (vui64_t) CONST_VINT64_DW (1000000000, 1000000000 );
+  m = (vui64_t) CONST_VINT64_DW (1000000000, 1000000000 );
+  e = (vui128_t) CONST_VINT128_DW128 (0, 1000000001000000000UL);
+  k = vec_vmaddeud (i, j, m);
+
+#ifdef __DEBUG_PRINT__
+  print_v2int64 ("vmaddeud ( ", i);
+  print_v2int64 ("          ,", j);
+  print_v2int64 ("          ,", m);
+  print_vint128 ("         )=", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_maddeud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW ( 1000000000000000000UL, 0 );
+  j = (vui64_t) CONST_VINT64_DW ( 1000000000000000000UL, 0 );
+  m = (vui64_t) CONST_VINT64_DW ( 1000000000000000000UL, 0 );
+  e = (vui128_t) CONST_VINT128_DW128 ( 0x00c097ce7bc90715UL, 0xc12c55c3a7640000UL );
+  k = vec_vmaddeud (i, j, m);
+
+#ifdef __DEBUG_PRINT__
+  print_v2int64 ("vmaddeud ( ", i);
+  print_v2int64 ("          ,", j);
+  print_v2int64 ("          ,", m);
+  print_vint128 ("         )=", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_vmaddeud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW ( 0xffffffffffffffffUL, 0x0000000000000000UL );
+  j = (vui64_t) CONST_VINT64_DW ( 0xffffffffffffffffUL, 0x0000000000000000UL );
+  m = (vui64_t) CONST_VINT64_DW ( 0xffffffffffffffffUL, 0x0000000000000000UL );
+  e = (vui128_t) CONST_VINT128_DW128 (0xffffffffffffffffUL, 0x0000000000000000UL );
+  k = vec_vmaddeud (i, j, m);
+
+#ifdef __DEBUG_PRINT__
+  print_v2int64 ("vmaddeud ( ", i);
+  print_v2int64 ("          ,", j);
+  print_v2int64 ("          ,", m);
+  print_vint128 ("         )=", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_vmaddeud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW (1, 2);
+  j = (vui64_t) CONST_VINT64_DW (101, 102);
+  m = (vui64_t) CONST_VINT64_DW (10, 20);
+  n = (vui64_t) CONST_VINT64_DW (4, 1);
+  e = (vui128_t) CONST_VINT128_DW128(0, 115);
+  k = vec_vmadd2eud (i, j, m, n);
+
+#ifdef __DEBUG_PRINT__
+  print_v2int64 ("vmadd2eud ( ", i);
+  print_v2int64 ("           ,", j);
+  print_v2int64 ("           ,", m);
+  print_v2int64 ("           ,", n);
+  print_vint128 ("          )=", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_vmadd2eud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW ( 1000000000000000000UL, 0 );
+  j = (vui64_t) CONST_VINT64_DW ( 1000000000000000000UL, 0 );
+  m = (vui64_t) CONST_VINT64_DW ( 0, 1000000000000000000UL );
+  n = (vui64_t) CONST_VINT64_DW ( 1000000000000000000UL, 0 );
+//  e = (vui128_t) CONST_VINT128_DW128 ( 0x00c097ce7bc90715UL, 0xc12c55c3a7640000UL );
+  e = CONST_VUINT128_Qx18d (1000000000000000001UL, 000000000000000000UL);
+  k = vec_vmadd2eud (i, j, m, n);
+
+#ifdef __DEBUG_PRINT__
+  print_v2int64 ("vmadd2eud ( ", i);
+  print_v2int64 ("           ,", j);
+  print_v2int64 ("           ,", m);
+  print_v2int64 ("           ,", n);
+  print_vint128 ("          )=", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_vmadd2eud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW ( 1000000000000000000UL, 0 );
+  j = (vui64_t) CONST_VINT64_DW ( 1000000000000000000UL, 0 );
+  m = (vui64_t) CONST_VINT64_DW ( 1000000000000000000UL, 0 );
+  n = (vui64_t) CONST_VINT64_DW ( 1000000000000000000UL, 0 );
+  e = CONST_VUINT128_Qx18d (1000000000000000002UL, 000000000000000000UL);
+  k = vec_vmadd2eud (i, j, m, n);
+
+#ifdef __DEBUG_PRINT__
+  print_v2int64 ("vmadd2eud ( ", i);
+  print_v2int64 ("           ,", j);
+  print_v2int64 ("           ,", m);
+  print_v2int64 ("           ,", n);
+  print_vint128 ("          )=", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_vmadd2eud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW ( 0xffffffffffffffffUL, 0x0000000000000000UL );
+  j = (vui64_t) CONST_VINT64_DW ( 0xffffffffffffffffUL, 0x0000000000000000UL );
+  m = (vui64_t) CONST_VINT64_DW ( 0xffffffffffffffffUL, 0x0000000000000000UL );
+  n = (vui64_t) CONST_VINT64_DW ( 0x0000000000000000UL, 0xffffffffffffffffUL );
+  e = (vui128_t) CONST_VINT128_DW128 (0xffffffffffffffffUL, 0x0000000000000000UL );
+  k = vec_vmadd2eud (i, j, m, n);
+
+#ifdef __DEBUG_PRINT__
+  print_v2int64 ("vmadd2eud ( ", i);
+  print_v2int64 ("           ,", j);
+  print_v2int64 ("           ,", m);
+  print_v2int64 ("           ,", n);
+  print_vint128 ("          )=", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_vmadd2eud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW ( 0xffffffffffffffffUL, 0x0000000000000000UL );
+  j = (vui64_t) CONST_VINT64_DW ( 0xffffffffffffffffUL, 0x0000000000000000UL );
+  m = (vui64_t) CONST_VINT64_DW ( 0xffffffffffffffffUL, 0x0000000000000000UL );
+  n = (vui64_t) CONST_VINT64_DW ( 0xffffffffffffffffUL, 0x0000000000000000UL );
+  e = (vui128_t) CONST_VINT128_DW128 (0xffffffffffffffffUL, 0xffffffffffffffffUL );
+  k = vec_vmadd2eud (i, j, m, n);
+
+#ifdef __DEBUG_PRINT__
+  print_v2int64 ("vmadd2eud ( ", i);
+  print_v2int64 ("           ,", j);
+  print_v2int64 ("           ,", m);
+  print_v2int64 ("           ,", n);
+  print_vint128 ("          )=", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_vmadd2eud:", (vui128_t)k, (vui128_t) e);
+
+  return (rc);
+}
+
+//#define __DEBUG_PRINT__ 1
+int
+test_vmaddoud (void)
+{
+  vui64_t i, j, m, n;
+  vui128_t k, e;
+  int rc = 0;
+
+  printf ("\ntest_vmaddeud Vector Multiply-Add Odd Unsigned Doublewords\n");
+  i = (vui64_t) CONST_VINT64_DW (1, 2);
+  j = (vui64_t) CONST_VINT64_DW (101, 102);
+  m = (vui64_t) CONST_VINT64_DW (10, 20);
+  e = (vui128_t) CONST_VINT128_DW128(0, 224);
+  k = vec_vmaddoud (i, j, m);
+
+#ifdef __DEBUG_PRINT__
+  print_v2int64 ("vmaddoud ( ", i);
+  print_v2int64 ("          ,", j);
+  print_v2int64 ("          ,", m);
+  print_vint128 ("         )=", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_vmaddoud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW (1000000000, 1000000000 );
+  j = (vui64_t) CONST_VINT64_DW (1000000000, 1000000000 );
+  m = (vui64_t) CONST_VINT64_DW (1000000000, 1000000000 );
+  e = (vui128_t) CONST_VINT128_DW128 (0, 1000000001000000000UL);
+  k = vec_vmaddoud (i, j, m);
+
+#ifdef __DEBUG_PRINT__
+  print_v2int64 ("vmaddoud ( ", i);
+  print_v2int64 ("          ,", j);
+  print_v2int64 ("          ,", m);
+  print_vint128 ("         )=", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_maddoud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW ( 0, 1000000000000000000UL );
+  j = (vui64_t) CONST_VINT64_DW ( 0, 1000000000000000000UL );
+  m = (vui64_t) CONST_VINT64_DW ( 0, 1000000000000000000UL );
+//  e = (vui128_t) CONST_VINT128_DW128 ( 0x00c097ce7bc90715UL, 0xc12c55c3a7640000UL );
+  e = CONST_VUINT128_Qx18d (1000000000000000001UL, 000000000000000000UL);
+  k = vec_vmaddoud (i, j, m);
+
+#ifdef __DEBUG_PRINT__
+  print_v2int64 ("vmaddoud ( ", i);
+  print_v2int64 ("          ,", j);
+  print_v2int64 ("          ,", m);
+  print_vint128 ("         )=", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_vmaddoud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW ( 0xffffffffffffffffUL, 0x0000000000000000UL );
+  j = (vui64_t) CONST_VINT64_DW ( 0xffffffffffffffffUL, 0x0000000000000000UL );
+  m = (vui64_t) CONST_VINT64_DW ( 0xffffffffffffffffUL, 0x0000000000000000UL );
+  e = (vui128_t) CONST_VINT128_DW128 (0x0000000000000000UL, 0x0000000000000000UL );
+  k = vec_vmaddoud (i, j, m);
+
+#ifdef __DEBUG_PRINT__
+  print_v2int64 ("vmaddoud ( ", i);
+  print_v2int64 ("          ,", j);
+  print_v2int64 ("          ,", m);
+  print_vint128 ("         )=", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_vmaddoud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW ( 0, 0xffffffffffffffffUL );
+  j = (vui64_t) CONST_VINT64_DW ( 0, 0xffffffffffffffffUL );
+  m = (vui64_t) CONST_VINT64_DW ( 0, 0xffffffffffffffffUL );
+  e = (vui128_t) CONST_VINT128_DW128 (0xffffffffffffffffUL, 0x0000000000000000UL );
+  k = vec_vmaddoud (i, j, m);
+
+#ifdef __DEBUG_PRINT__
+  print_v2int64 ("vmaddoud ( ", i);
+  print_v2int64 ("          ,", j);
+  print_v2int64 ("          ,", m);
+  print_vint128 ("         )=", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_vmaddoud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW (1, 2);
+  j = (vui64_t) CONST_VINT64_DW (101, 102);
+  m = (vui64_t) CONST_VINT64_DW (10, 20);
+  n = (vui64_t) CONST_VINT64_DW (4, 1);
+  e = (vui128_t) CONST_VINT128_DW128(0, 225);
+  k = vec_vmadd2oud (i, j, m, n);
+
+#ifdef __DEBUG_PRINT__
+  print_v2int64 ("vmadd2oud ( ", i);
+  print_v2int64 ("           ,", j);
+  print_v2int64 ("           ,", m);
+  print_v2int64 ("           ,", n);
+  print_vint128 ("          )=", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_vmadd2oud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW ( 0, 1000000000000000000UL );
+  j = (vui64_t) CONST_VINT64_DW ( 0, 1000000000000000000UL );
+  m = (vui64_t) CONST_VINT64_DW ( 0, 1000000000000000000UL );
+  n = (vui64_t) CONST_VINT64_DW ( 1000000000000000000UL, 0 );
+//  e = (vui128_t) CONST_VINT128_DW128 ( 0x00c097ce7bc90715UL, 0xc12c55c3a7640000UL );
+  e = CONST_VUINT128_Qx18d (1000000000000000001UL, 000000000000000000UL);
+  k = vec_vmadd2oud (i, j, m, n);
+
+#ifdef __DEBUG_PRINT__
+  print_v2int64 ("vmadd2oud ( ", i);
+  print_v2int64 ("           ,", j);
+  print_v2int64 ("           ,", m);
+  print_v2int64 ("           ,", n);
+  print_vint128 ("          )=", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_vmadd2oud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW ( 0, 1000000000000000000UL );
+  j = (vui64_t) CONST_VINT64_DW ( 0, 1000000000000000000UL );
+  m = (vui64_t) CONST_VINT64_DW ( 0, 1000000000000000000UL );
+  n = (vui64_t) CONST_VINT64_DW ( 0, 1000000000000000000UL );
+//  e = (vui128_t) CONST_VINT128_DW128 ( 0x00c097ce7bc90715UL, 0xc12c55c3a7640000UL );
+  e = CONST_VUINT128_Qx18d (1000000000000000002UL, 000000000000000000UL);
+  k = vec_vmadd2oud (i, j, m, n);
+
+#ifdef __DEBUG_PRINT__
+  print_v2int64 ("vmadd2oud ( ", i);
+  print_v2int64 ("           ,", j);
+  print_v2int64 ("           ,", m);
+  print_v2int64 ("           ,", n);
+  print_vint128 ("          )=", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_vmadd2oud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW ( 0, 0xffffffffffffffffUL );
+  j = (vui64_t) CONST_VINT64_DW ( 0, 0xffffffffffffffffUL );
+  m = (vui64_t) CONST_VINT64_DW ( 0xffffffffffffffffUL, 0x0000000000000000UL );
+  n = (vui64_t) CONST_VINT64_DW ( 0x0000000000000000UL, 0xffffffffffffffffUL );
+  e = (vui128_t) CONST_VINT128_DW128 (0xffffffffffffffffUL, 0x0000000000000000UL );
+  k = vec_vmadd2oud (i, j, m, n);
+
+#ifdef __DEBUG_PRINT__
+  print_v2int64 ("vmadd2oud ( ", i);
+  print_v2int64 ("           ,", j);
+  print_v2int64 ("           ,", m);
+  print_v2int64 ("           ,", n);
+  print_vint128 ("          )=", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_vmadd2oud:", (vui128_t)k, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW ( 0, 0xffffffffffffffffUL );
+  j = (vui64_t) CONST_VINT64_DW ( 0, 0xffffffffffffffffUL );
+  m = (vui64_t) CONST_VINT64_DW ( 0, 0xffffffffffffffffUL );
+  n = (vui64_t) CONST_VINT64_DW ( 0, 0xffffffffffffffffUL );
+  e = (vui128_t) CONST_VINT128_DW128 (0xffffffffffffffffUL, 0xffffffffffffffffUL );
+  k = vec_vmadd2oud (i, j, m, n);
+
+#ifdef __DEBUG_PRINT__
+  print_v2int64 ("vmadd2oud ( ", i);
+  print_v2int64 ("           ,", j);
+  print_v2int64 ("           ,", m);
+  print_v2int64 ("           ,", n);
+  print_vint128 ("          )=", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_vmadd2oud:", (vui128_t)k, (vui128_t) e);
+
+  return (rc);
+}
+
 //#define __DEBUG_PRINT__ 1
 int
 test_vmuleud (void)
@@ -11554,6 +11869,8 @@ test_vec_i64 (void)
   rc += test_srdi ();
   rc += test_sldi ();
   rc += test_rldi ();
+  rc += test_vmaddeud ();
+  rc += test_vmaddoud ();
 
   return (rc);
 }

--- a/src/testsuite/vec_int64_dummy.c
+++ b/src/testsuite/vec_int64_dummy.c
@@ -566,6 +566,39 @@ __test_cmpleud (vui64_t a, vui64_t b)
 }
 
 vui64_t
+__test_vmaddeuw (vui32_t a, vui32_t b, vui32_t c)
+{
+  return vec_vmaddeuw (a, b, c);
+}
+
+vui64_t
+__test_vmaddouw (vui32_t a, vui32_t b, vui32_t c)
+{
+  return vec_vmaddouw (a, b, c);
+}
+
+vui64_t
+__test_vmadd2euw (vui32_t a, vui32_t b, vui32_t c, vui32_t d)
+{
+  return vec_vmadd2euw (a, b, c, d);
+}
+
+vui64_t
+__test_vmadd2ouw (vui32_t a, vui32_t b, vui32_t c, vui32_t d)
+{
+  return vec_vmadd2ouw (a, b, c, d);
+}
+
+vui64_t
+__test_vmadduw (vui32_t a, vui32_t b, vui32_t c)
+{
+  vui64_t ep, op;
+  ep = vec_vmaddeuw (a, b, c);
+  op = vec_vmaddouw (a, b, c);
+  return vec_addudm (ep, op);
+}
+
+vui64_t
 __test_vmuludm (vui64_t vra, vui64_t vrb)
 {
   vui64_t s32 = (vui64_t) { 32, 32 };


### PR DESCRIPTION
Added multiply-add operations to doubleword (POWER8/9) in support of multiple quadword multiply.
Used \copybrief so that doubleword operations, that are implemented in other headers, can appear in alphabetical order with other doubleword operations.
Added appropriate unit and compile tests.

	* src/pveclib/vec_int64_ppc.h (vec_msumudm, vec_muleud,
	vec_mulhud, vec_muloud, vec_muludm): Doxygen copybrief from
	vec_int128_ppc.h.
	(vec_vmadd2eud, vec_vmaddeud, vec_vmadd2oud, vec_vmaddoud,
	vec_vmuleud, vec_vmuloud, vec_vmsumeud, vec_vmsumoud):
	Doxygen copybrief from vec_int128_ppc.h.
	(vec_vmaddeuw, vec_vmadd2euw, vec_vmaddouw, vec_vmadd2ouw):
	New operations.
	(vec_vmsumuwm): Doxygen text edits.

	* src/testsuite/arith128_test_i64.c (test_vmaddeud,
	test_vmaddoud): New Unit test.
	(test_vmuleud): Add tests to test driver.

	* src/testsuite/vec_int64_dummy.c (__test_vmaddeuw,
	__test_vmaddouw, __test_vmadd2euw, __test_vmadd2ouw,
	__test_vmadduw): New compile tests.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>