### PR TITLE
Initial support for Gather/Scatter ops, for doubleword int.

### DIFF
--- a/src/pveclib/vec_int64_ppc.h
+++ b/src/pveclib/vec_int64_ppc.h
@@ -952,7 +952,7 @@ vec_addudm(vui64_t a, vui64_t b)
 }
 
 /** \brief Vector Count Leading Zeros Doubleword for unsigned
- *  long long int elements.
+ *  long long elements.
  *
  *  Count the number of leading '0' bits (0-64) within each doubleword
  *  element of a 128-bit vector.
@@ -967,7 +967,7 @@ vec_addudm(vui64_t a, vui64_t b)
  *  |power9   |   2   | 2/cycle  |
  *
  *  @param vra a 128-bit vector treated as 2 x 64-bit unsigned
- *  long long int (doubleword) elements.
+ *  long long (doubleword) elements.
  *  @return 128-bit vector with the leading zeros count for each
  *  doubleword element.
  */
@@ -1006,7 +1006,7 @@ vec_clzd (vui64_t vra)
 }
 
 /** \brief Vector Count Trailing Zeros Doubleword for unsigned
- *  long long int elements.
+ *  long long elements.
  *
  *  Count the number of trailing '0' bits (0-64) within each doubleword
  *  element of a 128-bit vector.
@@ -2180,11 +2180,11 @@ vec_cmpud_any_ne (vui64_t a, vui64_t b)
   return (result);
 }
 
-/** \brief Vector Load with gather unsigned doubleword from offsets.
+/** \brief Vector Load with Gather Unsigned Doubleword from Offsets.
  *
  *  For each doubleword element [i] of vra, load the doubleword
- *  element at *array+vra[i]. Merge those doubleword elements and
- *  return the resulting vector.
+ *  element at *(char*)array+vra[i]. Merge those doubleword elements
+ *  and return the resulting vector.
  *
  *  \note As effective address calculation is modulo 64-bits, signed or
  *  unsigned doubleword offsets are equivalent.
@@ -2195,13 +2195,13 @@ vec_cmpud_any_ne (vui64_t a, vui64_t b)
  *  |power9   |   11  | 1/cycle  |
  *
  *  @param array Pointer to array of unsigned doublewords.
- *  @param vra Vector of doubleword offsets.
+ *  @param vra Vector of doubleword (64-bit) byte offsets from &array.
  *  @return vector doubleword containing elements loaded from
- *  *array+vra[0] and *array+vra[1].
+ *  *(char*)array+vra[0] and *(char*)array+vra[1].
  */
 static inline
 vui64_t
-vec_lvgudo (unsigned long long int *array, vui64_t vra)
+vec_lvgudo (unsigned long long *array, vui64_t vra)
 {
   vui64_t rese0, rese1;
 
@@ -2214,8 +2214,11 @@ vec_lvgudo (unsigned long long int *array, vui64_t vra)
  *
  *  For each doubleword element [i] of vra, load the doubleword
  *  element array[vra[i] * (1 << scale)]. Merge those doubleword
- *  elements and return the resulting vector. Indexes are converted to
- *  offsets from *array by shifting each doubleword left (3+scale) bits.
+ *  elements and return the resulting vector. Array element indices are
+ *  converted to byte offsets from (array) by multiplying each index by
+ *  (sizeof (array element) * scale), which is effected by shifting
+ *  left (3+scale) bits.
+ *
  *
  *  \note As effective address calculation is modulo 64-bits, signed or
  *  unsigned doubleword indexes are equivalent.
@@ -2227,13 +2230,13 @@ vec_lvgudo (unsigned long long int *array, vui64_t vra)
  *
  *  @param array Pointer to array of unsigned doublewords.
  *  @param vra Vector of doubleword indexes.
- *  @param scale Factor effectually multiplying the indexes by
+ *  @param scale 8-bit integer. Indexes are multiplying by
  *  2<sup>scale</sup>.
  *  @return vector containing dwords array[vra[0]*(1<<scale)]
  *  and array[vra[1]*(1<<scale)].
  */
 static inline vui64_t
-vec_lvgudsx (unsigned long long int *array, vui64_t vra,
+vec_lvgudsx (unsigned long long *array, vui64_t vra,
 	     const unsigned char scale)
 {
   vui64_t offset;
@@ -2242,12 +2245,14 @@ vec_lvgudsx (unsigned long long int *array, vui64_t vra,
   return vec_lvgudo (array, offset);
 }
 
-/** \brief Vector Load with gather unsigned doubleword indexed.
+/** \brief Vector Load with Gather Unsigned Doubleword Indexed.
  *
  *  For each doubleword element [i] of vra, load the doubleword
  *  element array[vra[i]]. Merge those doubleword elements and
- *  return the resulting vector. The indexes are converted to offsets
- *  from *array by shifting each doubleword left 3-bits (*8).
+ *  return the resulting vector. Array element indices are
+ *  converted to byte offsets from (array) by multiplying each index by
+ *  (sizeof (array element) * scale), which is effected by shifting
+ *  left 3 bits.
  *
  *  \note As effective address calculation is modulo 64-bits, signed or
  *  unsigned doubleword indexes are equivalent.
@@ -2263,7 +2268,7 @@ vec_lvgudsx (unsigned long long int *array, vui64_t vra,
  */
 static inline
 vui64_t
-vec_lvgudx (unsigned long long int *array, vui64_t vra)
+vec_lvgudx (unsigned long long *array, vui64_t vra)
 {
   vui64_t offset;
 
@@ -3188,7 +3193,7 @@ vec_sradi (vi64_t vra, const unsigned int shb)
 /** \brief Vector Store with Scatter Unsigned Doubleword from Offsets.
  *
  *  For each doubleword element [i] of vra, Store the doubleword
- *  element xs[i] at *array+vra[i].
+ *  element xs[i] at the address *(char*)array+vra[i].
  *
  *  \note As effective address calculation is modulo 64-bits, signed or
  *  unsigned doubleword offsets are equivalent.
@@ -3200,11 +3205,10 @@ vec_sradi (vi64_t vra, const unsigned int shb)
  *
  *  @param xs Vector of doubleword elements to store.
  *  @param array Pointer to array of unsigned doublewords.
- *  @param vra Vector of doubleword offsets.
+ *  @param vra Vector of doubleword (64-bit) byte offsets from &array.
  */
 static inline void
-vec_stvsudo (vui64_t xs, unsigned long long int *array,
-	    vui64_t vra)
+vec_stvsudo (vui64_t xs, unsigned long long *array, vui64_t vra)
 {
   vui64_t xs1;
 
@@ -3216,12 +3220,13 @@ vec_stvsudo (vui64_t xs, unsigned long long int *array,
 /** \brief Vector Store with Scatter Unsigned Doubleword Scaled Index.
  *
  *  For each doubleword element [i] of vra, store the doubleword
- *  element xs[i] at array[vra[i] * (1 << scale)]. Indexes are
- *  converted to offsets from *array by shifting each doubleword of vra
- *  left (3+scale) bits.
+ *  element xs[i] at array[vra[i] * (1 << scale)]. Array element
+ *  indices are converted to byte offsets from (array) by multiplying
+ *  each index by (sizeof (array element) * scale), which is effected
+ *  by shifting left (3+scale) bits.
  *
  *  \note As effective address calculation is modulo 64-bits, signed or
- *  unsigned doubleword indexes are equivalent.
+ *  unsigned doubleword indices are equivalent.
  *
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
@@ -3230,12 +3235,12 @@ vec_stvsudo (vui64_t xs, unsigned long long int *array,
  *
  *  @param xs Vector of doubleword elements to store.
  *  @param array Pointer to array of unsigned doublewords.
- *  @param vra Vector of doubleword indexes.
- *  @param scale Factor effectually multiplying the indexes by
+ *  @param vra Vector of doubleword indices.
+ *  @param scale 8-bit integer. Indexes are multiplying by
  *  2<sup>scale</sup>.
  */
 static inline void
-vec_stvsudsx (vui64_t xs, unsigned long long int *array,
+vec_stvsudsx (vui64_t xs, unsigned long long *array,
 	    vui64_t vra, const unsigned char scale)
 {
   vui64_t offset;
@@ -3264,7 +3269,7 @@ vec_stvsudsx (vui64_t xs, unsigned long long int *array,
  *  @param vra Vector of doubleword indexes.
  */
 static inline void
-vec_stvsudx (vui64_t xs, unsigned long long int *array,
+vec_stvsudx (vui64_t xs, unsigned long long *array,
 	    vui64_t vra)
 {
   vui64_t offset;
@@ -3768,13 +3773,25 @@ vec_xxspltd (vui64_t vra, const int ctl)
   return (result);
 }
 
-/** \brief Vector Load Scalar doubleword indexed.
+/** \brief Vector Load Scalar Doubleword Indexed.
  *
- *  This operation is an alternate form of vector load element, with
- *  the added simplification that data is always left justified in the
- *  vector. This simplifies merging elements for gather operations.
+ *  Load the left most doubleword of vector <B>xt</B> as a scalar
+ *  doubleword from the effective address formed by <B>rb+ra</B>. The
+ *  operand <B>rb</B> is a pointer to an array of doubleword integers.
+ *  The operand <B>ra</B> is a doubleword integer byte offset
+ *  from <B>rb</B>. The result <B>xt</B> is returned as a vui64_t
+ *  vector. For best performance <B>rb</B> and <B>ra</B>
+ *  should be doubleword aligned (integer multiple of 8).
  *
- *  \note This is instruction was introduced in PowerISA 2.06 (POWER7).
+ *  \note the right most doubleword of vector <B>xt</B> is left
+ *  <I>undefined</I> by this operation.
+ *
+ *  This operation is an alternate form of Vector Load Element
+ *  (vec_lde), with the added simplification that data is always
+ *  left justified in the vector. This simplifies merging elements
+ *  for gather operations.
+ *
+ *  \note This instruction was introduced in PowerISA 2.06 (POWER7).
  *  For POWER8/9 there are additional optimizations by effectively
  *  converting small constant index values into displacements. For
  *  POWER8 a specific pattern of addi/lsxdx instruction is <I>fused</I>
@@ -3786,10 +3803,10 @@ vec_xxspltd (vui64_t vra, const int ctl)
  *  |power8   |   5   | 2/cycle  |
  *  |power9   |   5   | 2/cycle  |
  *
- *  @param ra const doubleword index (displacement).
+ *  @param ra const doubleword index (offset/displacement).
  *  @param rb const doubleword pointer to an array of doublewords.
- *  @return The data (ra + rb) is loaded into vector doubleword
- *  element 0. Element 1 is undefined.
+ *  @return The data stored at (ra + rb) is loaded into vector
+ *   doubleword element 0. Element 1 is undefined.
  */
 static inline vui64_t
 vec_vlxsdx (const unsigned long long ra, const unsigned long long *rb)
@@ -3813,22 +3830,20 @@ vec_vlxsdx (const unsigned long long ra, const unsigned long long *rb)
 	      : "Z" (*rb)
 	      : );
 	} else {
-	  // Would be better if li and lxsdx shared a single asm block
+	  unsigned long long rt;
+#if defined (_ARCH_PWR8)
+	  // For P8 better if li and lxsdx shared a single asm block
 	  // (enforcing consecutive instructions).
 	  // This enables instruction fusion for P8.
-	  unsigned long long rt;
-#if 0     // Expected this combination of constraints to work. But the
-	  // compiler does not recognize the early clobber of rt and
-	  // generates bad code.
 	  __asm__(
 	      "li %0,%2;"
-	      "lxsdx %x1,%y3;"
+	      "lxsdx %x1,%3,%0;"
 	      : "=&r" (rt), "=wa" (xt)
-	      : "I" (ra), "Z" (*((char *)rb+rt))
+	      : "I" (ra), "b" (rb), "Z" (*((char *)rb+rt))
 	      : );
-#else
-	  // This generates operationally correct code, but the compiler
-	  // may rearrange code and break the fusion pattern.
+#else // _ARCH_PWR7
+	  // This generates operationally the same code, but the
+	  // compiler may rearrange/schedule the code.
 	  __asm__(
 	      "li %0,%1;"
 	      : "=r" (rt)
@@ -3852,18 +3867,23 @@ vec_vlxsdx (const unsigned long long ra, const unsigned long long *rb)
   return xt;
 }
 
-/** \brief Vector Store Scalar doubleword indexed.
+/** \brief Vector Store Scalar Doubleword Indexed.
+ *
+ *  Store the left most doubleword of vector <B>xs</B> as a scalar
+ *  doubleword at the effective address formed by <B>rb+ra</B>. The
+ *  operand <B>rb</B> is a pointer to an array of doubleword integers.
+ *  The operand <B>ra</B> is a doubleword integer byte offset
+ *  from <B>rb</B>. For best performance <B>rb</B> and <B>ra</B>
+ *  should be doubleword aligned (integer multiple of 8).
  *
  *  This operation is an alternate form of vector store element, with
  *  the added simplification that data is always left justified in the
  *  vector. This simplifies scatter operations.
  *
- *  \note This is instruction was introduced in PowerISA 2.06 (POWER7).
- *  For POWER8/9 there are additional optimizations by effectively
+ *  \note This instruction was introduced in PowerISA 2.06 (POWER7).
+ *  For POWER9 there are additional optimizations by effectively
  *  converting small constant index values into displacements. For
- *  POWER8 a specific pattern of addi/stsxdx instruction is <I>fused</I>
- *  into a single load displacement internal operation. For POWER9 we can
- *  use the stxsd (DS-form) instruction directly.
+ *  POWER9 we can use the stxsd (DS-form) instruction directly.
  *
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
@@ -3871,7 +3891,7 @@ vec_vlxsdx (const unsigned long long ra, const unsigned long long *rb)
  *  |power9   | 0 - 2 | 4/cycle  |
  *
  *  @param xs vector doubleword element 0 to be stored.
- *  @param ra const doubleword index (displacement).
+ *  @param ra const doubleword index (offset/displacement).
  *  @param rb const doubleword pointer to an array of doublewords.
  */
 static inline void

--- a/src/testsuite/arith128_test_i64.c
+++ b/src/testsuite/arith128_test_i64.c
@@ -994,6 +994,7 @@ test_lvgudx (void)
 
   rc += check_vuint128x ("vec_lxsdx 5:", (vui128_t) j, (vui128_t) e);
 
+  // This test depends on the merge of scalars from lxsdx 4/5
   e =  (vui64_t) { 1, 15 };
 #if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   j = vec_permdi (j1, j0, 0);
@@ -1003,6 +1004,7 @@ test_lvgudx (void)
 
   rc += check_vuint128x ("vec_lxsdx2 :", (vui128_t) j, (vui128_t) e);
 
+  // This test replecates the results of the last 3 tests in single op.
   e =  (vui64_t) { 1, 15 };
   j = vec_lvgudo (test_ui64, i1);
 

--- a/src/testsuite/arith128_test_i64.c
+++ b/src/testsuite/arith128_test_i64.c
@@ -948,6 +948,195 @@ test_rldi (void)
 }
 #undef __DEBUG_PRINT__
 
+static unsigned long long test_ui64[] =
+    {
+	0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+    };
+
+int
+test_lvgudx (void)
+{
+  vui64_t i1, i2, e;
+  vui64_t j, j0, j1;
+  int rc = 0;
+
+  printf ("\ntest_Load Vector with gather Doubleword\n");
+
+  e =  (vui64_t) CONST_VINT64_DW ( 0, -1 );
+  j0 = vec_vlxsdx (0, test_ui64);
+  j = vec_permdi (j0, e, 1);
+
+  rc += check_vuint128x ("vec_lxsdx 1:", (vui128_t) j, (vui128_t) e);
+
+  e =  (vui64_t) CONST_VINT64_DW ( 1, -1 );
+  j0 = vec_vlxsdx (8, test_ui64);
+  j = vec_permdi (j0, e, 1);
+
+  rc += check_vuint128x ("vec_lxsdx 2:", (vui128_t) j, (vui128_t) e);
+
+  e =  (vui64_t) CONST_VINT64_DW ( 15, -1 );
+  j0 = vec_vlxsdx (120, test_ui64);
+  j = vec_permdi (j0, e, 1);
+
+  rc += check_vuint128x ("vec_lxsdx 3:", (vui128_t) j, (vui128_t) e);
+
+  i1 = (vui64_t) { 8, 120 };
+  e =  (vui64_t) CONST_VINT64_DW ( 1, -1 );
+  j0 = vec_vlxsdx (i1[0], test_ui64);
+  j = vec_permdi (j0, e, 1);
+
+  rc += check_vuint128x ("vec_lxsdx 4:", (vui128_t) j, (vui128_t) e);
+
+  i1 = (vui64_t) { 8, 120 };
+  e =  (vui64_t) CONST_VINT64_DW ( 15, -1 );
+  j1 = vec_vlxsdx (i1[1], test_ui64);
+  j = vec_permdi (j1, e, 1);
+
+  rc += check_vuint128x ("vec_lxsdx 5:", (vui128_t) j, (vui128_t) e);
+
+  e =  (vui64_t) { 1, 15 };
+#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+  j = vec_permdi (j1, j0, 0);
+#else
+  j = vec_permdi (j0, j1, 0);
+#endif
+
+  rc += check_vuint128x ("vec_lxsdx2 :", (vui128_t) j, (vui128_t) e);
+
+  e =  (vui64_t) { 1, 15 };
+  j = vec_lvgudo (test_ui64, i1);
+
+  rc += check_vuint128x ("vec_lxsdxo :", (vui128_t) j, (vui128_t) e);
+
+
+  i2 = (vui64_t) { 1, 15 };
+  i1 = vec_sldi (i2, 3);
+  e =  (vui64_t) CONST_VINT64_DW ( 1, -1 );
+  j0 = vec_vlxsdx (i1[0], test_ui64);
+  j = vec_permdi (j0, e, 1);
+
+  rc += check_vuint128x ("vec_lxsdx 6:", (vui128_t) j, (vui128_t) e);
+
+  e =  (vui64_t) CONST_VINT64_DW ( 15, -1 );
+  j1 = vec_vlxsdx (i1[1], test_ui64);
+  j = vec_permdi (j1, e, 1);
+
+  rc += check_vuint128x ("vec_lxsdx 7:", (vui128_t) j, (vui128_t) e);
+
+  e =  (vui64_t) { 1, 15 };
+#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+  j = vec_permdi (j1, j0, 0);
+#else
+  j = vec_permdi (j0, j1, 0);
+#endif
+
+  rc += check_vuint128x ("vec_lxsdx2 :", (vui128_t) j, (vui128_t) e);
+
+  i1 = (vui64_t) { 1, 2 };
+  e =  (vui64_t) { 1, 2 };
+  j = vec_lvgudx (test_ui64, i1);
+
+  rc += check_vuint128x ("vec_lvgudx :", (vui128_t) j, (vui128_t) e);
+
+  i1 = (vui64_t) { 15, 7 };
+  e =  (vui64_t) { 15, 7 };
+  j = vec_lvgudx (test_ui64, i1);
+
+  rc += check_vuint128x ("vec_lvgudx :", (vui128_t) j, (vui128_t) e);
+
+  i1 = (vui64_t) { 1, 2 };
+  e =  (vui64_t) { 2, 4 };
+  j = vec_lvgudsx (test_ui64, i1, 1);
+
+  rc += check_vuint128x ("vec_lvgudsx :", (vui128_t) j, (vui128_t) e);
+
+  i1 = (vui64_t) { 3, 2 };
+  e =  (vui64_t) { 12, 8 };
+  j = vec_lvgudsx (test_ui64, i1, 2);
+
+  rc += check_vuint128x ("vec_lvgudsx :", (vui128_t) j, (vui128_t) e);
+
+  return (rc);
+}
+
+static unsigned long long test_stui64[16];
+
+int
+test_stvgudx (void)
+{
+  vui64_t i1, i2, e, *mem;
+  vui64_t j, j0, j1;
+  int rc = 0;
+  int i;
+
+  mem = (vui64_t *)& test_stui64;
+
+  for (i=0; i<16; i++)
+    test_stui64[i] = test_ui64[i];
+
+  printf ("\ntest_Store Vector with scatter Doubleword\n");
+
+  i1 = (vui64_t) CONST_VINT64_DW ( 16, 1616 );
+  i2 = (vui64_t) CONST_VINT64_DW ( 31, 3131 );
+  vec_vstxsdx (i1, 0, test_stui64);
+  vec_vstxsdx (i2, 120, test_stui64);
+
+  j = mem [0];
+  e = (vui64_t) { 16, 1 };
+
+  rc += check_vuint128x ("vec_stxsdx 1:", (vui128_t) j, (vui128_t) e);
+
+  j = mem [7];
+  e = (vui64_t) { 14, 31 };
+
+  rc += check_vuint128x ("vec_stxsdx 2:", (vui128_t) j, (vui128_t) e);
+
+  i1 = (vui64_t) { 17, 30 };
+  i2 = (vui64_t) { 8, 112 };
+  vec_stvsudo (i1, test_stui64, i2);
+
+  j = mem [0];
+  e = (vui64_t) { 16, 17 };
+
+  rc += check_vuint128x ("vec_stvsudo 1:", (vui128_t) j, (vui128_t) e);
+
+  j = mem [7];
+  e = (vui64_t) { 30, 31 };
+
+  rc += check_vuint128x ("vec_stvsudo 2:", (vui128_t) j, (vui128_t) e);
+
+  i1 = (vui64_t) { 18, 29 };
+  i2 = (vui64_t) { 2, 13 };
+  vec_stvsudx (i1, test_stui64, i2);
+
+  j = mem [1];
+  e = (vui64_t) { 18, 3 };
+
+  rc += check_vuint128x ("vec_stvsudx 1:", (vui128_t) j, (vui128_t) e);
+
+  j = mem [6];
+  e = (vui64_t) { 12, 29 };
+
+  rc += check_vuint128x ("vec_stvsudx 2:", (vui128_t) j, (vui128_t) e);
+
+  i1 = (vui64_t) { 20, 28 };
+  i2 = (vui64_t) { 2, 6 };
+  vec_stvsudsx (i1, test_stui64, i2, 1);
+
+  j = mem [2];
+  e = (vui64_t) { 20, 5 };
+
+  rc += check_vuint128x ("vec_stvsudsx 1:", (vui128_t) j, (vui128_t) e);
+
+  j = mem [6];
+  e = (vui64_t) { 28, 29 };
+
+  rc += check_vuint128x ("vec_stvsudsx 2:", (vui128_t) j, (vui128_t) e);
+
+
+  return (rc);
+}
+
 int
 test_mrghld (void)
 {
@@ -11999,6 +12188,8 @@ test_vec_i64 (void)
   rc += test_rldi ();
   rc += test_vmaddeud ();
   rc += test_vmaddoud ();
+  rc += test_lvgudx ();
+  rc += test_stvgudx ();
 
   return (rc);
 }

--- a/src/testsuite/vec_int64_dummy.c
+++ b/src/testsuite/vec_int64_dummy.c
@@ -22,6 +22,195 @@
 
 #include <pveclib/vec_int128_ppc.h>
 
+unsigned __int128
+test_unpack_dw (vui64_t vra)
+{
+  __VEC_U_128 t;
+  t.vx2 = vra;
+  return (t.i128);
+}
+
+void
+test_vstxsdx (vui64_t data, unsigned long long int *array, unsigned long offset)
+{
+  vec_vstxsdx (data, offset, array);
+}
+
+void
+test_vstxsdx_c0 (vui64_t data, unsigned long long int *array)
+{
+  vec_vstxsdx (data, 0, array);
+}
+
+void
+test_vstxsdx_c1 (vui64_t data, unsigned long long int *array)
+{
+  vec_vstxsdx (data, 8, array);
+}
+
+void
+test_vstxsdx_c2 (vui64_t data, unsigned long long int *array)
+{
+  vec_vstxsdx (data, 32760, array);
+}
+
+void
+test_vstxsdx_c3 (vui64_t data, unsigned long long int *array)
+{
+  vec_vstxsdx (data, 32758, array);
+}
+
+void
+test_vstxsdx_c4 (vui64_t data, unsigned long long int *array)
+{
+  vec_vstxsdx (data, 32768, array);
+}
+
+void
+test_stvsud_v1 (vui64_t xs, unsigned long long int *array,
+		unsigned long offset0, unsigned long offset1)
+{
+  vui64_t rese1;
+
+  rese1 = vec_xxspltd (xs, 1);
+  vec_vstxsdx (xs, offset0, array);
+  vec_vstxsdx (rese1, offset1, array);
+}
+
+void
+test_stvsud_v2 (vui64_t data, unsigned long long int *array, vui64_t vra)
+{
+  vui64_t rese1;
+
+  rese1 = vec_xxspltd (data, 1);
+  vec_vstxsdx (data, vra[VEC_DW_H], array);
+  vec_vstxsdx (rese1, vra[VEC_DW_L], array);
+}
+
+void
+test_stvsud_v3 (vui64_t data, unsigned long long int *array, vui64_t vra)
+{
+  vui64_t rese1, offset;
+
+  offset = vec_sldi (vra, 3);
+  rese1 = vec_xxspltd (data, 1);
+  vec_vstxsdx (data, offset[VEC_DW_H], array);
+  vec_vstxsdx (rese1, offset[VEC_DW_L], array);
+}
+
+void
+test_stvsudo (vui64_t data, unsigned long long int *array, vui64_t vra)
+{
+  vec_stvsudo (data, array, vra);
+}
+
+void
+test_stvsudx (vui64_t data, unsigned long long int *array, vui64_t vra)
+{
+  vec_stvsudx (data, array, vra);
+}
+
+void
+test_stvsudsx (vui64_t data, unsigned long long int *array, vui64_t vra)
+{
+  vec_stvsudsx (data, array, vra, 4);
+}
+
+vui64_t
+test_vslxsdx (unsigned long long int *array, unsigned long offset)
+{
+  return vec_vlxsdx (offset, array);
+}
+
+vui64_t
+test_vslxsdx_c0 (unsigned long long int *array)
+{
+  return vec_vlxsdx (0, array);
+}
+
+vui64_t
+test_vslxsdx_c1 (unsigned long long int *array)
+{
+  return vec_vlxsdx (8, array);
+}
+
+vui64_t
+test_vslxsdx_c2 (unsigned long long int *array)
+{
+  return vec_vlxsdx (32768, array);
+}
+
+vui64_t
+test_lvgud_v1 (unsigned long long int *array, unsigned long offset0, unsigned long offset1)
+{
+  vui64_t rese0, rese1;
+
+  rese0 = vec_vlxsdx (offset0, array);
+  rese1 = vec_vlxsdx (offset1, array);
+  return vec_permdi (rese0, rese1, 0);
+}
+
+vui64_t
+test_lvgud_v2 (unsigned long long int *array, vui64_t vra)
+{
+  vui64_t rese0, rese1;
+
+  rese0 = vec_vlxsdx (vra[VEC_DW_H], array);
+  rese1 = vec_vlxsdx (vra[VEC_DW_L], array);
+  return vec_xxpermdi (rese0, rese1, 0);
+}
+
+vui64_t
+test_lvgud_v3 (unsigned long long int *array, vui64_t vra)
+{
+  vui64_t rese0, rese1, offset;
+#if 0
+  // This always loads the {3, 3} const vector from rodata.
+  offset = vec_sldi (vra, 3);
+#else
+  {
+    // This also loads the {3, 3} const vector from rodata.
+    vui32_t lshift = vec_splats((unsigned)3);
+    offset = vec_vsld (vra, (vui64_t) lshift);
+  }
+#endif
+  rese0 = vec_vlxsdx (offset[VEC_DW_H], array);
+  rese1 = vec_vlxsdx (offset[VEC_DW_L], array);
+  return vec_xxpermdi (rese0, rese1, 0);
+}
+
+#if (__GNUC__ > 7)  && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+vui64_t
+test_lvgud_v4 (unsigned long long int *array, vui64_t vra)
+{
+  vui64_t rese0, rese1;
+  __VEC_U_128 t;
+  t.vx2 = vra;
+
+  rese0 = vec_xl (t.ulong.lower, array);
+  rese1 = vec_xl (t.ulong.upper, array);
+  return  vec_permdi (rese0, rese1, 0);
+}
+#endif
+
+vui64_t
+test_vec_lvgudo (unsigned long long int *array, vui64_t vra)
+{
+  return vec_lvgudo (array, vra);
+}
+
+vui64_t
+test_vec_lvgudx (unsigned long long int *array, vui64_t vra)
+{
+  return vec_lvgudx (array, vra);
+}
+
+vui64_t
+test_vec_lvgudsx (unsigned long long int *array, vui64_t vra)
+{
+  return vec_lvgudsx (array, vra, 4);
+}
+
 vui64_t
 test_ctzd_v1 (vui64_t vra)
 {

--- a/src/testsuite/vec_int64_dummy.c
+++ b/src/testsuite/vec_int64_dummy.c
@@ -67,6 +67,16 @@ test_vstxsdx_c4 (vui64_t data, unsigned long long int *array)
 }
 
 void
+test_vstxsdx_c5 (vui64_t data, unsigned long long int *array)
+{
+  vui64_t data1;
+
+  data1 = vec_xxspltd (data, 1);
+  vec_vstxsdx (data, 16, array);
+  vec_vstxsdx (data1, 48, array);
+}
+
+void
 test_stvsud_v1 (vui64_t xs, unsigned long long int *array,
 		unsigned long offset0, unsigned long offset1)
 {
@@ -138,6 +148,16 @@ vui64_t
 test_vslxsdx_c2 (unsigned long long int *array)
 {
   return vec_vlxsdx (32768, array);
+}
+
+vui64_t
+test_vslxsdx_c3 (unsigned long long int *array)
+{
+  vui64_t rese0, rese1;
+
+  rese0 = vec_vlxsdx (8, array);
+  rese1 = vec_vlxsdx (40, array);
+  return vec_permdi (rese0, rese1, 0);
 }
 
 vui64_t

--- a/src/testsuite/vec_int64_dummy.c
+++ b/src/testsuite/vec_int64_dummy.c
@@ -214,6 +214,16 @@ test_lvgud_v4 (unsigned long long int *array, vui64_t vra)
 #endif
 
 vui64_t
+test_lvgud_v5 (unsigned long long int *array, vui64_t vra)
+{
+  unsigned char *arr = (unsigned char *)array;
+
+  vui64_t r = { *(unsigned long long int *)(&arr[vra[VEC_DW_H]]),
+                *(unsigned long long int *)(&arr[vra[VEC_DW_L]]) };
+  return r;
+}
+
+vui64_t
 test_vec_lvgudo (unsigned long long int *array, vui64_t vra)
 {
   return vec_lvgudo (array, vra);

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -39,6 +39,66 @@
 #include <pveclib/vec_f32_ppc.h>
 #include <pveclib/vec_bcd_ppc.h>
 
+vui64_t
+test_vslxsdx_PWR9 (unsigned long long int *array, unsigned long offset)
+{
+  return vec_vlxsdx (offset, array);
+}
+
+vui64_t
+test_vslxsdx_c0 (unsigned long long int *array)
+{
+  return vec_vlxsdx (0, array);
+}
+
+vui64_t
+test_vslxsdx_c1_PWR9 (unsigned long long int *array)
+{
+  return vec_vlxsdx (8, array);
+}
+
+vui64_t
+test_vslxsdx_c6_PWR9 (unsigned long long int *array)
+{
+  return vec_vlxsdx (6, array);
+}
+
+vui64_t
+test_vec_lvgudo_PWR9 (unsigned long long int *array, vui64_t vra)
+{
+  return vec_lvgudo (array, vra);
+}
+
+vui64_t
+test_vec_lvgudx_PWR9 (unsigned long long int *array, vui64_t vra)
+{
+  return vec_lvgudx (array, vra);
+}
+
+vui64_t
+test_vec_lvgudsx_PWR9 (unsigned long long int *array, vui64_t vra)
+{
+  return vec_lvgudsx (array, vra, 4);
+}
+
+void
+test_stvsudo_PWR9 (vui64_t data, unsigned long long int *array, vui64_t vra)
+{
+  vec_stvsudo (data, array, vra);
+}
+
+void
+test_stvsudx_PWR9 (vui64_t data, unsigned long long int *array, vui64_t vra)
+{
+  vec_stvsudx (data, array, vra);
+}
+
+void
+test_stvsudsx_PWR9 (vui64_t data, unsigned long long int *array, vui64_t vra)
+{
+  vec_stvsudsx (data, array, vra, 4);
+}
+
 vui8_t
 __test_absdub_PWR9 (vui8_t __A, vui8_t __B)
 {

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -82,6 +82,18 @@ test_vec_lvgudsx_PWR9 (unsigned long long int *array, vui64_t vra)
 }
 
 void
+test_vstxsdx_c0_PWR9 (vui64_t data, unsigned long long int *array)
+{
+  vec_vstxsdx (data, 0, array);
+}
+
+void
+test_vstxsdx_c1_PWR9 (vui64_t data, unsigned long long int *array)
+{
+  vec_vstxsdx (data, 8, array);
+}
+
+void
 test_stvsudo_PWR9 (vui64_t data, unsigned long long int *array, vui64_t vra)
 {
   vec_stvsudo (data, array, vra);

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -46,7 +46,7 @@ test_vslxsdx_PWR9 (unsigned long long int *array, unsigned long offset)
 }
 
 vui64_t
-test_vslxsdx_c0 (unsigned long long int *array)
+test_vslxsdx_c0_PWR9 (unsigned long long int *array)
 {
   return vec_vlxsdx (0, array);
 }


### PR DESCRIPTION
This is the simplest case for gather/scatter for PowerISA (which does
not have equivalent instructions). Requires transfer of offsets/indexes
from VSRs to GPRs (mfvsrd) and indexed (doubleword) element load/stores
to/from VSRs. Looked at and rejected using existing "load/store
element" forms because: no doubleword load/store element support,
The VR element is determined by the address, and lvsr/lvsl are
deprecated with extreme prejudice (for LE). Used the VSX scalar
indexed load/stores as they allow access to the full VSR range and
place/access the element consistently in the VSR. Quickly noted that
there is no built-in support for these and so provided inline asm
implementations. From there simple merge ops are used to stage/gather
elements.

	* src/pveclib/vec_int64_ppc.h [@cond INTERNAL] Forward ref
	vec_sldi, vec_vlxsdx, vec_vstxsdx.
	(vec_lvgudo, vec_lvgudsx, vec_lvgudx): New operations.
	(vec_sldi): Correct comment.
	(vec_stvsudo, vec_stvsudsx, vec_stvsudx): New operations.
	(vec_vlxsdx, vec_vstxsdx): New operations.

	* src/testsuite/arith128_test_i64.c (test_ui64): Test data.
	(test_lvgudx): New unit test.
	(test_stui64): Test data.
	(test_stvgudx): New unit test.
	(test_vec_i64): Call test_lvgudx, test_stvgudx.

	* src/testsuite/vec_int64_dummy.c (test_unpack_dw):
	New Compile test.
	(test_vstxsdx, test_vstxsdx_c0, test_vstxsdx_c1,
	test_vstxsdx_c2, test_vstxsdx_c3, test_vstxsdx_c4,
	test_stvsud_v1, test_stvsud_v2, test_stvsud_v3):
	New Compile test for vec_vstxsdx.
	(test_stvsudo, test_stvsudx, test_stvsudsx):
	New Compile tests.
	(test_vslxsdx, test_vslxsdx_c0, test_vslxsdx_c1,
	test_vslxsdx_c2, test_lvgud_v1, test_lvgud_v2, test_lvgud_v3):
	New Compile test for vec_vlxsdx.
	[__GNUC__>7) &&(__BYTE_ORDER__==__ORDER_LITTLE_ENDIAN__)]
	(test_lvgud_v4): New Compile test for vec_xl.
	(test_vec_lvgudo, test_vec_lvgudx, test_vec_lvgudsx):
	New Compile tests.

	* src/testsuite/vec_pwr9_dummy.c (test_vslxsdx_PWR9,
	test_vslxsdx_c0, test_vslxsdx_c1_PWR9, test_vslxsdx_c6_PWR9):
	New Compile test for vec_vlxsdx.
	(test_vec_lvgudo_PWR9, test_vec_lvgudx_PWR9,
	test_vec_lvgudsx_PWR9): New Compile tests.
	(test_stvsudo_PWR9, test_stvsudx_PWR9, test_stvsudsx_PWR9):
	New Compile tests.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>