### PR TITLE
Add missing files to the distribution

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,7 +15,21 @@ dist_doc_DATA = COPYING CONTRIBUTING.md README.md ChangeLog.md
 
 SUBDIRS= src
 
-EXTRA_DIST = $(DX_CONFIG) doc/pveclibmaindox.h
+EXTRA_DIST = $(DX_CONFIG) doc/pveclibmaindox.h \
+  testprograms/test_ppc_970.c \
+  testprograms/test_ppc_bool_int128.c \
+  testprograms/test_ppc_const_int128.c \
+  testprograms/test_ppc_DFP.c \
+  testprograms/test_ppc_F128arith.c \
+  testprograms/test_ppc_F128.c \
+  testprograms/test_ppc_F128math.c \
+  testprograms/test_ppc_int128.c \
+  testprograms/test_ppc_PWR6.c \
+  testprograms/test_ppc_PWR7.c \
+  testprograms/test_ppc_PWR8.c \
+  testprograms/test_ppc_PWR9.c \
+  testprograms/test_ppc_VMX.c \
+  testprograms/test_ppc_VSX.c
 
 distclean-local:
 	rm $(top_builddir)/aminclude.am

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -127,7 +127,15 @@ endif
 	$(PVECCOMPILE) -fpic $(PVECLIB_DEFAULT_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_common.c
 endif
 
-EXTRA_DIST =
+EXTRA_DIST = \
+  vec_runtime_PWR7.c \
+  vec_runtime_PWR8.c \
+  vec_runtime_PWR9.c \
+  vec_runtime_common.c \
+  vec_int512_runtime.c
+
+distclean-local:
+	rm $(DEPDIR)/*.Plo
 
 # This rule is necessary because pvec_test needs to statically link
 # .libs/libpvecstatic.a and if make is executed in parallel (-jN) the 


### PR DESCRIPTION
While working on an early Debian package for the newer version of pveclib (1.0.4), I noticed that 'make dist' produces tarballs that have missing files. These missing files also cause 'make distclean' and 'make distcheck' to fail. This patch addresses these problems.