### PR TITLE
Fix make check error on Debian and newest gcc

### DIFF
--- a/src/testsuite/vec_perf_f64.c
+++ b/src/testsuite/vec_perf_f64.c
@@ -76,7 +76,7 @@ int timed_is_f64 (void)
 int timed_fpclassify_f64 (void)
 {
 #ifndef PVECLIB_DISABLE_F128MATH
-  vb64_t accum = {0,0};
+  vui64_t accum = {0,0};
   int i;
 
   for (i=0; i<N; i++)


### PR DESCRIPTION
On Debian, building the test suite with gcc (Version Debian 10.2.0-17)
causes the following error message:

  testsuite/vec_perf_f64.c: In function ‘timed_fpclassify_f64’:
  testsuite/vec_perf_f64.c:84:13: error: invalid operands to binary | (have ‘vb64_t’ {aka ‘__vector(2) long unsigned int’} and ‘vui64_t’ {aka ‘__vector(2) long long unsigned int’})
     84 |       accum |= test_fpclassify_f64 (data0);
        |             ^~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~
        |                |
        |                vui64_t {aka __vector(2) long long unsigned int}