### PR TITLE
Optimizations for multiple quadword precision integer support (multi-quadword).

### DIFF
--- a/src/pveclib/vec_int512_ppc.h
+++ b/src/pveclib/vec_int512_ppc.h
@@ -363,19 +363,6 @@
  * the point where all 64 VSRs are in use, but no spilling to stack
  * memory is required.
  *
- * \todo The above above is true for vec_mul2048x2048_PWR9
- * but vec_mul2048x2048_PWR8 does kick out a few vector spills.
- * Need to look into this and resolve.
- *
- * \todo Look into adding multiply-sum forms of 512x128 and 512x512
- * defined to add to the low order product and propagate the carries.
- * The msum512x128s128 and msum512x512s512 operations will not generate
- * a carry out of 640-bit or 1024-bit product-sum and still fit within
- * the homogeneous aggregate size limits for return values. This will
- * reduce the live range for column sums and should reduce register
- * pressure.
- *
- *
  * \subsection i512_security_issues_0_0_3 So what does this all mean?
  *
  * The 2048x2048 multiplicands and the resulting product are so large
@@ -468,8 +455,6 @@
  *
  * \section i512_Endian_issues_0_0 Endian for Multi-quadword precision operations
  *
- * \todo Describe the background and rationale
- *
  * As described in \ref mainpage_endian_issues_1_1
  * and \ref i128_endian_issues_0_0
  * supporting both big and little endian in a single implementation
@@ -497,7 +482,7 @@
  *
  * It is best for the API if the order of quadwords in multi-quadword
  * integers match the endian of the platform. This should be
- * helpful where we want the use the PVEVLIB implementations
+ * helpful where we want the use the PVECLIB implementations
  * under existing APIs using arrays of smaller integer types.
  *
  * So on powerpc64le systems the low order quadword is the first
@@ -580,9 +565,8 @@ const __VEC_U_512  vec512_ten128th = CONST_VINT512_Q
  *
  * \section i512_libary_issues_0_0 Putting the Library into PVECLIB
  *
- *
  * \todo General discussion of static and dynamic libraries should be
- * moved (eventually) to pveclibmaindox.h. While specifics of
+ * moved (eventually) to the main page. While specifics of
  * multiple quadword precision integer multiply should remain here.
  *
  * Until recently (as of v1.0.3) PVECLIB operations were
@@ -931,7 +915,6 @@ CFLAGS-vec_runtime_PWR9.c += -mcpu=power9
  * with -mcpu=power7 with -o vec_runtime_PWR7.o.
  * And similarly for PWR8/PWR9.
  *
- *
  * \subsection i512_libary_issues_0_0_1 Calling Multi-platform functions
  *
  * The next step is to provide mechanisms for applications to call
@@ -1238,6 +1221,16 @@ typedef union
     __VEC_U_512 v0x512;
 #endif
   } x2;
+  struct
+  {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    vui128_t v1x128;
+    __VEC_U_512 v0x512;
+#else
+    __VEC_U_512 v0x512;
+    vui128_t v1x128;
+#endif
+  } x3;
   ///@endcond
 } __VEC_U_512x1;
 
@@ -1412,6 +1405,16 @@ typedef union
 {
   ///@cond INTERNAL
   __VEC_U_2048 x2048;
+  struct
+  {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    __VEC_U_1024 v0x1024;
+    __VEC_U_1024 v1x1024;
+#else
+    __VEC_U_1024 v1x1024;
+    __VEC_U_1024 v0x1024;
+#endif
+  } x2;
   struct
   {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
@@ -1591,6 +1594,30 @@ typedef union
   struct
   {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    __VEC_U_2048 v0x2048;
+    __VEC_U_2048 v1x2048;
+#else
+    __VEC_U_2048 v1x2048;
+    __VEC_U_2048 v0x2048;
+#endif
+  } x2;
+  struct
+  {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    __VEC_U_1024 v0x1024;
+    __VEC_U_1024 v1x1024;
+    __VEC_U_1024 v2x1024;
+    __VEC_U_1024 v3x1024;
+#else
+    __VEC_U_1024 v3x1024;
+    __VEC_U_1024 v2x1024;
+    __VEC_U_1024 v1x1024;
+    __VEC_U_1024 v0x1024;
+#endif
+  } x4;
+  struct
+  {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     __VEC_U_512 v0x512;
     __VEC_U_512 v1x512;
     __VEC_U_512 v2x512;
@@ -1619,10 +1646,11 @@ typedef union
  *  and code motion to smaller code blocks. This in turn reduces
  *  register pressure and avoids generating spill code.
  */
-#if 1
-#define COMPILE_FENCE __asm (";":::)
-#else
+#ifdef __VEC_EXPLICITE_FENCE_NOPS__
+// Generate NOPS inline to make compiler fences visible in obj code.
 #define COMPILE_FENCE __asm ("nop":::)
+#else
+#define COMPILE_FENCE __asm (";":::)
 #endif
 
 /*! \brief Macro to add platform suffix for static calls. */
@@ -1861,6 +1889,9 @@ vec_mul128x128_inline (vui128_t a, vui128_t b)
  *  The product is returned as single 512-bit integer in a
  *  homogeneous aggregate structure.
  *
+ *  \note Using the Multiple-Add form which applies the addend early
+ *  reduces the live ranges for registers passing partial products
+ *  for larger multiple precision multiplies.
  *  \note We use the COMPILER_FENCE to limit instruction scheduling
  *  and code motion to smaller code blocks. This in turn reduces
  *  register pressure and avoids generating spill code.
@@ -1882,18 +1913,15 @@ vec_mul256x256_inline (__VEC_U_256 m1, __VEC_U_256 m2)
   vui128_t mc, mp, mq, mqhl;
   vui128_t mphh, mphl, mplh, mpll;
   mpll = vec_muludq (&mplh, m1.vx0, m2.vx0);
+
+  mp = vec_madduq (&mphl, m1.vx1, m2.vx0, mplh);
+  mplh = mp;
   COMPILE_FENCE;
-  mp = vec_muludq (&mphl, m1.vx1, m2.vx0);
-  mplh = vec_addcq (&mc, mplh, mp);
-  mphl = vec_adduqm (mphl, mc);
-  COMPILE_FENCE;
-  mp = vec_muludq (&mqhl, m1.vx0, m2.vx1);
-  mplh = vec_addcq (&mq, mplh, mp);
-  mphl = vec_addeq (&mc, mphl, mqhl, mq);
-  COMPILE_FENCE;
-  mp = vec_muludq (&mphh, m1.vx1, m2.vx1);
-  mphl = vec_addcq (&mq, mphl, mp);
-  mphh = vec_addeuqm (mphh, mq, mc);
+
+  mp = vec_madduq (&mq, m1.vx0, m2.vx1, mplh);
+  mplh = mp;
+  mp = vec_madd2uq (&mphh, m1.vx1, m2.vx1, mphl, mq);
+  mphl = mp;
 
   result.vx0 = mpll;
   result.vx1 = mplh;
@@ -1909,6 +1937,9 @@ vec_mul256x256_inline (__VEC_U_256 m1, __VEC_U_256 m2)
  *  The product is returned as single 640-bit integer in a
  *  homogeneous aggregate structure.
  *
+ *  \note Using the Multiple-Add form which applies the addend early
+ *  reduces the live ranges for registers passing partial products
+ *  for larger multiple precision multiplies.
  *  \note We use the COMPILER_FENCE to limit instruction scheduling
  *  and code motion to smaller code blocks. This in turn reduces
  *  register pressure and avoids generating spill code.
@@ -1929,18 +1960,160 @@ vec_mul512x128_inline (__VEC_U_512 m1, vui128_t m2)
   __VEC_U_640 result;
   vui128_t mq3, mq2, mq1, mq0, mq, mc;
   vui128_t mpx0, mpx1, mpx2, mpx3;
+
   mpx0 = vec_muludq (&mq0, m1.vx0, m2);
+  mpx1 = vec_madduq (&mq1, m1.vx1, m2, mq0);
   COMPILE_FENCE;
-  mpx1 = vec_muludq (&mq1, m1.vx1, m2);
-  mpx1 = vec_addcq (&mc, mpx1, mq0);
+  mpx2 = vec_madduq (&mq2, m1.vx2, m2, mq1);
+  mpx3 = vec_madduq (&mq3, m1.vx3, m2, mq2);
+
+  result.vx0 = mpx0;
+  result.vx1 = mpx1;
+  result.vx2 = mpx2;
+  result.vx3 = mpx3;
+  result.vx4 = mq3;
+  return result;
+}
+
+/** \brief Vector 512x128-bit Multiply-Add Unsigned Integer.
+ *
+ *  Compute the 640 bit sum of 512 bit value m1 and
+ *  128-bit value m2 plus 128-bit value a1.
+ *  The product is returned as single 640-bit integer in a
+ *  homogeneous aggregate structure.
+ *
+ *  \note The advantage of this form is that the final 640 bit sum can
+ *  not overflow and carries between stages are eliminated.
+ *  Also applying the addend early (1st multiply stage) reduces the
+ *  live ranges for registers passing partial products for larger
+ *  multiple precision multiplies.
+ *
+ *  \note We use the COMPILER_FENCE to limit instruction scheduling
+ *  and code motion to smaller code blocks. This in turn reduces
+ *  register pressure and avoids generating spill code.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   |224-232| 1/cycle  |
+ *  |power9   |132-135| 1/cycle  |
+ *
+ *  @param m1 vector representation of a unsigned 512-bit integer.
+ *  @param m2 vector representation of a unsigned 128-bit integer.
+ *  @param a1 vector representation of a unsigned 128-bit integer.
+ *  @return homogeneous aggregate representation of the unsigned
+ *  640-bit sum of (m1 * m2) + c.
+ */
+static inline __VEC_U_640
+vec_madd512x128a128_inline (__VEC_U_512 m1, vui128_t m2, vui128_t a1)
+{
+  __VEC_U_640 result;
+  vui128_t mq3, mq2, mq1, mq0, mq, mc;
+  vui128_t mpx0, mpx1, mpx2, mpx3;
+
+  mpx0 = vec_madduq (&mq0, m1.vx0, m2, a1);
+  mpx1 = vec_madduq (&mq1, m1.vx1, m2, mq0);
   COMPILE_FENCE;
-  mpx2 = vec_muludq (&mq2, m1.vx2, m2);
-  mpx2 = vec_addeq (&mq, mpx2, mq1, mc);
+  mpx2 = vec_madduq (&mq2, m1.vx2, m2, mq1);
+  mpx3 = vec_madduq (&mq3, m1.vx3, m2, mq2);
+
+  result.vx0 = mpx0;
+  result.vx1 = mpx1;
+  result.vx2 = mpx2;
+  result.vx3 = mpx3;
+  result.vx4 = mq3;
+  return result;
+}
+
+/** \brief Vector 512x128-bit Multiply-Add Unsigned Integer.
+ *
+ *  Compute the 640 bit sum of 512 bit value m1 and
+ *  128-bit value m2 plus 512-bit value a2.
+ *  The sum is returned as single 640-bit integer in a
+ *  homogeneous aggregate structure.
+ *
+ *  \note The advantage of this form is that the final 640 bit sum can
+ *  not overflow and carries between stages are eliminated.
+ *  Also applying the addend early (1st multiply stage) reduces the
+ *  live ranges for registers passing partial products for larger
+ *  multiple precision multiplies.
+ *
+ *  \note We use the COMPILER_FENCE to limit instruction scheduling
+ *  and code motion to smaller code blocks. This in turn reduces
+ *  register pressure and avoids generating spill code.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   |224-232| 1/cycle  |
+ *  |power9   |132-135| 1/cycle  |
+ *
+ *  @param m1 vector representation of a unsigned 512-bit integer.
+ *  @param m2 vector representation of a unsigned 128-bit integer.
+ *  @param a2 vector representation of a unsigned 512-bit integer.
+ *  @return homogeneous aggregate representation of the unsigned
+ *  640-bit sum of (m1 * m2) + a1.
+ */
+static inline __VEC_U_640
+vec_madd512x128a512_inline (__VEC_U_512 m1, vui128_t m2, __VEC_U_512 a2)
+{
+  __VEC_U_640 result;
+  vui128_t mq3, mq2, mq1, mq0, mq, mc;
+  vui128_t mpx0, mpx1, mpx2, mpx3;
+
+  mpx0 = vec_madduq (&mq0, m1.vx0, m2, a2.vx0);
+  mpx1 = vec_madd2uq (&mq1, m1.vx1, m2, mq0, a2.vx1);
   COMPILE_FENCE;
-  mpx3 = vec_muludq (&mq3, m1.vx3, m2);
-  mpx3 = vec_addeq (&mc, mpx3, mq2, mq);
-  mq3 = vec_adduqm (mc, mq3);
+  mpx2 = vec_madd2uq (&mq2, m1.vx2, m2, mq1, a2.vx2);
+  mpx3 = vec_madd2uq (&mq3, m1.vx3, m2, mq2, a2.vx3);
+
+  result.vx0 = mpx0;
+  result.vx1 = mpx1;
+  result.vx2 = mpx2;
+  result.vx3 = mpx3;
+  result.vx4 = mq3;
+  return result;
+}
+
+/** \brief Vector 512x128-bit Multiply-Add Unsigned Integer.
+ *
+ *  Compute the 640 bit sum of 512 bit value m1 and
+ *  128-bit value m2, plus 128-bit value a1, plus 512-bit value a2.
+ *  The sum is returned as single 640-bit integer in a
+ *  homogeneous aggregate structure.
+ *
+ *  \note The advantage of this form is that the final 640 bit sum can
+ *  not overflow and carries between stages are eliminated.
+ *  Also applying the addend early (1st multiply stage) reduces the
+ *  live ranges for registers passing partial products for larger
+ *  multiple precision multiplies.
+ *
+ *  \note We use the COMPILER_FENCE to limit instruction scheduling
+ *  and code motion to smaller code blocks. This in turn reduces
+ *  register pressure and avoids generating spill code.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   |224-232| 1/cycle  |
+ *  |power9   |132-135| 1/cycle  |
+ *
+ *  @param m1 vector representation of a unsigned 512-bit integer.
+ *  @param m2 vector representation of a unsigned 128-bit integer.
+ *  @param a1 vector representation of a unsigned 128-bit integer.
+ *  @param a2 vector representation of a unsigned 512-bit integer.
+ *  @return homogeneous aggregate representation of the unsigned
+ *  640-bit sum of (m1 * m2) + a1.
+ */
+static inline __VEC_U_640
+vec_madd512x128a128a512_inline (__VEC_U_512 m1, vui128_t m2, vui128_t a1, __VEC_U_512 a2)
+{
+  __VEC_U_640 result;
+  vui128_t mq3, mq2, mq1, mq0, mq, mc;
+  vui128_t mpx0, mpx1, mpx2, mpx3;
+
+  mpx0 = vec_madd2uq (&mq0, m1.vx0, m2, a1, a2.vx0);
+  mpx1 = vec_madd2uq (&mq1, m1.vx1, m2, mq0, a2.vx1);
   COMPILE_FENCE;
+  mpx2 = vec_madd2uq (&mq2, m1.vx2, m2, mq1, a2.vx2);
+  mpx3 = vec_madd2uq (&mq3, m1.vx3, m2, mq2, a2.vx3);
 
   result.vx0 = mpx0;
   result.vx1 = mpx1;
@@ -1952,13 +2125,17 @@ vec_mul512x128_inline (__VEC_U_512 m1, vui128_t m2)
 
 /** \brief Vector 512x512-bit Unsigned Integer Multiply.
  *
- *  Compute the 640 bit product of 512 bit values m1 and m2.
+ *  Compute the 1024 bit product of 512 bit values m1 and m2.
  *  The product is returned as single 1024-bit integer in a
  *  homogeneous aggregate structure.
  *
  *  \note We use the COMPILER_FENCE to limit instruction scheduling
  *  and code motion to smaller code blocks. This in turn reduces
  *  register pressure and avoids generating spill code.
+ *
+ *  \note Using the Multiple-Add form which applies the addend early
+ *  reduces the live ranges for registers passing partial products
+ *  for larger multiple precision multiplies.
  *
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
@@ -1975,32 +2152,77 @@ vec_mul512x512_inline (__VEC_U_512 m1, __VEC_U_512 m2)
 {
   __VEC_U_1024 result;
   vui128_t mc, mp, mq;
-  __VEC_U_640 mp3, mp2, mp1, mp0;
+  __VEC_U_512x1 mp3, mp2, mp1, mp0;
 
-  mp0 = vec_mul512x128_inline (m1, m2.vx0);
-  result.vx0 = mp0.vx0;
+  mp0.x640 = vec_mul512x128_inline (m1, m2.vx0);
+  result.vx0 = mp0.x3.v1x128;
   COMPILE_FENCE;
-  mp1 = vec_mul512x128_inline (m1, m2.vx1);
-  result.vx1 = vec_addcq (&mq, mp1.vx0, mp0.vx1);
-  result.vx2 = vec_addeq (&mp, mp1.vx1, mp0.vx2, mq);
-  result.vx3 = vec_addeq (&mq, mp1.vx2, mp0.vx3, mp);
-  result.vx4 = vec_addeq (&mp, mp1.vx3, mp0.vx4, mq);
-  result.vx5 = vec_addcq (&result.vx6, mp1.vx4, mp);
+  mp1.x640 = vec_madd512x128a512_inline (m1, m2.vx1, mp0.x3.v0x512);
+  result.vx1 = mp1.x3.v1x128;
   COMPILE_FENCE;
-  mp2 = vec_mul512x128_inline (m1, m2.vx2);
-  result.vx2 = vec_addcq (&mq, mp2.vx0, result.vx2);
-  result.vx3 = vec_addeq (&mp, mp2.vx1, result.vx3, mq);
-  result.vx4 = vec_addeq (&mq, mp2.vx2, result.vx4, mp);
-  result.vx5 = vec_addeq (&mp, mp2.vx3, result.vx5, mq);
-  result.vx6 = vec_addeq (&result.vx7, mp2.vx4, result.vx6, mp);
+  mp2.x640 = vec_madd512x128a512_inline (m1, m2.vx2, mp1.x3.v0x512);
+  result.vx2 = mp2.x3.v1x128;
   COMPILE_FENCE;
-  mp3 = vec_mul512x128_inline (m1, m2.vx3);
-  result.vx3 = vec_addcq (&mq, mp3.vx0, result.vx3);
-  result.vx4 = vec_addeq (&mp, mp3.vx1, result.vx4, mq);
-  result.vx5 = vec_addeq (&mq, mp3.vx2, result.vx5, mp);
-  result.vx6 = vec_addeq (&mp, mp3.vx3, result.vx6, mq);
-  result.vx7 = vec_addeuqm (result.vx7, mp3.vx4, mp);
+  mp3.x640 = vec_madd512x128a512_inline (m1, m2.vx3, mp2.x3.v0x512);
+
+  result.vx3 = mp3.x3.v1x128;
+  result.vx4 = mp3.x3.v0x512.vx0;
+  result.vx5 = mp3.x3.v0x512.vx1;
+  result.vx6 = mp3.x3.v0x512.vx2;
+  result.vx7 = mp3.x3.v0x512.vx3;
+  return result;
+}
+
+/** \brief Vector 512-bit Unsigned Integer Multiply-Add.
+ *
+ *  Compute the 1024 bit sum of the product of 512 bit values m1 and
+ *  m2 and 512 bit addend a1.
+ *  The sum is returned as single 1024-bit integer in a
+ *  homogeneous aggregate structure.
+ *
+ *  \note The advantage of this form is that the final 1024 bit sum can
+ *  not overflow and carries between stages are eliminated.
+ *  Also applying the addend early (1st multiply stage) reduces the
+ *  live ranges for registers passing partial products for larger
+ *  multiple precision multiplies.
+ *  \note We use the COMPILER_FENCE to limit instruction scheduling
+ *  and code motion to smaller code blocks. This in turn reduces
+ *  register pressure and avoids generating spill code.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | ?? | 1/cycle  |
+ *  |power9   | ?? | 1/cycle  |
+ *
+ *  @param m1 vector representation of a unsigned 512-bit integer.
+ *  @param m2 vector representation of a unsigned 512-bit integer.
+ *  @param a1 vector representation of a unsigned 512-bit integer.
+ *  @return homogeneous aggregate representation of the unsigned
+ *  1028-bit product of a * b.
+ */
+static inline __VEC_U_1024
+vec_madd512x512a512_inline (__VEC_U_512 m1, __VEC_U_512 m2, __VEC_U_512 a1)
+{
+  __VEC_U_1024 result;
+  vui128_t mc, mp, mq;
+  __VEC_U_512x1 mp3, mp2, mp1, mp0;
+
+  mp0.x640 = vec_madd512x128a512_inline (m1, m2.vx0, a1);
+  result.vx0 = mp0.x3.v1x128;
   COMPILE_FENCE;
+  mp1.x640 = vec_madd512x128a512_inline (m1, m2.vx1, mp0.x3.v0x512);
+  result.vx1 = mp1.x3.v1x128;
+  COMPILE_FENCE;
+  mp2.x640 = vec_madd512x128a512_inline (m1, m2.vx2, mp1.x3.v0x512);
+  result.vx2 = mp2.x3.v1x128;
+  COMPILE_FENCE;
+  mp3.x640 = vec_madd512x128a512_inline (m1, m2.vx3, mp2.x3.v0x512);
+
+  result.vx3 = mp3.x3.v1x128;
+  result.vx4 = mp3.x3.v0x512.vx0;
+  result.vx5 = mp3.x3.v0x512.vx1;
+  result.vx6 = mp3.x3.v0x512.vx2;
+  result.vx7 = mp3.x3.v0x512.vx3;
   return result;
 }
 
@@ -2017,8 +2239,8 @@ vec_mul512x512_inline (__VEC_U_512 m1, __VEC_U_512 m2)
  *
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
- *  |power8   | 56-64 | 1/cycle  |
- *  |power9   | 33-39 | 1/cycle  |
+ *  |power8   | 48-56 | 1/cycle  |
+ *  |power9   | 16-24 | 1/cycle  |
  *
  *  @param m1 vector representation of a unsigned 128-bit integer.
  *  @param m2 vector representation of a unsigned 128-bit integer.
@@ -2041,8 +2263,8 @@ vec_mul128x128 (vui128_t m1, vui128_t m2);
  *
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
- *  |power8   |224-232| 1/cycle  |
- *  |power9   |132-135| 1/cycle  |
+ *  |power8   |140-150| 1/cycle  |
+ *  |power9   | 46-58 | 1/cycle  |
  *
  *  @param m1 vector representation of a unsigned 256-bit integer.
  *  @param m2 vector representation of a unsigned 256-bit integer.
@@ -2091,7 +2313,7 @@ vec_mul512x128 (__VEC_U_512 m1, vui128_t m2);
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
  *  |power8   | ~600  | 1/cycle  |
- *  |power9   | ~240  | 1/cycle  |
+ *  |power9   | ~210  | 1/cycle  |
  *
  *  @param m1 vector representation of a unsigned 512-bit integer.
  *  @param m2 vector representation of a unsigned 512-bit integer.
@@ -2111,11 +2333,18 @@ vec_mul512x512 (__VEC_U_512 m1, __VEC_U_512 m2);
  *  The static implementations are vec_mul1024x1024_PWR8 and
  *  vec_mul1024x1024_PWR9. For static calls the __VEC_PWR_IMP() macro
  *  will add appropriate suffix based on the compile -mcpu= option.
+ *  \note The storage order for quadwords matches the system endian.
+ *  On Little Endian systems the least significant quadword is
+ *  quadword element 0. The most significant is quadword elements
+ *  [M-1], [N-1], and [M+N-1].
+ *  On Big Endian systems the least significant quadword is
+ *  quadword elements [M-1], [N-1], and [M+N-1].
+ *  The most significant is quadword element 0.
  *
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
- *  |power8   | ?? | 1/cycle  |
- *  |power9   | ?? | 1/cycle  |
+ *  |power8   | ~2500 | 1/cycle  |
+ *  |power9   | ~810  | 1/cycle  |
  *
  *  @param p2048 vector result as a unsigned 2048-bit integer in storage.
  *  @param m1 vector representation of a unsigned 1024-bit integer.
@@ -2134,11 +2363,19 @@ vec_mul1024x1024 (__VEC_U_2048 *p2048, __VEC_U_1024 *m1, __VEC_U_1024 *m2);
  *  The static implementations are vec_mul2048x2048_PWR8 and
  *  vec_mul2048x2048_PWR9. For static calls the __VEC_PWR_IMP() macro
  *  will add appropriate suffix based on the compile -mcpu= option.
+ *  \note The storage order for quadwords matches the system endian.
+ *  On Little Endian systems the least significant quadword is
+ *  quadword element 0. The most significant is quadword elements
+ *  [M-1], [N-1], and [M+N-1].
+ *  On Big Endian systems the least significant quadword is
+ *  quadword elements [M-1], [N-1], and [M+N-1].
+ *  The most significant is quadword element 0.
+ *
  *
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
- *  |power8   | ?? | 1/cycle  |
- *  |power9   | ?? | 1/cycle  |
+ *  |power8   |~12000 | 1/cycle  |
+ *  |power9   | 4770  | 1/cycle  |
  *
  *  @param p4096 vector result as a unsigned 4096-bit integer in storage.
  *  @param m1 vector representation of a unsigned 2048-bit integer.
@@ -2147,6 +2384,72 @@ vec_mul1024x1024 (__VEC_U_2048 *p2048, __VEC_U_1024 *m1, __VEC_U_1024 *m2);
 extern void
 vec_mul2048x2048 (__VEC_U_4096 *p4096,
                   __VEC_U_2048 *m1, __VEC_U_2048 *m2);
+
+/** \brief Vector Unsigned Integer Quadword MxN Multiply.
+ *
+ *  Compute the M+N quadword product of two quadword arrays  m1, m2.
+ *  The product is returned as M+N quadword array p.
+ *
+ *  \note This is the dynamic call ABI for IFUNC selection.
+ *  The static implementations are vec_mul128_byMN_PWR8 and
+ *  vec_mul128_byMN_PWR9. For static calls the __VEC_PWR_IMP() macro
+ *  will add appropriate suffix based on the compile -mcpu= option.
+ *  \note The storage order for quadwords matches the system endian.
+ *  On Little Endian systems the least significant quadword is
+ *  quadword element 0. The most significant is quadword elements
+ *  [M-1], [N-1], and [M+N-1].
+ *  On Big Endian systems the least significant quadword is
+ *  quadword elements [M-1], [N-1], and [M+N-1].
+ *  The most significant is quadword element 0.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | ??? | 1/cycle  |
+ *  |power9   | ??? | 1/cycle  |
+ *
+ *  @param p pointer to vector result as a unsigned (M+N)x128-bit integer in storage.
+ *  @param m1 pointer to vector representation of a unsigned Mx128-bit integer.
+ *  @param m2 pointer ro vector representation of a unsigned Nx128-bit integer.
+ *  @param M long int specifying the number of quadword in m1.
+ *  @param N long int specifying the number of quadword in m2.
+ */
+extern void
+vec_mul128_byMN  (vui128_t *p,
+		  vui128_t *m1, vui128_t *m2,
+		  unsigned long M, unsigned long N);
+
+/** \brief Vector Unsigned Integer Quadword 4xMxN Multiply.
+ *
+ *  Compute the 4xM+N quadword product of two quadword arrays m1, m2.
+ *  The product is returned as 4xM+N quadword array p.
+ *
+ *  \note This is the dynamic call ABI for IFUNC selection.
+ *  The static implementations are vec_mul512_byMN_PWR8 and
+ *  vec_mul512_byMN_PWR9. For static calls the __VEC_PWR_IMP() macro
+ *  will add appropriate suffix based on the compile -mcpu= option.
+ *  \note The storage order for quadwords matches the system endian.
+ *  On Little Endian systems the least significant quadword is
+ *  quadword element 0. The most significant is quadword elements
+ *  [M-1], [N-1], and [M+N-1].
+ *  On Big Endian systems the least significant quadword is
+ *  quadword elements [M-1], [N-1], and [M+N-1].
+ *  The most significant is quadword element 0.
+ *
+ *  |processor|  Latency   |Throughput|
+ *  |--------:|:----------:|:---------|
+ *  |power8   | ~570*(M*N) | 1/cycle  |
+ *  |power9   | ~260*(M*N) | 1/cycle  |
+ *
+ *  @param p pointer to vector result as a unsigned (M+N)x512-bit integer in storage.
+ *  @param m1 pointer to vector representation of a unsigned Mx512-bit integer.
+ *  @param m2 pointer ro vector representation of a unsigned Nx512-bit integer.
+ *  @param M long int specifying the number of 4x quadwords in m1.
+ *  @param N long int specifying the number of 4x quadwords in m2.
+ */
+extern void
+vec_mul512_byMN  (__VEC_U_512 *p,
+                  __VEC_U_512 *m1, __VEC_U_512 *m2,
+		  unsigned long M, unsigned long N);
 
 ///@cond INTERNAL
 /* Doxygen can not handle macros or attributes */
@@ -2159,8 +2462,24 @@ __VEC_PWR_IMP (vec_mul256x256) (__VEC_U_256 m1, __VEC_U_256 m2);
 extern __VEC_U_640
 __VEC_PWR_IMP (vec_mul512x128) (__VEC_U_512 m1, vui128_t m2);
 
+extern __VEC_U_640
+ __VEC_PWR_IMP (vec_madd512x128a128) (__VEC_U_512 m1, vui128_t m2,
+				      vui128_t a1);
+
+extern __VEC_U_640
+ __VEC_PWR_IMP (vec_madd512x128a512) (__VEC_U_512 m1, vui128_t m2,
+				      __VEC_U_512 a2);
+
+extern __VEC_U_640
+ __VEC_PWR_IMP (vec_madd512x128a128a512) (__VEC_U_512 m1, vui128_t m2,
+					  vui128_t a1, __VEC_U_512 a2);
+
 extern __VEC_U_1024
 __VEC_PWR_IMP (vec_mul512x512) (__VEC_U_512 m1, __VEC_U_512 m2);
+
+extern __VEC_U_1024
+__VEC_PWR_IMP (vec_madd512x512a512) (__VEC_U_512 m1, __VEC_U_512 m2,
+                                     __VEC_U_512 a1);
 
 extern void
 __VEC_PWR_IMP (vec_mul1024x1024) (__VEC_U_2048 *r2048,
@@ -2169,6 +2488,16 @@ __VEC_PWR_IMP (vec_mul1024x1024) (__VEC_U_2048 *r2048,
 extern void
 __VEC_PWR_IMP (vec_mul2048x2048) (__VEC_U_4096 *r4096,
                                   __VEC_U_2048 *m1_2048, __VEC_U_2048 *m2_2048);
+
+extern void
+__VEC_PWR_IMP (vec_mul128_byMN) (vui128_t *p,
+		  vui128_t *m1, vui128_t *m2,
+		  unsigned long M, unsigned long N);
+
+extern void
+__VEC_PWR_IMP (vec_mul512_byMN) (__VEC_U_512 *p,
+                  __VEC_U_512 *m1, __VEC_U_512 *m2,
+		  unsigned long M, unsigned long N);
 ///@endcond
 
 #endif /* SRC_PVECLIB_VEC_INT512_PPC_H_ */

--- a/src/testsuite/arith128_test_i512.c
+++ b/src/testsuite/arith128_test_i512.c
@@ -208,6 +208,118 @@ const __VEC_U_512 vec512_ten1024_0 = CONST_VINT512_Q
       (vui128_t) ((unsigned __int128) 0)
     );
 
+const __VEC_U_512 vec512_ten2048_13 = CONST_VINT512_Q
+    (
+	(vui128_t) ((unsigned __int128) 0),
+	(vui128_t) ((unsigned __int128) 0),
+	CONST_VUINT128_QxW (0x00000000, 0x00000000, 0x00000000, 0x0009e8b3),
+	CONST_VUINT128_QxW (0xb5dc53d5, 0xde4a74d2, 0x8ce329ac, 0xe526a319)
+    );
+
+const __VEC_U_512 vec512_ten2048_12 = CONST_VINT512_Q
+    (
+	CONST_VUINT128_QxW (0x7bbebe30, 0x34f77154, 0xce2bcba1, 0x9648b21c),
+	CONST_VUINT128_QxW (0x11eb962b, 0x1b61b93c, 0xf2ee5ca6, 0xf7e928e6),
+	CONST_VUINT128_QxW (0x1d08e2d6, 0x94222771, 0xe50f3027, 0x8c983623),
+	CONST_VUINT128_QxW (0x0af908b4, 0x0a753b7d, 0x77cd8c6b, 0xe7151aab)
+    );
+
+const __VEC_U_512 vec512_ten2048_11 = CONST_VINT512_Q
+    (
+	CONST_VUINT128_QxW (0x4efac5dc, 0xd83e49d6, 0x907855ee, 0xb028af62),
+	CONST_VUINT128_QxW (0x3f6f7024, 0xd2c36fa9, 0xce9d04a4, 0x87fa1fb9),
+	CONST_VUINT128_QxW (0x92be221e, 0xf1bd0ad5, 0xf775677c, 0xe0de0840),
+	CONST_VUINT128_QxW (0x2ad3fa14, 0x0eac7d56, 0xc7c9dee0, 0xbedd8a6c)
+    );
+
+const __VEC_U_512 vec512_ten2048_10 = CONST_VINT512_Q
+    (
+	CONST_VUINT128_QxW (0x038f9245, 0xb2e87c34, 0x8ad803ec, 0xca8f0070),
+	CONST_VUINT128_QxW (0xf8dbb57a, 0x6a445f27, 0x8b3d5cf4, 0x2915e818),
+	CONST_VUINT128_QxW (0x415c7f3e, 0xf82df846, 0x58ccf45c, 0xfad37943),
+	CONST_VUINT128_QxW (0x3f3389a4, 0x408f43c5, 0x13ef5a83, 0xfb8886fb)
+    );
+
+const __VEC_U_512 vec512_ten2048_9 = CONST_VINT512_Q
+    (
+	CONST_VUINT128_QxW (0xf56d9d4b, 0xd5f86079, 0x2e55ecee, 0x70beb181),
+	CONST_VUINT128_QxW (0x0d76ce39, 0xde9ec24b, 0xcf99d019, 0x53761abd),
+	CONST_VUINT128_QxW (0x9d7389c0, 0xa244de3c, 0x195355d8, 0x4eeebeee),
+	CONST_VUINT128_QxW (0x6f46eadb, 0x56c6815b, 0x785ce6b7, 0xb125ac8e)
+    );
+
+const __VEC_U_512 vec512_ten2048_8 = CONST_VINT512_Q
+    (
+	CONST_VUINT128_QxW (0xdb0708fd, 0x8f6cae5f, 0x5715f791, 0x5b33eb41),
+	CONST_VUINT128_QxW (0x7bf03c19, 0xd7917c7b, 0xa1fc6b96, 0x81428c85),
+	CONST_VUINT128_QxW (0x744695f0, 0xe866d7ef, 0xc9ac375d, 0x77c1a42f),
+	CONST_VUINT128_QxW (0x40660460, 0x944545ff, 0x87a7dc62, 0xd752f7a6)
+    );
+
+const __VEC_U_512 vec512_ten2048_7 = CONST_VINT512_Q
+    (
+	CONST_VUINT128_QxW (0x6a57b1ab, 0x730f203c, 0x1aa9f444, 0x84d80e2e),
+	CONST_VUINT128_QxW (0x5fc5a047, 0x79c56b8a, 0x9e110c7b, 0xcbea4ca7),
+	CONST_VUINT128_QxW (0x982da466, 0x3cfe491d, 0x0dbd21fe, 0xab498697),
+	CONST_VUINT128_QxW (0x33554c36, 0x685e5510, 0xc4a65665, 0x4419bd43)
+    );
+
+const __VEC_U_512 vec512_ten2048_6 = CONST_VINT512_Q
+    (
+	CONST_VUINT128_QxW (0x8e48ff35, 0xd6c7d6ab, 0x91bac974, 0xfb1264b4),
+	CONST_VUINT128_QxW (0xf111821f, 0xa2bca416, 0xafe609c3, 0x13b41e44),
+	CONST_VUINT128_QxW (0x9952fbed, 0x5a151440, 0x967abbb3, 0xa8281ed6),
+	CONST_VUINT128_QxW (0xa8f16f92, 0x10c17f94, 0xe3892ee9, 0x8074ff01)
+    );
+
+const __VEC_U_512 vec512_ten2048_5 = CONST_VINT512_Q
+    (
+	CONST_VUINT128_QxW (0xe3cb64f3, 0x2dbb6643, 0xa7a8289c, 0x8c6c54de),
+	CONST_VUINT128_QxW (0x34c10134, 0x9713b449, 0x38209ce1, 0xf3861ce0),
+	CONST_VUINT128_QxW (0xfb7fedcc, 0x235552eb, 0x57a7842d, 0x71c7fd8f),
+	CONST_VUINT128_QxW (0x66912e4a, 0xd2f869c2, 0x92794987, 0x19342c12)
+    );
+
+const __VEC_U_512 vec512_ten2048_4 = CONST_VINT512_Q
+    (
+	CONST_VUINT128_QxW (0x866ed6f1, 0xc850dabc, 0x98342c9e, 0x51b78db2),
+	CONST_VUINT128_QxW (0xea50d142, 0xfd827773, 0x2ed56d55, 0xa5e5a191),
+	CONST_VUINT128_QxW (0x368b8abb, 0xb6067584, 0xee87e354, 0xec2e4721),
+	CONST_VUINT128_QxW (0x49e28dcf, 0xb27d4d3f, 0xe3096865, 0x1333e001)
+    );
+
+const __VEC_U_512 vec512_ten2048_3 = CONST_VINT512_Q
+    (
+      (vui128_t) ((unsigned __int128) 0),
+      (vui128_t) ((unsigned __int128) 0),
+      (vui128_t) ((unsigned __int128) 0),
+      (vui128_t) ((unsigned __int128) 0)
+    );
+
+const __VEC_U_512 vec512_ten2048_2 = CONST_VINT512_Q
+    (
+      (vui128_t) ((unsigned __int128) 0),
+      (vui128_t) ((unsigned __int128) 0),
+      (vui128_t) ((unsigned __int128) 0),
+      (vui128_t) ((unsigned __int128) 0)
+    );
+
+const __VEC_U_512 vec512_ten2048_1 = CONST_VINT512_Q
+    (
+      (vui128_t) ((unsigned __int128) 0),
+      (vui128_t) ((unsigned __int128) 0),
+      (vui128_t) ((unsigned __int128) 0),
+      (vui128_t) ((unsigned __int128) 0)
+    );
+
+const __VEC_U_512 vec512_ten2048_0 = CONST_VINT512_Q
+    (
+      (vui128_t) ((unsigned __int128) 0),
+      (vui128_t) ((unsigned __int128) 0),
+      (vui128_t) ((unsigned __int128) 0),
+      (vui128_t) ((unsigned __int128) 0)
+    );
+
 #define TIMING_ITERATIONS 10
 
 int
@@ -217,6 +329,34 @@ test_time_i512 (void)
   uint64_t t_start, t_end, t_delta;
   double delta_sec;
   int rc = 0;
+
+  printf ("\n%s mul128x128 start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_mul128x128 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s mul128x128 end", __FUNCTION__);
+  printf ("\n%s mul128x128 delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
+	  delta_sec);
+
+  printf ("\n%s mul256x256 start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_mul256x256 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s mul256x256 end", __FUNCTION__);
+  printf ("\n%s mul256x256 delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
+	  delta_sec);
 
   printf ("\n%s mul512x512 start, ...\n", __FUNCTION__);
   t_start = __builtin_ppc_get_timebase ();
@@ -230,6 +370,20 @@ test_time_i512 (void)
 
   printf ("\n%s mul512x512 end", __FUNCTION__);
   printf ("\n%s mul512x512 delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
+	  delta_sec);
+
+  printf ("\n%s mul512x512by8 start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_mul512x512by8 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s mul512x512by8 end", __FUNCTION__);
+  printf ("\n%s mul512x512by8 delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
 	  delta_sec);
 
   printf ("\n%s mul1024x1024 start, ...\n", __FUNCTION__);
@@ -246,6 +400,20 @@ test_time_i512 (void)
   printf ("\n%s mul1024x1024 delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
 	  delta_sec);
 
+  printf ("\n%s mul1024x1024by8 start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_mul1024x1024by8 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s mul1024x1024by8 end", __FUNCTION__);
+  printf ("\n%s mul1024x1024by8 delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
+	  delta_sec);
+
   printf ("\n%s mul2048x2048 start, ...\n", __FUNCTION__);
   t_start = __builtin_ppc_get_timebase ();
   for (i = 0; i < TIMING_ITERATIONS; i++)
@@ -258,6 +426,48 @@ test_time_i512 (void)
 
   printf ("\n%s mul2048x2048 end", __FUNCTION__);
   printf ("\n%s mul2048x2048 delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
+	  delta_sec);
+
+  printf ("\n%s mul2048x2048by8 start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_mul2048x2048by8 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s mul2048x2048by8 end", __FUNCTION__);
+  printf ("\n%s mul2048x2048by8 delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
+	  delta_sec);
+
+  printf ("\n%s timed_mul2048x2048_MN start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_mul2048x2048_MN ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s timed_mul2048x2048_MN end", __FUNCTION__);
+  printf ("\n%s timed_mul2048x2048_MN delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
+	  delta_sec);
+
+  printf ("\n%s timed_mul4096x4096_MN start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_mul4096x4096_MN ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s timed_mul4096x4096_MN end", __FUNCTION__);
+  printf ("\n%s timed_mul4096x4096_MN delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
 	  delta_sec);
 
   return (rc);
@@ -433,6 +643,114 @@ test_mul256x256 (void)
   return (rc);
 }
 
+
+int
+test_mul512x128_MN (void)
+{
+  __VEC_U_640 k, e;
+  __VEC_U_512x1 ke, ep;
+  __VEC_U_512 i;
+  vui128_t *kp, *ip, *jp;
+  vui128_t j;
+  int rc = 0;
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  kp = &k.vx0;
+  ip = &i.vx0;
+  jp = &j;
+#else
+  kp = &k.vx4;
+  ip = &i.vx3;
+  jp = &j;
+#endif
+
+  printf ("\ntest_mul512x128_MN vector multiply quadword, 640-bit product\n");
+
+  i.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j     = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  __VEC_PWR_IMP (vec_mul128_byMN) (kp, ip, jp, 4, 1);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" 2**128-1   ", i);
+  print_vint128x (" * 2**128-1 ", j);
+  print_vint640x ("          = ", k);
+#endif
+  ke.x640 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x128 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vuint128x ("vec_mul512x128_MN 1a:", ke.x2.v1x128, ep.x2.v1x128);
+  rc += check_vint512   ("vec_mul512x128_MN 1b:", ke.x2.v0x512, ep.x2.v0x512);
+
+  __VEC_PWR_IMP (vec_mul128_byMN) (kp, ip, jp, 4, 1);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" 2**128-1   ", i);
+  print_vint128x (" * 2**128-1 ", j);
+  print_vint640x ("          = ", k);
+#endif
+  ke.x640 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x128 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vuint128x ("vec_mul512x128_MN 2a:", ke.x2.v1x128, ep.x2.v1x128);
+  rc += check_vint512   ("vec_mul512x128_MN 2b:", ke.x2.v0x512, ep.x2.v0x512);
+
+  i.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx3 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j     = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+
+  __VEC_PWR_IMP (vec_mul128_byMN) (kp, ip, jp, 4, 1);
+
+#ifdef __DEBUG_PRINT__
+  kp.x640 = k;
+  print_vint512x (" 2**512-2**396-1 ", i);
+  print_vint128x ("      * 2**128-1 ", j);
+  print_vint640x ("               = ", k);
+#endif
+  ke.x640 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ep.x2.v1x128 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  rc += check_vuint128x ("vec_mul512x128_MN 3a:", ke.x2.v1x128, ep.x2.v1x128);
+  rc += check_vint512   ("vec_mul512x128_MN 3b:", ke.x2.v0x512, ep.x2.v0x512);
+
+  i.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx2 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx3 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j     = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+
+  __VEC_PWR_IMP (vec_mul128_byMN) (kp, ip, jp, 4, 1);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x ("  2**512-1 ", i);
+  print_vint128x ("* 2**128-1 ", j);
+  print_vint640x ("         = ", k);
+#endif
+  ke.x640 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  ep.x2.v1x128 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  rc += check_vuint128x ("vec_mul512x128_MN 4a:", ke.x2.v1x128, ep.x2.v1x128);
+  rc += check_vint512   ("vec_mul512x128_MN 4b:", ke.x2.v0x512, ep.x2.v0x512);
+
+  return (rc);
+}
+
 int
 test_mul512x128 (void)
 {
@@ -553,6 +871,341 @@ test_mul512x128 (void)
   return (rc);
 }
 
+int
+test_madd512x128 (void)
+{
+  __VEC_U_640 k, e;
+  __VEC_U_512x1 kp, ep;
+  __VEC_U_512 i, m;
+  vui128_t j, n;
+  int rc = 0;
+
+  printf ("\ntest_madd512x128 vector multiply-add quadword, 512-bit product\n");
+
+  i.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j     = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  n     = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  k = __VEC_PWR_IMP (vec_madd512x128a128)(i, j, n);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" 2**128-1   ", i);
+  print_vint128x (" * 2**128-1 ", j);
+  print_vint128x (" * 2**128-1 ", n);
+  print_vint640x ("          = ", k);
+#endif
+  kp.x640 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x128 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vuint128x ("vec_madd512x128a128 1a:", kp.x2.v1x128, ep.x2.v1x128);
+  rc += check_vint512   ("vec_madd512x128a128 1b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  i.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j     = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  n     = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  k = __VEC_PWR_IMP (vec_madd512x128a128)(i, j, n);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" 2**128-1   ", i);
+  print_vint128x (" * 2**128-1 ", j);
+  print_vint128x (" + 2**128-1 ", n);
+  print_vint640x ("          = ", k);
+#endif
+  kp.x640 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x128 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vuint128x ("vec_madd512x128a128 2a:", kp.x2.v1x128, ep.x2.v1x128);
+  rc += check_vint512   ("vec_madd512x128a128 2b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  i.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j     = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  n     = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  k = __VEC_PWR_IMP (vec_madd512x128a128)(i, j, n);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" 2**256-2**128-1 ", i);
+  print_vint128x ("      * 2**128-1 ", j);
+  print_vint128x ("      + 2**128-1 ", n);
+  print_vint640x ("               = ", k);
+#endif
+  kp.x640 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x128 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vuint128x ("vec_madd512x128a128 3a:", kp.x2.v1x128, ep.x2.v1x128);
+  rc += check_vint512   ("vec_madd512x128a128 3b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  i.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx2 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx3 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j     = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  n     = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  k = __VEC_PWR_IMP (vec_madd512x128a128)(i, j, n);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x ("  2**512-1 ", i);
+  print_vint128x ("* 2**128-1 ", j);
+  print_vint128x ("+ 2**128-1 ", n);
+  print_vint640x ("         = ", k);
+#endif
+  kp.x640 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x128 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  rc += check_vuint128x ("vec_madd512x128a128 4a:", kp.x2.v1x128, ep.x2.v1x128);
+  rc += check_vint512   ("vec_madd512x128a128 4b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  i.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx2 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx3 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j     = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  m.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  m.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  m.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  m.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  n     = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  k = __VEC_PWR_IMP (vec_madd512x128a512)(i, j, m);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x ("  2**512-1 ", i);
+  print_vint128x ("* 2**128-1 ", j);
+  print_vint128x ("+ 2**128-1 ", m);
+  print_vint640x ("         = ", k);
+#endif
+  kp.x640 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x128 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  rc += check_vuint128x ("vec_madd512x128a512 5a:", kp.x2.v1x128, ep.x2.v1x128);
+  rc += check_vint512   ("vec_madd512x128a512 5b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  i.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx2 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx3 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j     = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  m.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  m.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  m.vx2 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  m.vx3 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  n     = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  k = __VEC_PWR_IMP (vec_madd512x128a512)(i, j, m);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x ("  2**512-1 ", i);
+  print_vint128x ("* 2**128-1 ", j);
+  print_vint128x ("+ 2**128-1 ", m);
+  print_vint640x ("         = ", k);
+#endif
+  kp.x640 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  ep.x2.v1x128 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  rc += check_vuint128x ("vec_madd512x128a512 6a:", kp.x2.v1x128, ep.x2.v1x128);
+  rc += check_vint512   ("vec_madd512x128a512 6b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  i.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx2 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx3 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j     = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  m.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  m.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  m.vx2 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  m.vx3 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  n     = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  k = __VEC_PWR_IMP (vec_madd512x128a128a512)(i, j, n, m);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x ("  2**512-1 ", i);
+  print_vint128x ("* 2**128-1 ", j);
+  print_vint128x ("+ 2**128-1 ", m);
+  print_vint640x ("         = ", k);
+#endif
+  kp.x640 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  ep.x2.v1x128 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  rc += check_vuint128x ("vec_madd512x128a128a512 7a:", kp.x2.v1x128, ep.x2.v1x128);
+  rc += check_vint512   ("vec_madd512x128a128a512 7b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  return (rc);
+}
+
+//#define __DEBUG_PRINT__ 1
+int
+test_mul512x512_MN (void)
+{
+  __VEC_U_1024 k, e;
+  __VEC_U_1024x512 ke, ep;
+  __VEC_U_512 i, j;
+  vui128_t *kp, *ip, *jp;
+  int rc = 0;
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  kp = &k.vx0;
+  ip = &i.vx0;
+  jp = &j.vx0;
+#else
+  kp = &k.vx7;
+  ip = &i.vx3;
+  jp = &j.vx3;
+#endif
+
+  printf ("\ntest_mul512x512_MN vector multiply quadword, 1024-bit product\n");
+
+  i.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  __VEC_PWR_IMP (vec_mul128_byMN) (kp, ip, jp, 4, 4);
+
+#ifdef __DEBUG_PRINT__
+  kp.x1024 = k;
+  print_vint512x (" 2**128-1   ", i);
+  print_vint512x (" * 2**128-1 ", j);
+  print_vint512x ("     = h512 ", kp.x2.v1x512);
+  print_vint512x ("       l512 ", kp.x2.v0x512);
+#endif
+  ke.x1024 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint512 ("vec_mul512x512_MN 1a:", ke.x2.v1x512, ep.x2.v1x512);
+  rc += check_vint512 ("vec_mul512x512_MN 1b:", ke.x2.v0x512, ep.x2.v0x512);
+
+  i.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx2 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx3 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  __VEC_PWR_IMP (vec_mul128_byMN) (kp, ip, jp, 4, 4);
+
+#ifdef __DEBUG_PRINT__
+  kp.x1024 = k;
+  print_vint512x (" 2**128-1   ", i);
+  print_vint512x (" * 2**128-1 ", j);
+  print_vint512x ("     = h512 ", kp.x2.v1x512);
+  print_vint512x ("       l512 ", kp.x2.v0x512);
+#endif
+  ke.x1024 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  ep.x2.v1x512.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint512 ("vec_mul512x512_MN 2a:", ke.x2.v1x512, ep.x2.v1x512);
+  rc += check_vint512 ("vec_mul512x512_MN 2b:", ke.x2.v0x512, ep.x2.v0x512);
+
+  i.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx2 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx3 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  __VEC_PWR_IMP (vec_mul128_byMN) (kp, ip, jp, 4, 4);
+
+#ifdef __DEBUG_PRINT__
+  kp.x1024 = k;
+  print_vint512x (" 2**128-1   ", i);
+  print_vint512x (" * 2**128-1 ", j);
+  print_vint512x ("     = h512 ", kp.x2.v1x512);
+  print_vint512x ("       l512 ", kp.x2.v0x512);
+#endif
+  ke.x1024 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000001);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  ep.x2.v1x512.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe);
+  ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vint512 ("vec_mul512x512_MN 3a:", ke.x2.v1x512, ep.x2.v1x512);
+  rc += check_vint512 ("vec_mul512x512_MN 3b:", ke.x2.v0x512, ep.x2.v0x512);
+
+  i.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx2 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  i.vx3 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j.vx0 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j.vx2 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  j.vx3 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+  __VEC_PWR_IMP (vec_mul128_byMN) (kp, ip, jp, 4, 4);
+
+#ifdef __DEBUG_PRINT__
+  kp.x1024 = k;
+  print_vint512x (" 2**128-1   ", i);
+  print_vint512x (" * 2**128-1 ", j);
+  print_vint512x ("     = h512 ", kp.x2.v1x512);
+  print_vint512x ("       l512 ", kp.x2.v0x512);
+#endif
+  ke.x1024 = k;
+  rc += check_vint512 ("vec_mul512x512_MN 4a:", ke.x2.v1x512, vec512_foxeasy);
+  rc += check_vint512 ("vec_mul512x512_MN 4b:", ke.x2.v0x512, vec512_one);
+
+  i = vec512_ten128th;
+  j = vec512_ten128th;
+  __VEC_PWR_IMP (vec_mul128_byMN) (kp, ip, jp, 4, 4);
+
+#ifdef __DEBUG_PRINT__
+  kp.x1024 = k;
+  print_vint512x (" 2**128-1   ", i);
+  print_vint512x (" * 2**128-1 ", j);
+  print_vint512x ("     = h512 ", kp.x2.v1x512);
+  print_vint512x ("       l512 ", kp.x2.v0x512);
+#endif
+  ke.x1024 = k;
+  rc += check_vint512 ("vec_mul512x512_MN 5a:", ke.x2.v1x512, vec512_ten256_h);
+  rc += check_vint512 ("vec_mul512x512_MN 5b:", ke.x2.v0x512, vec512_ten256_l);
+
+  return (rc);
+}
+
 //#define __DEBUG_PRINT__ 1
 int
 test_mul512x512 (void)
@@ -590,8 +1243,8 @@ test_mul512x512 (void)
   ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
   ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
   ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
-  rc += check_vint512 ("vec_mul512x128 1a:", kp.x2.v1x512, ep.x2.v1x512);
-  rc += check_vint512 ("vec_mul512x128 1b:", kp.x2.v0x512, ep.x2.v0x512);
+  rc += check_vint512 ("vec_mul512x512 1a:", kp.x2.v1x512, ep.x2.v1x512);
+  rc += check_vint512 ("vec_mul512x512 1b:", kp.x2.v0x512, ep.x2.v0x512);
 
   j.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
   j.vx1 = (vui128_t) CONST_VINT128_W (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
@@ -615,8 +1268,8 @@ test_mul512x512 (void)
   ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
   ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
   ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
-  rc += check_vint512 ("vec_mul512x128 2a:", kp.x2.v1x512, ep.x2.v1x512);
-  rc += check_vint512 ("vec_mul512x128 2b:", kp.x2.v0x512, ep.x2.v0x512);
+  rc += check_vint512 ("vec_mul512x512 2a:", kp.x2.v1x512, ep.x2.v1x512);
+  rc += check_vint512 ("vec_mul512x512 2b:", kp.x2.v0x512, ep.x2.v0x512);
   k = __VEC_PWR_IMP (vec_mul512x512)(j, i);
 
 #ifdef __DEBUG_PRINT__
@@ -635,8 +1288,8 @@ test_mul512x512 (void)
   ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
   ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
   ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
-  rc += check_vint512 ("vec_mul512x128 2a:", kp.x2.v1x512, ep.x2.v1x512);
-  rc += check_vint512 ("vec_mul512x128 2b:", kp.x2.v0x512, ep.x2.v0x512);
+  rc += check_vint512 ("vec_mul512x512 2a:", kp.x2.v1x512, ep.x2.v1x512);
+  rc += check_vint512 ("vec_mul512x512 2b:", kp.x2.v0x512, ep.x2.v0x512);
 
   j.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
   j.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
@@ -660,8 +1313,8 @@ test_mul512x512 (void)
   ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
   ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
   ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
-  rc += check_vint512 ("vec_mul512x128 3a:", kp.x2.v1x512, ep.x2.v1x512);
-  rc += check_vint512 ("vec_mul512x128 3b:", kp.x2.v0x512, ep.x2.v0x512);
+  rc += check_vint512 ("vec_mul512x512 3a:", kp.x2.v1x512, ep.x2.v1x512);
+  rc += check_vint512 ("vec_mul512x512 3b:", kp.x2.v0x512, ep.x2.v0x512);
   k = __VEC_PWR_IMP (vec_mul512x512)(j, i);
 
 #ifdef __DEBUG_PRINT__
@@ -680,8 +1333,8 @@ test_mul512x512 (void)
   ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
   ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
   ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
-  rc += check_vint512 ("vec_mul512x128 4a:", kp.x2.v1x512, ep.x2.v1x512);
-  rc += check_vint512 ("vec_mul512x128 4b:", kp.x2.v0x512, ep.x2.v0x512);
+  rc += check_vint512 ("vec_mul512x512 4a:", kp.x2.v1x512, ep.x2.v1x512);
+  rc += check_vint512 ("vec_mul512x512 4b:", kp.x2.v0x512, ep.x2.v0x512);
 
   j.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
   j.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
@@ -705,8 +1358,8 @@ test_mul512x512 (void)
   ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
   ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
   ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
-  rc += check_vint512 ("vec_mul512x128 5a:", kp.x2.v1x512, ep.x2.v1x512);
-  rc += check_vint512 ("vec_mul512x128 5b:", kp.x2.v0x512, ep.x2.v0x512);
+  rc += check_vint512 ("vec_mul512x512 5a:", kp.x2.v1x512, ep.x2.v1x512);
+  rc += check_vint512 ("vec_mul512x512 5b:", kp.x2.v0x512, ep.x2.v0x512);
   k = __VEC_PWR_IMP (vec_mul512x512)(j, i);
 
 #ifdef __DEBUG_PRINT__
@@ -725,8 +1378,8 @@ test_mul512x512 (void)
   ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
   ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
   ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
-  rc += check_vint512 ("vec_mul512x128 6a:", kp.x2.v1x512, ep.x2.v1x512);
-  rc += check_vint512 ("vec_mul512x128 6b:", kp.x2.v0x512, ep.x2.v0x512);
+  rc += check_vint512 ("vec_mul512x512 6a:", kp.x2.v1x512, ep.x2.v1x512);
+  rc += check_vint512 ("vec_mul512x512 6b:", kp.x2.v0x512, ep.x2.v0x512);
 
   i.vx0 = (vui128_t) CONST_VINT128_W (0x000004ee, 0x2d6d415b, 0x85acef81, 0x00000000);
   i.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
@@ -754,8 +1407,8 @@ test_mul512x512 (void)
   ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
   ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
   ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
-  rc += check_vint512 ("vec_mul512x128 7a:", kp.x2.v1x512, ep.x2.v1x512);
-  rc += check_vint512 ("vec_mul512x128 7b:", kp.x2.v0x512, ep.x2.v0x512);
+  rc += check_vint512 ("vec_mul512x512 7a:", kp.x2.v1x512, ep.x2.v1x512);
+  rc += check_vint512 ("vec_mul512x512 7b:", kp.x2.v0x512, ep.x2.v0x512);
 
   kp.x1024 = k;
   i = kp.x2.v0x512;
@@ -778,8 +1431,8 @@ test_mul512x512 (void)
   ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
   ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
   ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
-  rc += check_vint512 ("vec_mul512x128 8a:", kp.x2.v1x512, ep.x2.v1x512);
-  rc += check_vint512 ("vec_mul512x128 8b:", kp.x2.v0x512, ep.x2.v0x512);
+  rc += check_vint512 ("vec_mul512x512 8a:", kp.x2.v1x512, ep.x2.v1x512);
+  rc += check_vint512 ("vec_mul512x512 8b:", kp.x2.v0x512, ep.x2.v0x512);
 
   kp.x1024 = k;
   i = kp.x2.v0x512;
@@ -802,8 +1455,8 @@ test_mul512x512 (void)
   ep.x2.v1x512.vx1 = (vui128_t) CONST_VINT128_W (0x80dcc7f7, 0x55bc28f2, 0x65f9ef17, 0xcc5573c0);
   ep.x2.v1x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x000553f7, 0x5fdcefce, 0xf46eeddc);
   ep.x2.v1x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
-  rc += check_vint512 ("vec_mul512x128 8a:", kp.x2.v1x512, ep.x2.v1x512);
-  rc += check_vint512 ("vec_mul512x128 8b:", kp.x2.v0x512, ep.x2.v0x512);
+  rc += check_vint512 ("vec_mul512x512 8a:", kp.x2.v1x512, ep.x2.v1x512);
+  rc += check_vint512 ("vec_mul512x512 8b:", kp.x2.v0x512, ep.x2.v0x512);
 
   return (rc);
 }
@@ -1054,6 +1707,606 @@ test_mul1024x1024 (void)
   rc += check_vint512 ("vec_mul1024x1024 10b:", k.x4.v2x512, e.x4.v2x512);
   rc += check_vint512 ("vec_mul1024x1024 10c:", k.x4.v1x512, e.x4.v1x512);
   rc += check_vint512 ("vec_mul1024x1024 10d:", k.x4.v0x512, e.x4.v0x512);
+
+  return (rc);
+}
+//#undef __DEBUG_PRINT__
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define __NDX16(__index) (__index)
+#else
+#define __NDX16(__index) ((16 - 1) - (__index))
+#endif
+//#define __DEBUG_PRINT__ 1
+int
+test_mul2048x2048_MN (void)
+{
+  __VEC_U_512 k1[16];
+  __VEC_U_4096x512 k, e;
+  __VEC_U_2048x512 m1, m2;
+  __VEC_U_512 i, j;
+  __VEC_U_512 *kp, *ip, *jp;
+  int rc = 0;
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  kp = &k.x8.v0x512;
+  ip = &m1.x4.v0x512;
+  jp = &m2.x4.v0x512;
+#else
+  kp = &k.x8.v7x512;
+  ip = &m1.x4.v3x512;
+  jp = &m2.x4.v3x512;
+#endif
+
+  printf ("\ntest_mul512_MN vector multiply quadwords, 4096-bit product\n");
+
+  m1.x4.v3x512 = vec512_zeros;
+  m1.x4.v2x512 = vec512_zeros;
+  m1.x4.v1x512 = vec512_zeros;
+  m1.x4.v0x512 = vec512_foxes;
+  m2.x4.v3x512 = vec512_zeros;
+  m2.x4.v2x512 = vec512_zeros;
+  m2.x4.v1x512 = vec512_zeros;
+  m2.x4.v0x512 = vec512_foxes;
+  __VEC_PWR_IMP (vec_mul512_byMN)(kp, ip, jp, 4, 4);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[3]   ", m1.x4.v3x512);
+  print_vint512x (" m1[2]   ", m1.x4.v2x512);
+  print_vint512x (" m1[1]   ", m1.x4.v1x512);
+  print_vint512x (" m1[0] * ", m1.x4.v0x512);
+  print_vint512x (" m2[3]   ", m2.x4.v3x512);
+  print_vint512x (" m2[2]   ", m2.x4.v2x512);
+  print_vint512x (" m2[1]   ", m2.x4.v1x512);
+  print_vint512x (" m2[0] = ", m2.x4.v0x512);
+  print_vint512x (" k [7]   ", k.x8.v7x512);
+  print_vint512x (" k [6]   ", k.x8.v6x512);
+  print_vint512x (" k [5]   ", k.x8.v5x512);
+  print_vint512x (" k [4] = ", k.x8.v4x512);
+  print_vint512x (" k [3]   ", k.x8.v3x512);
+  print_vint512x (" k [2]   ", k.x8.v2x512);
+  print_vint512x (" k [1]   ", k.x8.v1x512);
+  print_vint512x (" k [0] = ", k.x8.v0x512);
+#endif
+  e.x8.v0x512 = vec512_one;
+  e.x8.v1x512 = vec512_foxeasy;
+  e.x8.v2x512 = vec512_zeros;
+  e.x8.v3x512 = vec512_zeros;
+  e.x8.v4x512 = vec512_zeros;
+  e.x8.v5x512 = vec512_zeros;
+  e.x8.v6x512 = vec512_zeros;
+  e.x8.v7x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul512_byMN 1a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul512_byMN 1b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul512_byMN 1c:", k.x8.v5x512, e.x8.v5x512);
+  rc += check_vint512 ("vec_mul512_byMN 1d:", k.x8.v4x512, e.x8.v4x512);
+  rc += check_vint512 ("vec_mul512_byMN 1e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul512_byMN 1f:", k.x8.v2x512, e.x8.v2x512);
+  rc += check_vint512 ("vec_mul512_byMN 1g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul512_byMN 1h:", k.x8.v0x512, e.x8.v0x512);
+
+  m1.x4.v3x512 = vec512_zeros;
+  m1.x4.v2x512 = vec512_zeros;
+  m1.x4.v1x512 = vec512_foxes;
+  m1.x4.v0x512 = vec512_zeros;
+  m2.x4.v3x512 = vec512_zeros;
+  m2.x4.v2x512 = vec512_zeros;
+  m2.x4.v1x512 = vec512_zeros;
+  m2.x4.v0x512 = vec512_foxes;
+  __VEC_PWR_IMP (vec_mul512_byMN)(kp, ip, jp, 4, 4);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[3]   ", m1.x4.v3x512);
+  print_vint512x (" m1[2]   ", m1.x4.v2x512);
+  print_vint512x (" m1[1]   ", m1.x4.v1x512);
+  print_vint512x (" m1[0] * ", m1.x4.v0x512);
+  print_vint512x (" m2[3]   ", m2.x4.v3x512);
+  print_vint512x (" m2[2]   ", m2.x4.v2x512);
+  print_vint512x (" m2[1]   ", m2.x4.v1x512);
+  print_vint512x (" m2[0] = ", m2.x4.v0x512);
+  print_vint512x (" k [7]   ", k.x8.v7x512);
+  print_vint512x (" k [6]   ", k.x8.v6x512);
+  print_vint512x (" k [5]   ", k.x8.v5x512);
+  print_vint512x (" k [4]   ", k.x8.v4x512);
+  print_vint512x (" k [3]   ", k.x8.v3x512);
+  print_vint512x (" k [2]   ", k.x8.v2x512);
+  print_vint512x (" k [1]   ", k.x8.v1x512);
+  print_vint512x (" k [0]   ", k.x8.v0x512);
+#endif
+  e.x8.v0x512 = vec512_zeros;
+  e.x8.v1x512 = vec512_one;
+  e.x8.v2x512 = vec512_foxeasy;
+  e.x8.v3x512 = vec512_zeros;
+  e.x8.v4x512 = vec512_zeros;
+  e.x8.v5x512 = vec512_zeros;
+  e.x8.v6x512 = vec512_zeros;
+  e.x8.v7x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul512_byMN 2a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul512_byMN 2b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul512_byMN 2c:", k.x8.v5x512, e.x8.v5x512);
+  rc += check_vint512 ("vec_mul512_byMN 2d:", k.x8.v4x512, e.x8.v4x512);
+  rc += check_vint512 ("vec_mul512_byMN 2e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul512_byMN 2f:", k.x8.v2x512, e.x8.v2x512);
+  rc += check_vint512 ("vec_mul512_byMN 2g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul512_byMN 2h:", k.x8.v0x512, e.x8.v0x512);
+
+  __VEC_PWR_IMP (vec_mul512_byMN)(kp, ip, jp, 4, 4);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[3]   ", m2.x4.v3x512);
+  print_vint512x (" m1[2]   ", m2.x4.v2x512);
+  print_vint512x (" m1[1]   ", m2.x4.v1x512);
+  print_vint512x (" m1[0] * ", m2.x4.v0x512);
+  print_vint512x (" m2[3]   ", m1.x4.v3x512);
+  print_vint512x (" m2[2]   ", m1.x4.v2x512);
+  print_vint512x (" m2[1]   ", m1.x4.v1x512);
+  print_vint512x (" m2[0] = ", m1.x4.v0x512);
+  print_vint512x (" k [7]   ", k.x8.v7x512);
+  print_vint512x (" k [6]   ", k.x8.v6x512);
+  print_vint512x (" k [5]   ", k.x8.v5x512);
+  print_vint512x (" k [4]   ", k.x8.v4x512);
+  print_vint512x (" k [3]   ", k.x8.v3x512);
+  print_vint512x (" k [2]   ", k.x8.v2x512);
+  print_vint512x (" k [1]   ", k.x8.v1x512);
+  print_vint512x (" k [0]   ", k.x8.v0x512);
+#endif
+  rc += check_vint512 ("vec_mul512_byMN 3a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul512_byMN 3b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul512_byMN 3c:", k.x8.v5x512, e.x8.v5x512);
+  rc += check_vint512 ("vec_mul512_byMN 3d:", k.x8.v4x512, e.x8.v4x512);
+  rc += check_vint512 ("vec_mul512_byMN 3e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul512_byMN 3f:", k.x8.v2x512, e.x8.v2x512);
+  rc += check_vint512 ("vec_mul512_byMN 3g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul512_byMN 3h:", k.x8.v0x512, e.x8.v0x512);
+
+  m1.x4.v3x512 = vec512_zeros;
+  m1.x4.v2x512 = vec512_foxes;
+  m1.x4.v1x512 = vec512_zeros;
+  m1.x4.v0x512 = vec512_zeros;
+  m2.x4.v3x512 = vec512_zeros;
+  m2.x4.v2x512 = vec512_zeros;
+  m2.x4.v1x512 = vec512_zeros;
+  m2.x4.v0x512 = vec512_foxes;
+  __VEC_PWR_IMP (vec_mul512_byMN)(kp, ip, jp, 4, 4);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[3]   ", m1.x4.v3x512);
+  print_vint512x (" m1[2]   ", m1.x4.v2x512);
+  print_vint512x (" m1[1]   ", m1.x4.v1x512);
+  print_vint512x (" m1[0] * ", m1.x4.v0x512);
+  print_vint512x (" m2[3]   ", m2.x4.v3x512);
+  print_vint512x (" m2[2]   ", m2.x4.v2x512);
+  print_vint512x (" m2[1]   ", m2.x4.v1x512);
+  print_vint512x (" m2[0] = ", m2.x4.v0x512);
+  print_vint512x (" k [7]   ", k.x8.v7x512);
+  print_vint512x (" k [6]   ", k.x8.v6x512);
+  print_vint512x (" k [5]   ", k.x8.v5x512);
+  print_vint512x (" k [4]   ", k.x8.v4x512);
+  print_vint512x (" k [3]   ", k.x8.v3x512);
+  print_vint512x (" k [2]   ", k.x8.v2x512);
+  print_vint512x (" k [1]   ", k.x8.v1x512);
+  print_vint512x (" k [0]   ", k.x8.v0x512);
+#endif
+  e.x8.v0x512 = vec512_zeros;
+  e.x8.v1x512 = vec512_zeros;
+  e.x8.v2x512 = vec512_one;
+  e.x8.v3x512 = vec512_foxeasy;
+  e.x8.v4x512 = vec512_zeros;
+  e.x8.v5x512 = vec512_zeros;
+  e.x8.v6x512 = vec512_zeros;
+  e.x8.v7x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul512_byMN 4a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul512_byMN 4b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul512_byMN 4c:", k.x8.v5x512, e.x8.v5x512);
+  rc += check_vint512 ("vec_mul512_byMN 4d:", k.x8.v4x512, e.x8.v4x512);
+  rc += check_vint512 ("vec_mul512_byMN 4e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul512_byMN 4f:", k.x8.v2x512, e.x8.v2x512);
+  rc += check_vint512 ("vec_mul512_byMN 4g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul512_byMN 4h:", k.x8.v0x512, e.x8.v0x512);
+
+  __VEC_PWR_IMP (vec_mul512_byMN)(kp, ip, jp, 4, 4);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[3]   ", m2.x4.v3x512);
+  print_vint512x (" m1[2]   ", m2.x4.v2x512);
+  print_vint512x (" m1[1]   ", m2.x4.v1x512);
+  print_vint512x (" m1[0] * ", m2.x4.v0x512);
+  print_vint512x (" m2[3]   ", m1.x4.v3x512);
+  print_vint512x (" m2[2]   ", m1.x4.v2x512);
+  print_vint512x (" m2[1]   ", m1.x4.v1x512);
+  print_vint512x (" m2[0] = ", m1.x4.v0x512);
+  print_vint512x (" k [7]   ", k.x8.v7x512);
+  print_vint512x (" k [6]   ", k.x8.v6x512);
+  print_vint512x (" k [5]   ", k.x8.v5x512);
+  print_vint512x (" k [4]   ", k.x8.v4x512);
+  print_vint512x (" k [3]   ", k.x8.v3x512);
+  print_vint512x (" k [2]   ", k.x8.v2x512);
+  print_vint512x (" k [1]   ", k.x8.v1x512);
+  print_vint512x (" k [0]   ", k.x8.v0x512);
+#endif
+  rc += check_vint512 ("vec_mul512_byMN 5a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul512_byMN 5b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul512_byMN 5c:", k.x8.v5x512, e.x8.v5x512);
+  rc += check_vint512 ("vec_mul512_byMN 5d:", k.x8.v4x512, e.x8.v4x512);
+  rc += check_vint512 ("vec_mul512_byMN 5e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul512_byMN 5f:", k.x8.v2x512, e.x8.v2x512);
+  rc += check_vint512 ("vec_mul512_byMN 5g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul512_byMN 5h:", k.x8.v0x512, e.x8.v0x512);
+
+  m1.x4.v3x512 = vec512_foxes;
+  m1.x4.v2x512 = vec512_zeros;
+  m1.x4.v1x512 = vec512_zeros;
+  m1.x4.v0x512 = vec512_zeros;
+  m2.x4.v3x512 = vec512_zeros;
+  m2.x4.v2x512 = vec512_zeros;
+  m2.x4.v1x512 = vec512_zeros;
+  m2.x4.v0x512 = vec512_foxes;
+  __VEC_PWR_IMP (vec_mul512_byMN)(kp, ip, jp, 4, 4);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[3]   ", m1.x4.v3x512);
+  print_vint512x (" m1[2]   ", m1.x4.v2x512);
+  print_vint512x (" m1[1]   ", m1.x4.v1x512);
+  print_vint512x (" m1[0] * ", m1.x4.v0x512);
+  print_vint512x (" m2[3]   ", m2.x4.v3x512);
+  print_vint512x (" m2[2]   ", m2.x4.v2x512);
+  print_vint512x (" m2[1]   ", m2.x4.v1x512);
+  print_vint512x (" m2[0] = ", m2.x4.v0x512);
+  print_vint512x (" k [7]   ", k.x8.v7x512);
+  print_vint512x (" k [6]   ", k.x8.v6x512);
+  print_vint512x (" k [5]   ", k.x8.v5x512);
+  print_vint512x (" k [4]   ", k.x8.v4x512);
+  print_vint512x (" k [3]   ", k.x8.v3x512);
+  print_vint512x (" k [2]   ", k.x8.v2x512);
+  print_vint512x (" k [1]   ", k.x8.v1x512);
+  print_vint512x (" k [0]   ", k.x8.v0x512);
+#endif
+  e.x8.v0x512 = vec512_zeros;
+  e.x8.v1x512 = vec512_zeros;
+  e.x8.v2x512 = vec512_zeros;
+  e.x8.v3x512 = vec512_one;
+  e.x8.v4x512 = vec512_foxeasy;
+  e.x8.v5x512 = vec512_zeros;
+  e.x8.v6x512 = vec512_zeros;
+  e.x8.v7x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul512_byMN 6a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul512_byMN 6b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul512_byMN 6c:", k.x8.v5x512, e.x8.v5x512);
+  rc += check_vint512 ("vec_mul512_byMN 6d:", k.x8.v4x512, e.x8.v4x512);
+  rc += check_vint512 ("vec_mul512_byMN 6e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul512_byMN 6f:", k.x8.v2x512, e.x8.v2x512);
+  rc += check_vint512 ("vec_mul512_byMN 6g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul512_byMN 6h:", k.x8.v0x512, e.x8.v0x512);
+
+  __VEC_PWR_IMP (vec_mul512_byMN)(kp, ip, jp, 4, 4);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[3]   ", m2.x4.v3x512);
+  print_vint512x (" m1[2]   ", m2.x4.v2x512);
+  print_vint512x (" m1[1]   ", m2.x4.v1x512);
+  print_vint512x (" m1[0] * ", m2.x4.v0x512);
+  print_vint512x (" m2[3]   ", m1.x4.v3x512);
+  print_vint512x (" m2[2]   ", m1.x4.v2x512);
+  print_vint512x (" m2[1]   ", m1.x4.v1x512);
+  print_vint512x (" m2[0] = ", m1.x4.v0x512);
+  print_vint512x (" k [7]   ", k.x8.v7x512);
+  print_vint512x (" k [6]   ", k.x8.v6x512);
+  print_vint512x (" k [5]   ", k.x8.v5x512);
+  print_vint512x (" k [4]   ", k.x8.v4x512);
+  print_vint512x (" k [3]   ", k.x8.v3x512);
+  print_vint512x (" k [2]   ", k.x8.v2x512);
+  print_vint512x (" k [1]   ", k.x8.v1x512);
+  print_vint512x (" k [0]   ", k.x8.v0x512);
+#endif
+  rc += check_vint512 ("vec_mul512_byMN 7a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul512_byMN 7b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul512_byMN 7c:", k.x8.v5x512, e.x8.v5x512);
+  rc += check_vint512 ("vec_mul512_byMN 7d:", k.x8.v4x512, e.x8.v4x512);
+  rc += check_vint512 ("vec_mul512_byMN 7e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul512_byMN 7f:", k.x8.v2x512, e.x8.v2x512);
+  rc += check_vint512 ("vec_mul512_byMN 7g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul512_byMN 7h:", k.x8.v0x512, e.x8.v0x512);
+
+  m1.x4.v3x512 = vec512_foxes;
+  m1.x4.v2x512 = vec512_foxes;
+  m1.x4.v1x512 = vec512_foxes;
+  m1.x4.v0x512 = vec512_foxes;
+  m2.x4.v3x512 = vec512_foxes;
+  m2.x4.v2x512 = vec512_foxes;
+  m2.x4.v1x512 = vec512_foxes;
+  m2.x4.v0x512 = vec512_foxes;
+  __VEC_PWR_IMP (vec_mul512_byMN)(kp, ip, jp, 4, 4);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[3]   ", m1.x4.v3x512);
+  print_vint512x (" m1[2]   ", m1.x4.v2x512);
+  print_vint512x (" m1[1]   ", m1.x4.v1x512);
+  print_vint512x (" m1[0] * ", m1.x4.v0x512);
+  print_vint512x (" m2[3]   ", m2.x4.v3x512);
+  print_vint512x (" m2[2]   ", m2.x4.v2x512);
+  print_vint512x (" m2[1]   ", m2.x4.v1x512);
+  print_vint512x (" m2[0] = ", m2.x4.v0x512);
+  print_vint512x (" k [7]   ", k.x8.v7x512);
+  print_vint512x (" k [6]   ", k.x8.v6x512);
+  print_vint512x (" k [5]   ", k.x8.v5x512);
+  print_vint512x (" k [4]   ", k.x8.v4x512);
+  print_vint512x (" k [3]   ", k.x8.v3x512);
+  print_vint512x (" k [2]   ", k.x8.v2x512);
+  print_vint512x (" k [1]   ", k.x8.v1x512);
+  print_vint512x (" k [0]   ", k.x8.v0x512);
+#endif
+  e.x8.v0x512 = vec512_one;
+  e.x8.v1x512 = vec512_zeros;
+  e.x8.v2x512 = vec512_zeros;
+  e.x8.v3x512 = vec512_zeros;
+  e.x8.v4x512 = vec512_foxeasy;
+  e.x8.v5x512 = vec512_foxes;
+  e.x8.v6x512 = vec512_foxes;
+  e.x8.v7x512 = vec512_foxes;
+  rc += check_vint512 ("vec_mul512_byMN 8a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul512_byMN 8b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul512_byMN 8c:", k.x8.v5x512, e.x8.v5x512);
+  rc += check_vint512 ("vec_mul512_byMN 8d:", k.x8.v4x512, e.x8.v4x512);
+  rc += check_vint512 ("vec_mul512_byMN 8e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul512_byMN 8f:", k.x8.v2x512, e.x8.v2x512);
+  rc += check_vint512 ("vec_mul512_byMN 8g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul512_byMN 8h:", k.x8.v0x512, e.x8.v0x512);
+
+  m1.x4.v3x512 = vec512_zeros;
+  m1.x4.v2x512 = vec512_zeros;
+  m1.x4.v1x512 = vec512_foxes;
+  m1.x4.v0x512 = vec512_foxes;
+  m2.x4.v3x512 = vec512_zeros;
+  m2.x4.v2x512 = vec512_zeros;
+  m2.x4.v1x512 = vec512_foxes;
+  m2.x4.v0x512 = vec512_foxes;
+  __VEC_PWR_IMP (vec_mul512_byMN)(kp, ip, jp, 4, 4);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[3]   ", m1.x4.v3x512);
+  print_vint512x (" m1[2]   ", m1.x4.v2x512);
+  print_vint512x (" m1[1]   ", m1.x4.v1x512);
+  print_vint512x (" m1[0] * ", m1.x4.v0x512);
+  print_vint512x (" m2[3]   ", m2.x4.v3x512);
+  print_vint512x (" m2[2]   ", m2.x4.v2x512);
+  print_vint512x (" m2[1]   ", m2.x4.v1x512);
+  print_vint512x (" m2[0] = ", m2.x4.v0x512);
+  print_vint512x (" k [7]   ", k.x8.v7x512);
+  print_vint512x (" k [6]   ", k.x8.v6x512);
+  print_vint512x (" k [5]   ", k.x8.v5x512);
+  print_vint512x (" k [4]   ", k.x8.v4x512);
+  print_vint512x (" k [3]   ", k.x8.v3x512);
+  print_vint512x (" k [2]   ", k.x8.v2x512);
+  print_vint512x (" k [1]   ", k.x8.v1x512);
+  print_vint512x (" k [0]   ", k.x8.v0x512);
+#endif
+  e.x8.v0x512 = vec512_one;
+  e.x8.v1x512 = vec512_zeros;
+  e.x8.v2x512 = vec512_foxeasy;
+  e.x8.v3x512 = vec512_foxes;
+  e.x8.v4x512 = vec512_zeros;
+  e.x8.v5x512 = vec512_zeros;
+  e.x8.v6x512 = vec512_zeros;
+  e.x8.v7x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul512_byMN 9a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul512_byMN 9b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul512_byMN 9c:", k.x8.v5x512, e.x8.v5x512);
+  rc += check_vint512 ("vec_mul512_byMN 9d:", k.x8.v4x512, e.x8.v4x512);
+  rc += check_vint512 ("vec_mul512_byMN 9e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul512_byMN 9f:", k.x8.v2x512, e.x8.v2x512);
+  rc += check_vint512 ("vec_mul512_byMN 9g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul512_byMN 9h:", k.x8.v0x512, e.x8.v0x512);
+
+  m1.x4.v3x512 = vec512_foxes;
+  m1.x4.v2x512 = vec512_foxes;
+  m1.x4.v1x512 = vec512_foxes;
+  m1.x4.v0x512 = vec512_foxes;
+  m2.x4.v3x512 = vec512_zeros;
+  m2.x4.v2x512 = vec512_zeros;
+  m2.x4.v1x512 = vec512_zeros;
+  m2.x4.v0x512 = vec512_foxes;
+  __VEC_PWR_IMP (vec_mul512_byMN)(kp, ip, jp, 4, 4);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[3]   ", m1.x4.v3x512);
+  print_vint512x (" m1[2]   ", m1.x4.v2x512);
+  print_vint512x (" m1[1]   ", m1.x4.v1x512);
+  print_vint512x (" m1[0] * ", m1.x4.v0x512);
+  print_vint512x (" m2[3]   ", m2.x4.v3x512);
+  print_vint512x (" m2[2]   ", m2.x4.v2x512);
+  print_vint512x (" m2[1]   ", m2.x4.v1x512);
+  print_vint512x (" m2[0] = ", m2.x4.v0x512);
+  print_vint512x (" k [7]   ", k.x8.v7x512);
+  print_vint512x (" k [6]   ", k.x8.v6x512);
+  print_vint512x (" k [5]   ", k.x8.v5x512);
+  print_vint512x (" k [4]   ", k.x8.v4x512);
+  print_vint512x (" k [3]   ", k.x8.v3x512);
+  print_vint512x (" k [2]   ", k.x8.v2x512);
+  print_vint512x (" k [1]   ", k.x8.v1x512);
+  print_vint512x (" k [0]   ", k.x8.v0x512);
+#endif
+  e.x8.v0x512 = vec512_one;
+  e.x8.v1x512 = vec512_foxes;
+  e.x8.v2x512 = vec512_foxes;
+  e.x8.v3x512 = vec512_foxes;
+  e.x8.v4x512 = vec512_foxeasy;
+  e.x8.v5x512 = vec512_zeros;
+  e.x8.v6x512 = vec512_zeros;
+  e.x8.v7x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul512_byMN 10a:", k.x8.v7x512, e.x8.v7x512);
+  rc += check_vint512 ("vec_mul512_byMN 10b:", k.x8.v6x512, e.x8.v6x512);
+  rc += check_vint512 ("vec_mul512_byMN 10c:", k.x8.v5x512, e.x8.v5x512);
+  rc += check_vint512 ("vec_mul512_byMN 10d:", k.x8.v4x512, e.x8.v4x512);
+  rc += check_vint512 ("vec_mul512_byMN 10e:", k.x8.v3x512, e.x8.v3x512);
+  rc += check_vint512 ("vec_mul512_byMN 10f:", k.x8.v2x512, e.x8.v2x512);
+  rc += check_vint512 ("vec_mul512_byMN 10g:", k.x8.v1x512, e.x8.v1x512);
+  rc += check_vint512 ("vec_mul512_byMN 10h:", k.x8.v0x512, e.x8.v0x512);
+
+  m1.x4.v3x512 = vec512_zeros;
+  m1.x4.v2x512 = vec512_zeros;
+  m1.x4.v1x512 = vec512_zeros;
+  m1.x4.v0x512 = vec512_ten128th;
+  m2.x4.v3x512 = vec512_zeros;
+  m2.x4.v2x512 = vec512_zeros;
+  m2.x4.v1x512 = vec512_zeros;
+  m2.x4.v0x512 = vec512_ten128th;
+  __VEC_PWR_IMP (vec_mul512_byMN)(kp, ip, jp, 4, 4);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[3]   ", m1.x4.v3x512);
+  print_vint512x (" m1[2]   ", m1.x4.v2x512);
+  print_vint512x (" m1[1]   ", m1.x4.v1x512);
+  print_vint512x (" m1[0] * ", m1.x4.v0x512);
+  print_vint512x (" m2[3]   ", m2.x4.v3x512);
+  print_vint512x (" m2[2]   ", m2.x4.v2x512);
+  print_vint512x (" m2[1]   ", m2.x4.v1x512);
+  print_vint512x (" m2[0] = ", m2.x4.v0x512);
+  print_vint512x (" k [7]   ", k.x8.v7x512);
+  print_vint512x (" k [6]   ", k.x8.v6x512);
+  print_vint512x (" k [5]   ", k.x8.v5x512);
+  print_vint512x (" k [4]   ", k.x8.v4x512);
+  print_vint512x (" k [3]   ", k.x8.v3x512);
+  print_vint512x (" k [2]   ", k.x8.v2x512);
+  print_vint512x (" k [1]   ", k.x8.v1x512);
+  print_vint512x (" k [0]   ", k.x8.v0x512);
+#endif
+  e.x8.v0x512 = vec512_ten256_l;
+  e.x8.v1x512 = vec512_ten256_h;
+  e.x8.v2x512 = vec512_zeros;
+  e.x8.v3x512 = vec512_zeros;
+  e.x8.v4x512 = vec512_zeros;
+  e.x8.v5x512 = vec512_zeros;
+  e.x8.v6x512 = vec512_zeros;
+  e.x8.v7x512 = vec512_zeros;
+  rc += check_vint512 ("vec_mul512_byMN 11a:", k.x8.v7x512, vec512_zeros);
+  rc += check_vint512 ("vec_mul512_byMN 11b:", k.x8.v6x512, vec512_zeros);
+  rc += check_vint512 ("vec_mul512_byMN 11c:", k.x8.v5x512, vec512_zeros);
+  rc += check_vint512 ("vec_mul512_byMN 11d:", k.x8.v4x512, vec512_zeros);
+  rc += check_vint512 ("vec_mul512_byMN 11e:", k.x8.v3x512, vec512_zeros);
+  rc += check_vint512 ("vec_mul512_byMN 11f:", k.x8.v2x512, vec512_zeros);
+  rc += check_vint512 ("vec_mul512_byMN 11g:", k.x8.v1x512, vec512_ten256_h);
+  rc += check_vint512 ("vec_mul512_byMN 11h:", k.x8.v0x512, vec512_ten256_l);
+
+  m1.x4.v3x512 = vec512_zeros;
+  m1.x4.v2x512 = vec512_zeros;
+  m1.x4.v1x512 = e.x8.v1x512;
+  m1.x4.v0x512 = e.x8.v0x512;
+  m2.x4.v3x512 = vec512_zeros;
+  m2.x4.v2x512 = vec512_zeros;
+  m2.x4.v1x512 = e.x8.v1x512;
+  m2.x4.v0x512 = e.x8.v0x512;
+  __VEC_PWR_IMP (vec_mul512_byMN)(kp, ip, jp, 4, 4);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[3]   ", m1.x4.v3x512);
+  print_vint512x (" m1[2]   ", m1.x4.v2x512);
+  print_vint512x (" m1[1]   ", m1.x4.v1x512);
+  print_vint512x (" m1[0] * ", m1.x4.v0x512);
+  print_vint512x (" m2[3]   ", m2.x4.v3x512);
+  print_vint512x (" m2[2]   ", m2.x4.v2x512);
+  print_vint512x (" m2[1]   ", m2.x4.v1x512);
+  print_vint512x (" m2[0] = ", m2.x4.v0x512);
+  print_vint512x (" k [7]   ", k.x8.v7x512);
+  print_vint512x (" k [6]   ", k.x8.v6x512);
+  print_vint512x (" k [5]   ", k.x8.v5x512);
+  print_vint512x (" k [4]   ", k.x8.v4x512);
+  print_vint512x (" k [3]   ", k.x8.v3x512);
+  print_vint512x (" k [2]   ", k.x8.v2x512);
+  print_vint512x (" k [1]   ", k.x8.v1x512);
+  print_vint512x (" k [0]   ", k.x8.v0x512);
+#endif
+  rc += check_vint512 ("vec_mul512_byMN 12a:", k.x8.v7x512, vec512_zeros);
+  rc += check_vint512 ("vec_mul512_byMN 12b:", k.x8.v6x512, vec512_zeros);
+  rc += check_vint512 ("vec_mul512_byMN 12c:", k.x8.v5x512, vec512_zeros);
+  rc += check_vint512 ("vec_mul512_byMN 12d:", k.x8.v4x512, vec512_zeros);
+  rc += check_vint512 ("vec_mul512_byMN 12e:", k.x8.v3x512, vec512_ten512_3);
+  rc += check_vint512 ("vec_mul512_byMN 12f:", k.x8.v2x512, vec512_ten512_2);
+  rc += check_vint512 ("vec_mul512_byMN 12g:", k.x8.v1x512, vec512_ten512_1);
+  rc += check_vint512 ("vec_mul512_byMN 12h:", k.x8.v0x512, vec512_zeros);
+
+  m1.x4.v3x512 = vec512_ten512_3;
+  m1.x4.v2x512 = vec512_ten512_2;
+  m1.x4.v1x512 = vec512_ten512_1;
+  m1.x4.v0x512 = vec512_zeros;
+  m2.x4.v3x512 = vec512_ten512_3;
+  m2.x4.v2x512 = vec512_ten512_2;
+  m2.x4.v1x512 = vec512_ten512_1;
+  m2.x4.v0x512 = vec512_zeros;
+  __VEC_PWR_IMP (vec_mul512_byMN)(kp, ip, jp, 4, 4);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" m1[3]   ", m1.x4.v3x512);
+  print_vint512x (" m1[2]   ", m1.x4.v2x512);
+  print_vint512x (" m1[1]   ", m1.x4.v1x512);
+  print_vint512x (" m1[0] * ", m1.x4.v0x512);
+  print_vint512x (" m2[3]   ", m2.x4.v3x512);
+  print_vint512x (" m2[2]   ", m2.x4.v2x512);
+  print_vint512x (" m2[1]   ", m2.x4.v1x512);
+  print_vint512x (" m2[0] = ", m2.x4.v0x512);
+  print_vint512x (" k [7]   ", k.x8.v7x512);
+  print_vint512x (" k [6]   ", k.x8.v6x512);
+  print_vint512x (" k [5]   ", k.x8.v5x512);
+  print_vint512x (" k [4]   ", k.x8.v4x512);
+  print_vint512x (" k [3]   ", k.x8.v3x512);
+  print_vint512x (" k [2]   ", k.x8.v2x512);
+  print_vint512x (" k [1]   ", k.x8.v1x512);
+  print_vint512x (" k [0]   ", k.x8.v0x512);
+#endif
+  rc += check_vint512 ("vec_mul512_byMN 13a:", k.x8.v7x512, vec512_zeros);
+  rc += check_vint512 ("vec_mul512_byMN 13b:", k.x8.v6x512, vec512_ten1024_6);
+  rc += check_vint512 ("vec_mul512_byMN 13c:", k.x8.v5x512, vec512_ten1024_5);
+  rc += check_vint512 ("vec_mul512_byMN 13d:", k.x8.v4x512, vec512_ten1024_4);
+  rc += check_vint512 ("vec_mul512_byMN 13e:", k.x8.v3x512, vec512_ten1024_3);
+  rc += check_vint512 ("vec_mul512_byMN 13f:", k.x8.v2x512, vec512_ten1024_2);
+  rc += check_vint512 ("vec_mul512_byMN 13g:", k.x8.v1x512, vec512_zeros);
+  rc += check_vint512 ("vec_mul512_byMN 13h:", k.x8.v0x512, vec512_zeros);
+
+
+  __VEC_PWR_IMP (vec_mul512_byMN)(k1, kp, kp, 8, 8);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x (" k [7]^2 ", k.x8.v7x512);
+  print_vint512x (" k [6]   ", k.x8.v6x512);
+  print_vint512x (" k [5]   ", k.x8.v5x512);
+  print_vint512x (" k [4]   ", k.x8.v4x512);
+  print_vint512x (" k [3]   ", k.x8.v3x512);
+  print_vint512x (" k [2]   ", k.x8.v2x512);
+  print_vint512x (" k [1]   ", k.x8.v1x512);
+  print_vint512x (" k [0] = ", k.x8.v0x512);
+  print_vint512x (" k1 [15] ", k1[15]);
+  print_vint512x (" k1 [14] ", k1[14]);
+  print_vint512x (" k1 [13] ", k1[13]);
+  print_vint512x (" k1 [12] ", k1[12]);
+  print_vint512x (" k1 [11] ", k1[11]);
+  print_vint512x (" k1 [10] ", k1[10]);
+  print_vint512x (" k1 [9]  ", k1[9]);
+  print_vint512x (" k1 [8]  ", k1[8]);
+  print_vint512x (" k1 [7]  ", k1[7]);
+  print_vint512x (" k1 [6]  ", k1[6]);
+  print_vint512x (" k1 [5]  ", k1[5]);
+  print_vint512x (" k1 [4]  ", k1[4]);
+  print_vint512x (" k1 [3]  ", k1[3]);
+  print_vint512x (" k1 [2]  ", k1[2]);
+  print_vint512x (" k1 [1]  ", k1[1]);
+  print_vint512x (" k1 [0]  ", k1[0]);
+#endif
+
+  rc += check_vint512 ("vec_mulx4096_MN 14a:", k1[__NDX16(15)], vec512_zeros);
+  rc += check_vint512 ("vec_mulx4096_MN 14b:", k1[__NDX16(14)], vec512_zeros);
+  rc += check_vint512 ("vec_mulx4096_MN 14c:", k1[__NDX16(13)], vec512_ten2048_13);
+  rc += check_vint512 ("vec_mulx4096_MN 14d:", k1[__NDX16(12)], vec512_ten2048_12);
+  rc += check_vint512 ("vec_mulx4096_MN 14e:", k1[__NDX16(11)], vec512_ten2048_11);
+  rc += check_vint512 ("vec_mulx4096_MN 14f:", k1[__NDX16(10)], vec512_ten2048_10);
+  rc += check_vint512 ("vec_mulx4096_MN 14g:", k1[__NDX16(9)], vec512_ten2048_9);
+  rc += check_vint512 ("vec_mulx4096_MN 14h:", k1[__NDX16(8)], vec512_ten2048_8);
+  rc += check_vint512 ("vec_mulx4096_MN 14i:", k1[__NDX16(7)], vec512_ten2048_7);
+  rc += check_vint512 ("vec_mulx4096_MN 14j:", k1[__NDX16(6)], vec512_ten2048_6);
+  rc += check_vint512 ("vec_mulx4096_MN 14k:", k1[__NDX16(5)], vec512_ten2048_5);
+  rc += check_vint512 ("vec_mulx4096_MN 14l:", k1[__NDX16(4)], vec512_ten2048_4);
+  rc += check_vint512 ("vec_mulx4096_MN 14m:", k1[__NDX16(3)], vec512_ten2048_3);
+  rc += check_vint512 ("vec_mulx4096_MN 14n:", k1[__NDX16(2)], vec512_ten2048_2);
+  rc += check_vint512 ("vec_mulx4096_MN 14o:", k1[__NDX16(1)], vec512_zeros);
+  rc += check_vint512 ("vec_mulx4096_MN 14p:", k1[__NDX16(0)], vec512_zeros);
 
   return (rc);
 }
@@ -1626,6 +2879,10 @@ test_vec_i512 (void)
   rc += test_mul512x512 ();
   rc += test_mul1024x1024 ();
   rc += test_mul2048x2048 ();
+  rc += test_madd512x128 ();
+  rc += test_mul512x128_MN ();
+  rc += test_mul512x512_MN ();
+  rc += test_mul2048x2048_MN ();
 #endif
 #if 1
   rc += test_time_i512();

--- a/src/testsuite/arith128_test_i512.h
+++ b/src/testsuite/arith128_test_i512.h
@@ -51,10 +51,26 @@ extern const __VEC_U_512 vec512_ten1024_2;
 extern const __VEC_U_512 vec512_ten1024_1;
 extern const __VEC_U_512 vec512_ten1024_0;
 
+extern const __VEC_U_512 vec512_ten2048_13;
+extern const __VEC_U_512 vec512_ten2048_12;
+extern const __VEC_U_512 vec512_ten2048_11;
+extern const __VEC_U_512 vec512_ten2048_10;
+extern const __VEC_U_512 vec512_ten2048_9;
+extern const __VEC_U_512 vec512_ten2048_8;
+extern const __VEC_U_512 vec512_ten2048_7;
+extern const __VEC_U_512 vec512_ten2048_6;
+extern const __VEC_U_512 vec512_ten2048_5;
+extern const __VEC_U_512 vec512_ten2048_4;
+extern const __VEC_U_512 vec512_ten2048_3;
+extern const __VEC_U_512 vec512_ten2048_2;
+extern const __VEC_U_512 vec512_ten2048_1;
+extern const __VEC_U_512 vec512_ten2048_0;
+
 extern int test_mul128x128 (void);
 extern int test_mul256x256 (void);
 extern int test_mul512x128 (void);
 extern int test_mul512x512 (void);
+extern int test_mul1024x1024 (void);
 extern int test_mul2048x2048 (void);
 
 extern int test_vec_i512 (void);

--- a/src/testsuite/vec_perf_i512.c
+++ b/src/testsuite/vec_perf_i512.c
@@ -37,6 +37,272 @@
 #include <testsuite/arith128_test_i512.h>
 #include <testsuite/vec_perf_i512.h>
 
+/* 10^64th as a binary const requiring 256-bits.  */
+static const vui128_t c_zero =  (vui128_t) ((unsigned __int128) 0);
+static const vui128_t c_one =  (vui128_t) ((unsigned __int128) 1);
+static const vui128_t c_ten =  (vui128_t) ((unsigned __int128) 10);
+static const vui128_t c_hundred =  (vui128_t) ((unsigned __int128) 100);
+static const vui128_t c_10k =  (vui128_t) ((unsigned __int128) 10000);
+static const vui128_t c_100m =  (vui128_t) ((unsigned __int128) 100000000);
+static const vui32_t ten_64h =
+    CONST_VINT32_W(0x00000000, 0x00184f03, 0xe93ff9f4, 0xdaa797ed);
+static const vui32_t ten_64l =
+    CONST_VINT32_W(0x6e38ed64, 0xbf6a1f01, 0x00000000, 0x00000000);
+
+//#define __DEBUG_PRINT__ 1
+int
+timed_mul1024x1024by8 (void)
+{
+  __VEC_U_2048x512 k1, k2;
+  __VEC_U_1024x512 m1, m2;
+  int rc = 0;
+
+#ifdef __DEBUG_PRINT__
+  printf ("\ntest_mul1024x1024 vector multiply quadword, 2048-bit product\n");
+#endif
+
+  m1.x2.v1x512 = vec512_zeros;
+  m1.x2.v0x512.vx3 = c_zero;
+  m1.x2.v0x512.vx2 = c_zero;
+  m1.x2.v0x512.vx1 = c_zero;
+  m1.x2.v0x512.vx0 = c_hundred;
+  // 10^4 <-
+  __VEC_PWR_IMP (vec_mul1024x1024)(&k1.x2048, &m1.x1024, &m1.x1024);
+  // 10^8 <-
+  __VEC_PWR_IMP (vec_mul1024x1024)(&k2.x2048, &k1.x2.v0x1024, &k1.x2.v0x1024);
+  // 10^16 <-
+  __VEC_PWR_IMP (vec_mul1024x1024)(&k1.x2048, &k2.x2.v0x1024, &k2.x2.v0x1024);
+  // 10^32 <-
+  __VEC_PWR_IMP (vec_mul1024x1024)(&k2.x2048, &k1.x2.v0x1024, &k1.x2.v0x1024);
+  // 10^64 <-
+  __VEC_PWR_IMP (vec_mul1024x1024)(&k1.x2048, &k2.x2.v0x1024, &k2.x2.v0x1024);
+  // 10^128 <-
+  __VEC_PWR_IMP (vec_mul1024x1024)(&k2.x2048, &k1.x2.v0x1024, &k1.x2.v0x1024);
+  // 10^256 <-
+  __VEC_PWR_IMP (vec_mul1024x1024)(&k1.x2048, &k2.x2.v0x1024, &k2.x2.v0x1024);
+  // 10^512 <-
+  __VEC_PWR_IMP (vec_mul1024x1024)(&k2.x2048, &k1.x2.v0x1024, &k1.x2.v0x1024);
+
+  rc += check_vint512 ("vec_mul1024x1024 10a:", k2.x4.v3x512, vec512_ten512_3);
+  rc += check_vint512 ("vec_mul1024x1024 10b:", k2.x4.v2x512, vec512_ten512_2);
+  rc += check_vint512 ("vec_mul1024x1024 10c:", k2.x4.v1x512, vec512_ten512_1);
+  rc += check_vint512 ("vec_mul1024x1024 10d:", k2.x4.v0x512, vec512_ten512_0);
+
+  return (rc);
+}
+
+//#define __DEBUG_PRINT__ 1
+int
+timed_mul2048x2048by8 (void)
+{
+  __VEC_U_4096x512 k1, k2;
+  __VEC_U_2048x512 m1, m2;
+  __VEC_U_512 i, j;
+
+  int rc = 0;
+
+#ifdef __DEBUG_PRINT__
+  printf ("\ntimed_mul2048x2048 vector multiply quadword, 4096-bit product\n");
+#endif
+  m1.x4.v3x512 = vec512_zeros;
+  m1.x4.v2x512 = vec512_zeros;
+  m1.x4.v1x512 = vec512_zeros;
+  m1.x4.v0x512.vx3 = c_zero;
+  m1.x4.v0x512.vx2 = c_zero;
+  m1.x4.v0x512.vx1 = c_zero;
+  m1.x4.v0x512.vx0 = c_10k;
+  // 10^8 <-
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k1.x4096, &m1.x2048, &m1.x2048);
+  // 10^16 <-
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k2.x4096, &k1.x2.v0x2048, &k1.x2.v0x2048);
+  // 10^32 <-
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k1.x4096, &k2.x2.v0x2048, &k2.x2.v0x2048);
+  // 10^64 <-
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k2.x4096, &k1.x2.v0x2048, &k1.x2.v0x2048);
+  // 10^128 <-
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k1.x4096, &k2.x2.v0x2048, &k2.x2.v0x2048);
+  // 10^256 <-
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k2.x4096, &k1.x2.v0x2048, &k1.x2.v0x2048);
+  // 10^512 <-
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k1.x4096, &k2.x2.v0x2048, &k2.x2.v0x2048);
+  // 10^1024 <-
+  __VEC_PWR_IMP (vec_mul2048x2048)(&k2.x4096, &k1.x2.v0x2048, &k1.x2.v0x2048);
+
+#ifdef __DEBUG_PRINT__
+  rc += check_vint512 ("vec_mul2048x2048 10a:", k2.x8.v7x512, vec512_ten1024_0);
+#endif
+  rc += check_vint512 ("vec_mul2048x2048 10b:", k2.x8.v6x512, vec512_ten1024_6);
+  rc += check_vint512 ("vec_mul2048x2048 10c:", k2.x8.v5x512, vec512_ten1024_5);
+  rc += check_vint512 ("vec_mul2048x2048 10d:", k2.x8.v4x512, vec512_ten1024_4);
+  rc += check_vint512 ("vec_mul2048x2048 10e:", k2.x8.v3x512, vec512_ten1024_3);
+  rc += check_vint512 ("vec_mul2048x2048 10f:", k2.x8.v2x512, vec512_ten1024_2);
+#ifdef __DEBUG_PRINT__
+  rc += check_vint512 ("vec_mul2048x2048 10g:", k2.x8.v1x512, vec512_ten1024_1);
+  rc += check_vint512 ("vec_mul2048x2048 10h:", k2.x8.v0x512, vec512_ten1024_0);
+#endif
+
+  return (rc);
+}
+
+//#define __DEBUG_PRINT__ 1
+int
+timed_mul2048x2048_MN (void)
+{
+  __VEC_U_4096x512 k1, k2;
+  __VEC_U_2048x512 m1, m2;
+  __VEC_U_512 i, j;
+  __VEC_U_512 *kp1, *kp2, *ip, *jp1, *jp2;
+
+  int rc = 0;
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  kp1 = &k1.x8.v0x512;
+  kp2 = &k2.x8.v0x512;
+  ip = &m1.x4.v0x512;
+  // Low order 1024-bits of k1/k2
+  jp1 = &k1.x8.v0x512;
+  jp2 = &k2.x8.v0x512;
+
+#else
+  kp1 = &k1.x8.v7x512;
+  kp2 = &k2.x8.v7x512;
+  ip = &m1.x4.v3x512;
+  // Low order 1024-bits of k1/k2
+  jp1 = &k1.x8.v3x512;
+  jp2 = &k2.x8.v3x512;
+#endif
+
+#ifdef __DEBUG_PRINT__
+  printf ("\ntimed_mulx2048_MN vector multiply quadword, 4096-bit product\n");
+#endif
+  m1.x4.v3x512 = vec512_zeros;
+  m1.x4.v2x512 = vec512_zeros;
+  m1.x4.v1x512 = vec512_zeros;
+  m1.x4.v0x512.vx3 = c_zero;
+  m1.x4.v0x512.vx2 = c_zero;
+  m1.x4.v0x512.vx1 = c_zero;
+  m1.x4.v0x512.vx0 = c_10k;
+  // 10^8 <-
+  __VEC_PWR_IMP (vec_mul512_byMN)(kp1, ip, ip, 4, 4);
+  // 10^16 <-
+  __VEC_PWR_IMP (vec_mul512_byMN)(kp2, jp1, jp1, 4, 4);
+  // 10^32 <-
+  __VEC_PWR_IMP (vec_mul512_byMN)(kp1, jp2, jp2, 4, 4);
+  // 10^64 <-
+  __VEC_PWR_IMP (vec_mul512_byMN)(kp2, jp1, jp1, 4, 4);
+  // 10^128 <-
+  __VEC_PWR_IMP (vec_mul512_byMN)(kp1, jp2, jp2, 4, 4);
+  // 10^256 <-
+  __VEC_PWR_IMP (vec_mul512_byMN)(kp2, jp1, jp1, 4, 4);
+  // 10^512 <-
+  __VEC_PWR_IMP (vec_mul512_byMN)(kp1, jp2, jp2, 4, 4);
+  // 10^1024 <-
+  __VEC_PWR_IMP (vec_mul512_byMN)(kp2, jp1, jp1, 4, 4);
+
+#ifdef __DEBUG_PRINT__
+  rc += check_vint512 ("vec_mulx2048_MN 10a:", k2.x8.v7x512, vec512_ten1024_0);
+#endif
+  rc += check_vint512 ("vec_mulx2048_MN 10b:", k2.x8.v6x512, vec512_ten1024_6);
+  rc += check_vint512 ("vec_mulx2048_MN 10c:", k2.x8.v5x512, vec512_ten1024_5);
+  rc += check_vint512 ("vec_mulx2048_MN 10d:", k2.x8.v4x512, vec512_ten1024_4);
+  rc += check_vint512 ("vec_mulx2048_MN 10e:", k2.x8.v3x512, vec512_ten1024_3);
+  rc += check_vint512 ("vec_mulx2048_MN 10f:", k2.x8.v2x512, vec512_ten1024_2);
+#ifdef __DEBUG_PRINT__
+  rc += check_vint512 ("vec_mulx2048_MN 10g:", k2.x8.v1x512, vec512_ten1024_1);
+  rc += check_vint512 ("vec_mulx2048_MN 10h:", k2.x8.v0x512, vec512_ten1024_0);
+#endif
+
+  return (rc);
+}
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define __NDX16(__index) (__index)
+#else
+#define __NDX16(__index) ((16 - 1) - (__index))
+#endif
+//#define __DEBUG_PRINT__ 1
+int
+timed_mul4096x4096_MN (void)
+{
+  __VEC_U_512 k1[16], k2[16];
+  __VEC_U_4096x512 m1, m2;
+  __VEC_U_512 i, j;
+  __VEC_U_512 *kp1, *kp2, *ip, *jp1, *jp2;
+
+  int rc = 0;
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  kp1 = &k1[0];
+  kp2 = &k2[0];
+  ip = &m1.x8.v0x512;
+  // Low order 2048-bits of k1/k2
+  jp1 = &k1[0];
+  jp2 = &k2[0];
+
+#else
+  kp1 = &k1[0];
+  kp2 = &k2[0];
+  ip = &m1.x8.v7x512;
+  // Low order 2048-bits of k1/k2
+  jp1 = &k1[8];
+  jp2 = &k2[8];
+#endif
+
+#ifdef __DEBUG_PRINT__
+  printf ("\ntimed_mulx4096_MN vector multiply quadword, 8192-bit product\n");
+#endif
+  m1.x8.v7x512 = vec512_zeros;
+  m1.x8.v6x512 = vec512_zeros;
+  m1.x8.v5x512 = vec512_zeros;
+  m1.x8.v4x512 = vec512_zeros;
+  m1.x8.v3x512 = vec512_zeros;
+  m1.x8.v2x512 = vec512_zeros;
+  m1.x8.v1x512 = vec512_zeros;
+  m1.x8.v0x512.vx3 = c_zero;
+  m1.x8.v0x512.vx2 = c_zero;
+  m1.x8.v0x512.vx1 = c_zero;
+  m1.x8.v0x512.vx0 = c_100m;
+  // 10^8 <-
+  __VEC_PWR_IMP (vec_mul512_byMN)(kp1, ip, ip, 8, 8);
+  // 10^16 <-
+  __VEC_PWR_IMP (vec_mul512_byMN)(kp2, jp1, jp1, 8, 8);
+  // 10^32 <-
+  __VEC_PWR_IMP (vec_mul512_byMN)(kp1, jp2, jp2, 8, 8);
+  // 10^64 <-
+  __VEC_PWR_IMP (vec_mul512_byMN)(kp2, jp1, jp1, 8, 8);
+  // 10^128 <-
+  __VEC_PWR_IMP (vec_mul512_byMN)(kp1, jp2, jp2, 8, 8);
+  // 10^256 <-
+  __VEC_PWR_IMP (vec_mul512_byMN)(kp2, jp1, jp1, 8, 8);
+  // 10^512 <-
+  __VEC_PWR_IMP (vec_mul512_byMN)(kp1, jp2, jp2, 8, 8);
+  // 10^1024 <-
+  __VEC_PWR_IMP (vec_mul512_byMN)(kp2, jp1, jp1, 8, 8);
+
+#ifdef __DEBUG_PRINT__
+  rc += check_vint512 ("vec_mulx4096_MN 14a:", kp2[__NDX16(15)], vec512_zeros);
+  rc += check_vint512 ("vec_mulx4096_MN 14b:", kp2[__NDX16(14)], vec512_zeros);
+#endif
+  rc += check_vint512 ("vec_mulx4096_MN 14c:", kp2[__NDX16(13)], vec512_ten2048_13);
+  rc += check_vint512 ("vec_mulx4096_MN 14d:", kp2[__NDX16(12)], vec512_ten2048_12);
+  rc += check_vint512 ("vec_mulx4096_MN 14e:", kp2[__NDX16(11)], vec512_ten2048_11);
+  rc += check_vint512 ("vec_mulx4096_MN 14f:", kp2[__NDX16(10)], vec512_ten2048_10);
+  rc += check_vint512 ("vec_mulx4096_MN 14g:", kp2[__NDX16(9)], vec512_ten2048_9);
+  rc += check_vint512 ("vec_mulx4096_MN 14h:", kp2[__NDX16(8)], vec512_ten2048_8);
+  rc += check_vint512 ("vec_mulx4096_MN 14i:", kp2[__NDX16(7)], vec512_ten2048_7);
+  rc += check_vint512 ("vec_mulx4096_MN 14j:", kp2[__NDX16(6)], vec512_ten2048_6);
+  rc += check_vint512 ("vec_mulx4096_MN 14k:", kp2[__NDX16(5)], vec512_ten2048_5);
+  rc += check_vint512 ("vec_mulx4096_MN 14l:", kp2[__NDX16(4)], vec512_ten2048_4);
+  rc += check_vint512 ("vec_mulx4096_MN 14m:", kp2[__NDX16(3)], vec512_ten2048_3);
+  rc += check_vint512 ("vec_mulx4096_MN 14n:", kp2[__NDX16(2)], vec512_ten2048_2);
+#ifdef __DEBUG_PRINT__
+  rc += check_vint512 ("vec_mulx4096_MN 14o:", kp2[__NDX16(1)], vec512_zeros);
+  rc += check_vint512 ("vec_mulx4096_MN 14p:", kp2[__NDX16(0)], vec512_zeros);
+#endif
+
+  return (rc);
+}
+
 //#define __DEBUG_PRINT__ 1
 int
 timed_mul1024x1024 (void)
@@ -619,6 +885,108 @@ timed_mul2048x2048 (void)
 
 
   return (rc);
+}
+
+  /* Older (GCC6) compilers ignore the "no-unroll-loops" pragma and make
+   it hard to isolate each iteration of vec_muludq.  This version
+   calls __test_muludq from vec_int128_dummy.c as a work around.  */
+
+int __attribute__((optimize ("unroll-loops")))
+timed_mul128x128 (void)
+{
+  vui128_t i, j;
+  __VEC_U_256 k, k2;
+  int rc = 0;
+
+  i = (vui128_t) c_ten;
+  j = (vui128_t) c_one;
+  k2 = __VEC_PWR_IMP (vec_mul128x128) (j, j);
+  j = k2.vx0;
+  k  = __VEC_PWR_IMP (vec_mul128x128) (i, j);
+  i = k.vx0;
+  k2 = __VEC_PWR_IMP (vec_mul128x128) (i, i);
+  i = k2.vx0;
+  k  = __VEC_PWR_IMP (vec_mul128x128) (i, i);
+  i = k.vx0;
+  k2 = __VEC_PWR_IMP (vec_mul128x128) (i, i);
+  i = k2.vx0;
+  k  = __VEC_PWR_IMP (vec_mul128x128) (i, i);
+  i = k.vx0;
+  k2  = __VEC_PWR_IMP (vec_mul128x128) (i, i);
+  i = k2.vx0;
+  k  =  __VEC_PWR_IMP (vec_mul128x128) (i, i);
+
+  rc += check_vint256 ("vec_mul128x128 1:", k.vx1, k.vx0, (vui128_t)ten_64h, (vui128_t)ten_64l);
+
+  return rc;
+}
+
+int __attribute__((optimize ("unroll-loops")))
+timed_mul256x256 (void)
+{
+  __VEC_U_256 i, j;
+  __VEC_U_512 k, k2;
+  int rc = 0;
+
+  i.vx0 = (vui128_t) c_ten;
+  i.vx1 = (vui128_t) c_zero;
+  j.vx0 = (vui128_t) c_one;
+  j.vx1 = (vui128_t) c_zero;
+
+  k2 = __VEC_PWR_IMP (vec_mul256x256) (i, j);
+  i.vx0 = k2.vx0;
+  i.vx1 = k2.vx1;
+  k  = __VEC_PWR_IMP (vec_mul256x256) (i, i);
+  i.vx0 = k.vx0;
+  i.vx1 = k.vx1;
+  k2 = __VEC_PWR_IMP (vec_mul256x256) (i, i);
+  i.vx0 = k2.vx0;
+  i.vx1 = k2.vx1;
+  k  = __VEC_PWR_IMP (vec_mul256x256) (i, i);
+  i.vx0 = k.vx0;
+  i.vx1 = k.vx1;
+  k2 = __VEC_PWR_IMP (vec_mul256x256) (i, i);
+  i.vx0 = k2.vx0;
+  i.vx1 = k2.vx1;
+  k  = __VEC_PWR_IMP (vec_mul256x256) (i, i);
+  i.vx0 = k.vx0;
+  i.vx1 = k.vx1;
+  k2  = __VEC_PWR_IMP (vec_mul256x256) (i, i);
+  i.vx0 = k2.vx0;
+  i.vx1 = k2.vx1;
+  k  =  __VEC_PWR_IMP (vec_mul256x256) (i, i);
+
+  rc += check_vint512 ("vec_mul256x256:", k, vec512_ten128th);
+
+  return rc;
+}
+
+int __attribute__((optimize ("unroll-loops")))
+timed_mul512x512by8 (void)
+{
+  __VEC_U_512 i;
+  __VEC_U_1024x512 k, k2;
+  int rc = 0;
+
+//  i.vx0 = (vui128_t) c_hundred;
+  i.vx0 = (vui128_t) c_ten;
+  i.vx1 = (vui128_t) c_zero;
+  i.vx2 = (vui128_t) c_zero;
+  i.vx3 = (vui128_t) c_zero;
+
+  k2.x1024 = __VEC_PWR_IMP (vec_mul512x512) (i, i);
+  k.x1024 = __VEC_PWR_IMP (vec_mul512x512) (k2.x2.v0x512, k2.x2.v0x512);
+  k2.x1024 = __VEC_PWR_IMP (vec_mul512x512) (k.x2.v0x512, k.x2.v0x512);
+  k.x1024 = __VEC_PWR_IMP (vec_mul512x512) (k2.x2.v0x512, k2.x2.v0x512);
+  k2.x1024 = __VEC_PWR_IMP (vec_mul512x512) (k.x2.v0x512, k.x2.v0x512);
+  k.x1024 = __VEC_PWR_IMP (vec_mul512x512) (k2.x2.v0x512, k2.x2.v0x512);
+  k2.x1024 = __VEC_PWR_IMP (vec_mul512x512) (k.x2.v0x512, k.x2.v0x512);
+  k.x1024 = __VEC_PWR_IMP (vec_mul512x512) (k2.x2.v0x512, k2.x2.v0x512);
+
+  rc += check_vint512 ("vec_mul512x512a:", k.x2.v1x512, vec512_ten256_h);
+  rc += check_vint512 ("vec_mul512x512b:", k.x2.v0x512, vec512_ten256_l);
+
+  return rc;
 }
 
 int

--- a/src/testsuite/vec_perf_i512.c
+++ b/src/testsuite/vec_perf_i512.c
@@ -887,11 +887,7 @@ timed_mul2048x2048 (void)
   return (rc);
 }
 
-  /* Older (GCC6) compilers ignore the "no-unroll-loops" pragma and make
-   it hard to isolate each iteration of vec_muludq.  This version
-   calls __test_muludq from vec_int128_dummy.c as a work around.  */
-
-int __attribute__((optimize ("unroll-loops")))
+int
 timed_mul128x128 (void)
 {
   vui128_t i, j;
@@ -921,7 +917,7 @@ timed_mul128x128 (void)
   return rc;
 }
 
-int __attribute__((optimize ("unroll-loops")))
+int
 timed_mul256x256 (void)
 {
   __VEC_U_256 i, j;
@@ -961,7 +957,7 @@ timed_mul256x256 (void)
   return rc;
 }
 
-int __attribute__((optimize ("unroll-loops")))
+int
 timed_mul512x512by8 (void)
 {
   __VEC_U_512 i;

--- a/src/testsuite/vec_perf_i512.h
+++ b/src/testsuite/vec_perf_i512.h
@@ -23,8 +23,15 @@
 #ifndef SRC_TESTSUITE_VEC_PERF_I512_H_
 #define SRC_TESTSUITE_VEC_PERF_I512_H_
 
+extern int timed_mul128x128 (void);
+extern int timed_mul256x256 (void);
 extern int timed_mul512x512 (void);
+extern int timed_mul512x512by8 (void);
 extern int timed_mul1024x1024 (void);
+extern int timed_mul1024x1024by8 (void);
 extern int timed_mul2048x2048 (void);
+extern int timed_mul2048x2048by8 (void);
+extern int timed_mul2048x2048_MN (void);
+extern int timed_mul4096x4096_MN (void);
 
 #endif /* SRC_TESTSUITE_VEC_PERF_I512_H_ */

--- a/src/vec_int512_runtime.c
+++ b/src/vec_int512_runtime.c
@@ -22,6 +22,55 @@
 
 #include <pveclib/vec_int512_ppc.h>
 
+#ifdef __VEC_EXPLICITE_FENCE_NOPS__
+#undef COMPILE_FENCE
+// Generate NOPS inline to make compiler fences visible in obj code.
+#define COMPILE_FENCE __asm ("nop":::)
+#define COMPILE_FENCE1 __asm ("ori 1,1,0":::)
+#define COMPILE_FENCE2 __asm ("ori 2,2,0":::)
+#define COMPILE_FENCE3 __asm ("ori 3,3,0":::)
+#define COMPILE_FENCE10 __asm ("ori 10,10,0":::)
+#define COMPILE_FENCE11 __asm ("ori 11,11,0":::)
+#define COMPILE_FENCE12 __asm ("ori 12,12,0":::)
+#define COMPILE_FENCE13 __asm ("ori 13,13,0":::)
+#define COMPILE_FENCE14 __asm ("ori 14,14,0":::)
+#define COMPILE_FENCE15 __asm ("ori 15,15,0":::)
+#define COMPILE_FENCE16 __asm ("ori 16,16,0":::)
+#define COMPILE_FENCE17 __asm ("ori 17,17,0":::)
+#define COMPILE_FENCE20 __asm ("ori 20,20,0":::)
+#define COMPILE_FENCE21 __asm ("ori 21,21,0":::)
+#define COMPILE_FENCE22 __asm ("ori 22,22,0":::)
+#define COMPILE_FENCE23 __asm ("ori 23,23,0":::)
+#define COMPILE_FENCE24 __asm ("ori 24,24,0":::)
+#define COMPILE_FENCE25 __asm ("ori 25,25,0":::)
+#define COMPILE_FENCE26 __asm ("ori 26,26,0":::)
+#define COMPILE_FENCE27 __asm ("ori 27,27,0":::)
+#define COMPILE_FENCE28 __asm ("ori 28,28,0":::)
+#define COMPILE_FENCE29 __asm ("ori 29,29,0":::)
+#else
+#define COMPILE_FENCE1 COMPILE_FENCE
+#define COMPILE_FENCE2 COMPILE_FENCE
+#define COMPILE_FENCE3 COMPILE_FENCE
+#define COMPILE_FENCE10 COMPILE_FENCE
+#define COMPILE_FENCE11 COMPILE_FENCE
+#define COMPILE_FENCE12 COMPILE_FENCE
+#define COMPILE_FENCE13 COMPILE_FENCE
+#define COMPILE_FENCE14 COMPILE_FENCE
+#define COMPILE_FENCE15 COMPILE_FENCE
+#define COMPILE_FENCE16 COMPILE_FENCE
+#define COMPILE_FENCE17 COMPILE_FENCE
+#define COMPILE_FENCE20 COMPILE_FENCE
+#define COMPILE_FENCE21 COMPILE_FENCE
+#define COMPILE_FENCE22 COMPILE_FENCE
+#define COMPILE_FENCE23 COMPILE_FENCE
+#define COMPILE_FENCE24 COMPILE_FENCE
+#define COMPILE_FENCE25 COMPILE_FENCE
+#define COMPILE_FENCE26 COMPILE_FENCE
+#define COMPILE_FENCE27 COMPILE_FENCE
+#define COMPILE_FENCE28 COMPILE_FENCE
+#define COMPILE_FENCE29 COMPILE_FENCE
+#endif
+
 __VEC_U_256
 __VEC_PWR_IMP (vec_mul128x128) (vui128_t m1l, vui128_t m2l)
 {
@@ -31,19 +80,256 @@ __VEC_PWR_IMP (vec_mul128x128) (vui128_t m1l, vui128_t m2l)
 __VEC_U_512
 __VEC_PWR_IMP (vec_mul256x256) (__VEC_U_256 m1, __VEC_U_256 m2)
 {
+#ifdef _ARCH_PWR9
+  __VEC_U_512 result;
+  vui128_t mc, mp, mq, mqhl;
+  vui128_t mphh, mphl, mplh, mpll;
+  mpll = vec_muludq (&mplh, m1.vx0, m2.vx0);
+
+  mp = vec_muludq (&mphl, m1.vx1, m2.vx0);
+  mplh = vec_addcq (&mc, mplh, mp);
+  mphl = vec_adduqm (mphl, mc);
+
+  mp = vec_muludq (&mqhl, m1.vx0, m2.vx1);
+  mplh = vec_addcq (&mq, mplh, mp);
+  mphl = vec_addeq (&mc, mphl, mqhl, mq);
+
+  mp = vec_muludq (&mphh, m1.vx1, m2.vx1);
+  mphl = vec_addcq (&mq, mphl, mp);
+  mphh = vec_addeuqm (mphh, mq, mc);
+
+  result.vx0 = mpll;
+  result.vx1 = mplh;
+  result.vx2 = mphl;
+  result.vx3 = mphh;
+  return result;
+#else
+#ifdef _ARCH_PWR8
+  __VEC_U_512 result;
+  vui128_t mc, mp, mq, mqhl;
+  vui128_t mphh, mphl, mplh, mpll;
+  mpll = vec_muludq (&mplh, m1.vx0, m2.vx0);
+
+  mp = vec_madduq (&mphl, m1.vx1, m2.vx0, mplh);
+  mplh = mp;
+  COMPILE_FENCE1;
+  mp = vec_madduq (&mq, m1.vx0, m2.vx1, mplh);
+  mplh = mp;
+
+  mp = vec_madd2uq (&mphh, m1.vx1, m2.vx1, mphl, mq);
+  mphl = mp;
+
+  result.vx0 = mpll;
+  result.vx1 = mplh;
+  result.vx2 = mphl;
+  result.vx3 = mphh;
+  return result;
+#else
   return vec_mul256x256_inline (m1, m2);
+#endif
+#endif
 }
 
 __VEC_U_640
 __VEC_PWR_IMP (vec_mul512x128) (__VEC_U_512 m1, vui128_t m2)
 {
+#ifdef _ARCH_PWR9
+  __VEC_U_640 result;
+  vui128_t mq3, mq2, mq1, mq0, mq, mc;
+  vui128_t mpx0, mpx1, mpx2, mpx3;
+  mpx0 = vec_muludq (&mq0, m1.vx0, m2);
+
+  mpx1 = vec_muludq (&mq1, m1.vx1, m2);
+  mpx1 = vec_addcq (&mc, mpx1, mq0);
+
+  mpx2 = vec_muludq (&mq2, m1.vx2, m2);
+  mpx2 = vec_addeq (&mq, mpx2, mq1, mc);
+
+  mpx3 = vec_muludq (&mq3, m1.vx3, m2);
+  mpx3 = vec_addeq (&mc, mpx3, mq2, mq);
+  mq3 = vec_adduqm (mc, mq3);
+
+  result.vx0 = mpx0;
+  result.vx1 = mpx1;
+  result.vx2 = mpx2;
+  result.vx3 = mpx3;
+  result.vx4 = mq3;
+  return result;
+#else
+#ifdef _ARCH_PWR8
+  __VEC_U_640 result;
+  vui128_t mq3, mq2, mq1, mq0, mq, mc;
+  vui128_t mpx0, mpx1, mpx2, mpx3;
+  mpx0 = vec_muludq (&mq0, m1.vx0, m2);
+  mpx1 = vec_madduq (&mq1, m1.vx1, m2, mq0);
+  COMPILE_FENCE1;
+  mpx2 = vec_madduq (&mq2, m1.vx2, m2, mq1);
+  mpx3 = vec_madduq (&mq3, m1.vx3, m2, mq2);
+
+  result.vx0 = mpx0;
+  result.vx1 = mpx1;
+  result.vx2 = mpx2;
+  result.vx3 = mpx3;
+  result.vx4 = mq3;
+  return result;
+#else
   return vec_mul512x128_inline (m1, m2);
+#endif
+#endif
+}
+
+__VEC_U_640
+__VEC_PWR_IMP (vec_madd512x128a128) (__VEC_U_512 m1, vui128_t m2,
+                                     vui128_t a1)
+{
+  return vec_madd512x128a128_inline (m1, m2, a1);
+}
+
+__VEC_U_640
+__VEC_PWR_IMP (vec_madd512x128a512) (__VEC_U_512 m1, vui128_t m2,
+                                     __VEC_U_512 a2)
+{
+#ifdef _ARCH_PWR9
+  __VEC_U_640 result;
+  vui128_t mq3, mq2, mq1, mq0, mq, mc;
+  vui128_t mpx0, mpx1, mpx2, mpx3;
+  mpx0 = vec_madduq (&mq0, m1.vx0, m2, a2.vx0);
+
+  mpx1 = vec_madd2uq (&mq1, m1.vx1, m2, mq0, a2.vx1);
+  COMPILE_FENCE1;
+  mpx2 = vec_madd2uq (&mq2, m1.vx2, m2, mq1, a2.vx2);
+
+  mpx3 = vec_madd2uq (&mq3, m1.vx3, m2, mq2, a2.vx3);
+  COMPILE_FENCE3;
+
+  result.vx0 = mpx0;
+  result.vx1 = mpx1;
+  result.vx2 = mpx2;
+  result.vx3 = mpx3;
+  result.vx4 = mq3;
+  return result;
+#else
+#ifdef _ARCH_PWR8
+  __VEC_U_640 result;
+  vui128_t mq3, mq2, mq1, mq0, mq, mc;
+  vui128_t mpx0, mpx1, mpx2, mpx3;
+  mpx0 = vec_madduq (&mq0, m1.vx0, m2, a2.vx0);
+
+  mpx1 = vec_madd2uq (&mq1, m1.vx1, m2, mq0, a2.vx1);
+  COMPILE_FENCE1;
+  mpx2 = vec_madd2uq (&mq2, m1.vx2, m2, mq1, a2.vx2);
+
+  mpx3 = vec_madd2uq (&mq3, m1.vx3, m2, mq2, a2.vx3);
+
+  result.vx0 = mpx0;
+  result.vx1 = mpx1;
+  result.vx2 = mpx2;
+  result.vx3 = mpx3;
+  result.vx4 = mq3;
+  return result;
+#else
+  return vec_madd512x128a512_inline (m1, m2, a2);
+#endif
+#endif
+}
+
+__VEC_U_640
+__VEC_PWR_IMP (vec_madd512x128a128a512) (__VEC_U_512 m1, vui128_t m2,
+                                         vui128_t a1, __VEC_U_512 a2)
+{
+  return vec_madd512x128a128a512_inline (m1, m2, a1, a2);
 }
 
 __VEC_U_1024 __attribute__((flatten))
 __VEC_PWR_IMP (vec_mul512x512) (__VEC_U_512 m1, __VEC_U_512 m2)
 {
+#ifdef _ARCH_PWR8
+  __VEC_U_1024 result;
+#ifdef _ARCH_PWR9
+  vui128_t mc, mp, mq;
+  __VEC_U_640 mp3, mp2, mp1, mp0;
+
+  mp0 = __VEC_PWR_IMP (vec_mul512x128) (m1, m2.vx0);
+  result.vx0 = mp0.vx0;
+  COMPILE_FENCE10;
+
+  mp1 = __VEC_PWR_IMP (vec_mul512x128) (m1, m2.vx1);
+  result.vx1 = vec_addcq (&mq, mp1.vx0, mp0.vx1);
+  result.vx2 = vec_addeq (&mp, mp1.vx1, mp0.vx2, mq);
+  result.vx3 = vec_addeq (&mq, mp1.vx2, mp0.vx3, mp);
+  result.vx4 = vec_addeq (&mp, mp1.vx3, mp0.vx4, mq);
+  result.vx5 = vec_addcq (&result.vx6, mp1.vx4, mp);
+  COMPILE_FENCE11;
+
+
+  mp2 = __VEC_PWR_IMP (vec_mul512x128) (m1, m2.vx2);
+  result.vx2 = vec_addcq (&mq, mp2.vx0, result.vx2);
+  result.vx3 = vec_addeq (&mp, mp2.vx1, result.vx3, mq);
+  result.vx4 = vec_addeq (&mq, mp2.vx2, result.vx4, mp);
+  result.vx5 = vec_addeq (&mp, mp2.vx3, result.vx5, mq);
+  result.vx6 = vec_addeq (&result.vx7, mp2.vx4, result.vx6, mp);
+  COMPILE_FENCE12;
+
+  mp3 = __VEC_PWR_IMP (vec_mul512x128) (m1, m2.vx3);
+  result.vx3 = vec_addcq (&mq, mp3.vx0, result.vx3);
+  result.vx4 = vec_addeq (&mp, mp3.vx1, result.vx4, mq);
+  result.vx5 = vec_addeq (&mq, mp3.vx2, result.vx5, mp);
+  result.vx6 = vec_addeq (&mp, mp3.vx3, result.vx6, mq);
+  result.vx7 = vec_addeuqm (result.vx7, mp3.vx4, mp);
+#else
+  vui128_t mc, mp, mq;
+  __VEC_U_512x1 mp3, mp2, mp1, mp0;
+
+  mp0.x640 = __VEC_PWR_IMP(vec_mul512x128) (m1, m2.vx0);
+  result.vx0 = mp0.x3.v1x128;
+  COMPILE_FENCE10;
+  mp1.x640 = __VEC_PWR_IMP(vec_madd512x128a512) (m1, m2.vx1, mp0.x3.v0x512);
+  result.vx1 = mp1.x3.v1x128;
+  COMPILE_FENCE11;
+  mp2.x640 = __VEC_PWR_IMP(vec_madd512x128a512) (m1, m2.vx2, mp1.x3.v0x512);
+  result.vx2 = mp2.x3.v1x128;
+  COMPILE_FENCE12;
+  mp3.x640 = __VEC_PWR_IMP(vec_madd512x128a512) (m1, m2.vx3, mp2.x3.v0x512);
+  result.vx3 = mp3.x3.v1x128;
+  result.vx4 = mp3.x3.v0x512.vx0;
+  result.vx5 = mp3.x3.v0x512.vx1;
+  result.vx6 = mp3.x3.v0x512.vx2;
+  result.vx7 = mp3.x3.v0x512.vx3;
+#endif
+  return result;
+#else
   return vec_mul512x512_inline (m1, m2);
+#endif
+}
+
+__VEC_U_1024 __attribute__((flatten))
+__VEC_PWR_IMP (vec_madd512x512a512) (__VEC_U_512 m1, __VEC_U_512 m2,
+                                     __VEC_U_512 a1)
+{
+#ifdef _ARCH_PWR8
+  __VEC_U_1024 result;
+  __VEC_U_512x1 mp3, mp2, mp1, mp0;
+  vui128_t mc, mp, mq;
+
+  mp0.x640 = __VEC_PWR_IMP(vec_madd512x128a512) (m1, m2.vx0, a1);
+  result.vx0 = mp0.x3.v1x128;
+  COMPILE_FENCE14;
+  mp1.x640 = __VEC_PWR_IMP(vec_madd512x128a512) (m1, m2.vx1, mp0.x3.v0x512);
+  result.vx1 = mp1.x3.v1x128;
+  COMPILE_FENCE15;
+  mp2.x640 = __VEC_PWR_IMP(vec_madd512x128a512) (m1, m2.vx2, mp1.x3.v0x512);
+  result.vx2 = mp2.x3.v1x128;
+  COMPILE_FENCE16;
+  mp3.x640 = __VEC_PWR_IMP(vec_madd512x128a512) (m1, m2.vx3, mp2.x3.v0x512);
+  result.vx3 = mp3.x3.v1x128;
+  result.vx4 = mp3.x3.v0x512.vx0;
+  result.vx5 = mp3.x3.v0x512.vx1;
+  result.vx6 = mp3.x3.v0x512.vx2;
+  result.vx7 = mp3.x3.v0x512.vx3;
+  return result;
+#else
+  return vec_madd512x512a512_inline (m1, m2, a1);
+#endif
 }
 
 /** \brief Macros that invert the indexes so that quadword array endian
@@ -64,7 +350,7 @@ __VEC_PWR_IMP (vec_mul512x512) (__VEC_U_512 m1, __VEC_U_512 m2)
 #endif
 
 void __attribute__((flatten ))
-#if 0
+#ifdef __VEC_USE_RESTRICT__
 /* The Compiler team strongly suggested using  restrict here
  * but in practice (at least for GCC 8/9) we are better off without.
  * Waiting for a bug fix.
@@ -78,42 +364,73 @@ __VEC_PWR_IMP (vec_mul1024x1024) (__VEC_U_2048* r2048,
 				  __VEC_U_1024* m2_1024)
 #endif
 {
+#ifdef _ARCH_PWR8
   __VEC_U_512 *p2048, *m1, *m2;
   __VEC_U_1024x512 subp0, subp1, subp2, subp3;
-  __VEC_U_512x1 sum0, sum1, sum2, sum3, sumx;
+  __VEC_U_512x1 sum0, sum1, sum2, sum3;
+  __VEC_U_512x1 sumx;
   __VEC_U_512 temp[3];
 
   p2048 = (__VEC_U_512 *) r2048;
   m1 = (__VEC_U_512 *) m1_1024;
   m2 = (__VEC_U_512 *) m2_1024;
 
-  subp0.x1024 = vec_mul512x512_inline (m1[__NDX2(0)], m2[__NDX2(0)]);
+  subp0.x1024 = __VEC_PWR_IMP(vec_mul512x512) (m1[__NDX2(0)], m2[__NDX2(0)]);
   p2048[__NDX4(0)] = subp0.x2.v0x512;
 
-  subp1.x1024 = vec_mul512x512_inline (m1[__NDX2(1)], m2[__NDX2(0)]);
+  COMPILE_FENCE20;
+  subp1.x1024 = __VEC_PWR_IMP(vec_mul512x512) (m1[__NDX2(1)], m2[__NDX2(0)]);
   sum1.x640 = vec_add512cu (subp1.x2.v0x512, subp0.x2.v1x512);
-
   temp[0] = sum1.x2.v0x512;
   temp[1] = vec_add512ze (subp1.x2.v1x512, sum1.x2.v1x128);
-  COMPILE_FENCE;
 
-  subp2.x1024 = vec_mul512x512_inline (m1[__NDX2(0)], m2[__NDX2(1)]);
+  COMPILE_FENCE21;
+  subp2.x1024 = __VEC_PWR_IMP(vec_mul512x512) (m1[__NDX2(0)], m2[__NDX2(1)]);
   sum2.x640 = vec_add512cu (temp[0], subp2.x2.v0x512);
   temp[2] = sum2.x2.v0x512;
   p2048[__NDX4(1)] = temp[2];
   sumx.x640 = vec_add512ecu (temp[1], subp2.x2.v1x512, sum2.x2.v1x128);
   temp[1] = sumx.x2.v0x512;
-  COMPILE_FENCE;
 
-  subp3.x1024 = vec_mul512x512_inline (m1[__NDX2(1)], m2[__NDX2(1)]);
+  COMPILE_FENCE22;
+  subp3.x1024 = __VEC_PWR_IMP(vec_mul512x512) (m1[__NDX2(1)], m2[__NDX2(1)]);
   sum3.x640 = vec_add512cu (sumx.x2.v0x512, subp3.x2.v0x512);
   p2048[__NDX4(2)] = sum3.x2.v0x512;
   p2048[__NDX4(3)] = vec_add512ze2 (subp3.x2.v1x512,
 				    sumx.x2.v1x128, sum3.x2.v1x128);
+#else
+  __VEC_U_512 *p2048, *m1, *m2;
+  __VEC_U_1024x512 subp0, subp1, subp2, subp3;
+  __VEC_U_512x1 sumx;
+
+  p2048 = (__VEC_U_512 *) r2048;
+  m1 = (__VEC_U_512 *) m1_1024;
+  m2 = (__VEC_U_512 *) m2_1024;
+
+  subp0.x1024 = __VEC_PWR_IMP(vec_mul512x512) (m1[__NDX2(0)], m2[__NDX2(0)]);
+  p2048[__NDX4(0)] = subp0.x2.v0x512;
+
+  COMPILE_FENCE20;
+  subp1.x1024 = __VEC_PWR_IMP(vec_madd512x512a512) (m1[__NDX2(1)], m2[__NDX2(0)],
+					    subp0.x2.v1x512);
+
+  COMPILE_FENCE21;
+  subp2.x1024 = __VEC_PWR_IMP(vec_madd512x512a512) (m1[__NDX2(0)], m2[__NDX2(1)],
+					    subp1.x2.v0x512);
+  p2048[__NDX4(1)] = subp2.x2.v0x512;
+
+  sumx.x640 = vec_add512cu (subp1.x2.v1x512, subp2.x2.v1x512);
+
+  COMPILE_FENCE22;
+  subp3.x1024 = __VEC_PWR_IMP(vec_madd512x512a512) (m1[__NDX2(1)], m2[__NDX2(1)],
+					    sumx.x2.v0x512);
+  p2048[__NDX4(2)] = subp3.x2.v0x512;
+  p2048[__NDX4(3)] = vec_add512ze (subp3.x2.v1x512, sumx.x2.v1x128);
+#endif
 }
 
 void __attribute__((flatten ))
-#if 0
+#ifdef __VEC_USE_RESTRICT__
 /* The Compiler team strongly suggested using  restrict here
  * but in practice (at least for GCC 8/9) we are better off without.
  * Waiting for a bug fix.
@@ -127,6 +444,7 @@ __VEC_PWR_IMP (vec_mul2048x2048) (__VEC_U_4096* r4096,
 				__VEC_U_2048* m2_2048)
 #endif
   {
+#ifdef _ARCH_PWR9
     __VEC_U_512 *p4096, *m1, *m2;
     __VEC_U_1024x512 subp0, subp1, subp2, subp3;
     __VEC_U_512x1 sum0, sum1, sum2, sum3, sumx;
@@ -136,103 +454,370 @@ __VEC_PWR_IMP (vec_mul2048x2048) (__VEC_U_4096* r4096,
     m1 = (__VEC_U_512 *) m1_2048;
     m2 = (__VEC_U_512 *) m2_2048;
 
-    subp0.x1024 = vec_mul512x512_inline (m1[__NDX4(0)], m2[__NDX4(0)]);
+    subp0.x1024 = __VEC_PWR_IMP(vec_mul512x512) (m1[__NDX4(0)], m2[__NDX4(0)]);
     p4096[__NDX8(0)] = subp0.x2.v0x512;
 
-    subp1.x1024 = vec_mul512x512_inline (m1[__NDX4(1)], m2[__NDX4(0)]);
+    COMPILE_FENCE20;
+    subp1.x1024 = __VEC_PWR_IMP(vec_mul512x512) (m1[__NDX4(1)], m2[__NDX4(0)]);
     sum1.x640 = vec_add512cu (subp1.x2.v0x512, subp0.x2.v1x512);
     temp[0] = sum1.x2.v0x512;
-    COMPILE_FENCE;
 
-    subp2.x1024 = vec_mul512x512_inline (m1[__NDX4(2)], m2[__NDX4(0)]);
+    COMPILE_FENCE20;
+    subp2.x1024 = __VEC_PWR_IMP(vec_mul512x512) (m1[__NDX4(2)], m2[__NDX4(0)]);
     sum2.x640 = vec_add512ecu (subp2.x2.v0x512, subp1.x2.v1x512, sum1.x2.v1x128);
     temp[1] = sum2.x2.v0x512;
-    COMPILE_FENCE;
 
-    subp3.x1024 = vec_mul512x512_inline (m1[__NDX4(3)], m2[__NDX4(0)]);
+    COMPILE_FENCE21;
+    subp3.x1024 = __VEC_PWR_IMP(vec_mul512x512) (m1[__NDX4(3)], m2[__NDX4(0)]);
     sum3.x640 = vec_add512ecu (subp3.x2.v0x512, subp2.x2.v1x512, sum2.x2.v1x128);
 
     temp[2] = sum3.x2.v0x512;
     temp[3] = vec_add512ze (subp3.x2.v1x512, sum3.x2.v1x128);
-    COMPILE_FENCE;
 
-    subp0.x1024 = vec_mul512x512_inline (m1[__NDX4(0)], m2[__NDX4(1)]);
+    COMPILE_FENCE22;
+    subp0.x1024 = __VEC_PWR_IMP(vec_mul512x512) (m1[__NDX4(0)], m2[__NDX4(1)]);
     sum0.x640 = vec_add512cu (subp0.x2.v0x512, temp[0]);
     p4096[__NDX8(1)] = sum0.x2.v0x512;
-    COMPILE_FENCE;
 
-    subp1.x1024 = vec_mul512x512_inline (m1[__NDX4(1)], m2[__NDX4(1)]);
+    COMPILE_FENCE23;
+    subp1.x1024 = __VEC_PWR_IMP(vec_mul512x512) (m1[__NDX4(1)], m2[__NDX4(1)]);
     sum1.x640 = vec_add512ecu (subp1.x2.v0x512, subp0.x2.v1x512, sum0.x2.v1x128);
     sumx.x640 = vec_add512cu (sum1.x2.v0x512, temp[1]);
     temp[0] = sumx.x2.v0x512;
-    COMPILE_FENCE;
 
-    subp2.x1024 = vec_mul512x512_inline (m1[__NDX4(2)], m2[__NDX4(1)]);
+    COMPILE_FENCE24;
+    subp2.x1024 = __VEC_PWR_IMP(vec_mul512x512) (m1[__NDX4(2)], m2[__NDX4(1)]);
     sum2.x640 = vec_add512ecu (subp2.x2.v0x512, subp1.x2.v1x512, sum1.x2.v1x128);
     sumx.x640 = vec_add512ecu (sum2.x2.v0x512, temp[2], sumx.x2.v1x128);
     temp[1] = sumx.x2.v0x512;
-    COMPILE_FENCE;
 
-    subp3.x1024 = vec_mul512x512_inline (m1[__NDX4(3)], m2[__NDX4(1)]);
+    COMPILE_FENCE25;
+    subp3.x1024 = __VEC_PWR_IMP(vec_mul512x512) (m1[__NDX4(3)], m2[__NDX4(1)]);
     sum3.x640 = vec_add512ecu (subp3.x2.v0x512, subp2.x2.v1x512, sum2.x2.v1x128);
     subp3.x2.v1x512 = vec_add512ze (subp3.x2.v1x512, sum3.x2.v1x128);
     sumx.x640 = vec_add512ecu (sum3.x2.v0x512, temp[3], sumx.x2.v1x128);
     temp[2] = sumx.x2.v0x512;
-    COMPILE_FENCE;
 
     temp[3] = vec_add512ze (subp3.x2.v1x512, sumx.x2.v1x128);
-    COMPILE_FENCE;
 
-    subp0.x1024 = vec_mul512x512_inline (m1[__NDX4(0)], m2[__NDX4(2)]);
+    COMPILE_FENCE26;
+    subp0.x1024 = __VEC_PWR_IMP(vec_mul512x512) (m1[__NDX4(0)], m2[__NDX4(2)]);
     sum0.x640 = vec_add512cu (subp0.x2.v0x512, temp[0]);
     p4096[__NDX8(2)] = sum0.x2.v0x512;
-    COMPILE_FENCE;
 
-    subp1.x1024 = vec_mul512x512_inline (m1[__NDX4(1)], m2[__NDX4(2)]);
+    COMPILE_FENCE27;
+    subp1.x1024 = __VEC_PWR_IMP(vec_mul512x512) (m1[__NDX4(1)], m2[__NDX4(2)]);
     sum1.x640 = vec_add512ecu (subp1.x2.v0x512, subp0.x2.v1x512, sum0.x2.v1x128);
     sumx.x640 = vec_add512cu (sum1.x2.v0x512, temp[1]);
     temp[0] = sumx.x2.v0x512;
-    COMPILE_FENCE;
 
-    subp2.x1024 = vec_mul512x512_inline (m1[__NDX4(2)], m2[__NDX4(2)]);
+    COMPILE_FENCE28;
+    subp2.x1024 = __VEC_PWR_IMP(vec_mul512x512) (m1[__NDX4(2)], m2[__NDX4(2)]);
     sum2.x640 = vec_add512ecu (subp2.x2.v0x512, subp1.x2.v1x512, sum1.x2.v1x128);
     sumx.x640 = vec_add512ecu (sum2.x2.v0x512, temp[2], sumx.x2.v1x128);
     temp[1] = sumx.x2.v0x512;
-    COMPILE_FENCE;
 
-    subp3.x1024 = vec_mul512x512_inline (m1[__NDX4(3)], m2[__NDX4(2)]);
+    COMPILE_FENCE20;
+    subp3.x1024 = __VEC_PWR_IMP(vec_mul512x512) (m1[__NDX4(3)], m2[__NDX4(2)]);
     sum3.x640 = vec_add512ecu (subp3.x2.v0x512, subp2.x2.v1x512, sum2.x2.v1x128);
     subp3.x2.v1x512 = vec_add512ze (subp3.x2.v1x512, sum3.x2.v1x128);
     sumx.x640 = vec_add512ecu (sum3.x2.v0x512, temp[3], sumx.x2.v1x128);
     temp[2] = sumx.x2.v0x512;
-    COMPILE_FENCE;
-
     temp[3] = vec_add512ze (subp3.x2.v1x512, sumx.x2.v1x128);
-    COMPILE_FENCE;
 
-    subp0.x1024 = vec_mul512x512_inline (m1[__NDX4(0)], m2[__NDX4(3)]);
+    COMPILE_FENCE21;
+    subp0.x1024 = __VEC_PWR_IMP(vec_mul512x512) (m1[__NDX4(0)], m2[__NDX4(3)]);
     sum0.x640 = vec_add512cu (subp0.x2.v0x512, temp[0]);
     p4096[__NDX8(3)] = sum0.x2.v0x512;
-    COMPILE_FENCE;
 
-    subp1.x1024 = vec_mul512x512_inline (m1[__NDX4(1)], m2[__NDX4(3)]);
+    COMPILE_FENCE22;
+    subp1.x1024 = __VEC_PWR_IMP(vec_mul512x512) (m1[__NDX4(1)], m2[__NDX4(3)]);
     sum1.x640 = vec_add512ecu (subp1.x2.v0x512, subp0.x2.v1x512, sum0.x2.v1x128);
     sumx.x640 = vec_add512cu (sum1.x2.v0x512, temp[1]);
     p4096[__NDX8(4)] = sumx.x2.v0x512;
-    COMPILE_FENCE;
 
-    subp2.x1024 = vec_mul512x512_inline (m1[__NDX4(2)], m2[__NDX4(3)]);
+    COMPILE_FENCE23;
+    subp2.x1024 = __VEC_PWR_IMP(vec_mul512x512) (m1[__NDX4(2)], m2[__NDX4(3)]);
     sum2.x640 = vec_add512ecu (subp2.x2.v0x512, subp1.x2.v1x512, sum1.x2.v1x128);
     sumx.x640 = vec_add512ecu (sum2.x2.v0x512, temp[2], sumx.x2.v1x128);
     p4096[__NDX8(5)] = sumx.x2.v0x512;
-    COMPILE_FENCE;
 
-    subp3.x1024 = vec_mul512x512_inline (m1[__NDX4(3)], m2[__NDX4(3)]);
+    COMPILE_FENCE24;
+    subp3.x1024 = __VEC_PWR_IMP(vec_mul512x512) (m1[__NDX4(3)], m2[__NDX4(3)]);
     sum3.x640 = vec_add512ecu (subp3.x2.v0x512, subp2.x2.v1x512, sum2.x2.v1x128);
     subp3.x2.v1x512 = vec_add512ze (subp3.x2.v1x512, sum3.x2.v1x128);
     sumx.x640 = vec_add512ecu (sum3.x2.v0x512, temp[3], sumx.x2.v1x128);
     p4096[__NDX8(6)] = sumx.x2.v0x512;
-    COMPILE_FENCE;
+    COMPILE_FENCE25;
 
     p4096[__NDX8(7)] = vec_add512ze (subp3.x2.v1x512, sumx.x2.v1x128);
+#else
+    __VEC_U_512 *p4096, *m1, *m2;
+    __VEC_U_1024x512 subp0, subp1, subp2, subp3;
+    __VEC_U_512x1 sumx;
+    __VEC_U_512 temp[4];
+
+    p4096 = (__VEC_U_512 *)r4096;
+    m1 = (__VEC_U_512 *) m1_2048;
+    m2 = (__VEC_U_512 *) m2_2048;
+
+    subp0.x1024 = __VEC_PWR_IMP(vec_mul512x512) (m1[__NDX4(0)], m2[__NDX4(0)]);
+    p4096[__NDX8(0)] = subp0.x2.v0x512;
+
+    COMPILE_FENCE20;
+    subp1.x1024 = __VEC_PWR_IMP(vec_madd512x512a512) (m1[__NDX4(1)], m2[__NDX4(0)],
+					      subp0.x2.v1x512);
+    temp[0] = subp1.x2.v0x512;
+    COMPILE_FENCE20;
+
+    subp2.x1024 = __VEC_PWR_IMP(vec_madd512x512a512) (m1[__NDX4(2)], m2[__NDX4(0)],
+					      subp1.x2.v1x512);
+    temp[1] = subp2.x2.v0x512;
+    COMPILE_FENCE21;
+
+    subp3.x1024 = __VEC_PWR_IMP(vec_madd512x512a512) (m1[__NDX4(3)], m2[__NDX4(0)],
+					      subp2.x2.v1x512);
+    temp[2] = subp3.x2.v0x512;
+    temp[3] = subp3.x2.v1x512;
+    COMPILE_FENCE22;
+
+    subp0.x1024 = __VEC_PWR_IMP(vec_madd512x512a512) (m1[__NDX4(0)], m2[__NDX4(1)],
+					      temp[0]);
+    p4096[__NDX8(1)] = subp0.x2.v0x512;
+    COMPILE_FENCE23;
+
+    subp1.x1024 = __VEC_PWR_IMP(vec_madd512x512a512) (m1[__NDX4(1)], m2[__NDX4(1)],
+					      temp[1]);
+    sumx.x640 = vec_add512cu (subp1.x2.v0x512, subp0.x2.v1x512);
+    temp[0] = sumx.x2.v0x512;
+    COMPILE_FENCE24;
+
+    subp2.x1024 = __VEC_PWR_IMP(vec_madd512x512a512) (m1[__NDX4(2)], m2[__NDX4(1)],
+					      temp[2]);
+    sumx.x640 = vec_add512ecu (subp2.x2.v0x512, subp1.x2.v1x512, sumx.x2.v1x128);
+    temp[1] = sumx.x2.v0x512;
+    COMPILE_FENCE25;
+
+    subp3.x1024 = __VEC_PWR_IMP(vec_madd512x512a512) (m1[__NDX4(3)], m2[__NDX4(1)],
+					      temp[3]);
+    sumx.x640 = vec_add512ecu (subp3.x2.v0x512, subp2.x2.v1x512, sumx.x2.v1x128);
+    temp[2] = sumx.x2.v0x512;
+    temp[3] = vec_add512ze (subp3.x2.v1x512, sumx.x2.v1x128);
+    COMPILE_FENCE26;
+
+    subp0.x1024 = __VEC_PWR_IMP(vec_madd512x512a512) (m1[__NDX4(0)], m2[__NDX4(2)],
+					      temp[0]);
+    p4096[__NDX8(2)] = subp0.x2.v0x512;
+    COMPILE_FENCE27;
+
+    subp1.x1024 = __VEC_PWR_IMP(vec_madd512x512a512) (m1[__NDX4(1)], m2[__NDX4(2)],
+					      temp[1]);
+    sumx.x640 = vec_add512cu (subp1.x2.v0x512, subp0.x2.v1x512);
+    temp[0] = sumx.x2.v0x512;
+    COMPILE_FENCE20;
+
+    subp2.x1024 = __VEC_PWR_IMP(vec_madd512x512a512) (m1[__NDX4(2)], m2[__NDX4(2)],
+					      temp[2]);
+    sumx.x640 = vec_add512ecu (subp2.x2.v0x512, subp1.x2.v1x512, sumx.x2.v1x128);
+    temp[1] = sumx.x2.v0x512;
+    COMPILE_FENCE21;
+
+    subp3.x1024 = __VEC_PWR_IMP(vec_madd512x512a512) (m1[__NDX4(3)], m2[__NDX4(2)],
+					      temp[3]);
+    sumx.x640 = vec_add512ecu (subp3.x2.v0x512, subp2.x2.v1x512, sumx.x2.v1x128);
+    temp[2] = sumx.x2.v0x512;
+
+    temp[3] = vec_add512ze (subp3.x2.v1x512, sumx.x2.v1x128);
+    COMPILE_FENCE22;
+
+    subp0.x1024 = __VEC_PWR_IMP(vec_madd512x512a512) (m1[__NDX4(0)], m2[__NDX4(3)],
+					      temp[0]);
+    p4096[__NDX8(3)] = subp0.x2.v0x512;
+    COMPILE_FENCE23;
+
+    subp1.x1024 = __VEC_PWR_IMP(vec_madd512x512a512) (m1[__NDX4(1)], m2[__NDX4(3)],
+					      temp[1]);
+    sumx.x640 = vec_add512cu (subp1.x2.v0x512, subp0.x2.v1x512);
+    p4096[__NDX8(4)] = sumx.x2.v0x512;
+    COMPILE_FENCE24;
+
+    subp2.x1024 = __VEC_PWR_IMP(vec_madd512x512a512) (m1[__NDX4(2)], m2[__NDX4(3)],
+					      temp[2]);
+    sumx.x640 = vec_add512ecu (subp2.x2.v0x512, subp1.x2.v1x512, sumx.x2.v1x128);
+    p4096[__NDX8(5)] = sumx.x2.v0x512;
+    COMPILE_FENCE25;
+
+    subp3.x1024 = __VEC_PWR_IMP(vec_madd512x512a512) (m1[__NDX4(3)], m2[__NDX4(3)],
+					      temp[3]);
+    sumx.x640 = vec_add512ecu (subp3.x2.v0x512, subp2.x2.v1x512, sumx.x2.v1x128);
+    p4096[__NDX8(6)] = sumx.x2.v0x512;
+    COMPILE_FENCE26;
+
+    p4096[__NDX8(7)] = vec_add512ze (subp3.x2.v1x512, sumx.x2.v1x128);
+#endif
   }
+
+// Adjust the order of quadwords in multiple quadword precision value,
+// to match the endian order of the bytes in a quadword.
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define __MDX(__index) (__index)
+#define __NDX(__index) (__index)
+#define __PDX(__index) (__index)
+#else
+#define __NDX(__index) ((nx - 1) - (__index))
+#define __MDX(__index) ((mx - 1) - (__index))
+#define __PDX(__index) ((px - 1) - (__index))
+#endif
+
+void __attribute__((flatten ))
+__VEC_PWR_IMP (vec_mul128_byMN) (vui128_t *p,
+		  vui128_t *m1, vui128_t *m2,
+		  unsigned long M, unsigned long N)
+{
+  vui128_t *mp = m1;
+  vui128_t *np = m2;
+  unsigned long mx = M;
+  unsigned long nx = N;
+  unsigned long px = M + N;
+  unsigned long i, j;
+  vui128_t mpx0, mqx0, mpx1, mqx1;
+
+  /* sizeof(m1) < sizeof(m2) swap the pointers and quadword counts.
+   * This allows for early exit when size of either is 1. */
+  if (mx < nx)
+    {
+      vui128_t *xp;
+      unsigned long x;
+
+      x = mx;
+      xp = mp;
+      mx = nx;
+      mp = np;
+      nx = x;
+      np = xp;
+    }
+
+  if (nx > 0)
+    {
+      mpx0 = vec_muludq (&mqx0, mp[__MDX(0)], np[__NDX(0)]);
+      p[__PDX(0)] = mpx0;
+      for (i = 1; i < mx; i++)
+	{
+	  mpx1 = vec_madduq (&mqx1, mp[__MDX(i)], np[__NDX(0)], mqx0);
+	  p[__PDX(i)] = mpx1;
+	  mqx0 = mqx1;
+	}
+      p[__PDX(mx)] = mqx0;
+
+      for (j = 1; j < nx; j++)
+	{
+	  mpx0 = vec_madduq (&mqx0, mp[__MDX(0)], np[__NDX(j)], p[__PDX(j)]);
+	  p[__PDX(j)] = mpx0;
+	  for (i = 1; i < mx; i++)
+	    {
+	      mpx1 = vec_madd2uq (&mqx1, mp[__MDX(i)], np[__NDX(j)], mqx0,
+				  p[__PDX(i + j)]);
+	      p[__PDX(i + j)] = mpx1;
+	      mqx0 = mqx1;
+	    }
+	  p[__PDX(mx + j)] = mqx0;
+	}
+    }
+  else
+    {
+      /* If one of multipliers is sizeof() zero, treat it a multiply
+       * by zero, and if the other multiplier is not sizeof() zero, set
+       * the product array to 0. */
+      const vui128_t c_zero = (vui128_t) ((unsigned __int128) 0);
+      if (mx > 0)
+	{
+	  for (i = 0; i < mx; i++)
+	    {
+	      p[__PDX(i)] = c_zero;
+	    }
+	}
+    }
+}
+
+void __attribute__((flatten ))
+__VEC_PWR_IMP (vec_mul512_byMN) (__VEC_U_512 *p,
+                  __VEC_U_512 *m1, __VEC_U_512 *m2,
+		  unsigned long M, unsigned long N)
+{
+  __VEC_U_512 *mp = m1;
+  __VEC_U_512 *np = m2;
+  unsigned long mx = M;
+  unsigned long nx = N;
+  unsigned long px = M + N;
+  unsigned long i, j;
+  __VEC_U_1024x512 mpx0, mpx1;
+  __VEC_U_512x1 sum1;
+  __VEC_U_512 mqx0;
+  vui128_t mcx0;
+
+  /* sizeof(m1) < sizeof(m2) swap the pointers and quadword counts.
+   * This allows for early exit when size of either is 1. */
+  if (mx < nx)
+    {
+      __VEC_U_512 *xp;
+      unsigned long x;
+
+      x = mx;
+      xp = mp;
+      mx = nx;
+      mp = np;
+      nx = x;
+      np = xp;
+    }
+
+  if (nx > 0)
+    {
+      mpx0.x1024 = __VEC_PWR_IMP(vec_mul512x512) (mp[__MDX(0)], np[__NDX(0)]);
+      p[__PDX(0)] = mpx0.x2.v0x512;
+      mqx0 = mpx0.x2.v1x512;
+      for (i = 1; i < mx; i++)
+	{
+	  mpx1.x1024 = __VEC_PWR_IMP(vec_madd512x512a512) (mp[__MDX(i)], np[__NDX(0)], mqx0);
+	  p[__PDX(i)] = mpx1.x2.v0x512;
+	  mqx0 = mpx1.x2.v1x512;
+	}
+      p[__PDX(mx)] = mqx0;
+
+      for (j = 1; j < nx; j++)
+	{
+	  mpx0.x1024 = __VEC_PWR_IMP(vec_madd512x512a512) (mp[__MDX(0)], np[__NDX(j)], p[__PDX(j)]);
+	  p[__PDX(j)] = mpx0.x2.v0x512;
+	  mqx0 = mpx0.x2.v1x512;
+	  mcx0 = (vui128_t) ((unsigned __int128) 0);
+	  for (i = 1; i < mx; i++)
+	    {
+	      mpx1.x1024 = __VEC_PWR_IMP(vec_madd512x512a512) (mp[__MDX(i)], np[__NDX(j)], mqx0);
+
+	      sum1.x640 = vec_add512ecu (mpx1.x2.v0x512, p[__PDX(i + j)], mcx0);
+	      p[__PDX(i + j)] = sum1.x2.v0x512;
+	      mcx0 = sum1.x2.v1x128;
+	      mqx0 = mpx1.x2.v1x512;
+	    }
+	  p[__PDX(mx + j)] = vec_add512ze (mqx0, mcx0);
+	}
+    }
+  else
+    {
+      /* If one of multipliers is sizeof() zero, treat it a multiply
+       * by zero, and if the other multiplier is not sizeof() zero, set
+       * the product array to 0. */
+      __VEC_U_512 p_zero;
+      p_zero.vx0 = (vui128_t) ((unsigned __int128) 0);
+      p_zero.vx1 = (vui128_t) ((unsigned __int128) 0);
+      p_zero.vx2 = (vui128_t) ((unsigned __int128) 0);
+      p_zero.vx3 = (vui128_t) ((unsigned __int128) 0);
+      if (mx > 0)
+	{
+	  for (i = 0; i < mx; i++)
+	    {
+	      p[__PDX(i)] = p_zero;
+	    }
+	}
+    }
+}
+

--- a/src/vec_int512_runtime.c
+++ b/src/vec_int512_runtime.c
@@ -106,7 +106,7 @@ __VEC_PWR_IMP (vec_mul256x256) (__VEC_U_256 m1, __VEC_U_256 m2)
 #else
 #ifdef _ARCH_PWR8
   __VEC_U_512 result;
-  vui128_t mc, mp, mq, mqhl;
+  vui128_t mp, mq;
   vui128_t mphh, mphl, mplh, mpll;
   mpll = vec_muludq (&mplh, m1.vx0, m2.vx0);
 
@@ -191,7 +191,7 @@ __VEC_PWR_IMP (vec_madd512x128a512) (__VEC_U_512 m1, vui128_t m2,
 {
 #ifdef _ARCH_PWR9
   __VEC_U_640 result;
-  vui128_t mq3, mq2, mq1, mq0, mq, mc;
+  vui128_t mq3, mq2, mq1, mq0;
   vui128_t mpx0, mpx1, mpx2, mpx3;
   mpx0 = vec_madduq (&mq0, m1.vx0, m2, a2.vx0);
 
@@ -211,7 +211,7 @@ __VEC_PWR_IMP (vec_madd512x128a512) (__VEC_U_512 m1, vui128_t m2,
 #else
 #ifdef _ARCH_PWR8
   __VEC_U_640 result;
-  vui128_t mq3, mq2, mq1, mq0, mq, mc;
+  vui128_t mq3, mq2, mq1, mq0;
   vui128_t mpx0, mpx1, mpx2, mpx3;
   mpx0 = vec_madduq (&mq0, m1.vx0, m2, a2.vx0);
 
@@ -246,7 +246,7 @@ __VEC_PWR_IMP (vec_mul512x512) (__VEC_U_512 m1, __VEC_U_512 m2)
 #ifdef _ARCH_PWR8
   __VEC_U_1024 result;
 #ifdef _ARCH_PWR9
-  vui128_t mc, mp, mq;
+  vui128_t mp, mq;
   __VEC_U_640 mp3, mp2, mp1, mp0;
 
   mp0 = __VEC_PWR_IMP (vec_mul512x128) (m1, m2.vx0);
@@ -277,7 +277,6 @@ __VEC_PWR_IMP (vec_mul512x512) (__VEC_U_512 m1, __VEC_U_512 m2)
   result.vx6 = vec_addeq (&mp, mp3.vx3, result.vx6, mq);
   result.vx7 = vec_addeuqm (result.vx7, mp3.vx4, mp);
 #else
-  vui128_t mc, mp, mq;
   __VEC_U_512x1 mp3, mp2, mp1, mp0;
 
   mp0.x640 = __VEC_PWR_IMP(vec_mul512x128) (m1, m2.vx0);
@@ -309,7 +308,6 @@ __VEC_PWR_IMP (vec_madd512x512a512) (__VEC_U_512 m1, __VEC_U_512 m2,
 #ifdef _ARCH_PWR8
   __VEC_U_1024 result;
   __VEC_U_512x1 mp3, mp2, mp1, mp0;
-  vui128_t mc, mp, mq;
 
   mp0.x640 = __VEC_PWR_IMP(vec_madd512x128a512) (m1, m2.vx0, a1);
   result.vx0 = mp0.x3.v1x128;
@@ -664,8 +662,8 @@ __VEC_PWR_IMP (vec_mul2048x2048) (__VEC_U_4096* r4096,
 #define __NDX(__index) (__index)
 #define __PDX(__index) (__index)
 #else
-#define __NDX(__index) ((nx - 1) - (__index))
 #define __MDX(__index) ((mx - 1) - (__index))
+#define __NDX(__index) ((nx - 1) - (__index))
 #define __PDX(__index) ((px - 1) - (__index))
 #endif
 

--- a/src/vec_runtime_DYN.c
+++ b/src/vec_runtime_DYN.c
@@ -98,6 +98,16 @@ vec_mul1024x1024_PWR7 (__VEC_U_2048 *, __VEC_U_1024 *, __VEC_U_1024 *);
 
 extern void
 vec_mul2048x2048_PWR7 (__VEC_U_4096 *, __VEC_U_2048 *, __VEC_U_2048 *);
+
+extern void
+vec_mul128_byMN_PWR7 (vui128_t *p,
+		  vui128_t *m1, vui128_t *m2,
+		  unsigned long M, unsigned long N);
+
+extern void
+vec_mul512_byMN_PWR7 (__VEC_U_512 *p,
+                  __VEC_U_512 *m1, __VEC_U_512 *m2,
+		  unsigned long M, unsigned long N);
 #endif
 
 extern __VEC_U_256
@@ -117,6 +127,16 @@ vec_mul1024x1024_PWR8 (__VEC_U_2048 *, __VEC_U_1024 *, __VEC_U_1024 *);
 
 extern void
 vec_mul2048x2048_PWR8 (__VEC_U_4096 *, __VEC_U_2048 *, __VEC_U_2048 *);
+
+extern void
+vec_mul128_byMN_PWR8 (vui128_t *p,
+		  vui128_t *m1, vui128_t *m2,
+		  unsigned long M, unsigned long N);
+
+extern void
+vec_mul512_byMN_PWR8 (__VEC_U_512 *p,
+                  __VEC_U_512 *m1, __VEC_U_512 *m2,
+		  unsigned long M, unsigned long N);
 
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 /* Older distros running Big Endian are unlikely to support PWR9.
@@ -139,6 +159,16 @@ vec_mul1024x1024_PWR9 (__VEC_U_2048 *, __VEC_U_1024 *, __VEC_U_1024 *);
 
 extern void
 vec_mul2048x2048_PWR9 (__VEC_U_4096 *, __VEC_U_2048 *, __VEC_U_2048 *);
+
+extern void
+vec_mul128_byMN_PWR9 (vui128_t *p,
+		  vui128_t *m1, vui128_t *m2,
+		  unsigned long M, unsigned long N);
+
+extern void
+vec_mul512_byMN_PWR9 (__VEC_U_512 *p,
+                  __VEC_U_512 *m1, __VEC_U_512 *m2,
+		  unsigned long M, unsigned long N);
 #endif
 
 static
@@ -208,3 +238,32 @@ void
 void
 vec_mul2048x2048 (__VEC_U_4096 *, __VEC_U_2048 *, __VEC_U_2048 *)
 __attribute__ ((ifunc ("resolve_vec_mul2048x2048")));
+
+static
+void
+(*resolve_vec_mul128_byMN (void))
+(vui128_t *p, vui128_t *m1, vui128_t *m2,
+	  unsigned long M, unsigned long N)
+{
+  VEC_DYN_RESOLVER(vec_mul128_byMN);
+}
+
+void
+vec_mul128_byMN (vui128_t *p, vui128_t *m1, vui128_t *m2,
+		  unsigned long M, unsigned long N)
+__attribute__ ((ifunc ("resolve_vec_mul128_byMN")));
+
+static
+void
+(*resolve_vec_mul512_byMN (void))
+(__VEC_U_512 *p, __VEC_U_512 *m1, __VEC_U_512 *m2,
+	  unsigned long M, unsigned long N)
+{
+  VEC_DYN_RESOLVER(vec_mul512_byMN);
+}
+
+void
+vec_mul512_byMN (__VEC_U_512 *p, __VEC_U_512 *m1, __VEC_U_512 *m2,
+		  unsigned long M, unsigned long N)
+__attribute__ ((ifunc ("resolve_vec_mul512_byMN")));
+


### PR DESCRIPTION

Added multi-quadword multiply-add operations optimized for (POWER7/8/9).
Used them to optimize larger multi-quadword multiply while carefully
use COMPILER_FENCE to avoid register presure and spill code.
Added appropriate unit, compile, anf performance tests.

	* src/pveclib/vec_int512_ppc.h General doxygen text cleanup.
	[i512_security_issues_0_0_2]: Remove todos from subsection.
	[i512_Endian_issues_0_0]: Remove todos from section.
	(__VEC_U_512x1): Add x2 field to union in support of madd.
	(__VEC_U_4096x512): Add x4 field to union in support of add512.
	[__VEC_EXPLICITE_FENCE_NOPS__]: Enable explicite NOPS to make
	compiler fences visible.
	(vec_mul256x256_inline): Add doxygen note.
	Leverage madduq/madd2uq.
	(vec_mul512x128_inline): Add doxygen note. Leverage madduq.
	(vec_madd512x128a128_inline, ec_madd512x128a512_inline,
	vec_madd512x128a128a512_inline): New operation.
	(vec_mul512x512_inline): Add doxygen note.
	Leverage vec_madd512x128a512_inline.
	(vec_madd512x512a512_inline): New operation.
	(vec_mul128x128, vec_mul256x256): Update latency table.
	(vec_mul1024x1024, vec_mul2048x2048):
	Add note and update latency table.
	(vec_mul128_byMN, vec_mul512_byMN) New library functions.
	(vec_madd512x128a128, vec_madd512x128a512,
	vec_madd512x128a128a512, vec_madd512x512a512,
	vec_mul128_byMN, vec_mul512_byMN):
	New platform qualified externs.

	src/vec_int512_runtime.c [__VEC_EXPLICITE_FENCE_NOPS__]:
	Define COMPILE_FENCE, COMPILE_FENCE1, COMPILE_FENCE2,
	COMPILE_FENCE3, COMPILE_FENCE10, COMPILE_FENCE11,
	COMPILE_FENCE12, COMPILE_FENCE13, COMPILE_FENCE14,
	COMPILE_FENCE15, COMPILE_FENCE16, COMPILE_FENCE17,
	COMPILE_FENCE20, COMPILE_FENCE21, COMPILE_FENCE22,
	COMPILE_FENCE23, COMPILE_FENCE24, COMPILE_FENCE25,
	COMPILE_FENCE26, COMPILE_FENCE27, COMPILE_FENCE28,
	COMPILE_FENCE29):
	(vec_mul256x256, vec_mul512x128): Optimized for static
	implementation for PWR8/9.
	(vec_madd512x128a128, vec_madd512x128a512,
	vec_madd512x128a128a512): New function.
	(vec_mul512x512): Optimized for static
	implementation for PWR8/9.
	(vec_madd512x512a512):  New function.
	(vec_mul1024x1024 [__VEC_USE_RESTRICT__]):
	Disable restrict for now.
	(vec_mul1024x1024):
	Inline optimized PWR8/9 512-bit mul/madd implementions.
	(vec_mul2048x2048 [__VEC_USE_RESTRICT__]):
	Disable restrict for now.
	(vec_mul2048x2048):
	Inline optimized PWR8/9 512-bit mul/madd implementions.
	(vec_mul128_byMN, vec_mul512_byMN): New library functions.

	* src/vec_runtime_DYN.c ([__ORDER_BIG_ENDIAN__]
	vec_mul128_byMN_PWR7, vec_mul512_byMN_PWR7): New externs.
	([__ORDER_LITTLE_ENDIAN__] vec_mul128_byMN_PWR9,
	vec_mul512_byMN_PWR9): New externs.
	(vec_mul128_byMN_PWR8, vec_mul512_byMN_PWR8): New externs.
	(resolve_vec_mul128_byMN, resolve_vec_mul512_byMN):
	New resolver.
	(vec_mul128_byMN, vec_mul512_byMN): New IFUNC symbol.

	* src/testsuite/arith128_test_i512.c
	(vec512_ten2048_13, vec512_ten2048_12, vec512_ten2048_11,
	vec512_ten2048_10. vec512_ten2048_9, vec512_ten2048_8,
	vec512_ten2048_7, vec512_ten2048_6, vec512_ten2048_5,
	vec512_ten2048_4, vec512_ten2048_3, vec512_ten2048_2,
	vec512_ten2048_1, vec512_ten2048_0): Static const for 10^2048.
	(test_time_i512): Add timed Loops for timed_mul128x128,
	timed_mul256x256. timed_mul512x512by8, timed_mul1024x1024by8,
	timed_mul2048x2048by8, timed_mul2048x2048_MN, and
	timed_mul4096x4096_MN.
	(test_mul512x128_MN, test_madd512x128, test_mul512x512_MN,
	test_mul2048x2048_MN): New unit tests.
	(test_vec_i512): Add calls to unit tests test_madd512x128,
	test_mul512x128_MN, test_mul512x512_MN, and
	test_mul2048x2048_MN.
	* src/testsuite/arith128_test_i512.h
	(vec512_ten2048_13, vec512_ten2048_12, vec512_ten2048_11,
	vec512_ten2048_10. vec512_ten2048_9, vec512_ten2048_8,
	vec512_ten2048_7, vec512_ten2048_6, vec512_ten2048_5,
	vec512_ten2048_4, vec512_ten2048_3, vec512_ten2048_2,
	vec512_ten2048_1, vec512_ten2048_0): Add const externs.
	(test_mul1024x1024): Add function extern.

	* src/testsuite/vec_perf_i512.c (c_zero, c_one, c_ten,
	c_hundred, c_10k, c_100m, ten_64h,  ten_64l):
	New static consts.
	(timed_mul128x128, timed_mul256x256. timed_mul512x512by8,
	timed_mul1024x1024by8, timed_mul2048x2048by8,
	timed_mul2048x2048_MN, timed_mul4096x4096_MN):
	New timed functions.
	* src/testsuite/vec_perf_i512.h (timed_mul128x128,
	timed_mul256x256, timed_mul512x512by8, timed_mul1024x1024by8,
	timed_mul2048x2048by8, timed_mul2048x2048_MN,
	timed_mul4096x4096_MN): Externs for timed functions.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>