### PR TITLE
Continue (p5) update for Count Trailing Zeros (CTZ) operations.

### DIFF
--- a/src/pveclib/vec_int128_ppc.h
+++ b/src/pveclib/vec_int128_ppc.h
@@ -2465,7 +2465,8 @@ vec_addeq (vui128_t *cout, vui128_t a, vui128_t b, vui128_t ci)
   return ((vui128_t) t);
 }
 
-/** \brief Vector Count Leading Zeros Quadword.
+/** \brief Vector Count Leading Zeros Quadword for unsigned
+ *  __int128 elements.
  *
  *  Count leading zeros for a vector __int128 and return the count in a
  *  vector suitable for use with vector shift (left|right) and vector
@@ -2476,7 +2477,7 @@ vec_addeq (vui128_t *cout, vui128_t a, vui128_t b, vui128_t ci)
  *  |power8   |  8-10 | 1/cycle  |
  *  |power9   | 10-12 | 1/cycle  |
  *
- *  @param vra a 128-bit vector treated a __int128.
+ *  @param vra a 128-bit vector treated as unsigned __int128.
  *  @return a 128-bit vector with bits 121:127 containing the count of
  *  leading zeros.
  */
@@ -2530,7 +2531,8 @@ vec_clzq (vui128_t vra)
   return ((vui128_t) result);
 }
 
-/** \brief Vector Count Trailing Zeros Quadword.
+/** \brief Vector Count Trailing Zeros Quadword for unsigned
+ *  __int128 elements.
  *
  *  Count trailing zeros for a vector __int128 and return the count in a
  *  vector suitable for use with vector shift (left|right) and vector
@@ -2541,7 +2543,7 @@ vec_clzq (vui128_t vra)
  *  |power8   | 15-17 | 1/cycle  |
  *  |power9   | 13-16 | 1/cycle  |
  *
- *  @param vra a 128-bit vector treated as a __int128.
+ *  @param vra a 128-bit vector treated as unsigned __int128.
  *  @return a 128-bit vector with bits 121:127 containing the count of
  *  trailing zeros.
  */
@@ -5394,10 +5396,11 @@ vec_madd2uq (vui128_t *mulu, vui128_t a, vui128_t b, vui128_t c1, vui128_t c2)
   return (pl);
 }
 
-/** \brief Vector Population Count Quadword.
+/** \brief Vector Population Count Quadword for unsigned
+ *  __int128 elements.
  *
- *  Count the number of '1' bits within a vector __int128 and return
- *  the count (0-128) in a vector __int128.
+ *  Count the number of '1' bits within a vector unsigned __int128
+ *  and return the count (0-128) in a vector unsigned __int128.
  *
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|

--- a/src/testsuite/arith128_test_i128.c
+++ b/src/testsuite/arith128_test_i128.c
@@ -2799,7 +2799,129 @@ test_clzq (void)
 
   return (rc);
 }
-//#undef __DEBUG_PRINT__
+
+#define test_vec_ctzq(_l)	vec_ctzq(_l)
+//#define __DEBUG_PRINT__ 1
+int
+test_ctzq (void)
+{
+  vui32_t i, e;
+  vui128_t j;
+  int rc = 0;
+
+  printf ("\ntest_ctzq Vector Count Trailing Zeros in quadwords\n");
+
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 128);
+  j = test_vec_ctzq((vui128_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(0) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzq:", j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(0xffffffff, 0, 0, 0);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 96);
+  j = test_vec_ctzq((vui128_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(0xffffffff,0,0,0) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzq:", j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(0, 0xffffffff, 0, 0);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 64);
+  j = test_vec_ctzq((vui128_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(0,0xffffffff,0,0) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzq:", j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0, 0xffffffff);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
+  j = test_vec_ctzq((vui128_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(0,0,0,0xffffffff) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzq:", j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0xffffffff, 0);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 32);
+  j = test_vec_ctzq((vui128_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(0,0,0xffffffff,0) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzq:", j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0xffff, 0);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 32);
+  j = test_vec_ctzq((vui128_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(0,0,0xffff,0) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzq:", j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(0, 0, 0xffff0000, 0);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 48);
+  j = test_vec_ctzq((vui128_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(0,0,0xffff0000,0) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzq:", j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(0, 0xffffffff, 0, 0xffffffff);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
+  j = test_vec_ctzq((vui128_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(0,0xffffffff,0,0xffffffff) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzq:", j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(0, 0xffffffff,0xffffffff, 0);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 32);
+  j = test_vec_ctzq((vui128_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(0,0xffffffff,0xffffffff,0) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzq:", j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(0, 0xffff, 0xffff0000, 0);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 48);
+  j = test_vec_ctzq((vui128_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(0,0xffff,0xffff0000,0) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzq:", j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(0, 0xf, 0xf0000000, 0);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0, 60);
+  j = test_vec_ctzq((vui128_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(0,0xf,0xf0000000,0) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzq:", j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(0xf0000000, 0, 0, 0);
+  e = (vui32_t)CONST_VINT32_W(0, 0, 0,124);
+  j = test_vec_ctzq((vui128_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(0xf0000000,0,0,0) ", j);
+#endif
+  rc += check_vuint128x ("vec_ctzq:", j, (vui128_t) e);
+
+  return (rc);
+}
+#undef __DEBUG_PRINT__
 
 //#define __DEBUG_PRINT__ 1
 int
@@ -9938,6 +10060,7 @@ test_vec_i128 (void)
 #if 1
   rc += test_revbq ();
   rc += test_clzq ();
+  rc += test_ctzq ();
   rc += test_popcntq();
 
   rc += test_vsrq ();


### PR DESCRIPTION
Vector quadword implementation of ctz and improved clz and popcnt.
Depends on ctz_p3 merge.

	* src/pveclib/vec_int128_ppc.h [@cond INTERNAL]: Forward ref for
	vec_popcntq.
	(vec_clzq): Update doxygen latency for P8/P9.
	(vec_clzq[_ARCH_PWR8]): Update implementation.
	(vec_ctzq): New inline operation.
	(vec_popcntq): Update doxygen latency for P8/P9.
	(vec_popcntq[_ARCH_PWR9]): Add implementation.
	(vec_popcntq[_ARCH_PWR8]): Update implementation.
	Replace vec_sums with vec_vsumsw.

	* src/testsuite/arith128_test_i128.c (test_ctzq):
	New unit test.
	(test_vec_i128): Call test_ctzq.

	* src/testsuite/vec_int128_dummy.c (test_ctzq_v1, test_ctzq_v2,
	test_ctzq_v3, test_ctzq_v4, test_ctzq_v5, test_vec_ctzq):
	New compile tests.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>