### PR TITLE
Initial update for Count Trailing Zeros (CTZ) operations.

### DIFF
--- a/src/pveclib/vec_int32_ppc.h
+++ b/src/pveclib/vec_int32_ppc.h
@@ -394,6 +394,13 @@ example_convert_timebase (vui32_t *tb, vui32_t *timespec, int n)
 ///@cond INTERNAL
 static inline vui64_t vec_muleuw (vui32_t a, vui32_t b);
 static inline vui64_t vec_mulouw (vui32_t a, vui32_t b);
+#ifndef vec_popcntw
+static inline vui32_t vec_popcntw (vui32_t vra);
+#else
+/* Work around for GCC PR85830.  */
+#undef vec_popcntw
+#define vec_popcntw __builtin_vec_vpopcntw
+#endif
 static inline vi32_t vec_srawi (vi32_t vra, const unsigned int shb);
 static inline vui64_t vec_vmuleuw (vui32_t a, vui32_t b);
 static inline vui64_t vec_vmulouw (vui32_t a, vui32_t b);
@@ -532,6 +539,60 @@ vec_clzw (vui32_t vra)
   nt = vec_sub (n, x);
   n = vec_sel (nt, n, m);
   r = n;
+#endif
+  return ((vui32_t) r);
+}
+
+/** \brief Vector Count Trailing Zeros word.
+ *
+ *  Count the number of trailing '0' bits (0-32) within each word
+ *  element of a 128-bit vector.
+ *
+ *  For POWER9 (PowerISA 3.0B) or later use the Vector Count Trailing
+ *  Zeros Word instruction <B>vctzw</B>. Otherwise use a sequence of
+ *  pre ISA 3.0 VMX instructions.
+ *  SIMDized count Trailing zeros inspired by:
+ *
+ *  Warren, Henry S. Jr and <I>Hacker's Delight</I>, 2nd Edition,
+ *  Addison Wesley, 2013. Chapter 5 Counting Bits, Section 5-4.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   |  6-8  | 2/cycle  |
+ *  |power9   |   3   | 2/cycle  |
+ *
+ *  @param vra 128-bit vector treated as 4 x 32-bit integer (words)
+ *  elements.
+ *  @return 128-bit vector with the Trailng Zeros count for each word
+ *  element.
+ */
+static inline vui32_t
+vec_ctzw (vui32_t vra)
+{
+  vui32_t r;
+#ifdef _ARCH_PWR9
+#if defined (vec_cnttz)
+  r = vec_cnttz (vra);
+#elif defined (__clang__)
+  r = vec_cnttz (vra);
+#else
+  __asm__(
+      "vctzw %0,%1;"
+      : "=v" (r)
+      : "v" (vra)
+      : );
+#endif
+#else
+// For _ARCH_PWR8 and earlier. Generate 1's for the trailing zeros
+// and 0's otherwise. Then count (popcnt) the 1's. _ARCH_PWR8 uses
+// the hardware vpopcntw instruction. _ARCH_PWR7 and earlier use the
+// PVECLIB vec_popcntw implementation which runs ~20-28 instructions.
+  const vui32_t ones = { 1, 1, 1, 1 };
+  vui32_t tzmask;
+  // tzmask = (!vra & (vra - 1))
+  tzmask = vec_andc (vec_sub (vra, ones), vra);
+  // return = vec_popcnt (!vra & (vra - 1))
+  r = vec_popcntw (tzmask);
 #endif
   return ((vui32_t) r);
 }

--- a/src/pveclib/vec_int32_ppc.h
+++ b/src/pveclib/vec_int32_ppc.h
@@ -571,9 +571,7 @@ vec_ctzw (vui32_t vra)
 {
   vui32_t r;
 #ifdef _ARCH_PWR9
-#if defined (vec_cnttz)
-  r = vec_cnttz (vra);
-#elif defined (__clang__)
+#if defined (vec_cnttz) || defined (__clang__)
   r = vec_cnttz (vra);
 #else
   __asm__(

--- a/src/testsuite/arith128_test_i32.c
+++ b/src/testsuite/arith128_test_i32.c
@@ -309,6 +309,116 @@ test_clzw (void)
   return (rc);
 }
 
+int
+test_ctzw (void)
+{
+  vui32_t i, e, j;
+  int rc = 0;
+
+  printf ("\ntest_ctzw Vector Count Trailing Zeros in words\n");
+
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
+  e = (vui32_t)CONST_VINT32_W(32, 32, 32, 32);
+  j = vec_ctzw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(0) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(-1, 0, -1, 0);
+  e = (vui32_t)CONST_VINT32_W(0, 32, 0, 32);
+  j = vec_ctzw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(-1, 0, -1, 0) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(0, 1, 2, 4);
+  e = (vui32_t)CONST_VINT32_W(32, 0, 1, 2);
+  j = vec_ctzw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(0, 1, 2, 4) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(8, 16, 32, 64);
+  e = (vui32_t)CONST_VINT32_W(3, 4, 5, 6);
+  j = vec_ctzw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(8, 16, 32, 64) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(128, 256, 512, 1024);
+  e = (vui32_t)CONST_VINT32_W(7, 8, 9, 10);
+  j = vec_ctzw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(128, 256, 512, 1024) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(2048, 4096, 8192, 16384);
+  e = (vui32_t)CONST_VINT32_W(11, 12, 13, 14);
+  j = vec_ctzw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(2048, 4096, 8192, 16384) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(32768, 65536, 131072, 262144);
+  e = (vui32_t)CONST_VINT32_W(15, 16, 17, 18);
+  j = vec_ctzw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(32768, 65536, 131072, 262144) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(524288, 1048576, 2097152, 4194304);
+  e = (vui32_t)CONST_VINT32_W(19, 20, 21, 22);
+  j = vec_ctzw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(524288, 1048576, 2097152, 4194304) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(8388608, 16777216, 33554432, 67108864);
+  e = (vui32_t)CONST_VINT32_W(23, 24, 25, 26);
+  j = vec_ctzw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(8388608, 16777216, 33554432, 67108864) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(134217728, 268435456, 536870912, 1073741824);
+  e = (vui32_t)CONST_VINT32_W(27, 28, 29, 30);
+  j = vec_ctzw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(134217728, 268435456, 536870912, 1073741824) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(-2147483648, -268435456, -16777216, -1048576);
+  e = (vui32_t)CONST_VINT32_W(31, 28, 24, 20);
+  j = vec_ctzw(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(-2147483648, -268435456, -16777216, -1048576) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzw:", (vui128_t)j, (vui128_t) e);
+
+  return (rc);
+}
+
 //#define __DEBUG_PRINT__ 1
 int
 test_mulhuw (void)
@@ -1117,6 +1227,7 @@ test_vec_i32 (void)
 
   rc += test_revbw ();
   rc += test_clzw ();
+  rc += test_ctzw ();
   rc += test_popcntw();
   rc += test_mulesw();
   rc += test_mulosw();

--- a/src/testsuite/vec_int32_dummy.c
+++ b/src/testsuite/vec_int32_dummy.c
@@ -22,6 +22,47 @@
 
 #include <pveclib/vec_int128_ppc.h>
 
+vui32_t
+test_ctz_v1 (vui32_t vra)
+{
+  const vui32_t ones = { 1, 1, 1, 1 };
+  const vui32_t c32s = { 32, 32, 32, 32 };
+  vui32_t result, term;
+  // term = (!vra & (vra - 1))
+  term = vec_andc (vec_sub (vra, ones), vra);
+  // return = 32 - vec_clz (!vra & (vra - 1))
+  return (c32s - vec_clzw (term));
+}
+
+vui32_t
+test_ctz_v2 (vui32_t vra)
+{
+  const vui32_t ones = { 1, 1, 1, 1 };
+  vui32_t result, term;
+  // term = (!vra & (vra - 1))
+  term = vec_andc (vec_sub (vra, ones), vra);
+  // return = vec_popcnt (!vra & (vra - 1))
+  return (vec_popcntw (term));
+}
+
+vui32_t
+test_ctz_v3 (vui32_t vra)
+{
+  const vui32_t zeros = { 0, 0, 0, 0 };
+  const vui32_t c32s = { 32, 32, 32, 32 };
+  vui32_t result, term;
+  // term = (vra | -vra))
+  term = vec_or (vra, vec_sub (zeros, vra));
+  // return = 32 - vec_poptcnt (vra & -vra)
+  return (c32s - vec_popcntw (term));
+}
+
+vui32_t
+test_vec_ctzw (vui32_t vra)
+{
+  return (vec_ctzw (vra));
+}
+
 #ifdef _ARCH_PWR8
 #ifndef __clang__
 // clang does not support specific built-ins for new (PWR8) operations.


### PR DESCRIPTION
Vector Count Trailing Zeros instructions where added for POWER9.
These will be useful for implementing POWER10 Vector integer divide
and POWER9 Float128 round-to-odd operations on older processors. CTZ
can be implemented in a little as 3 instruction on POWER8.

	* src/pveclib/vec_int32_ppc.h [@cond INTERNAL] Forward ref
	vec_popcntw.
	(vec_ctzw): New operation.

	* src/testsuite/arith128_test_i32.c (test_ctzw): New Unit test.
	(test_vec_i32): Call test_ctzw.

	* src/testsuite/vec_int32_dummy.c (test_ctz_v1, test_ctz_v2,
	test_ctz_v3, test_vec_ctzw): New compile tests.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>