### PR TITLE
Lint and -Wall clean-up for V1.0.4. Unit/perf test files.

### DIFF
--- a/src/testsuite/arith128_print.c
+++ b/src/testsuite/arith128_print.c
@@ -611,15 +611,18 @@ print_v2b64c (char *prefix, vb64_t val)
 #endif
 }
 
+typedef unsigned long long int ullint_t;
+typedef long long int llint_t;
+
 void
 print_v2b64x (char *prefix, vb64_t boolval)
 {
   vui64_t val = (vui64_t)boolval;
 
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-  printf ("%s %016llx,%016llx\n", prefix, val[1], val[0]);
+  printf ("%s %016llx,%016llx\n", prefix, (ullint_t)val[1], (ullint_t)val[0]);
 #else
-  printf ("%s %016llx,%016llx\n", prefix, val[0], val[1]);
+  printf ("%s %016llx,%016llx\n", prefix, (ullint_t)val[0], (ullint_t)val[1]);
 #endif
 }
 
@@ -629,9 +632,9 @@ print_v2int64 (char *prefix, vui64_t val128)
   vui64_t val = (vui64_t) val128;
 
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-  printf ("%s %lld,%lld\n", prefix, val[1], val[0]);
+  printf ("%s %lld,%lld\n", prefix, (llint_t)val[1], (llint_t)val[0]);
 #else
-  printf ("%s %lld,%lld\n", prefix, val[0], val[1]);
+  printf ("%s %lld,%lld\n", prefix, (llint_t)val[0], (llint_t)val[1]);
 #endif
 }
 
@@ -641,9 +644,9 @@ print_v2xint64 (char *prefix, vui64_t val128)
   vui64_t val = (vui64_t) val128;
 
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-  printf ("%s %016llx,%016llx\n", prefix, val[1], val[0]);
+  printf ("%s %016llx,%016llx\n", prefix, (ullint_t)val[1], (ullint_t)val[0]);
 #else
-  printf ("%s %016llx,%016llx\n", prefix, val[0], val[1]);
+  printf ("%s %016llx,%016llx\n", prefix, (ullint_t)val[0], (ullint_t)val[1]);
 #endif
 }
 

--- a/src/testsuite/arith128_test_bcd.c
+++ b/src/testsuite/arith128_test_bcd.c
@@ -513,7 +513,7 @@ db_vec_cbcdaddcsq (vBCD_t *c, vBCD_t a, vBCD_t b)
     }
 #else
   vBCD_t sign_ab;
-  _Decimal128 d_a, d_b, d_s, d_t, d_m;
+  _Decimal128 d_a, d_b, d_s, d_t;
   vui32_t mz = CONST_VINT128_W(0, 0, 0, 0x0000000d);
   d_a = vec_BCD2DFP (a);
   d_b = vec_BCD2DFP (b);
@@ -531,6 +531,7 @@ db_vec_cbcdaddcsq (vBCD_t *c, vBCD_t a, vBCD_t b)
   if (!vec_all_eq(sign_ab, sum_ab) && !vec_all_eq(_BCD_CONST_ZERO, sum_ab))
     {
 #if 0
+      _Decimal128 d_m;
       // Optimization for P7 but failed test. need to come back to this
       const _Decimal128 ten31 = 10000000000000000000000000000000.0DL;
       t = vec_bcdcpsgn (_BCD_CONST_PLUS_ONE, sum_ab);
@@ -593,7 +594,7 @@ db_vec_cbcdaddecsq (vBCD_t *co, vBCD_t a, vBCD_t b, vBCD_t ci)
 #else
   const vui32_t mz = CONST_VINT128_W(0, 0, 0, 0x0000000d);
   vBCD_t sign_abc;
-  _Decimal128 d_a, d_b, d_c, d_s, d_t, d_m;
+  _Decimal128 d_a, d_b, d_c, d_s, d_t;
   d_a = vec_BCD2DFP (a);
   d_b = vec_BCD2DFP (b);
   d_c = vec_BCD2DFP (ci);
@@ -612,6 +613,7 @@ db_vec_cbcdaddecsq (vBCD_t *co, vBCD_t a, vBCD_t b, vBCD_t ci)
   if (!vec_all_eq(sign_abc, sum_abc))
     {
 #if 0
+      _Decimal128 d_m;
       // Optimization for P7 but failed test. need to come back to this
       const _Decimal128 ten31 = 10000000000000000000000000000000.0DL;
       c = vec_bcdcpsgn (_BCD_CONST_PLUS_ONE, sum_abc);
@@ -8352,7 +8354,7 @@ test_longbcdct_10e32 (void)
 	  { (__int128) 10000000000000000UL * (__int128) 10000000000000000UL };
 #endif
   vui128_t ix[8], jx[8];
-  vBCD_t el, er;
+  vBCD_t er;
   vBCD_t rm, bcd[10];
   long int cnt;
   int rc = 0;

--- a/src/testsuite/arith128_test_i512.c
+++ b/src/testsuite/arith128_test_i512.c
@@ -647,7 +647,7 @@ test_mul256x256 (void)
 int
 test_mul512x128_MN (void)
 {
-  __VEC_U_640 k, e;
+  __VEC_U_640 k;
   __VEC_U_512x1 ke, ep;
   __VEC_U_512 i;
   vui128_t *kp, *ip, *jp;
@@ -754,7 +754,7 @@ test_mul512x128_MN (void)
 int
 test_mul512x128 (void)
 {
-  __VEC_U_640 k, e;
+  __VEC_U_640 k;
   __VEC_U_512x1 kp, ep;
   __VEC_U_512 i;
   vui128_t j;
@@ -874,7 +874,7 @@ test_mul512x128 (void)
 int
 test_madd512x128 (void)
 {
-  __VEC_U_640 k, e;
+  __VEC_U_640 k;
   __VEC_U_512x1 kp, ep;
   __VEC_U_512 i, m;
   vui128_t j, n;
@@ -1062,7 +1062,7 @@ test_madd512x128 (void)
 int
 test_mul512x512_MN (void)
 {
-  __VEC_U_1024 k, e;
+  __VEC_U_1024 k;
   __VEC_U_1024x512 ke, ep;
   __VEC_U_512 i, j;
   vui128_t *kp, *ip, *jp;
@@ -1210,7 +1210,7 @@ test_mul512x512_MN (void)
 int
 test_mul512x512 (void)
 {
-  __VEC_U_1024 k, e;
+  __VEC_U_1024 k;
   __VEC_U_1024x512 kp, ep;
   __VEC_U_512 i, j;
   int rc = 0;
@@ -1468,7 +1468,6 @@ test_mul1024x1024 (void)
 {
   __VEC_U_2048x512 k, e;
   __VEC_U_1024x512 m1, m2;
-  __VEC_U_512 i, j;
 
   int rc = 0;
 
@@ -1724,7 +1723,6 @@ test_mul2048x2048_MN (void)
   __VEC_U_512 k1[16];
   __VEC_U_4096x512 k, e;
   __VEC_U_2048x512 m1, m2;
-  __VEC_U_512 i, j;
   __VEC_U_512 *kp, *ip, *jp;
   int rc = 0;
 
@@ -2318,7 +2316,6 @@ test_mul2048x2048 (void)
 {
   __VEC_U_4096x512 k, e;
   __VEC_U_2048x512 m1, m2;
-  __VEC_U_512 i, j;
 
   int rc = 0;
 

--- a/src/testsuite/vec_perf_i128.c
+++ b/src/testsuite/vec_perf_i128.c
@@ -496,14 +496,14 @@ timed_cfmaxdouble_10e32 (void)
 int
 timed_ctmaxdouble_10e32 (void)
 {
+  int rc = 0;
+#ifndef PVECLIB_DISABLE_F128MATH
   // Compiler __DBL_MAX__ "1.79769313486231570814527423731704e+308"
   // 53 digit precision equivalent of __DBL_MAX__
   char buf[64] = "1.7976931348623157081452742373170435679807056752584499e+308";
   char *res;
   double d = 0;
-  int rc = 0;
 
-#ifndef PVECLIB_DISABLE_F128MATH
   d = strtod (buf, &res);
 
   if (d != __DBL_MAX__)

--- a/src/testsuite/vec_perf_i512.c
+++ b/src/testsuite/vec_perf_i512.c
@@ -50,7 +50,7 @@ int
 timed_mul1024x1024by8 (void)
 {
   __VEC_U_2048x512 k1, k2;
-  __VEC_U_1024x512 m1, m2;
+  __VEC_U_1024x512 m1;
   int rc = 0;
 
 #ifdef __DEBUG_PRINT__
@@ -92,8 +92,7 @@ int
 timed_mul2048x2048by8 (void)
 {
   __VEC_U_4096x512 k1, k2;
-  __VEC_U_2048x512 m1, m2;
-  __VEC_U_512 i, j;
+  __VEC_U_2048x512 m1;
 
   int rc = 0;
 
@@ -145,8 +144,7 @@ int
 timed_mul2048x2048_MN (void)
 {
   __VEC_U_4096x512 k1, k2;
-  __VEC_U_2048x512 m1, m2;
-  __VEC_U_512 i, j;
+  __VEC_U_2048x512 m1;
   __VEC_U_512 *kp1, *kp2, *ip, *jp1, *jp2;
 
   int rc = 0;
@@ -221,8 +219,7 @@ int
 timed_mul4096x4096_MN (void)
 {
   __VEC_U_512 k1[16], k2[16];
-  __VEC_U_4096x512 m1, m2;
-  __VEC_U_512 i, j;
+  __VEC_U_4096x512 m1;
   __VEC_U_512 *kp1, *kp2, *ip, *jp1, *jp2;
 
   int rc = 0;
@@ -305,7 +302,6 @@ timed_mul1024x1024 (void)
 {
   __VEC_U_2048x512 k, e;
   __VEC_U_1024x512 m1, m2;
-  __VEC_U_512 i, j;
   int rc = 0;
 
 #ifdef __DEBUG_PRINT__
@@ -571,7 +567,6 @@ timed_mul2048x2048 (void)
 {
   __VEC_U_4096x512 k, e;
   __VEC_U_2048x512 m1, m2;
-  __VEC_U_512 i, j;
 
   int rc = 0;
 
@@ -984,7 +979,7 @@ timed_mul512x512by8 (void)
 int
 timed_mul512x512 (void)
 {
-  __VEC_U_1024 k, e;
+  __VEC_U_1024 k;
   __VEC_U_1024x512 kp, ep;
   __VEC_U_512 i, j;
   int rc = 0;


### PR DESCRIPTION
	* src/testsuite/arith128_print.c (print_v2b64x, print_v2int64,
	print_v2xint64): Work-around for GCC PR #96139.
	* src/testsuite/arith128_test_bcd.c (db_vec_cbcdaddcsq,
	test_longbcdct_10e32): Remove unused local vars.
	* src/testsuite/arith128_test_i512.c (test_mul512x128_MN,
	test_mul512x128, test_madd512x128, test_mul512x512_MN,
	test_mul512x512, test_mul1024x1024, test_mul2048x2048_MN,
	test_mul2048x2048): Remove unused local vars.
	* src/testsuite/vec_perf_i128.c [PVECLIB_DISABLE_F128MATH]:
	include local vars.
	* src/testsuite/vec_perf_i512.c (timed_mul1024x1024by8,
	timed_mul2048x2048_MN, timed_mul2048x2048by8,
	timed_mul4096x4096_MN, timed_mul1024x1024, timed_mul2048x2048,
	timed_mul512x512): Remove unused local vars.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>