### PR TITLE
Continue update for Count Trailing Zeros (CTZ) operations.

### DIFF
--- a/src/pveclib/vec_char_ppc.h
+++ b/src/pveclib/vec_char_ppc.h
@@ -137,6 +137,13 @@
  */
 
 ///@cond INTERNAL
+#ifndef vec_popcntb
+static inline vui8_t vec_popcntb (vui8_t vra);
+#else
+/* Work around for GCC PR85830.  */
+#undef vec_popcntb
+#define vec_popcntb __builtin_vec_vpopcntb
+#endif
 static inline vui8_t vec_vmrgeb (vui8_t vra, vui8_t vrb);
 static inline vui8_t vec_vmrgob (vui8_t vra, vui8_t vrb);
 ///@endcond
@@ -260,6 +267,70 @@ vec_clzb (vui8_t vra)
 #endif
 
   return (r);
+}
+
+/** \brief Vector Count Trailing Zeros Byte.
+ *
+ *  Count the number of trailing '0' bits (0-16) within each byte
+ *  element of a 128-bit vector.
+ *
+ *  For POWER9 (PowerISA 3.0B) or later use the Vector Count Trailing
+ *  Zeros Byte instruction <B>vctzb</B>. Otherwise use a sequence of
+ *  pre ISA 3.0 VMX instructions.
+ *  SIMDized count Trailing zeros inspired by:
+ *
+ *  Warren, Henry S. Jr and <I>Hacker's Delight</I>, 2nd Edition,
+ *  Addison Wesley, 2013. Chapter 5 Counting Bits, Section 5-4.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   |  6-8  | 2/cycle  |
+ *  |power9   |   3   | 2/cycle  |
+ *
+ *  @param vra 128-bit vector treated as 16 x 8-bit char
+ *  (byte) elements.
+ *  @return 128-bit vector with the Trailng Zeros count for each
+ *  byte element.
+ */
+static inline vui8_t
+vec_ctzb (vui8_t vra)
+{
+  vui8_t r;
+#ifdef _ARCH_PWR9
+#if defined (vec_cnttz) || defined (__clang__)
+  r = vec_cnttz (vra);
+#else
+  __asm__(
+      "vctzb %0,%1;"
+      : "=v" (r)
+      : "v" (vra)
+      : );
+#endif
+#elif _ARCH_PWR8
+// For _ARCH_PWR8. Generate 1's for the trailing zeros
+// and 0's otherwise. Then count (popcnt) the 1's.
+// _ARCH_PWR8 uses the hardware vpopcntb instruction.
+  const vui8_t ones = vec_splat_u8 (1);
+  vui8_t tzmask;
+  // tzmask = (!vra & (vra - 1))
+  tzmask = vec_andc (vec_sub (vra, ones), vra);
+  // return = vec_popcnt (!vra & (vra - 1))
+  r = vec_popcntb (tzmask);
+#else
+  // For _ARCH_PWR7 and earlier (without hardware clz or popcnt).
+  // Generate 1's for the trailing zeros and 0's otherwise.
+  // Then count leading 0's using the PVECLIB vec_clzb implementation
+  // which minimizes the number of constant loads (vs popcntb).
+  // Finally subtract this count from 8.
+  const vui8_t ones = vec_splat_u8 (1);
+  const vui8_t c8s = vec_splat_u8 (8);
+  vui8_t term;
+  // term = (!vra & (vra - 1))
+  term = vec_andc (vec_sub (vra, ones), vra);
+  // return = 8 - vec_clz (!vra & (vra - 1))
+  return vec_sub (c8s, vec_clzb (term));
+#endif
+  return ((vui8_t) r);
 }
 
 /** \brief Vector isalpha.

--- a/src/pveclib/vec_char_ppc.h
+++ b/src/pveclib/vec_char_ppc.h
@@ -186,14 +186,14 @@ vec_absdub (vui8_t vra, vui8_t vrb)
   return (result);
 }
 
-/** \brief Count leading zeros for a vector unsigned char (byte)
+/** \brief Vector Count Leading Zeros Byte for a unsigned char (byte)
  *  elements.
  *
  *  Count the number of leading '0' bits (0-7) within each byte
  *  element of a 128-bit vector.
  *
  *  For POWER8 (PowerISA 2.07B) or later use the Vector Count Leading
- *  Zeros byte instruction <B>vclzb</B>. Otherwise use sequence of pre
+ *  Zeros Byte instruction <B>vclzb</B>. Otherwise use sequence of pre
  *  2.07 VMX instructions.
  *  SIMDized count leading zeros inspired by:
  *
@@ -205,9 +205,9 @@ vec_absdub (vui8_t vra, vui8_t vrb)
  *  |power8   |   2   | 2/cycle  |
  *  |power9   |   3   | 2/cycle  |
  *
- *  @param vra 128-bit vector treated as 16 x 8-bit integer (byte)
- *  elements.
- *  @return 128-bit vector with the Leading Zeros count for each
+ *  @param vra 128-bit vector treated as 16 x 8-bit unsigned integer
+ *  (byte) elements.
+ *  @return 128-bit vector with the leading zeros count for each
  *  byte element.
  */
 static inline vui8_t
@@ -269,15 +269,16 @@ vec_clzb (vui8_t vra)
   return (r);
 }
 
-/** \brief Vector Count Trailing Zeros Byte.
+/** \brief Vector Count Trailing Zeros Byte for a unsigned char (byte)
+ *  elements.
  *
- *  Count the number of trailing '0' bits (0-16) within each byte
+ *  Count the number of trailing '0' bits (0-8) within each byte
  *  element of a 128-bit vector.
  *
  *  For POWER9 (PowerISA 3.0B) or later use the Vector Count Trailing
  *  Zeros Byte instruction <B>vctzb</B>. Otherwise use a sequence of
  *  pre ISA 3.0 VMX instructions.
- *  SIMDized count Trailing zeros inspired by:
+ *  SIMDized count trailing zeros inspired by:
  *
  *  Warren, Henry S. Jr and <I>Hacker's Delight</I>, 2nd Edition,
  *  Addison Wesley, 2013. Chapter 5 Counting Bits, Section 5-4.
@@ -287,9 +288,9 @@ vec_clzb (vui8_t vra)
  *  |power8   |  6-8  | 2/cycle  |
  *  |power9   |   3   | 2/cycle  |
  *
- *  @param vra 128-bit vector treated as 16 x 8-bit char
+ *  @param vra 128-bit vector treated as 16 x 8-bit unsigned char
  *  (byte) elements.
- *  @return 128-bit vector with the Trailng Zeros count for each
+ *  @return 128-bit vector with the trailing zeros count for each
  *  byte element.
  */
 static inline vui8_t

--- a/src/pveclib/vec_int16_ppc.h
+++ b/src/pveclib/vec_int16_ppc.h
@@ -532,7 +532,7 @@ vec_absduh (vui16_t vra, vui16_t vrb)
   return (result);
 }
 
-/** \brief Count Leading Zeros for a vector unsigned short (halfword)
+/** \brief Vector Count Leading Zeros Halfword for unsigned short
  *  elements.
  *
  *  Count the number of leading '0' bits (0-16) within each halfword
@@ -551,9 +551,9 @@ vec_absduh (vui16_t vra, vui16_t vrb)
  *  |power8   |   2   | 2/cycle  |
  *  |power9   |   3   | 2/cycle  |
  *
- *  @param vra 128-bit vector treated as 8 x 16-bit integer (halfword)
- *  elements.
- *  @return 128-bit vector with the Leading Zeros count for each
+ *  @param vra 128-bit vector treated as 8 x 16-bit unsigned integer
+ *  (halfword) elements.
+ *  @return 128-bit vector with the leading zeros count for each
  *  halfword element.
  */
 static inline vui16_t
@@ -622,7 +622,8 @@ vec_clzh (vui16_t vra)
   return (r);
 }
 
-/** \brief Vector Count Trailing Zeros Halfword.
+/** \brief Vector Count Trailing Zeros Halfword for unsigned short
+ *  elements.
  *
  *  Count the number of trailing '0' bits (0-16) within each halfword
  *  element of a 128-bit vector.
@@ -630,7 +631,7 @@ vec_clzh (vui16_t vra)
  *  For POWER9 (PowerISA 3.0B) or later use the Vector Count Trailing
  *  Zeros Halfword instruction <B>vctzh</B>. Otherwise use a sequence of
  *  pre ISA 3.0 VMX instructions.
- *  SIMDized count Trailing zeros inspired by:
+ *  SIMDized count trailing zeros inspired by:
  *
  *  Warren, Henry S. Jr and <I>Hacker's Delight</I>, 2nd Edition,
  *  Addison Wesley, 2013. Chapter 5 Counting Bits, Section 5-4.
@@ -640,9 +641,9 @@ vec_clzh (vui16_t vra)
  *  |power8   |  6-8  | 2/cycle  |
  *  |power9   |   3   | 2/cycle  |
  *
- *  @param vra 128-bit vector treated as 8 x 16-bit short integer
- *  (halfwords) elements.
- *  @return 128-bit vector with the Trailng Zeros count for each
+ *  @param vra 128-bit vector treated as 8 x 16-bit unsigned short
+ *  integer (halfwords) elements.
+ *  @return 128-bit vector with the trailing zeros count for each
  *  halfword element.
  */
 static inline vui16_t

--- a/src/pveclib/vec_int16_ppc.h
+++ b/src/pveclib/vec_int16_ppc.h
@@ -482,6 +482,13 @@ __test_div10000 (vui16_t n)
  */
 
 ///@cond INTERNAL
+#ifndef vec_popcnth
+static inline vui16_t vec_popcnth (vui16_t vra);
+#else
+/* Work around for GCC PR85830.  */
+#undef vec_popcnth
+#define vec_popcnth __builtin_vec_vpopcnth
+#endif
 static inline vui16_t vec_vmrgeh (vui16_t vra, vui16_t vrb);
 static inline vui16_t vec_vmrgoh (vui16_t vra, vui16_t vrb);
 ///@endcond
@@ -613,6 +620,58 @@ vec_clzh (vui16_t vra)
 #endif
 
   return (r);
+}
+
+/** \brief Vector Count Trailing Zeros Halfword.
+ *
+ *  Count the number of trailing '0' bits (0-16) within each halfword
+ *  element of a 128-bit vector.
+ *
+ *  For POWER9 (PowerISA 3.0B) or later use the Vector Count Trailing
+ *  Zeros Halfword instruction <B>vctzh</B>. Otherwise use a sequence of
+ *  pre ISA 3.0 VMX instructions.
+ *  SIMDized count Trailing zeros inspired by:
+ *
+ *  Warren, Henry S. Jr and <I>Hacker's Delight</I>, 2nd Edition,
+ *  Addison Wesley, 2013. Chapter 5 Counting Bits, Section 5-4.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   |  6-8  | 2/cycle  |
+ *  |power9   |   3   | 2/cycle  |
+ *
+ *  @param vra 128-bit vector treated as 8 x 16-bit short integer
+ *  (halfwords) elements.
+ *  @return 128-bit vector with the Trailng Zeros count for each
+ *  halfword element.
+ */
+static inline vui16_t
+vec_ctzh (vui16_t vra)
+{
+  vui16_t r;
+#ifdef _ARCH_PWR9
+#if defined (vec_cnttz) || defined (__clang__)
+  r = vec_cnttz (vra);
+#else
+  __asm__(
+      "vctzh %0,%1;"
+      : "=v" (r)
+      : "v" (vra)
+      : );
+#endif
+#else
+// For _ARCH_PWR8 and earlier. Generate 1's for the trailing zeros
+// and 0's otherwise. Then count (popcnt) the 1's. _ARCH_PWR8 uses
+// the hardware vpopcnth instruction. _ARCH_PWR7 and earlier use the
+// PVECLIB vec_popcnth implementation which runs ~20-26 instructions.
+  const vui16_t ones = vec_splat_u16 (1);
+  vui16_t tzmask;
+  // tzmask = (!vra & (vra - 1))
+  tzmask = vec_andc (vec_sub (vra, ones), vra);
+  // return = vec_popcnt (!vra & (vra - 1))
+  r = vec_popcnth (tzmask);
+#endif
+  return ((vui16_t) r);
 }
 
 /** \brief Vector Merge Algebraic High Halfword operation.

--- a/src/testsuite/arith128_test_char.c
+++ b/src/testsuite/arith128_test_char.c
@@ -246,6 +246,27 @@ test_clzb (void)
 }
 
 int
+test_ctzb (void)
+{
+  vui32_t i, e;
+  vui8_t j;
+  int rc = 0;
+
+  printf ("\ntest_ctzb Vector Count Trailing Zeros in bytes\n");
+
+  i = (vui32_t )CONST_VINT32_W(0x00010204, 0x08102040, 0x80882211, 0xf0ffaa55);
+  e = (vui32_t )CONST_VINT32_W(0x08000102, 0x03040506, 0x07030100, 0x04000100);
+  j = vec_ctzb((vui8_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("ctz(0x00010204, 0x08102040, 0x80882211, 0xf0ffaa55) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzb:", (vui128_t)j, (vui128_t) e);
+
+  return (rc);
+}
+
+int
 test_popcntb (void)
 {
   vui8_t i, e;
@@ -620,6 +641,7 @@ test_vec_char (void)
   printf ("\n%s\n", __FUNCTION__);
 #if 1
   rc += test_clzb ();
+  rc += test_ctzb ();
   rc += test_popcntb ();
   rc += test_vec_ischar ();
   rc += test_mrgeob ();

--- a/src/testsuite/arith128_test_i16.c
+++ b/src/testsuite/arith128_test_i16.c
@@ -87,6 +87,62 @@ test_clzh (void)
 }
 
 int
+test_ctzh (void)
+{
+  vui16_t i, e, j;
+  int rc = 0;
+
+  printf ("\ntest_ctzh Vector Count Trailing Zeros in halfwords\n");
+
+  i = (vui16_t )CONST_VINT16_H(0, 0, 0, 0, 0, 0, 0, 0);
+  e = (vui16_t )CONST_VINT16_H(16, 16, 16, 16, 16, 16, 16, 16);
+  j = vec_ctzh(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(0) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzh:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui16_t )CONST_VINT16_H(0x8000, 0xc000, 0xe000, 0xf000, 0xf800, 0xfc00, 0xfe00, 0xff00);
+  e = (vui16_t )CONST_VINT16_H(15, 14, 13, 12, 11, 10, 9, 8);
+  j = vec_ctzh(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(0x8000, 0xc000, 0xe000, 0xf000, 0xf800, 0xfc00, 0xfe00, 0xff00) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzh:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui16_t )CONST_VINT16_H(0, 1, 2, 4, 8, 16, 32, 64);
+  e = (vui16_t )CONST_VINT16_H(16, 0, 1, 2, 3, 4, 5, 6);
+  j = vec_ctzh(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(0, 1, 2, 4, 8, 16, 32, 64) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzh:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui16_t )CONST_VINT16_H(128, 256, 256, 512, 1024, 2048, 4096, 8192);
+  e = (vui16_t )CONST_VINT16_H(7, 8, 8, 9, 10, 11, 12, 13);
+  j = vec_ctzh(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(128, 256, 256, 512, 1024, 2048, 4096, 8192) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzh:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui16_t )CONST_VINT16_H(16384, 32768, 61440, 65280, 65520, 65535, 43690, 21845);
+  e = (vui16_t )CONST_VINT16_H(14, 15, 12, 8, 4, 0, 1, 0);
+  j = vec_ctzh(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(16384, 32768, 61440, 65280, 65520, 65535, 43690, 21845) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzh:", (vui128_t)j, (vui128_t) e);
+
+  return (rc);
+}
+
+int
 test_popcnth (void)
 {
   vui16_t i, e;
@@ -526,6 +582,7 @@ test_vec_i16 (void)
 #if 1
   rc += test_revbh ();
   rc += test_clzh ();
+  rc += test_ctzh ();
   rc += test_popcnth();
   rc += test_mrgeoh();
   rc += test_mrgahlh();

--- a/src/testsuite/vec_char_dummy.c
+++ b/src/testsuite/vec_char_dummy.c
@@ -5,12 +5,64 @@
         Author: sjmunroe
   */
 
-
 #include <stdint.h>
 
 //#define __DEBUG_PRINT__
 
 #include <pveclib/vec_char_ppc.h>
+
+vui8_t
+test_ctzb_v1 (vui8_t vra)
+{
+  const vui8_t ones = vec_splat_u8 (1);
+  const vui8_t c8s = vec_splat_u8 (8);
+  vui8_t term;
+  // term = (!vra & (vra - 1))
+  term = vec_andc (vec_sub (vra, ones), vra);
+  // return = 8 - vec_clz (!vra & (vra - 1))
+  return vec_sub (c8s, vec_clzb (term));
+}
+
+vui8_t
+test_ctzb_v2 (vui8_t vra)
+{
+  const vui8_t ones = vec_splat_u8 (1);
+  vui8_t term;
+  // term = (!vra & (vra - 1))
+  term = vec_andc (vec_sub (vra, ones), vra);
+  // return = vec_popcnt (!vra & (vra - 1))
+  return vec_popcntb (term);
+}
+
+vui8_t
+test_ctzb_v3 (vui8_t vra)
+{
+  const vui8_t zeros = vec_splat_u8 (0);
+  const vui8_t c8s = vec_splat_u8 (8);
+  vui8_t term;
+  // term = (vra | -vra))
+  term = vec_or (vra, vec_sub (zeros, vra));
+  // return = 8 - vec_poptcnt (vra & -vra)
+  return vec_sub (c8s, vec_popcntb (term));
+}
+
+vui8_t
+test_ctzb (vui8_t vra)
+{
+  return vec_ctzb (vra);
+}
+
+vui8_t
+test_clzb (vui8_t vra)
+{
+  return vec_clzb (vra);
+}
+
+vui8_t
+test_popcntb (vui8_t vra)
+{
+  return vec_popcntb (vra);
+}
 
 #if __GNUC__ >= 7
 /* Generic vec_mul not supported for vector char until GCC 7.  */

--- a/src/testsuite/vec_int16_dummy.c
+++ b/src/testsuite/vec_int16_dummy.c
@@ -23,6 +23,59 @@
 #include <pveclib/vec_int16_ppc.h>
 
 vui16_t
+test_ctzh_v1 (vui16_t vra)
+{
+  const vui16_t ones = vec_splat_u16 (1);
+  const vui16_t c16s = vec_splats ((unsigned short)16);
+  vui16_t term;
+  // term = (!vra & (vra - 1))
+  term = vec_andc (vec_sub (vra, ones), vra);
+  // return = 16 - vec_clz (!vra & (vra - 1))
+  return vec_sub (c16s, vec_clzh (term));
+}
+
+vui16_t
+test_ctzh_v2 (vui16_t vra)
+{
+  const vui16_t ones = vec_splat_u16 (1);
+  vui16_t term;
+  // term = (!vra & (vra - 1))
+  term = vec_andc (vec_sub (vra, ones), vra);
+  // return = vec_popcnt (!vra & (vra - 1))
+  return vec_popcnth (term);
+}
+
+vui16_t
+test_ctzh_v3 (vui16_t vra)
+{
+  const vui16_t zeros = vec_splat_u16 (0);
+  const vui16_t c16s = vec_splats ((unsigned short)16);
+  vui16_t term;
+  // term = (vra | -vra))
+  term = vec_or (vra, vec_sub (zeros, vra));
+  // return = 16 - vec_poptcnt (vra & -vra)
+  return vec_sub (c16s, vec_popcnth (term));
+}
+
+vui16_t
+test_ctzh (vui16_t vra)
+{
+  return vec_ctzh (vra);
+}
+
+vui16_t
+test_clzh (vui16_t vra)
+{
+  return vec_clzh (vra);
+}
+
+vui16_t
+test_popcnth (vui16_t vra)
+{
+  return vec_popcnth (vra);
+}
+
+vui16_t
 __test_absduh (vui16_t a, vui16_t b)
 {
   return vec_absduh (a, b);


### PR DESCRIPTION
Add byte and halfword forms of CTZ.

	* src/pveclib/vec_char_ppc.h [@cond INTERNAL] Forward ref
	vec_popcntb.
	(vec_ctzb): New operation.
	* src/pveclib/vec_int16_ppc.h [@cond INTERNAL] Forward ref
	vec_popcnth.
	(vec_ctzh): New operation.

	* src/testsuite/arith128_test_char.c (test_ctzb):
	New Unit test.
	(test_vec_char): Call test_ctzb.
	* src/testsuite/arith128_test_i16.c (test_ctzh):
	New Unit test.
	(test_vec_i16): Call test_ctzh.

	* src/testsuite/vec_char_dummy.c (test_ctzb_v1, test_ctzb_v2,
	test_ctzb_v3, test_ctzb, test_clzb): New compile tests.
	* src/testsuite/vec_int16_dummy.c (test_ctzh_v1, test_ctzh_v2,
	test_ctzh_v3, test_ctzh, test_clzh, test_popcnth):
	New compile tests.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>