### PR TITLE
Continue (p4) update for Count Trailing Zeros (CTZ) operations.

### DIFF
--- a/src/pveclib/vec_int64_ppc.h
+++ b/src/pveclib/vec_int64_ppc.h
@@ -946,20 +946,25 @@ vec_addudm(vui64_t a, vui64_t b)
   return ((vui64_t) r);
 }
 
-/** \brief Count leading zeros for a vector unsigned long int.
+/** \brief Vector Count Leading Zeros Doubleword for unsigned
+ *  long long int elements.
  *
- *  Count leading zeros for a vector __int128 and return the count in a
- *  vector suitable for use with vector shift (left|right) and vector
- *  shift (left|right) by octet instructions.
+ *  Count the number of leading '0' bits (0-64) within each doubleword
+ *  element of a 128-bit vector.
+ *
+ *  For POWER8 (PowerISA 2.07B) or later use the Vector Count Leading
+ *  Zeros Doubleword instruction <B>vclzd</B>. Otherwise use sequence of
+ *  pre 2.07 VMX instructions.
  *
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
  *  |power8   |   2   | 2/cycle  |
  *  |power9   |   2   | 2/cycle  |
  *
- *  @param vra a 128-bit vector treated a __int128.
- *  @return a 128-bit vector with bits 121:127 containing the count of
- *  leading zeros.
+ *  @param vra a 128-bit vector treated as 2 x 64-bit unsigned
+ *  long long int (doubleword) elements.
+ *  @return 128-bit vector with the leading zeros count for each
+ *  doubleword element.
  */
 static inline vui64_t
 vec_clzd (vui64_t vra)
@@ -995,7 +1000,8 @@ vec_clzd (vui64_t vra)
   return (r);
 }
 
-/** \brief Vector Count Trailing Zeros Doubleword.
+/** \brief Vector Count Trailing Zeros Doubleword for unsigned
+ *  long long int elements.
  *
  *  Count the number of trailing '0' bits (0-64) within each doubleword
  *  element of a 128-bit vector.
@@ -1015,7 +1021,7 @@ vec_clzd (vui64_t vra)
  *
  *  @param vra 128-bit vector treated as 2 x 64-bit integer
  *  (doublewords) elements.
- *  @return 128-bit vector with the Trailng Zeros count for each
+ *  @return 128-bit vector with the trailng zeros count for each
  *  doubleword element.
  */
 static inline vui64_t

--- a/src/testsuite/arith128_test_i64.c
+++ b/src/testsuite/arith128_test_i64.c
@@ -1547,6 +1547,136 @@ test_clzd (void)
   return (rc);
 }
 
+//#undef __DEBUG_PRINT__
+int
+test_ctzd (void)
+{
+  vui64_t i, e;
+  vui64_t j;
+  int rc = 0;
+
+  printf ("\ntest_ctzd Vector Count Leading Zeros in Doublewords\n");
+
+  i = (vui64_t) CONST_VINT64_DW (0, 0);
+  e = (vui64_t) CONST_VINT64_DW (64, 64);
+  j = vec_ctzd((vui64_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(0, 0) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzd:", (vui128_t) j, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW (-1, -1);
+  e = (vui64_t) CONST_VINT64_DW (0, 0);
+  j = vec_ctzd((vui64_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(-1, -1) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzd:", (vui128_t) j, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW (0, -1);
+  e = (vui64_t) CONST_VINT64_DW (64, 0);
+  j = vec_ctzd((vui64_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(0, -1) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzd:", (vui128_t) j, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW (-1, 0);
+  e = (vui64_t) CONST_VINT64_DW (0, 64);
+  j = vec_ctzd((vui64_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(-1, 0) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzd:", (vui128_t) j, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW (1, 8589934596);
+  e = (vui64_t) CONST_VINT64_DW (0, 2);
+  j = vec_ctzd((vui64_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(1, 8589934596) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzd:", (vui128_t) j, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW (34359738384, 137438953536);
+  e = (vui64_t) CONST_VINT64_DW (4, 6);
+  j = vec_ctzd((vui64_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(34359738384, 137438953536) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzd:", (vui128_t) j, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW (549755814144, 2199023256576);
+  e = (vui64_t) CONST_VINT64_DW (8, 10);
+  j = vec_ctzd((vui64_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(549755814144, 2199023256576) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzd:", (vui128_t) j, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW (8796093026304, 35184372105216);
+  e = (vui64_t) CONST_VINT64_DW (12, 14);
+  j = vec_ctzd((vui64_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(8796093026304, 35184372105216) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzd:", (vui128_t) j, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW (140737488420864, 562949953683456);
+  e = (vui64_t) CONST_VINT64_DW (16, 18);
+  j = vec_ctzd((vui64_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(140737488420864, 562949953683456) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzd:", (vui128_t) j, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW (2251799814733824, 9007199258935296);
+  e = (vui64_t) CONST_VINT64_DW (20, 22);
+  j = vec_ctzd((vui64_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(2251799814733824, 9007199258935296) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzd:", (vui128_t) j, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW (36028797035741184, 144115188142964736);
+  e = (vui64_t) CONST_VINT64_DW (24, 26);
+  j = vec_ctzd((vui64_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(36028797035741184, 144115188142964736) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzd:", (vui128_t) j, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW (576460752571858944, 2305843010287435776);
+  e = (vui64_t) CONST_VINT64_DW (28, 30);
+  j = vec_ctzd((vui64_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(576460752571858944, 2305843010287435776) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzd:", (vui128_t) j, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW (4611686020574871552UL, 18446744069414584320UL);
+  e = (vui64_t) CONST_VINT64_DW (31, 32);
+  j = vec_ctzd((vui64_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(4611686020574871552, 18446744069414584320) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzd:", (vui128_t) j, (vui128_t) e);
+
+  return (rc);
+}
+
 int
 test_muleud (void)
 {
@@ -11841,6 +11971,7 @@ test_vec_i64 (void)
   rc += test_splatd ();
   rc += test_revbd ();
   rc += test_clzd ();
+  rc += test_ctzd ();
   rc += test_popcntd ();
   rc += test_vrld ();
   rc += test_vsld ();

--- a/src/testsuite/vec_int64_dummy.c
+++ b/src/testsuite/vec_int64_dummy.c
@@ -23,6 +23,47 @@
 #include <pveclib/vec_int128_ppc.h>
 
 vui64_t
+test_ctzd_v1 (vui64_t vra)
+{
+  const vui64_t ones = { -1, -1 };
+  const vui64_t c64s = { 64, 64 };
+  vui64_t term;
+  // term = (!vra & (vra - 1))
+  term = vec_andc (vec_addudm (vra, ones), vra);
+  // return = 64 - vec_clz (!vra & (vra - 1))
+  return (c64s - vec_clzd (term));
+}
+
+vui64_t
+test_ctzd_v2 (vui64_t vra)
+{
+  const vui64_t ones = { -1, -1 };
+  vui64_t term;
+  // term = (!vra & (vra - 1))
+  term = vec_andc (vec_addudm (vra, ones), vra);
+  // return = vec_popcnt (!vra & (vra - 1))
+  return (vec_popcntd (term));
+}
+
+vui64_t
+test_ctzd_v3 (vui64_t vra)
+{
+  const vui64_t zeros = { 0, 0 };
+  const vui64_t c64s = { 64, 64 };
+  vui64_t term;
+  // term = (vra | -vra))
+  term = vec_or (vra, vec_subudm (zeros, vra));
+  // return = 64 - vec_poptcnt (vra & -vra)
+  return (c64s - vec_popcntd (term));
+}
+
+vui64_t
+test_vec_ctzd (vui64_t vra)
+{
+  return (vec_ctzd (vra));
+}
+
+vui64_t
 __test_vrld (vui64_t a, vui64_t b)
 {
   return vec_vrld (a, b);


### PR DESCRIPTION
Vector doubleword implementation of ctz and improved clz and popcnt
for power7. Depends on ctz-p3.

	* pveclib/vec_int64_ppc.h n[@cond INTERNAL]: Forward ref for
	vec_popcntd.
	(vec_clzd): Remove unnecessary cast. Replace vec_sum2s with
	vec_vsum2sw.
	(vec_ctzd): New inline operation.
	(vec_popcntd): Replace vec_sum2s with vec_vsum2sw.

	* src/testsuite/arith128_test_i64.c (test_ctzd) New unit test.
	(est_vec_i64): Call test_ctzd.

	* src/testsuite/vec_int64_dummy.c (test_ctzd_v1, test_ctzd_v2,
	test_ctzd_v3, test_vec_ctzd): New compile tests.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>