### PR TITLE
Initial support for Gather/Scatter ops, 2nd pass for double float.

### DIFF
--- a/src/pveclib/vec_f64_ppc.h
+++ b/src/pveclib/vec_f64_ppc.h
@@ -202,9 +202,9 @@ test_vec_cosf64 (vf64_t value)
 
 ///@cond INTERNAL
 static inline vf64_t
-vec_vlsfdux (const signed long long ra, const double *rb);
+vec_vlxsfdx (const signed long long ra, const double *rb);
 static inline void
-vec_vstsfdux (vf64_t xs, const signed long long ra, double *rb);
+vec_vstxsfdx (vf64_t xs, const signed long long ra, double *rb);
 ///@endcond
 
 /** \brief Vector double absolute value.
@@ -1167,9 +1167,9 @@ vec_vglfdso (double *array, const long long offset0,
 {
   vf64_t re0, re1, result;
 
-  re0 = vec_vlsfdux (offset0, array);
-  re1 = vec_vlsfdux (offset1, array);
-  /* Need to handle endian as the vec_vlsfdux result is always left
+  re0 = vec_vlxsfdx (offset0, array);
+  re1 = vec_vlxsfdx (offset1, array);
+  /* Need to handle endian as the vec_vlxsfdx result is always left
    * justified in VR, while element [0] may be left ot right. */
 #if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   result = (vf64_t) vec_permdi ((vui64_t) re1, (vui64_t) re0, 0);
@@ -1204,14 +1204,14 @@ vec_vglfddo (double *array, vi64_t vra)
   vf64_t rese0, rese1;
 
 #ifdef _ARCH_PWR8
-  rese0 = vec_vlsfdux (vra[VEC_DW_H], array);
-  rese1 = vec_vlsfdux (vra[VEC_DW_L], array);
+  rese0 = vec_vlxsfdx (vra[VEC_DW_H], array);
+  rese1 = vec_vlxsfdx (vra[VEC_DW_L], array);
 #else
   // Need to explicitly manage the VR/GPR xfer for PWR7
   unsigned __int128 gprp = vec_transfer_vui128t_to_uint128 ((vui128_t) vra);
 
-  rese0 = vec_vlsfdux (scalar_extract_uint64_from_high_uint128(gprp), array);
-  rese1 = vec_vlsfdux (scalar_extract_uint64_from_low_uint128(gprp), array);
+  rese0 = vec_vlxsfdx (scalar_extract_uint64_from_high_uint128(gprp), array);
+  rese1 = vec_vlxsfdx (scalar_extract_uint64_from_low_uint128(gprp), array);
 #endif
   return (vf64_t) vec_permdi ((vui64_t) rese0, (vui64_t) rese1, 0);
 }
@@ -1301,14 +1301,14 @@ vec_vsstfdso (vf64_t xs, double *array,
   vf64_t xs1;
 
   xs1 = (vf64_t) vec_xxspltd ((vui64_t) xs, 1);
-  /* Need to handle endian as vec_vstsfdux always left side of
+  /* Need to handle endian as vec_vstxsfdx always left side of
    * the VR, while the element [0] may in the left or right. */
 #if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
-  vec_vstsfdux (xs, offset1, array);
-  vec_vstsfdux (xs1, offset0, array);
+  vec_vstxsfdx (xs, offset1, array);
+  vec_vstxsfdx (xs1, offset0, array);
 #else
-  vec_vstsfdux (xs, offset0, array);
-  vec_vstsfdux (xs1, offset1, array);
+  vec_vstxsfdx (xs, offset0, array);
+  vec_vstxsfdx (xs1, offset1, array);
 #endif
 }
 
@@ -1335,13 +1335,13 @@ vec_vsstfddo (vf64_t xs, double *array,
 {
   vf64_t xs1 = (vf64_t) vec_xxspltd ((vui64_t) xs, 1);
 #ifdef _ARCH_PWR8
-  vec_vstsfdux (xs, vra[VEC_DW_H], array);
-  vec_vstsfdux (xs1, vra[VEC_DW_L], array);
+  vec_vstxsfdx (xs, vra[VEC_DW_H], array);
+  vec_vstxsfdx (xs1, vra[VEC_DW_L], array);
 #else
   // Need to explicitly manage the VR/GPR xfer for PWR7
   unsigned __int128 gprp = vec_transfer_vui128t_to_uint128 ((vui128_t) vra);
-  vec_vstsfdux (xs, scalar_extract_uint64_from_high_uint128(gprp), array);
-  vec_vstsfdux (xs1, scalar_extract_uint64_from_low_uint128(gprp), array);
+  vec_vstxsfdx (xs, scalar_extract_uint64_from_high_uint128(gprp), array);
+  vec_vstxsfdx (xs1, scalar_extract_uint64_from_low_uint128(gprp), array);
 #endif
 }
 
@@ -1404,7 +1404,7 @@ vec_vsstfddx (vf64_t xs, double *array, vi64_t vra)
   vec_vsstfddo (xs, array, offset);
 }
 
-/** \brief Vector Scalar Load Float Double Signed Doubleword Indexed.
+/** \brief Vector Load Scalar Float Double Indexed.
  *
  *  Load the left most doubleword of vector <B>xt</B> as a scalar
  *  double from the effective address formed by <B>rb+ra</B>. The
@@ -1440,7 +1440,7 @@ vec_vsstfddx (vf64_t xs, double *array, vi64_t vra)
  *  doubleword element 0. Element 1 is undefined.
  */
 static inline vf64_t
-vec_vlsfdux (const signed long long ra, const double *rb)
+vec_vlxsfdx (const signed long long ra, const double *rb)
 {
   vf64_t xt;
 
@@ -1477,7 +1477,7 @@ vec_vlsfdux (const signed long long ra, const double *rb)
 	      "li %0,%2;"
 	      "lxsdx %x1,%3,%0;"
 	      : "=&r" (rt), "=wa" (xt)
-	      : "I" (ra), "b" (rb), "m" (*(double*)((char *)rb+rt))
+	      : "I" (ra), "b" (rb), "m" (*(double*)((char *)rb+ra))
 	      : );
 #else // _ARCH_PWR7
 	  // This generates operationally the same code, but the
@@ -1506,7 +1506,7 @@ vec_vlsfdux (const signed long long ra, const double *rb)
   return xt;
 }
 
-/** \brief Vector Store Scalar Float Double Signed Doubleword Indexed.
+/** \brief Vector Store Scalar Float Double Indexed.
  *
  *  Stores the left most doubleword of vector <B>xs</B> as a scalar
  *  double float at the effective address formed by <B>rb+ra</B>. The
@@ -1534,7 +1534,7 @@ vec_vlsfdux (const signed long long ra, const double *rb)
  *  @param rb const doubleword pointer to an array of doubles.
  */
 static inline void
-vec_vstsfdux (vf64_t xs, const signed long long ra, double *rb)
+vec_vstxsfdx (vf64_t xs, const signed long long ra, double *rb)
 {
 #if defined (__clang__)
   __VEC_U_128 t;

--- a/src/testsuite/arith128_test_f64.c
+++ b/src/testsuite/arith128_test_f64.c
@@ -2473,36 +2473,36 @@ test_lvgdfdx (void)
   printf ("\ntest_Vector Gather-Load Float Double from Doubleword Offsets\n");
 
   e =  (vf64_t) CONST_VINT64_DW ( 0.0, -1.0 );
-  j0 = vec_vlsfdux (0, test_f64);
+  j0 = vec_vlxsfdx (0, test_f64);
   j = (vf64_t) vec_permdi ((vui64_t) j0, (vui64_t) e, 1);
 
-  rc += check_v2f64 ("vec_vlsfdux 1:", j, e);
+  rc += check_v2f64 ("vec_vlxsfdx 1:", j, e);
 
   e =  (vf64_t) CONST_VINT64_DW ( 1.0, -1.0 );
-  j0 = vec_vlsfdux (8, test_f64);
+  j0 = vec_vlxsfdx (8, test_f64);
   j = (vf64_t) vec_permdi ((vui64_t) j0, (vui64_t) e, 1);
 
-  rc += check_v2f64 ("vec_vlsfdux 2:", j, e);
+  rc += check_v2f64 ("vec_vlxsfdx 2:", j, e);
 
   e =  (vf64_t) CONST_VINT64_DW ( 15.0, -1.0 );
-  j0 = vec_vlsfdux (120, test_f64);
+  j0 = vec_vlxsfdx (120, test_f64);
   j = (vf64_t) vec_permdi ((vui64_t) j0, (vui64_t) e, 1);
 
-  rc += check_v2f64 ("vec_vlsfdux 3:", j, e);
+  rc += check_v2f64 ("vec_vlxsfdx 3:", j, e);
 
   i1 = (vi64_t) { 8, 120 };
   e =  (vf64_t) CONST_VINT64_DW ( 1.0, -1.0 );
-  j0 = vec_vlsfdux (i1[0], test_f64);
+  j0 = vec_vlxsfdx (i1[0], test_f64);
   j = (vf64_t) vec_permdi ((vui64_t) j0, (vui64_t) e, 1);
 
-  rc += check_v2f64 ("vec_vlsfdux 4:", j, e);
+  rc += check_v2f64 ("vec_vlxsfdx 4:", j, e);
 
   i1 = (vi64_t) { 8, 120 };
   e =  (vf64_t) CONST_VINT64_DW ( 15.0, -1.0 );
-  j1 = vec_vlsfdux (i1[1], test_f64);
+  j1 = vec_vlxsfdx (i1[1], test_f64);
   j = (vf64_t) vec_permdi ((vui64_t) j1, (vui64_t) e, 1);
 
-  rc += check_v2f64 ("vec_vlsfdux 5:", j, e);
+  rc += check_v2f64 ("vec_vlxsfdx 5:", j, e);
 
   // This test depends on the merge of scalars from lsfdux 4/5
   e =  (vf64_t) { 1.0, 15.0 };
@@ -2512,7 +2512,7 @@ test_lvgdfdx (void)
   j = (vf64_t) vec_permdi ((vui64_t) j0, (vui64_t) j1, 0);
 #endif
 
-  rc += check_v2f64 ("vec_vlsfdux2 :", j, e);
+  rc += check_v2f64 ("vec_vlxsfdx2 :", j, e);
 
   // This test replicates the results of the last 2 tests in single op.
   e =  (vf64_t) { 1.0, 15.0 };
@@ -2529,16 +2529,16 @@ test_lvgdfdx (void)
   i2 = (vi64_t) { 1, 15 };
   i1 = (vi64_t) vec_sldi ((vui64_t) i2, 3);
   e =  (vf64_t) CONST_VINT64_DW ( 1.0, -1.0 );
-  j0 = vec_vlsfdux (i1[0], test_f64);
+  j0 = vec_vlxsfdx (i1[0], test_f64);
   j = (vf64_t) vec_permdi ((vui64_t) j0, (vui64_t) e, 1);
 
-  rc += check_v2f64 ("vec_vlsfdux 6:", j, e);
+  rc += check_v2f64 ("vec_vlxsfdx 6:", j, e);
 
   e =  (vf64_t) CONST_VINT64_DW ( 15.0, -1.0 );
-  j1 = vec_vlsfdux (i1[1], test_f64);
+  j1 = vec_vlxsfdx (i1[1], test_f64);
   j = (vf64_t) vec_permdi ((vui64_t) j1, (vui64_t) e, 1);
 
-  rc += check_v2f64 ("vec_vlsfdux 7:",  j, e);
+  rc += check_v2f64 ("vec_vlxsfdx 7:",  j, e);
 
   e =  (vf64_t) { 1.0, 15.0 };
 #if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
@@ -2547,7 +2547,7 @@ test_lvgdfdx (void)
   j = (vf64_t) vec_permdi ((vui64_t) j0, (vui64_t) j1, 0);
 #endif
 
-  rc += check_v2f64 ("vec_vlsfdux2 :", j, e);
+  rc += check_v2f64 ("vec_vlxsfdx2 :", j, e);
 
   i1 = (vi64_t) { 1, 2 };
   e =  (vf64_t) { 1.0, 2.0 };
@@ -2581,8 +2581,8 @@ static double test_stf64[16];
 int
 test_stvgdfdx (void)
 {
-  vi64_t i1, i2;
-  vf64_t j, j0, j1, j2, e, *mem;
+  vi64_t i2;
+  vf64_t j, j1, j2, e, *mem;
   int rc = 0;
   int i;
 
@@ -2595,8 +2595,8 @@ test_stvgdfdx (void)
 
   j1 = (vf64_t) CONST_VINT64_DW ( 16.0, 1616.0 );
   j2 = (vf64_t) CONST_VINT64_DW ( 31.0, 3131.0 );
-  vec_vstsfdux (j1, 0, test_stf64);
-  vec_vstsfdux (j2, 120, test_stf64);
+  vec_vstxsfdx (j1, 0, test_stf64);
+  vec_vstxsfdx (j2, 120, test_stf64);
 
   j = mem [0];
   e = (vf64_t) { 16.0, 1.0 };
@@ -2757,7 +2757,6 @@ test_f64_matrix_transpose (double * tm, double * m)
 {
   long i, j, k, l;
   long rows, columns;
-  int rc = 0;
 
   rows = columns = MN;
 
@@ -2776,14 +2775,10 @@ void
 //__attribute__ ((optimize ("unroll-loops")))
 test_f64_matrix_gather_transpose (double * tm, double * m)
 {
-  vf64_t xt;
-  vi64_t vra =
-    { 0, MN * 8 };
-  vui64_t stride =
-    { MN * 8 * 2, MN * 8 * 2 };
-  long i, j, k, l;
+  vi64_t vra = { 0, MN * 8 };
+  vui64_t stride = { MN * 8 * 2, MN * 8 * 2 };
+  long i, j;
   long rows, columns;
-  int rc = 0;
 
   rows = columns = MN;
 
@@ -2804,14 +2799,12 @@ void
 //__attribute__ ((optimize ("unroll-loops")))
 test_f64_matrix_gatherx2_transpose (double * tm, double * m)
 {
-  vf64_t xt;
   vi64_t vra =
     { 0, MN * 8 };
   vui64_t stride =
     { MN * 8 * 2, MN * 8 * 2 };
-  long i, j, k, l;
+  long i, j;
   long rows, columns;
-  int rc = 0;
 
   rows = columns = MN;
 
@@ -2839,14 +2832,12 @@ void
 //__attribute__ ((optimize ("unroll-loops")))
 test_f64_matrix_gatherx4_transpose (double * tm, double * m)
 {
-  vf64_t xt;
   vi64_t vra =
     { 0, MN * 8 };
   vui64_t stride =
     { MN * 8 * 2, MN * 8 * 2 };
-  long i, j, k, l;
+  long i, j;
   long rows, columns;
-  int rc = 0;
 
   rows = columns = MN;
 

--- a/src/testsuite/vec_f64_dummy.c
+++ b/src/testsuite/vec_f64_dummy.c
@@ -68,37 +68,37 @@ test_stvsfdsx (vf64_t data, double *array, vi64_t vra)
 void
 test_vstfdux (vf64_t data, double *array, signed long offset)
 {
-  vec_vstsfdux (data, offset, array);
+  vec_vstxsfdx (data, offset, array);
 }
 
 void
 test_vstfdux_c0 (vf64_t data, double *array)
 {
-  vec_vstsfdux (data, 0, array);
+  vec_vstxsfdx (data, 0, array);
 }
 
 void
 test_vstfdux_c1 (vf64_t data, double *array)
 {
-  vec_vstsfdux (data, 8, array);
+  vec_vstxsfdx (data, 8, array);
 }
 
 void
 test_vstfdux_c2 (vf64_t data, double *array)
 {
-  vec_vstsfdux (data, 32760, array);
+  vec_vstxsfdx (data, 32760, array);
 }
 
 void
 test_vstfdux_c3 (vf64_t data, double *array)
 {
-  vec_vstsfdux (data, 32768, array);
+  vec_vstxsfdx (data, 32768, array);
 }
 
 void
 test_vstfdux_c5 (vf64_t data, double *array)
 {
-  vec_vstsfdux (data, -32768, array);
+  vec_vstxsfdx (data, -32768, array);
 }
 
 void
@@ -107,39 +107,39 @@ test_vstfdux_c4 (vf64_t data, double *array)
   vf64_t data1;
 
   data1 = (vf64_t) vec_xxspltd ((vui64_t) data, 1);
-  vec_vstsfdux (data, 16, array);
-  vec_vstsfdux (data1, 48, array);
+  vec_vstxsfdx (data, 16, array);
+  vec_vstxsfdx (data1, 48, array);
 }
 
 
 vf64_t
 test_vlfdux (double *array, unsigned long long offset)
 {
-  return vec_vlsfdux (offset, array);
+  return vec_vlxsfdx (offset, array);
 }
 
 vf64_t
 test_vldfdux_c0 (double *array)
 {
-  return vec_vlsfdux (0, array);
+  return vec_vlxsfdx (0, array);
 }
 
 vf64_t
 test_vldfdux_c1 (double *array)
 {
-  return vec_vlsfdux (8, array);
+  return vec_vlxsfdx (8, array);
 }
 
 vf64_t
 test_vlfsdux_c2 (double *array)
 {
-  return vec_vlsfdux (32768, array);
+  return vec_vlxsfdx (32768, array);
 }
 
 vf64_t
 test_vlfsdux_c4 (double *array)
 {
-  return vec_vlsfdux (-32768, array);
+  return vec_vlxsfdx (-32768, array);
 }
 
 vf64_t
@@ -147,8 +147,8 @@ test_vldfdux_c3 (double *array)
 {
   vf64_t rese0, rese1;
 
-  rese0 = vec_vlsfdux (8, array);
-  rese1 = vec_vlsfdux (40, array);
+  rese0 = vec_vlxsfdx (8, array);
+  rese1 = vec_vlxsfdx (40, array);
   return (vf64_t) vec_permdi ((vui64_t) rese0, (vui64_t) rese1, 0);
 }
 


### PR DESCRIPTION
Rationalizing the mnemonics and operation names for "Vector Load
Scalar Float Double Indexed" and "Vector Store Scalar Float Double
Indexed" Also some clean up for -Werror -Wall compiles.

	* src/pveclib/vec_f64_ppc.h: Rename vec_vlsfdux to vec_vlxsfdx.
	Rename vec_vstsfdux to vec_vstxsfdx.
	(vec_vlxsfdx): Change Doxygen full name to
	"Vector Load Scalar Float Double Indexed".
	Change "m' constraint to EA (rb+ra).
	(vec_vstxsfdx): Change Doxygen full name to
	"Vector Store Scalar Float Double Indexed".

	* src/testsuite/arith128_test_f64.c: Rename vec_vlsfdux to
	vec_vlxsfdx and vec_vstsfdux to vec_vstxsfdx.
	(test_stvgdfdx): Remove unused variables; i1, j0.
	(test_f64_matrix_transpose): Remove unused variable rc.
	(test_f64_matrix_gather_transpose): Reformate.
	Remove unused variables; xt, k, l, rc.
	(test_f64_matrix_gatherx2_transpose):
	Remove unused variables; xt, k, l, rc.
	(test_f64_matrix_gatherx4_transpose):
	Remove unused variables; xt, k, l, rc.

	* src/testsuite/vec_f64_dummy.c: Rename vec_vlsfdux to
	vec_vlxsfdx and vec_vstsfdux to vec_vstxsfdx.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>