### PR TITLE
Continue (p3) update for Count Trailing Zeros (CTZ) operations.

### DIFF
--- a/src/testsuite/arith128_test_i32.c
+++ b/src/testsuite/arith128_test_i32.c
@@ -419,6 +419,108 @@ test_ctzw (void)
   return (rc);
 }
 
+int
+test_sumsw (void)
+{
+  vi32_t i, j, e, k;
+  int rc = 0;
+
+  printf ("\ntest_sumsw Vector Sum-across Signed Word Saturate\n");
+
+  i = (vi32_t)CONST_VINT32_W(0, 0, 0, 0);
+  j = (vi32_t)CONST_VINT32_W(0, 0, 0, 0);
+  e = (vi32_t)CONST_VINT32_W(0, 0, 0, 0);
+  k = vec_vsumsw(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("sums(0, 0) ", k);
+#endif
+  rc += check_vuint128x ("vec_sumsw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vi32_t)CONST_VINT32_W(0, 1, 1, 3);
+  j = (vi32_t)CONST_VINT32_W(0, 0, 0, 5);
+  e = (vi32_t)CONST_VINT32_W(0, 0, 0, 10);
+  k = vec_vsumsw(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("sums([0,1,1,3}, 0) ", k);
+#endif
+  rc += check_vuint128x ("vec_sumsw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vi32_t)CONST_VINT32_W(0, 64, 0, 64);
+  j = (vi32_t)CONST_VINT32_W(0, 0, 0, -128);
+  e = (vi32_t)CONST_VINT32_W(0, 0, 0, 0);
+  k = vec_vsumsw(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("sums([0,64,0,64}, -128) ", k);
+#endif
+  rc += check_vuint128x ("vec_sumsw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vi32_t)CONST_VINT32_W(-32, -32, -32, -16);
+  j = (vi32_t)CONST_VINT32_W(0, 0, 0, 128);
+  e = (vi32_t)CONST_VINT32_W(0, 0, 0, 16);
+  k = vec_vsumsw(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("sums([-32,-32,-32,-16}, 128) ", k);
+#endif
+  rc += check_vuint128x ("vec_sumsw:", (vui128_t)k, (vui128_t) e);
+
+  return (rc);
+}
+
+int
+test_sum2sw (void)
+{
+  vi32_t i, j, e, k;
+  int rc = 0;
+
+  printf ("\ntest_sum2sw Vector Sum-across Signed Word Saturate\n");
+
+  i = (vi32_t)CONST_VINT32_W(0, 0, 0, 0);
+  j = (vi32_t)CONST_VINT32_W(0, 0, 0, 0);
+  e = (vi32_t)CONST_VINT32_W(0, 0, 0, 0);
+  k = vec_vsum2sw(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("sums(0, 0) ", k);
+#endif
+  rc += check_vuint128x ("vec_sum2sw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vi32_t)CONST_VINT32_W(0, 1, 1, 3);
+  j = (vi32_t)CONST_VINT32_W(0, 7, 0, 5);
+  e = (vi32_t)CONST_VINT32_W(0, 8, 0, 9);
+  k = vec_vsum2sw(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("sums([0,1,1,3}, {7,5}) ", k);
+#endif
+  rc += check_vuint128x ("vec_sum2sw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vi32_t)CONST_VINT32_W(32, 32, 32, 32);
+  j = (vi32_t)CONST_VINT32_W(0, -64, 0, -64);
+  e = (vi32_t)CONST_VINT32_W(0, 0, 0, 0);
+  k = vec_vsum2sw(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("sums([32,32,32,32}, {-64,-64) ", k);
+#endif
+  rc += check_vuint128x ("vec_sum2sw:", (vui128_t)k, (vui128_t) e);
+
+  i = (vi32_t)CONST_VINT32_W(-32, -32, -32, -16);
+  j = (vi32_t)CONST_VINT32_W(0, 64, 0, 64);
+  e = (vi32_t)CONST_VINT32_W(0, 0, 0, 16);
+  k = vec_vsum2sw(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("sums([-32,-32,-32,-16}, {64.64}) ", k);
+#endif
+  rc += check_vuint128x ("vec_sum2sw:", (vui128_t)k, (vui128_t) e);
+
+  return (rc);
+}
+
 //#define __DEBUG_PRINT__ 1
 int
 test_mulhuw (void)
@@ -1229,6 +1331,8 @@ test_vec_i32 (void)
   rc += test_clzw ();
   rc += test_ctzw ();
   rc += test_popcntw();
+  rc += test_sumsw ();
+  rc += test_sum2sw ();
   rc += test_mulesw();
   rc += test_mulosw();
   rc += test_muleuw();

--- a/src/testsuite/vec_int32_dummy.c
+++ b/src/testsuite/vec_int32_dummy.c
@@ -22,12 +22,37 @@
 
 #include <pveclib/vec_int128_ppc.h>
 
+
+vi32_t
+test_vec_sum2s (vi32_t vra, vi32_t vrb)
+{
+  return vec_sum2s (vra, vrb);
+}
+
+vi32_t
+test_vec_vsum2sw (vi32_t vra, vi32_t vrb)
+{
+  return vec_vsum2sw (vra, vrb);
+}
+
+vi32_t
+test_vec_sums (vi32_t vra, vi32_t vrb)
+{
+  return vec_sums (vra, vrb);
+}
+
+vi32_t
+test_vec_vsumsw (vi32_t vra, vi32_t vrb)
+{
+  return vec_vsumsw (vra, vrb);
+}
+
 vui32_t
 test_ctz_v1 (vui32_t vra)
 {
   const vui32_t ones = { 1, 1, 1, 1 };
   const vui32_t c32s = { 32, 32, 32, 32 };
-  vui32_t result, term;
+  vui32_t term;
   // term = (!vra & (vra - 1))
   term = vec_andc (vec_sub (vra, ones), vra);
   // return = 32 - vec_clz (!vra & (vra - 1))
@@ -38,7 +63,7 @@ vui32_t
 test_ctz_v2 (vui32_t vra)
 {
   const vui32_t ones = { 1, 1, 1, 1 };
-  vui32_t result, term;
+  vui32_t term;
   // term = (!vra & (vra - 1))
   term = vec_andc (vec_sub (vra, ones), vra);
   // return = vec_popcnt (!vra & (vra - 1))
@@ -50,7 +75,7 @@ test_ctz_v3 (vui32_t vra)
 {
   const vui32_t zeros = { 0, 0, 0, 0 };
   const vui32_t c32s = { 32, 32, 32, 32 };
-  vui32_t result, term;
+  vui32_t term;
   // term = (vra | -vra))
   term = vec_or (vra, vec_sub (zeros, vra));
   // return = 32 - vec_poptcnt (vra & -vra)


### PR DESCRIPTION
Add alt vec_sums vec_sum2s forms. This improves double/quadword
clz, ctz, and popcnt performance.

	* src/pveclib/vec_int32_ppc.h (vec_vsum2sw, vec_vsumsw):
	New inline operations.

	* src/testsuite/arith128_test_i32.c (test_sumsw, test_sum2sw):
	New unit text functions.
	(test_vec_i32): Call test_sumsw and test_sum2sw tests.

	* src/testsuite/vec_int32_dummy.c (test_vec_sum2s,
	test_vec_vsum2sw, test_vec_sums, test_vec_vsumsw):
	New compile tests.
	(test_ctz_v1, test_ctz_v2, test_ctz_v3): remove unused vars.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>