### PR TITLE
Initial support for Gather/Scatter ops. 2nd try for doubleword int.

### DIFF
--- a/src/pveclib/vec_int64_ppc.h
+++ b/src/pveclib/vec_int64_ppc.h
@@ -865,6 +865,7 @@ static inline vb64_t vec_cmpequd (vui64_t a, vui64_t b);
 static inline vb64_t vec_cmpgeud (vui64_t a, vui64_t b);
 static inline vb64_t vec_cmpgtud (vui64_t a, vui64_t b);
 static inline vb64_t vec_cmpneud (vui64_t a, vui64_t b);
+static inline vui64_t vec_sldi (vui64_t vra, const unsigned int shb);
 static inline vui64_t vec_maxud (vui64_t vra, vui64_t vrb);
 static inline vui64_t vec_minud (vui64_t vra, vui64_t vrb);
 static inline vui64_t vec_permdi (vui64_t vra, vui64_t vrb, const int ctl);
@@ -876,6 +877,10 @@ static inline vui64_t vec_popcntd (vui64_t vra);
 #define vec_popcntd __builtin_vec_vpopcntd
 #endif
 static inline vui64_t vec_subudm (vui64_t a, vui64_t b);
+static inline vui64_t
+vec_vlsidx (const signed long long a, const unsigned long long *b);
+static inline void
+vec_vstsidx (vui64_t xs, const signed long long ra, unsigned long long *rb);
 static inline vui64_t vec_xxspltd (vui64_t vra, const int ctl);
 ///@endcond
 
@@ -947,7 +952,7 @@ vec_addudm(vui64_t a, vui64_t b)
 }
 
 /** \brief Vector Count Leading Zeros Doubleword for unsigned
- *  long long int elements.
+ *  long long elements.
  *
  *  Count the number of leading '0' bits (0-64) within each doubleword
  *  element of a 128-bit vector.
@@ -962,7 +967,7 @@ vec_addudm(vui64_t a, vui64_t b)
  *  |power9   |   2   | 2/cycle  |
  *
  *  @param vra a 128-bit vector treated as 2 x 64-bit unsigned
- *  long long int (doubleword) elements.
+ *  long long (doubleword) elements.
  *  @return 128-bit vector with the leading zeros count for each
  *  doubleword element.
  */
@@ -1001,7 +1006,7 @@ vec_clzd (vui64_t vra)
 }
 
 /** \brief Vector Count Trailing Zeros Doubleword for unsigned
- *  long long int elements.
+ *  long long elements.
  *
  *  Count the number of trailing '0' bits (0-64) within each doubleword
  *  element of a 128-bit vector.
@@ -2867,7 +2872,6 @@ vec_rldi (vui64_t vra, const unsigned int shb)
 static inline vui64_t
 vec_sldi (vui64_t vra, const unsigned int shb)
 {
-  vui64_t lshift;
   vui64_t result;
 
   if (shb < 64)
@@ -2876,17 +2880,56 @@ vec_sldi (vui64_t vra, const unsigned int shb)
          a shift amount for each element. For the immediate form the
          shift constant is splatted to all elements of the
          shift control.  */
+#ifdef _ARCH_PWR8
+      vui64_t lshift;
+
       if (__builtin_constant_p (shb) && (shb < 16))
 	lshift = (vui64_t) vec_splat_s32(shb);
       else
 	lshift = vec_splats ((unsigned long long) shb);
-
-      /* Vector Shift right bytes based on the lower 6-bits of
+      /* Vector Shift left doubleword from the lower 6-bits of
          corresponding element of lshift.  */
       result = vec_vsld (vra, lshift);
+#else
+      /*
+       * POWER7 and earlier do not have vsld. So use the vector shift
+       * left bit/octet instructions. But these may shift bits from
+       * element 1 in the low bits of element 0. So generate a mask of
+       * '1's, shifted left by the same shb and rotated into the
+       * element 0 position.
+       */
+      vui8_t lshift;
+
+      if (__builtin_constant_p (shb) && (shb < 16))
+	lshift = vec_splat_u8(shb);
+      else
+	lshift = vec_splats ((unsigned char) shb);
+
+      {
+	vui8_t sl_a;
+	vui8_t sl_m = (vui8_t) vec_splat_s8(-1);
+
+	sl_a = ((vui8_t) vra);
+	if (shb > 7)
+	  {
+	    /* Vector Shift Left By Octet by bits 121-124 of lshift.  */
+	    sl_m = vec_slo (sl_m, lshift);
+	    sl_a = vec_slo ((vui8_t) vra, lshift);
+	  }
+	if ((shb & 7) != 0)
+	  {
+	    /* Vector Shift Left by bits 125-127 of lshift.  */
+	    sl_m = vec_sll (sl_m, lshift);
+	    sl_a = vec_sll (sl_a, lshift);
+	  }
+	/* Rotate mask and clear low order bits of Element 0. */
+	sl_m = vec_sld (sl_m, sl_m, 8);
+	result = (vui64_t) vec_and (sl_a, sl_m);
+      }
+#endif
     }
   else
-    { /* shifts greater then 31 bits return zeros.  */
+    { /* shifts greater then 63 bits return zeros.  */
       result = vec_xor ((vui64_t) vra, (vui64_t) vra);
     }
 
@@ -3008,7 +3051,6 @@ vec_spltd (vui64_t vra, const int ctl)
 static inline vui64_t
 vec_srdi (vui64_t vra, const unsigned int shb)
 {
-  vui64_t rshift;
   vui64_t result;
 
   if (shb < 64)
@@ -3017,6 +3059,9 @@ vec_srdi (vui64_t vra, const unsigned int shb)
          a shift amount for each element. For the immediate form the
          shift constant is splatted to all elements of the
          shift control.  */
+#ifdef _ARCH_PWR8
+      vui64_t rshift;
+
 #if defined (__GNUC__) && (__GNUC__ < 8)
       if (__builtin_constant_p (shb) && (shb < 16))
 	rshift = (vui64_t) vec_splat_s32(shb);
@@ -3028,6 +3073,43 @@ vec_srdi (vui64_t vra, const unsigned int shb)
       /* Vector Shift right bytes based on the lower 6-bits of
          corresponding element of rshift.  */
       result = vec_vsrd (vra, rshift);
+#else
+      /*
+       * POWER7 and earlier do not have vsrd. So use the vector shift
+       * right bit/octet instructions. But these may shift bits from
+       * element 0 in the high bits of element 1. So generate a mask of
+       * '1's, shifted right by the same shb and rotated into the
+       * element 1 position.
+       */
+      vui8_t rshift;
+
+      if (__builtin_constant_p (shb) && (shb < 16))
+	rshift = vec_splat_u8(shb);
+      else
+	rshift = vec_splats ((unsigned char) shb);
+
+      {
+	vui8_t sr_a;
+	vui8_t sr_m = (vui8_t) vec_splat_s8(-1);
+
+	sr_a = ((vui8_t) vra);
+	if (shb > 7)
+	  {
+	    /* Vector Shift Left By Octet by bits 121-124 of lshift.  */
+	    sr_m = vec_sro (sr_m, rshift);
+	    sr_a = vec_sro ((vui8_t) vra, rshift);
+	  }
+	if ((shb & 7) != 0)
+	  {
+	    /* Vector Shift Left by bits 125-127 of lshift.  */
+	    sr_m = vec_srl (sr_m, rshift);
+	    sr_a = vec_srl (sr_a, rshift);
+	  }
+	/* Rotate mask and clear high order bits of Element 1. */
+	sr_m = vec_sld (sr_m, sr_m, 8);
+	result = (vui64_t) vec_and (sr_a, sr_m);
+      }
+#endif
     }
   else
     { /* shifts greater then 63 bits return zeros.  */
@@ -3162,6 +3244,250 @@ vec_swapd (vui64_t vra)
   result = vec_permdi (vra, vra, 2);
 
   return (result);
+}
+
+/** \brief Vector Gather-Load Integer Doublewords from Vector Doubleword Offsets.
+ *
+ *  For each doubleword element [i] of vra, load the doubleword
+ *  element at *(char*)array+vra[i]. Merge those doubleword elements
+ *  and return the resulting vector. For best performance <B>&array</B>
+ *  and doubleword offsets <B>vra</B> should be doubleword aligned
+ *  (integer multiple of 8).
+ *
+ *  \note As effective address calculation is modulo 64-bits, signed or
+ *  unsigned doubleword offsets are equivalent.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   |   12  | 1/cycle  |
+ *  |power9   |   11  | 1/cycle  |
+ *
+ *  @param array Pointer to array of integer doublewords.
+ *  @param vra Vector of doubleword (64-bit) byte offsets from &array.
+ *  @return vector doubleword containing elements loaded from
+ *  *(char*)array+vra[0] and *(char*)array+vra[1].
+ */
+static inline
+vui64_t
+vec_vgluddo (unsigned long long *array, vi64_t vra)
+{
+  vui64_t rese0, rese1;
+
+#ifdef _ARCH_PWR8
+  rese0 = vec_vlsidx (vra[VEC_DW_H], array);
+  rese1 = vec_vlsidx (vra[VEC_DW_L], array);
+#else
+  // Need to explicitly manage the VR/GPR xfer for PWR7
+  unsigned __int128 gprp = vec_transfer_vui128t_to_uint128 ((vui128_t) vra);
+
+  rese0 = vec_vlsidx (scalar_extract_uint64_from_high_uint128(gprp), array);
+  rese1 = vec_vlsidx (scalar_extract_uint64_from_low_uint128(gprp), array);
+#endif
+  return  vec_permdi (rese0, rese1, 0);
+}
+
+/** \brief Vector Gather-Load Integer Doublewords from Vector Doubleword Scaled Indexes.
+ *
+ *  For each doubleword element [i] of vra, load the doubleword
+ *  element array[vra[i] * (1 << scale)]. Merge those doubleword
+ *  elements and return the resulting vector. Array element indices are
+ *  converted to byte offsets from (array) by multiplying each index by
+ *  (sizeof (array element) * scale), which is effected by shifting
+ *  left (3+scale) bits.
+ *
+ *
+ *  \note As effective address calculation is modulo 64-bits, signed or
+ *  unsigned doubleword indexes are equivalent.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 14-23 | 1/cycle  |
+ *  |power9   | 13-22 | 1/cycle  |
+ *
+ *  @param array Pointer to array of integer doublewords.
+ *  @param vra Vector of signed doubleword indexes.
+ *  @param scale 8-bit integer. Indexes are multiplying by
+ *  2<sup>scale</sup>.
+ *  @return vector containing doublewords from array[(vra[0,1]<<scale)].
+ */
+static inline vui64_t
+vec_vgluddsx (unsigned long long *array, vi64_t vra,
+	     const unsigned char scale)
+{
+  vi64_t offset;
+
+  offset = (vi64_t) vec_sldi ((vui64_t) vra, (3 + scale));
+  return vec_vgluddo (array, offset);
+}
+
+/** \brief Vector Gather-Load Integer Doublewords from Vector Doubleword Indexes.
+ *
+ *  For each doubleword element [i] of vra, load the doubleword
+ *  element from array[vra[i]]. Merge those doubleword elements and
+ *  return the resulting vector. Array element indices are
+ *  converted to byte offsets from (array) by multiplying each index by
+ *  (sizeof (array element) * scale), which is effected by shifting
+ *  left 3 bits.
+ *
+ *  \note As effective address calculation is modulo 64-bits, signed or
+ *  unsigned doubleword indexes are equivalent.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 14-23 | 1/cycle  |
+ *  |power9   | 13-22 | 1/cycle  |
+ *
+ *  @param array Pointer to array of integer doublewords.
+ *  @param vra Vector of signed doubleword indexes.
+ *  @return vector containing doublewords array[vra[0,1]].
+ */
+static inline
+vui64_t
+vec_vgluddx (unsigned long long *array, vi64_t vra)
+{
+  vi64_t offset;
+
+  offset = (vi64_t) vec_sldi ((vui64_t) vra, 3);
+  return vec_vgluddo (array, offset);
+}
+
+/** \brief Vector Gather-Load Integer Doublewords from Scalar Offsets.
+ *
+ *  For each scalar offset[0|1], load the doubleword element at
+ *  *(char*)array+offset[0|1]. Merge those doubleword elements
+ *  and return the resulting vector. For best performance <B>&array</B>
+ *  and doubleword offsets should be doubleword aligned
+ *  (integer multiple of 8).
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   |   7   | 1/cycle  |
+ *  |power9   |   8   | 1/cycle  |
+ *
+ *  @param array Pointer to array of integer doublewords.
+ *  @param offset0 Scalar (64-bit) byte offsets from &array.
+ *  @param offset1 Scalar (64-bit) byte offsets from &array.
+ *  @return vector doubleword containing elements loaded from
+ *  *(char*)array+offset0 and *(char*)array+offset1.
+ */
+static inline vui64_t
+vec_vgludso (unsigned long long *array, const long long offset0,
+	     const long long offset1)
+{
+  vui64_t re0, re1, result;
+
+  re0 = vec_vlsidx (offset0, array);
+  re1 = vec_vlsidx (offset1, array);
+  /* Need to handle endian as the vec_vlsidx result is always left
+   * justified in VSR, while element [0] may be left or right. */
+#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+  result = vec_permdi (re1, re0, 0);
+#else
+  result = vec_permdi (re0, re1, 0);
+#endif
+  return result;
+}
+
+/** \brief Vector Load Scalar Integer Doubleword Indexed.
+ *
+ *  Load the left most doubleword of vector <B>xt</B> as a scalar
+ *  doubleword from the effective address formed by <B>rb+ra</B>. The
+ *  operand <B>rb</B> is a pointer to an array of doublewords.
+ *  The operand <B>ra</B> is a doubleword integer byte offset
+ *  from <B>rb</B>. The result <B>xt</B> is returned as a vui64_t
+ *  vector. For best performance <B>rb</B> and <B>ra</B>
+ *  should be doubleword aligned (integer multiple of 8).
+ *
+ *  \note the right most doubleword of vector <B>xt</B> is left
+ *  <I>undefined</I> by this operation.
+ *
+ *  This operation is an alternate form of Vector Load Element
+ *  (vec_lde), with the added simplification that data is always left
+ *  justified in the vector. This simplifies merging elements for
+ *  gather operations.
+ *
+ *  \note This instruction was introduced in PowerISA 2.06 (POWER7).
+ *  For POWER8/9 there are additional optimizations by effectively
+ *  converting small constant index values into displacements. For
+ *  POWER8 a specific pattern of addi/lsxdx instruction is <I>fused</I>
+ *  into a single load displacement internal operation. For POWER9 we can
+ *  use the lxsd (DS-form) instruction directly.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   |   5   | 2/cycle  |
+ *  |power9   |   5   | 2/cycle  |
+ *
+ *  @param ra const signed doubleword index (offset/displacement).
+ *  @param rb const doubleword pointer to an array of doubles.
+ *  @return The data stored at (ra + rb) is loaded into vector
+ *  doubleword element 0. Element 1 is undefined.
+ */
+static inline vui64_t
+vec_vlsidx (const signed long long ra, const unsigned long long *rb)
+{
+  vui64_t xt;
+
+#if (defined(__clang__) && __clang_major__ < 8)
+  __VEC_U_128 t;
+  unsigned long long *p = (unsigned long long *)((char *)rb + ra);
+  t.ulong.upper = *p;
+  xt = t.vx1;
+#else
+  if (__builtin_constant_p (ra) && (ra <= 32760) && (ra >= -32768)
+      && ((ra & 3) == 0))
+    {
+#if defined (_ARCH_PWR9)
+      __asm__(
+	  "lxsd%X1 %0,%1;"
+	  : "=v" (xt)
+	  : "m" (*(unsigned long long *)((char *)rb + ra))
+	  : );
+#else
+      if (ra == 0)
+	{
+	  __asm__(
+	      "lxsdx %x0,%y1;"
+	      : "=wa" (xt)
+	      : "Z" (*rb)
+	      : );
+	} else {
+	  unsigned long long rt;
+#if defined (_ARCH_PWR8)
+	  // For P8 better if li and lxsdx shared a single asm block
+	  // (enforcing consecutive instructions).
+	  // This enables instruction fusion for P8.
+	  __asm__(
+	      "li %0,%2;"
+	      "lxsdx %x1,%3,%0;"
+	      : "=&r" (rt), "=wa" (xt)
+	      : "I" (ra), "b" (rb), "Z" (*(unsigned long long *)((char *)rb+ra))
+	      : );
+#else // _ARCH_PWR7
+	  // This generates operationally the same code, but the
+	  // compiler may rearrange/schedule the code.
+	  __asm__(
+	      "li %0,%1;"
+	      : "=r" (rt)
+	      : "I" (ra)
+	      : );
+	  __asm__(
+	      "lxsdx %x0,%y1;"
+	      : "=wa" (xt)
+	      : "Z" (*(unsigned long long *)((char *)rb+rt))
+	      : );
+#endif
+	}
+#endif
+    } else {
+      __asm__(
+	  "lxsdx %x0,%y1;"
+	  : "=wa" (xt)
+	  : "Z" (*(unsigned long long *)((char *)rb+ra))
+	  : );
+    }
+#endif
+  return xt;
 }
 
 /** \brief \copybrief vec_int128_ppc.h::vec_vmadd2eud()
@@ -3538,6 +3864,206 @@ vec_vsrd (vui64_t vra, vui64_t vrb)
   return ((vui64_t) result);
 }
 #endif
+
+/** \brief Vector Scatter-Store Integer Doublewords to Vector Doublewords Offsets.
+ *
+ *  For each doubleword element [i] of vra, Store the doubleword
+ *  element xs[i] at the address *(char*)array+vra[i]
+ *  For best performance <B>&array</B> and doubleword offsets <B>vra</B>
+ *  should be doubleword aligned (integer multiple of 8).
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   |   12  | 1/cycle  |
+ *  |power9   |   8   | 1/cycle  |
+ *
+ *  @param xs Vector of integer doubleword elements to scatter store.
+ *  @param array Pointer to array of integer doublewords.
+ *  @param vra Vector of doubleword (64-bit) byte offsets from &array.
+ */
+static inline void
+vec_vsstuddo (vui64_t xs, unsigned long long *array, vi64_t vra)
+{
+  vui64_t xs1;
+
+  xs1 = vec_xxspltd (xs, 1);
+#ifdef _ARCH_PWR8
+  vec_vstsidx (xs, vra[VEC_DW_H], array);
+  vec_vstsidx (xs1, vra[VEC_DW_L], array);
+#else
+  // Need to explicitly manage the VR/GPR xfer for PWR7
+  unsigned __int128 gprp = vec_transfer_vui128t_to_uint128 ((vui128_t) vra);
+  vec_vstsidx (xs, scalar_extract_uint64_from_high_uint128(gprp), array);
+  vec_vstsidx (xs1, scalar_extract_uint64_from_low_uint128(gprp), array);
+#endif
+}
+
+/** \brief Vector Scatter-Store Integer Doublewords to Vector Doubleword Scaled Indexes.
+ *
+ *  For each doubleword element [i] of vra, store the doubleword
+ *  element xs[i] at array[(vra[i] << scale)]. Array element
+ *  indices are converted to byte offsets from (array) by multiplying
+ *  each index by (sizeof (array element) * scale), which is effected
+ *  by shifting left (3+scale) bits.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 14-23 | 1/cycle  |
+ *  |power9   | 10-19 | 1/cycle  |
+ *
+ *  @param xs Vector of integer doubleword elements to scatter store.
+ *  @param array Pointer to array of integer doublewords.
+ *  @param vra Vector of signed doubleword indexes.
+ *  @param scale 8-bit integer. Indexes are multiplying by
+ *  2<sup>scale</sup>.
+ */
+static inline void
+vec_vsstuddsx (vui64_t xs, unsigned long long *array,
+	    vi64_t vra, const unsigned char scale)
+{
+  vi64_t offset;
+
+  offset = (vi64_t) vec_sldi ((vui64_t) vra, (3 + scale));
+  vec_vsstuddo (xs, array, offset);
+}
+
+/** \brief Vector Scatter-Store Integer Doublewords to Vector Doubleword Indexes.
+ *
+ *  For each doubleword element [i] of vra, store the doubleword
+ *  element xs[i] at array[vra[i]]. Indexes are converted to offsets
+ *  from *array by shifting each doubleword of vra
+ *  left (3+scale) bits.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 14-23 | 1/cycle  |
+ *  |power9   | 10-19 | 1/cycle  |
+ *
+ *  @param xs Vector of integer doubleword elements to scatter store.
+ *  @param array Pointer to array of integer doublewords.
+ *  @param vra Vector of signed doubleword indexes.
+ */
+static inline void
+vec_vsstuddx (vui64_t xs, unsigned long long *array,
+	    vi64_t vra)
+{
+  vi64_t offset;
+
+  offset = (vi64_t) vec_sldi ((vui64_t) vra, 3);
+  vec_vsstuddo (xs, array, offset);
+}
+
+/** \brief Vector Scatter-Store Integer Doublewords to Scalar Offsets.
+ *
+ *  For each doubleword element [i] of vra, Store the doubleword
+ *  element xs[i] at *(char*)array+offset[0|1].
+ *  For best performance, <B>&array</B> and doubleword offsets
+ *  should be doubleword aligned (integer multiple of 8).
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   |   12  | 1/cycle  |
+ *  |power9   |   8   | 1/cycle  |
+ *
+ *  @param xs Vector of integer doubleword elements to scatter store.
+ *  @param array Pointer to array of integer doublewords.
+ *  @param offset0 Scalar (64-bit) byte offset from &array.
+ *  @param offset1 Scalar (64-bit) byte offset from &array.
+ */
+static inline void
+vec_vsstudso (vui64_t xs, unsigned long long *array,
+	      const long long offset0, const long long offset1)
+{
+  vui64_t xs1;
+
+  xs1 = vec_xxspltd (xs, 1);
+  /* Need to handle endian as vec_vstsfdux always left side of
+   * the VR, while the element [0] may in the left or right. */
+#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+  vec_vstsidx (xs, offset1, array);
+  vec_vstsidx (xs1, offset0, array);
+#else
+  vec_vstsidx (xs, offset0, array);
+  vec_vstsidx (xs1, offset1, array);
+#endif
+}
+
+/** \brief Vector Store Scalar Integer Doubleword Indexed.
+ *
+ *  Stores the left most doubleword of vector <B>xs</B> as a scalar
+ *  doubleword at the effective address formed by <B>rb+ra</B>. The
+ *  operand <B>rb</B> is a pointer to an array of doublewords.
+ *  The operand <B>ra</B> is a doubleword integer byte offset
+ *  from <B>rb</B>. For best performance <B>rb</B> and <B>ra</B>
+ *  should be doubleword aligned (integer multiple of 8).
+ *
+ *  This operation is an alternate form of vector store element, with
+ *  the added simplification that data is always left justified in the
+ *  vector. This simplifies scatter operations.
+ *
+ *  \note This is instruction was introduced in PowerISA 2.06 (POWER7).
+ *  For POWER9 there are additional optimizations by effectively
+ *  converting small constant index values into displacements. For
+ *  POWER9 we can use the stxsd (DS-form) instruction directly.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 0 - 2 | 2/cycle  |
+ *  |power9   | 0 - 2 | 4/cycle  |
+ *
+ *  @param xs vector doubleword element 0 to be stored.
+ *  @param ra const signed long long index (offset/displacement).
+ *  @param rb const doubleword pointer to an array of doubles.
+ */
+static inline void
+vec_vstsidx (vui64_t xs, const signed long long ra, unsigned long long *rb)
+{
+#if (defined(__clang__) && __clang_major__ < 8)
+  __VEC_U_128 t;
+  unsigned long long *p = (unsigned long long *)((char *)rb + ra);
+  t.vx1 = xs;
+  *p = t.ulong.upper;
+#else
+  if (__builtin_constant_p (ra) &&  (ra <= 32760) && (ra >= -32768)
+      && ((ra & 3) == 0))
+    {
+#if defined (_ARCH_PWR9)
+      __asm__(
+	  "stxsd%X0 %1,%0;"
+	  : "=m" (*((char *)rb + ra))
+	  : "v" (xs)
+	  : );
+#else
+      if (ra == 0)
+	{
+	  __asm__(
+	      "stxsdx %x1,%y0;"
+	      : "=Z" (*rb)
+	      : "wa" (xs)
+	      : );
+	} else {
+	  unsigned long long rt;
+	  __asm__(
+	      "li %0,%1;"
+	      : "=r" (rt)
+	      : "I" (ra)
+	      : );
+	  __asm__(
+	      "stxsdx %x1,%y0;"
+	      : "=Z" (*((char *)rb+rt))
+	      : "wa" (xs)
+	      : );
+	}
+#endif
+    } else {
+      __asm__(
+	  "stxsdx %x1,%y0;"
+	  : "=Z" (*((char *)rb+ra))
+	  : "wa" (xs)
+	  : );
+    }
+#endif
+}
 
 /** \brief Vector splat doubleword.
  *  Duplicate the selected doubleword element across the doubleword

--- a/src/pveclib/vec_int64_ppc.h
+++ b/src/pveclib/vec_int64_ppc.h
@@ -3095,13 +3095,13 @@ vec_srdi (vui64_t vra, const unsigned int shb)
 	sr_a = ((vui8_t) vra);
 	if (shb > 7)
 	  {
-	    /* Vector Shift Left By Octet by bits 121-124 of lshift.  */
+	    /* Vector Shift Right By Octet by bits 121-124 of rshift.  */
 	    sr_m = vec_sro (sr_m, rshift);
 	    sr_a = vec_sro ((vui8_t) vra, rshift);
 	  }
 	if ((shb & 7) != 0)
 	  {
-	    /* Vector Shift Left by bits 125-127 of lshift.  */
+	    /* Vector Shift Right by bits 125-127 of rshift.  */
 	    sr_m = vec_srl (sr_m, rshift);
 	    sr_a = vec_srl (sr_a, rshift);
 	  }

--- a/src/testsuite/arith128_test_i128.c
+++ b/src/testsuite/arith128_test_i128.c
@@ -10065,7 +10065,7 @@ test_xfer_int128 (void)
   vi = (vui128_t) { 10000000000000000UL };
   e  = (unsigned __int128) 10000000000000000UL;
 
-  i  = vec_xfer_vui128t_2_uint128 (vi);
+  i  = vec_transfer_vui128t_to_uint128 (vi);
   rc += check_int128 ("xfer to int128 1", i , e);
 
   vi = (vui128_t) { (__int128) 10000000000000000UL
@@ -10073,11 +10073,11 @@ test_xfer_int128 (void)
   e  = (unsigned __int128) 10000000000000000UL
       * (unsigned __int128) 10000000000000000UL;
 
-  i  = vec_xfer_vui128t_2_uint128 (vi);
+  i  = vec_transfer_vui128t_to_uint128 (vi);
   rc += check_int128 ("xfer to int128 2", i , e);
 
-  low = ext_uint128_low (i);
-  high = ext_uint128_high (i);
+  low = scalar_extract_uint64_from_low_uint128 (i);
+  high = scalar_extract_uint64_from_high_uint128 (i);
 
   rc = check_uint64 ("ext_uint128_low", low, 9632337040368467968UL);
   rc = check_uint64 ("ext_uint128_high", high, 5421010862427UL);
@@ -10085,7 +10085,7 @@ test_xfer_int128 (void)
   i  = (unsigned __int128) 10000000000000000UL;
   ve = (vui128_t) { 10000000000000000UL };
 
-  vi = vec_xfer_uint128_2_vui128t (i);
+  vi = vec_transfer_uint128_to_vui128t (i);
   rc += check_vuint128x ("xfer from int128 1", vi , ve);
 
   i  = (unsigned __int128) 10000000000000000UL
@@ -10093,7 +10093,7 @@ test_xfer_int128 (void)
   ve = (vui128_t) { (__int128) 10000000000000000UL
                   * (__int128) 10000000000000000UL };
 
-  vi = vec_xfer_uint128_2_vui128t (i);
+  vi = vec_transfer_uint128_to_vui128t (i);
   rc += check_vuint128x ("xfer from int128 1", vi , ve);
 
   return (rc);

--- a/src/testsuite/arith128_test_i64.c
+++ b/src/testsuite/arith128_test_i64.c
@@ -948,6 +948,205 @@ test_rldi (void)
 }
 #undef __DEBUG_PRINT__
 
+static unsigned long long test_ui64[] =
+    {
+	0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+    };
+
+int
+test_lvgudx (void)
+{
+  vi64_t i1, i2;
+  vui64_t e;
+  vui64_t j, j0, j1;
+  int rc = 0;
+
+  printf ("\ntest_Vector Gather-Load Doubleword\n");
+
+  e =  (vui64_t) CONST_VINT64_DW ( 0, -1 );
+  j0 = vec_vlsidx (0, test_ui64);
+  j = vec_permdi (j0, e, 1);
+
+  rc += check_vuint128x ("vec_vlsidx 1:", (vui128_t) j, (vui128_t) e);
+
+  e =  (vui64_t) CONST_VINT64_DW ( 1, -1 );
+  j0 = vec_vlsidx (8, test_ui64);
+  j = vec_permdi (j0, e, 1);
+
+  rc += check_vuint128x ("vec_vlsidx 2:", (vui128_t) j, (vui128_t) e);
+
+  e =  (vui64_t) CONST_VINT64_DW ( 15, -1 );
+  j0 = vec_vlsidx (120, test_ui64);
+  j = vec_permdi (j0, e, 1);
+
+  rc += check_vuint128x ("vec_vlsidx 3:", (vui128_t) j, (vui128_t) e);
+
+  i1 = (vi64_t) { 8, 120 };
+  e =  (vui64_t) CONST_VINT64_DW ( 1, -1 );
+  j0 = vec_vlsidx (i1[0], test_ui64);
+  j = vec_permdi (j0, e, 1);
+
+  rc += check_vuint128x ("vec_vlsidx 4:", (vui128_t) j, (vui128_t) e);
+
+  i1 = (vi64_t) { 8, 120 };
+  e =  (vui64_t) CONST_VINT64_DW ( 15, -1 );
+  j1 = vec_vlsidx (i1[1], test_ui64);
+  j = vec_permdi (j1, e, 1);
+
+  rc += check_vuint128x ("vec_vlsidx 5:", (vui128_t) j, (vui128_t) e);
+
+  // This test depends on the merge of scalars from lsudux 4/5
+  e =  (vui64_t) { 1, 15 };
+#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+  j = vec_permdi (j1, j0, 0);
+#else
+  j = vec_permdi (j0, j1, 0);
+#endif
+
+  rc += check_vuint128x ("vec_vlsidx2 :", (vui128_t) j, (vui128_t) e);
+
+  // This test replecates the results of the last 3 tests in single op.
+  e =  (vui64_t) { 1, 15 };
+  j = vec_vgludso (test_ui64, 8, 120);
+
+  rc += check_vuint128x ("vec_vgludso :", (vui128_t) j, (vui128_t) e);
+
+  // This test replecates the results of the last 3 tests in single op.
+  e =  (vui64_t) { 1, 15 };
+  j = vec_vgluddo (test_ui64, i1);
+
+  rc += check_vuint128x ("vec_vgluddo :", (vui128_t) j, (vui128_t) e);
+
+
+  i2 = (vi64_t) { 1, 15 };
+  i1 = (vi64_t) vec_sldi ((vui64_t) i2, 3);
+  e =  (vui64_t) CONST_VINT64_DW ( 1, -1 );
+  j0 = vec_vlsidx (i1[0], test_ui64);
+  j = vec_permdi (j0, e, 1);
+
+  rc += check_vuint128x ("vec_vlsidx 6:", (vui128_t) j, (vui128_t) e);
+
+  e =  (vui64_t) CONST_VINT64_DW ( 15, -1 );
+  j1 = vec_vlsidx (i1[1], test_ui64);
+  j = vec_permdi (j1, e, 1);
+
+  rc += check_vuint128x ("vec_vlsidx 7:", (vui128_t) j, (vui128_t) e);
+
+  e =  (vui64_t) { 1, 15 };
+#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+  j = vec_permdi (j1, j0, 0);
+#else
+  j = vec_permdi (j0, j1, 0);
+#endif
+
+  rc += check_vuint128x ("vec_vlsidx2 :", (vui128_t) j, (vui128_t) e);
+
+  i1 = (vi64_t) { 1, 2 };
+  e =  (vui64_t) { 1, 2 };
+  j = vec_vgluddx (test_ui64, i1);
+
+  rc += check_vuint128x ("vec_vgluddx :", (vui128_t) j, (vui128_t) e);
+
+  i1 = (vi64_t) { 15, 7 };
+  e =  (vui64_t) { 15, 7 };
+  j = vec_vgluddx (test_ui64, i1);
+
+  rc += check_vuint128x ("vec_vgluddx :", (vui128_t) j, (vui128_t) e);
+
+  i1 = (vi64_t) { 1, 2 };
+  e =  (vui64_t) { 2, 4 };
+  j = vec_vgluddsx (test_ui64, i1, 1);
+
+  rc += check_vuint128x ("vec_vgluddsx :", (vui128_t) j, (vui128_t) e);
+
+  i1 = (vi64_t) { 3, 2 };
+  e =  (vui64_t) { 12, 8 };
+  j = vec_vgluddsx (test_ui64, i1, 2);
+
+  rc += check_vuint128x ("vec_vgluddsx :", (vui128_t) j, (vui128_t) e);
+
+  return (rc);
+}
+
+static unsigned long long test_stui64[16];
+
+int
+test_stvgudx (void)
+{
+  vi64_t i2;
+  vui64_t e, *mem;
+  vui64_t j, j1, j2;
+  int rc = 0;
+  int i;
+
+  mem = (vui64_t *)& test_stui64;
+
+  for (i=0; i<16; i++)
+    test_stui64[i] = test_ui64[i];
+
+  printf ("\ntest_Store Vector with scatter Doubleword\n");
+
+  j1 = (vui64_t) CONST_VINT64_DW ( 16, 1616 );
+  j2 = (vui64_t) CONST_VINT64_DW ( 31, 3131 );
+  vec_vstsidx (j1, 0, test_stui64);
+  vec_vstsidx (j2, 120, test_stui64);
+
+  j = mem [0];
+  e = (vui64_t) { 16, 1 };
+
+  rc += check_vuint128x ("vec_stsudux 1:", (vui128_t) j, (vui128_t) e);
+
+  j = mem [7];
+  e = (vui64_t) { 14, 31 };
+
+  rc += check_vuint128x ("vec_stsudux 2:", (vui128_t) j, (vui128_t) e);
+
+  j1 = (vui64_t) { 17, 30 };
+  i2 = (vi64_t) { 8, 112 };
+  vec_vsstuddo (j1, test_stui64, i2);
+
+  j = mem [0];
+  e = (vui64_t) { 16, 17 };
+
+  rc += check_vuint128x ("vec_stvsudo 1:", (vui128_t) j, (vui128_t) e);
+
+  j = mem [7];
+  e = (vui64_t) { 30, 31 };
+
+  rc += check_vuint128x ("vec_stvsudo 2:", (vui128_t) j, (vui128_t) e);
+
+  j1 = (vui64_t) { 18, 29 };
+  i2 = (vi64_t) { 2, 13 };
+  vec_vsstuddx (j1, test_stui64, i2);
+
+  j = mem [1];
+  e = (vui64_t) { 18, 3 };
+
+  rc += check_vuint128x ("vec_stvsudx 1:", (vui128_t) j, (vui128_t) e);
+
+  j = mem [6];
+  e = (vui64_t) { 12, 29 };
+
+  rc += check_vuint128x ("vec_stvsudx 2:", (vui128_t) j, (vui128_t) e);
+
+  j1 = (vui64_t) { 20, 28 };
+  i2 = (vi64_t) { 2, 6 };
+  vec_vsstuddsx (j1, test_stui64, i2, 1);
+
+  j = mem [2];
+  e = (vui64_t) { 20, 5 };
+
+  rc += check_vuint128x ("vec_stvsudsx 1:", (vui128_t) j, (vui128_t) e);
+
+  j = mem [6];
+  e = (vui64_t) { 28, 29 };
+
+  rc += check_vuint128x ("vec_stvsudsx 2:", (vui128_t) j, (vui128_t) e);
+
+
+  return (rc);
+}
+
 int
 test_mrghld (void)
 {
@@ -11999,6 +12198,8 @@ test_vec_i64 (void)
   rc += test_rldi ();
   rc += test_vmaddeud ();
   rc += test_vmaddoud ();
+  rc += test_lvgudx ();
+  rc += test_stvgudx ();
 
   return (rc);
 }

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -39,6 +39,78 @@
 #include <pveclib/vec_f32_ppc.h>
 #include <pveclib/vec_bcd_ppc.h>
 
+vui64_t
+test_vslsudux_PWR9 (unsigned long long int *array, unsigned long offset)
+{
+  return vec_vlsidx (offset, array);
+}
+
+vui64_t
+test_vslsudux_c0_PWR9 (unsigned long long int *array)
+{
+  return vec_vlsidx (0, array);
+}
+
+vui64_t
+test_vslsudux_c1_PWR9 (unsigned long long int *array)
+{
+  return vec_vlsidx (8, array);
+}
+
+vui64_t
+test_vslsudux_c6_PWR9 (unsigned long long int *array)
+{
+  return vec_vlsidx (6, array);
+}
+
+vui64_t
+test_vec_lvgudo_PWR9 (unsigned long long int *array, vi64_t vra)
+{
+  return vec_vgluddo (array, vra);
+}
+
+vui64_t
+test_vec_lvgudx_PWR9 (unsigned long long int *array, vi64_t vra)
+{
+  return vec_vgluddx (array, vra);
+}
+
+vui64_t
+test_vec_lvgudsx_PWR9 (unsigned long long int *array, vi64_t vra)
+{
+  return vec_vgluddsx (array, vra, 4);
+}
+
+void
+test_vstsudux_c0_PWR9 (vui64_t data, unsigned long long int *array)
+{
+  vec_vstsidx (data, 0, array);
+}
+
+void
+test_vstsudux_c1_PWR9 (vui64_t data, unsigned long long int *array)
+{
+  vec_vstsidx (data, 8, array);
+}
+
+void
+test_stvsudo_PWR9 (vui64_t data, unsigned long long int *array, vi64_t vra)
+{
+  vec_vsstuddo (data, array, vra);
+}
+
+void
+test_stvsudx_PWR9 (vui64_t data, unsigned long long int *array, vi64_t vra)
+{
+  vec_vsstuddx (data, array, vra);
+}
+
+void
+test_stvsudsx_PWR9 (vui64_t data, unsigned long long int *array, vi64_t vra)
+{
+  vec_vsstuddsx (data, array, vra, 4);
+}
+
 vui8_t
 __test_absdub_PWR9 (vui8_t __A, vui8_t __B)
 {


### PR DESCRIPTION
The PowerISA does not support gather/scatter directly, but does provide
instructions to:
- Load/Store scalar elements directly to/from vector registers
- Combine and split these elements within vectors registers.
- Transfer scalar elements directly from vectors to GRPs for effective
  address calculations (PWR8+).

This is sufficient to implement Gather/Scatter operations small enough
to be inline functions. Quickly noted that some instructions have no
built-in support. So provided inline asm implementations where needed.

This is a rethink and replacement for the 1st implementations. After
implementing float double and integer word form, I see a number of
misconceptions and poor naming choices that should be rectified.
- Change to Vector Gather-Load and Vector Scatter Store naming.
- Change Vector Load Scalar and Vector Store Scalar naming to
  reflect the VSX instructions used. Preferencially use VSX
  instructions to access the VSR (64-register) range.
  - When appropriate VSX instructions are not available, for the
    specific platform, the implementation will:
  - Use vec_lde/vec_ste for word and smaller.
  - Otherwise use unions and allow the compiler to implement the
    transfer (via storage).
- Offsets and Indexes are signed (both scalar (GPR) and Vector forms).
  - Smaller offsets/indexes are expanded to doubleword first.
  - Indexes are converted to offsets by shifting doublewords left.
  - Vector doublewords are transferred to GPRs.
    - For PWR8+ let the compiler generate direct moves
    - For PWR7- use the PVECLIB transfer ops.

	* src/pveclib/vec_common_ppc.h
	(vec_transfer_vui128t_to_uint128 [_ARCH_PWR7]): Replace vec_sld
	with vec_xxpermdi for swapd operation. Replace stfd with
	stxsdx. Replace "m" constraint with "Z".
	[!_ARCH_PWR7] Otherwise use union for VR-GPR transfer.

	* src/pveclib/vec_int64_ppc.h [@cond INTERNAL] Forward ref
	vec_sldi, vec_vlxsdx, vec_vstxsdx.
	(vec_sldi): Fix Doxygen and code comments.
	(vec_sldi[_ARCH_PWR8]): Fix scope of lshift variable.
	(vec_sldi[!_ARCH_PWR8]): Optimized vector doubleword shift
	left.
	(vec_srdi): Fix Doxygen comments.
	(vec_srdi[_ARCH_PWR8]): Fix scope of rshift variable.
	(vec_srdi[!_ARCH_PWR8]): Optimized vector doubleword shift
	right.
	(vec_vgluddo, vec_vgluddsx, vec_vgluddx, vec_vgludso,
	vec_vlsidx): New Gather operations.
	(vec_vsstuddo, vec_vsstuddsx, vec_vsstuddx, vec_vsstudso,
	vec_vstsidx): New Scatter operations.

	* src/testsuite/arith128_test_i128.c (test_xfer_int128):
	Use renamed vec_transfer_vui128t_to_uint128,
	scalar_extract_uint64_from_low_uint128,
	scalar_extract_uint64_from_high_uint128,
	vec_transfer_uint128_to_vui128t/

	* src/testsuite/arith128_test_i64.c (test_ui64): New array.
	(test_lvgudx): New unit test function.
	(test_stui64): New array.
	(test_stvgudx): New unit test function.
	(test_vec_i64): Add new unit tests to driver.

	* src/testsuite/vec_int64_dummy.c (test_slli_3, test_unpack_dw,
	test_unpack_dw_2, test_unpack_dw_3, test_unpack_dw_4,
	test_vstsudux, test_vstsudux_c0, test_vstsudux_c1,
	test_vstsudux_c2, test_vstsudux_c3, test_vstsudux_c4,
	test_vstsudux_c5, test_stvsud_v1, test_stvsud_v2,
	test_stvsud_v3, test_stvsudo, test_stvsudsx, test_vslsudux,
	test_vslsudux_c0, test_vslsudux_c1, test_vslsudux_c2,
	test_vslsudux_c3, test_lvgud_v1, test_lvgud_v2, test_lvgud_v3,
	test_lvgud_v4, test_lvgud_v5, test_lvgud_v5b, test_lvgud_v6,
	test_lvgud_v6b, test_lvgud_v6c, test_lvgud_v7, test_lvgud_v7b,
	test_vec_lvgudo, test_vec_lvgudx, test_vec_lvgudsx):
	New compile test functions.

	* src/testsuite/vec_pwr9_dummy.c (test_vslxsdx_PWR9,
	test_vslxsdx_c0, test_vslxsdx_c1_PWR9, test_vslxsdx_c6_PWR9):
	New Compile test for vec_vlxsdx.
	(test_vec_lvgudo_PWR9, test_vec_lvgudx_PWR9,
	test_vec_lvgudsx_PWR9): New Compile tests.
	(test_stvsudo_PWR9, test_stvsudx_PWR9, test_stvsudsx_PWR9):
	New Compile tests.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>