### PR TITLE
Lint and -Wall clean-up for V1.0.4. Implementation files.

### DIFF
--- a/src/pveclib/vec_f64_ppc.h
+++ b/src/pveclib/vec_f64_ppc.h
@@ -24,7 +24,7 @@
 #define VEC_F64_PPC_H_
 
 #include <pveclib/vec_common_ppc.h>
-#include <pveclib/vec_int64_ppc.h>
+#include <pveclib/vec_int128_ppc.h>
 /*!
  * \file  vec_f64_ppc.h
  * \brief Header package containing a collection of 128-bit SIMD

--- a/src/vec_int512_runtime.c
+++ b/src/vec_int512_runtime.c
@@ -676,7 +676,9 @@ __VEC_PWR_IMP (vec_mul128_byMN) (vui128_t *p,
   vui128_t *np = m2;
   unsigned long mx = M;
   unsigned long nx = N;
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
   unsigned long px = M + N;
+#endif
   unsigned long i, j;
   vui128_t mpx0, mqx0, mpx1, mqx1;
 
@@ -746,7 +748,9 @@ __VEC_PWR_IMP (vec_mul512_byMN) (__VEC_U_512 *p,
   __VEC_U_512 *np = m2;
   unsigned long mx = M;
   unsigned long nx = N;
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
   unsigned long px = M + N;
+#endif
   unsigned long i, j;
   __VEC_U_1024x512 mpx0, mpx1;
   __VEC_U_512x1 sum1;


### PR DESCRIPTION
	* src/pveclib/vec_f64_ppc.h: Include vec_int128_ppc.h> to
	resolve forward refs.
	* src/pveclib/vec_int128_ppc.h (vec_muludm, vec_mulhuq,
	vec_muludq, vec_madduq, vec_madd2uq, vec_vmadd2oud,
	vec_vmsumeud): Remove unused local vars.
	* src/vec_int512_runtime.c (vec_mul128_byMN, vec_mul512_byMN):
	Remove unused local vars.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>