### PR TITLE
Lint and -Wall clean-up for V1.0.4. Compile test files.

### DIFF
--- a/src/testsuite/vec_int128_dummy.c
+++ b/src/testsuite/vec_int128_dummy.c
@@ -1178,6 +1178,8 @@ example_print_vint128 (vi128_t value)
   t_high = (vui64_t) vec_srqi (tmpq, shift_ten16);
   tmp = vec_vmuloud (t_high, (vui64_t) mul_ten16);
   t_mid = (vui64_t) vec_subuqm (val128, tmp);
+
+  // Work-around for GCC PR 96139
 #ifdef __clang__
   printf ("%c%07llu%016llu%016llu", sign, t_high[VEC_DW_L],
 	  t_mid[VEC_DW_L], t_low[VEC_DW_L]);

--- a/src/testsuite/vec_int128_dummy.c
+++ b/src/testsuite/vec_int128_dummy.c
@@ -906,8 +906,8 @@ __test_mulhuq (vui128_t a, vui128_t b)
 vui128_t
 __test_mulhuq2 (vui128_t a, vui128_t b)
 {
-  vui128_t mq, r;
-  r = vec_muludq (&mq, a, b);
+  vui128_t mq;
+  vec_muludq (&mq, a, b);
   return mq;
 }
 
@@ -1017,7 +1017,9 @@ test_mul128_MN (vui128_t *p, vui128_t *m1, vui128_t *m2,
   vui128_t *np = m2;
   unsigned long mx = M;
   unsigned long nx = N;
-  unsigned long px = M+N;
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  unsigned long px = M + N;
+#endif
   unsigned long i, j;
   vui128_t mpx0, mqx0, mpx1, mqx1;
 
@@ -1065,7 +1067,7 @@ test_mul128_MN (vui128_t *p, vui128_t *m1, vui128_t *m2,
 }
 
 void
-example_qw_convert_decimal (vui64_t *ten_16, vui128_t value)
+example_qw_convert_decimal (uint64_t *ten_16, vui128_t value)
 {
   /* Magic numbers for multiplicative inverse to divide by 10**32
    are 211857340822306639531405861550393824741, corrective add,
@@ -1086,6 +1088,7 @@ example_qw_convert_decimal (vui64_t *ten_16, vui128_t value)
 							 10000000000000000UL);
 
   vui128_t tmpq, tmpr, tmpc, tmp;
+  __VEC_U_128 tmp_16;
 
   // First divide/modulo by 10**32 to separate the top 7 digits from
   // the lower 32 digits
@@ -1102,7 +1105,8 @@ example_qw_convert_decimal (vui64_t *ten_16, vui128_t value)
   tmpr = vec_subuqm (value, tmp);
 
   // return top 16 digits
-  ten_16[0] = (vui64_t) tmpq[VEC_DW_L];
+  tmp_16.vx1 = tmpq;
+  ten_16[0] = tmp_16.ulong.lower;
 
   // Next divide/modulo the remaining 32 digits by 10**16.
   // This separates the middle and low 16 digits into doublewords.
@@ -1116,9 +1120,11 @@ example_qw_convert_decimal (vui64_t *ten_16, vui128_t value)
   tmpr = vec_subuqm (value, tmp);
 
   // return middle 16 digits
-  ten_16[1] = (vui64_t) tmpq[VEC_DW_L];
+  tmp_16.vx1 = tmpq;
+  ten_16[1] = tmp_16.ulong.lower;
   // return low 16 digits
-  ten_16[2] = (vui64_t) tmpr[VEC_DW_L];
+  tmp_16.vx1 = tmpr;
+  ten_16[2] = tmp_16.ulong.lower;
 }
 
 
@@ -1172,9 +1178,13 @@ example_print_vint128 (vi128_t value)
   t_high = (vui64_t) vec_srqi (tmpq, shift_ten16);
   tmp = vec_vmuloud (t_high, (vui64_t) mul_ten16);
   t_mid = (vui64_t) vec_subuqm (val128, tmp);
- 
+#ifdef __clang__
   printf ("%c%07llu%016llu%016llu", sign, t_high[VEC_DW_L],
 	  t_mid[VEC_DW_L], t_low[VEC_DW_L]);
+#else
+  printf ("%c%07lu%016lu%016lu", sign, t_high[VEC_DW_L],
+	  t_mid[VEC_DW_L], t_low[VEC_DW_L]);
+#endif
 }
 
 void

--- a/src/testsuite/vec_int16_dummy.c
+++ b/src/testsuite/vec_int16_dummy.c
@@ -144,7 +144,8 @@ __test_mrgeh2mrgoh (vui16_t a, vui16_t b, vui16_t c, vui16_t d)
 // Divide vector integer by constant divisor
 // Using multiplicative inverse
 static vui16_t
-__test_mulinvuh (vui16_t n, const unsigned short M, const unsigned short a,
+__test_mulinvuh (vui16_t n, const unsigned short M,
+		 const unsigned short a,
 		 const unsigned short s)
 {
   vui16_t result, q;
@@ -153,8 +154,7 @@ __test_mulinvuh (vui16_t n, const unsigned short M, const unsigned short a,
   q = vec_mulhuh (n, magic);
   if (a)
     {
-      const vui16_t vec_ones =
-	{ 1, 1, 1, 1, 1, 1, 1, 1 };
+      const vui16_t vec_ones = { 1, 1, 1, 1, 1, 1, 1, 1 };
       vui16_t n_1 = vec_sub (n, vec_ones);
       q = vec_avg (q, n_1);
       if (s > 1)

--- a/src/testsuite/vec_int16_dummy.c
+++ b/src/testsuite/vec_int16_dummy.c
@@ -135,128 +135,6 @@ __test_vaddcuq_alt7 (vui32_t a, vui32_t b)
   return ((vui32_t) co);
 }
 
-vui32_t
-__test_vmadduh_alt7 (vui32_t *mulh, vui16_t a, vui16_t b, vui16_t c)
-{
-  vui32_t t, tmq;// _ARCH_PWR7 or earlier and Big Endian only.  */
-
-  /* We use Vector Multiply Even/Odd Unsigned Halfword to compute
-   * the 128 x 16 partial (144-bit) product of vector a with a
-   * halfword element of b. The (for each halfword of vector b)
-   * 8 X 144-bit partial products are  summed to produce the full
-   * 256-bit product. */
-  vui16_t tsw;
-  vui16_t tc;
-  vui16_t t_odd, t_even;
-  vui16_t z = { 0, 0, 0, 0, 0, 0, 0, 0 };
-
-  tsw = vec_splat ((vui16_t) b, 7);
-#if 1
-  t_even = (vui16_t)vec_vmuleuh((vui16_t)a, tsw);
-  t_odd = (vui16_t)vec_vmulouh((vui16_t)a, tsw);
-#else
-  t_even = (vui16_t)vec_vmaddeuh((vui16_t)a, tsw, (vui16_t)c);
-  t_odd = (vui16_t)vec_vmaddouh((vui16_t)a, tsw, (vui16_t)c);
-#endif
-
-  /* Rotate the low 16-bits (right) into tmq. This is actually
-   * implemented as 112-bit (14-byte) shift left. */
-  tmq = (vui32_t)vec_sld (t_odd, z, 14);
-  /* shift the low 128 bits of partial product right 16-bits */
-  t_odd = vec_sld (z, t_odd, 14);
-  /* add the high 128 bits of even / odd partial products */
-  t = (vui32_t) __test_vadduqm_alt7 ((vui32_t) t_even, (vui32_t) t_odd);
-
-  tsw = vec_splat ((vui16_t) b, 6);
-  t_even = (vui16_t)vec_vmaddeuh((vui16_t)a, tsw, (vui16_t)t);
-  t_odd = (vui16_t)vec_vmaddouh((vui16_t)a, tsw, (vui16_t)t);
-
-  /* rotate right the low 16-bits into tmq */
-  tmq = (vui32_t)vec_sld (t_odd, (vui16_t)tmq, 14);
-  /* shift the low 128 bits (with carry) of partial product right
-   * 16-bits */
-  t_odd = vec_sld (tc, t_odd, 14);
-  /* add the top 128 bits of even / odd partial products */
-  t = (vui32_t) __test_vadduqm_alt7 ((vui32_t) t_even, (vui32_t) t_odd);
-
-  tsw = vec_splat ((vui16_t) b, 5);
-  t_even = (vui16_t)vec_vmaddeuh((vui16_t)a, tsw, (vui16_t)t);
-  t_odd = (vui16_t)vec_vmaddouh((vui16_t)a, tsw, (vui16_t)t);
-
-  /* rotate right the low 16-bits into tmq */
-  tmq = (vui32_t)vec_sld (t_odd, (vui16_t)tmq, 14);
-  /* shift the low 128 bits (with carry) of partial product right
-   * 16-bits */
-  t_odd = vec_sld (tc, t_odd, 14);
-  /* add the top 128 bits of even / odd partial products */
-  t = (vui32_t) __test_vadduqm_alt7 ((vui32_t) t_even, (vui32_t) t_odd);
-
-  tsw = vec_splat ((vui16_t) b, 4);
-  t_even = (vui16_t)vec_vmaddeuh((vui16_t)a, tsw, (vui16_t)t);
-  t_odd = (vui16_t)vec_vmaddouh((vui16_t)a, tsw, (vui16_t)t);
-
-  /* rotate right the low 16-bits into tmq */
-  tmq = (vui32_t)vec_sld (t_odd, (vui16_t)tmq, 14);
-  /* shift the low 128 bits (with carry) of partial product right
-   * 16-bits */
-  t_odd = vec_sld (tc, t_odd, 14);
-  /* add the top 128 bits of even / odd partial products */
-  t = (vui32_t) __test_vadduqm_alt7 ((vui32_t) t_even, (vui32_t) t_odd);
-
-  tsw = vec_splat ((vui16_t) b, 3);
-  t_even = (vui16_t)vec_vmaddeuh((vui16_t)a, tsw, (vui16_t)t);
-  t_odd = (vui16_t)vec_vmaddouh((vui16_t)a, tsw, (vui16_t)t);
-
-  /* rotate right the low 16-bits into tmq */
-  tmq = (vui32_t)vec_sld (t_odd, (vui16_t)tmq, 14);
-  /* shift the low 128 bits (with carry) of partial product right
-   * 16-bits */
-  t_odd = vec_sld (tc, t_odd, 14);
-  /* add the top 128 bits of even / odd partial products */
-  t = (vui32_t) __test_vadduqm_alt7 ((vui32_t) t_even, (vui32_t) t_odd);
-
-
-  tsw = vec_splat ((vui16_t) b, 2);
-  t_even = (vui16_t)vec_vmaddeuh((vui16_t)a, tsw, (vui16_t)t);
-  t_odd = (vui16_t)vec_vmaddouh((vui16_t)a, tsw, (vui16_t)t);
-
-  /* rotate right the low 16-bits into tmq */
-  tmq = (vui32_t)vec_sld (t_odd, (vui16_t)tmq, 14);
-  /* shift the low 128 bits (with carry) of partial product right
-   * 16-bits */
-  t_odd = vec_sld (tc, t_odd, 14);
-  /* add the top 128 bits of even / odd partial products */
-  t = (vui32_t) __test_vadduqm_alt7 ((vui32_t) t_even, (vui32_t) t_odd);
-
-  tsw = vec_splat ((vui16_t) b, 1);
-  t_even = (vui16_t)vec_vmaddeuh((vui16_t)a, tsw, (vui16_t)t);
-  t_odd = (vui16_t)vec_vmaddouh((vui16_t)a, tsw, (vui16_t)t);
-
-  /* rotate right the low 16-bits into tmq */
-  tmq = (vui32_t)vec_sld (t_odd, (vui16_t)tmq, 14);
-  /* shift the low 128 bits (with carry) of partial product right
-   * 16-bits */
-  t_odd = vec_sld (tc, t_odd, 14);
-  /* add the top 128 bits of even / odd partial products */
-  t = (vui32_t) __test_vadduqm_alt7 ((vui32_t) t_even, (vui32_t) t_odd);
-
-
-  tsw = vec_splat ((vui16_t) b, 0);
-  t_even = (vui16_t)vec_vmaddeuh((vui16_t)a, tsw, (vui16_t)t);
-  t_odd = (vui16_t)vec_vmaddouh((vui16_t)a, tsw, (vui16_t)t);
-
-  /* rotate right the low 16-bits into tmq */
-  tmq = (vui32_t)vec_sld (t_odd, (vui16_t)tmq, 14);
-  /* shift the low 128 bits (with carry) of partial product right
-   * 16-bits */
-  t_odd = vec_sld (tc, t_odd, 14);
-  /* add the top 128 bits of even / odd partial products */
-  t = (vui32_t) __test_vadduqm_alt7 ((vui32_t) t_even, (vui32_t) t_odd);
-
-  *mulh = t;
-  return ((vui32_t) tmq);
-}
-
 vui16_t
 __test_mrgeh2mrgoh (vui16_t a, vui16_t b, vui16_t c, vui16_t d)
 {
@@ -281,6 +159,8 @@ __test_mulinvuh (vui16_t n, const unsigned short M, const unsigned short a,
       q = vec_avg (q, n_1);
       if (s > 1)
 	result = vec_srhi (q, (s - 1));
+      else
+	result = q;
     }
   else
     result = vec_srhi (q, s);

--- a/src/testsuite/vec_int32_dummy.c
+++ b/src/testsuite/vec_int32_dummy.c
@@ -20,7 +20,7 @@
       Created on: Mar 29, 2018
  */
 
-#include <pveclib/vec_int32_ppc.h>
+#include <pveclib/vec_int128_ppc.h>
 
 #ifdef _ARCH_PWR8
 #ifndef __clang__

--- a/src/testsuite/vec_int512_dummy.c
+++ b/src/testsuite/vec_int512_dummy.c
@@ -280,8 +280,7 @@ void __attribute__((flatten))
 __VEC_PWR_IMP (test_mulu2048x512) (__VEC_U_512 p2560[5], __VEC_U_512 m1[4], __VEC_U_512 m2)
 {
   __VEC_U_1024x512 subp0, subp1, subp2, subp3;
-  __VEC_U_512x1 sum0, sum1, sum2, sum3, sumx;
-  __VEC_U_512 temp[4];
+  __VEC_U_512x1 sum0, sum1, sum2;
 
   subp0.x1024 = vec_mul512x512_inline (m1[0], m2);
   p2560[0] = subp0.x2.v0x512;
@@ -313,7 +312,7 @@ __VEC_PWR_IMP (test_mul1024x1024) (__VEC_U_2048 r2048, __VEC_U_1024 m1_1024, __V
   __VEC_U_2048x512 *p2048;
   __VEC_U_1024x512 *m1, *m2;
   __VEC_U_1024x512 subp0, subp1, subp2, subp3;
-  __VEC_U_512x1 sum0, sum1, sum2, sum3, sumx;
+  __VEC_U_512x1 sum1, sum2, sum3, sumx;
   __VEC_U_512 temp[3];
 
   p2048 = (__VEC_U_2048x512 *) &r2048;
@@ -350,7 +349,7 @@ __VEC_PWR_IMP (test_mul1024x1024x) (__VEC_U_2048 *r2048, __VEC_U_1024 *m1_1024, 
 {
   __VEC_U_512 *p2048, *m1, *m2;
   __VEC_U_1024x512 subp0, subp1, subp2, subp3;
-  __VEC_U_512x1 sum0, sum1, sum2, sum3, sumx;
+  __VEC_U_512x1 sum1, sum2, sum3, sumx;
   __VEC_U_512 temp[3];
 
   p2048 = (__VEC_U_512 *)r2048;
@@ -388,7 +387,7 @@ __VEC_PWR_IMP (test_mul1024x1024y) (__VEC_U_2048 *r2048, __VEC_U_1024 *m1_1024, 
   __VEC_U_2048x512 *p2048;
   __VEC_U_1024x512 *m1, *m2;
   __VEC_U_1024x512 subp0, subp1, subp2, subp3;
-  __VEC_U_512x1 sum0, sum1, sum2, sum3, sumx;
+  __VEC_U_512x1 sum1, sum2, sum3, sumx;
   __VEC_U_512 temp[3];
 
   p2048 = (__VEC_U_2048x512 *)r2048;
@@ -423,15 +422,9 @@ __VEC_PWR_IMP (test_mul1024x1024y) (__VEC_U_2048 *r2048, __VEC_U_1024 *m1_1024, 
 void  __attribute__((flatten ))
 __VEC_PWR_IMP (test_mul1024x1024z) (__VEC_U_2048x512 p2048, __VEC_U_1024x512 m1, __VEC_U_1024x512 m2)
 {
-  //__VEC_U_2048x512 *p2048;
-  //__VEC_U_1024x512 *m1, *m2;
   __VEC_U_1024x512 subp0, subp1, subp2, subp3;
-  __VEC_U_512x1 sum0, sum1, sum2, sum3, sumx;
+  __VEC_U_512x1 sum1, sum2, sum3, sumx;
   __VEC_U_512 temp[3];
-
-  //p2048 = (__VEC_U_2048x512 *)r2048;
-  //m1 = (__VEC_U_1024x512 *) m1_1024;
-  //m2 = (__VEC_U_1024x512 *) m2_1024;
 
   subp0.x1024 = vec_mul512x512_inline (m1.x2.v0x512, m2.x2.v0x512);
   p2048.x4.v0x512 = subp0.x2.v0x512;
@@ -462,7 +455,7 @@ void  __attribute__((flatten /*, target_clones("cpu=power9,default") */))
 __VEC_PWR_IMP (test_mulu2048x2048) (__VEC_U_512 p4096[8], __VEC_U_512 m1[4], __VEC_U_512 m2[4])
 {
   __VEC_U_1024x512 subp0, subp1, subp2, subp3;
-  __VEC_U_512x1 sum0, sum1, sum2, sum3, sumx;
+  __VEC_U_512x1 sum0, sum1, sum2, sumx;
   __VEC_U_512 temp[4];
 
   subp0.x1024 = vec_mul512x512_inline (m1[0], m2[0]);
@@ -589,7 +582,7 @@ __VEC_PWR_IMP (test_mulu2048x2048z) (__VEC_U_4096 *r4096,
 {
   __VEC_U_512 *p4096, *m1, *m2;
   __VEC_U_1024x512 subp0, subp1, subp2, subp3;
-  __VEC_U_512x1 sum0, sum1, sum2, sum3, sumx;
+  __VEC_U_512x1 sum0, sum1, sum2, sumx;
   __VEC_U_512 temp[4];
 
   p4096 = (__VEC_U_512 *)r4096;

--- a/src/testsuite/vec_int64_dummy.c
+++ b/src/testsuite/vec_int64_dummy.c
@@ -20,7 +20,7 @@
       Created on: Mar 29, 2018
  */
 
-#include <pveclib/vec_int64_ppc.h>
+#include <pveclib/vec_int128_ppc.h>
 
 vui64_t
 __test_vrld (vui64_t a, vui64_t b)

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -250,9 +250,8 @@ __test_muludq_y_PWR9 (vui128_t *mulu, vui128_t a, vui128_t b)
    * address of the 1st parm. The low 128-bits are the return
    * value.
    */
-  const vui64_t zero = { 0, 0 };
   vui64_t a_swap = vec_swapd ((vui64_t) a);
-  vui128_t tmh, tab, tba, tb0, tc1, tc2;
+  vui128_t tab, tba, tc1;
   /* multiply the low 64-bits of a and b.  For PWR9 this is just
    * vmsumudm with conditioned inputs.  */
   tmq = (vui32_t) vec_vmuloud ((vui64_t)a, (vui64_t)b);
@@ -407,8 +406,8 @@ __test_mulhluq_PWR9 (vui128_t *mulh, vui128_t a, vui128_t b)
 vui128_t
 __test_mulhuq2_PWR9 (vui128_t a, vui128_t b)
 {
-  vui128_t mq, r;
-  r = vec_muludq (&mq, a, b);
+  vui128_t mq;
+  vec_muludq (&mq, a, b);
   return mq;
 }
 
@@ -1505,7 +1504,7 @@ __test_remudq_10e32_PWR9  (vui128_t a, vui128_t b)
 }
 
 void
-example_qw_convert_decimal_PWR9 (vui64_t *ten_16, vui128_t value)
+example_qw_convert_decimal_PWR9 (uint64_t *ten_16, vui128_t value)
 {
   /* Magic numbers for multiplicative inverse to divide by 10**32
    are 211857340822306639531405861550393824741, corrective add,
@@ -1526,6 +1525,7 @@ example_qw_convert_decimal_PWR9 (vui64_t *ten_16, vui128_t value)
 							 10000000000000000UL);
 
   vui128_t tmpq, tmpr, tmpc, tmp;
+  __VEC_U_128 tmp_16;
 
   // First divide/modulo by 10**32 to separate the top 7 digits from
   // the lower 32 digits
@@ -1542,7 +1542,8 @@ example_qw_convert_decimal_PWR9 (vui64_t *ten_16, vui128_t value)
   tmpr = vec_subuqm (value, tmp);
 
   // return top 16 digits
-  ten_16[0] = (vui64_t) tmpq[VEC_DW_L];
+  tmp_16.vx1 = tmpq;
+  ten_16[0] = tmp_16.ulong.lower;
 
   // Next divide/modulo the remaining 32 digits by 10**16.
   // This separates the middle and low 16 digits into doublewords.
@@ -1556,9 +1557,11 @@ example_qw_convert_decimal_PWR9 (vui64_t *ten_16, vui128_t value)
   tmpr = vec_subuqm (value, tmp);
 
   // return middle 16 digits
-  ten_16[1] = (vui64_t) tmpq[VEC_DW_L];
+  tmp_16.vx1 = tmpq;
+  ten_16[1] = tmp_16.ulong.lower;
   // return low 16 digits
-  ten_16[2] = (vui64_t) tmpr[VEC_DW_L];
+  tmp_16.vx1 = tmpr;
+  ten_16[2] = tmp_16.ulong.lower;
 }
 
 vui128_t
@@ -1744,7 +1747,6 @@ __VEC_U_1024  __attribute__((flatten ))
 __test_madd512x512a512_PWR9 (__VEC_U_512 m1, __VEC_U_512 m2, __VEC_U_512 a1)
 {
   __VEC_U_1024 result;
-  vui128_t mc, mp, mq;
 #ifndef __clang__
 // Clang does not support register variables.
   register vui128_t t0 asm("vs10");
@@ -1839,7 +1841,7 @@ test_vec_mul1024x1024_PWR9 (__VEC_U_2048* r2048,
 #endif
 {
   __VEC_U_1024x512 subp0, subp1, subp2, subp3;
-  __VEC_U_512x1 sum0, sum1, sum2, sum3, sumx;
+  __VEC_U_512x1 sum1, sum2, sum3, sumx;
   __VEC_U_512 temp[3];
 #if 0
   __VEC_U_1024x512 * restrict pm1 = (__VEC_U_1024x512 *) m1_1024;


### PR DESCRIPTION
	* src/testsuite/vec_int128_dummy.c (__test_mulhuq,
	test_mul128_MN): Remove unused local vars.
	(example_qw_convert_decimal): Fix element extract type.
	(example_print_vint128): GCC PR #96139.
	* src/testsuite/vec_int16_dummy.c (__test_vmadduh_alt7):
	Removed.
	(__test_mrgeh2mrgoh): Initialize result for all paths.
	* src/testsuite/vec_int32_dummy.c: Include vec_int128_ppc.h>
	to resolve forward refs.
	* src/testsuite/vec_int512_dummy.c (test_mulu2048x512,
	test_mul1024x1024, test_mul1024x1024x, test_mul1024x1024y,
	test_mulu2048x2048): Remove unused local vars.
	* src/testsuite/vec_int64_dummy.c: Include vec_int128_ppc.h>
	to resolve forward refs.
	* src/testsuite/vec_pwr9_dummy.c: (__test_muludq_y_PWR9,
	__test_mulhuq2_PWR9): Remove unused local vars.
	(example_qw_convert_decimal_PWR9): Fix element extract type.
	(__test_madd512x512a512_PWR9): Remove unused local vars.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>