### PR TITLE
Fix for --disable-static and a question

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -228,7 +228,7 @@ pveclib_test_SOURCES = \
 	testsuite/vec_perf_i128.h
 
 pveclib_test_CFLAGS = $(AM_CPPFLAGS) $(PVECLIB_DEFAULT_CFLAGS) $(AM_CFLAGS)
-pveclib_test_LDADD = .libs/libpvecstatic.a .libs/libvecdummy.a
+pveclib_test_LDADD = libpvec.la libvecdummy.la
 	
 TESTS += vec_dummy
 

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -202,7 +202,7 @@ am_pveclib_test_OBJECTS =  \
 	testsuite/pveclib_test-arith128_test_char.$(OBJEXT) \
 	testsuite/pveclib_test-arith128_test_bcd.$(OBJEXT)
 pveclib_test_OBJECTS = $(am_pveclib_test_OBJECTS)
-pveclib_test_DEPENDENCIES = .libs/libpvecstatic.a .libs/libvecdummy.a
+pveclib_test_DEPENDENCIES = libpvec.la libvecdummy.la
 pveclib_test_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 	$(LIBTOOLFLAGS) --mode=link $(CCLD) $(pveclib_test_CFLAGS) \
 	$(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $@
@@ -734,7 +734,7 @@ pveclib_test_SOURCES = \
 	testsuite/vec_perf_i128.h
 
 pveclib_test_CFLAGS = $(AM_CPPFLAGS) $(PVECLIB_DEFAULT_CFLAGS) $(AM_CFLAGS)
-pveclib_test_LDADD = .libs/libpvecstatic.a .libs/libvecdummy.a
+pveclib_test_LDADD = libpvec.la libvecdummy.la
 
 #Dummy main to force generation of vec_dummy_* codes
 vec_dummy_SOURCES = testsuite/vec_dummy_main.c 


### PR DESCRIPTION
See commit message for the rationale.

Extra question:

I don't see the point in shipping libpvecstatic.a. It contains the same functions from libpvec.a, except that it does not provide IFUNCs.

As far as I can tell, a user cannot use libpvecstatic.a directly, for instance, with the following program:

```
#include <pveclib/vec_int512_ppc.h>
int main (void) {
  __VEC_U_512 in1, in2;
  vec_mul512x512 (in1, in2);
  return 0;
}
```

which would give the following error:

```
$ gcc -mcpu=power8 -I. *.c /usr/lib64/libpvecstatic.a 
/usr/lib64/gcc/powerpc64le-suse-linux/10/../../../../powerpc64le-suse-linux/bin/ld: /tmp/cc1WgMJp.o: in function `main':
test.c:(.text+0x9c): undefined reference to `vec_mul512x512'
collect2: error: ld returned 1 exit status
```

Whereas it would work correctly with both libpvec.so and libpvec.a:

```
$ gcc -mcpu=power8 -I. *.c /usr/lib64/libpvec.a 
$ gcc -mcpu=power8 -I. *.c -lpvec
(no errors)
```

Now, assuming the purpose of libpvecstatic is to avoid the use of IFUNCs, if a user wants to avoid them, they have to use the __VEC_PWR_IMP macro, like what's done in test_pveclib.c. However, using this macro avoids the use of ifuncs anyway, even with libpvec.so and libpvec.a...

...Soooo, what is the purpose of libpvecstatic?