### PR TITLE
Initial support for Gather/Scatter ops, 1st pass for int32.

### DIFF
--- a/src/testsuite/arith128_test_i32.c
+++ b/src/testsuite/arith128_test_i32.c
@@ -1320,6 +1320,379 @@ test_muluwm (void)
   return (rc);
 }
 
+static unsigned int test_ui32[] =
+    {
+	0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+	0, -1, -2, -3, -4, -5, -6, -7,
+	-8, -9, -10, -11, -12, -13, -14, -15
+    };
+
+int
+test_lvguwx (void)
+{
+  vi32_t i1;
+  vui32_t e;
+  vui32_t j, j0, j1;
+  vi64_t id1, id2;
+  vui64_t ed;
+  vui64_t jd, jd0, jd1;
+  int rc = 0;
+
+  printf ("\ntest_Vector Gather-Load Word\n");
+
+  e =  (vui32_t) CONST_VINT32_W ( 0, 0, -2, -3);
+  jd0 = vec_vlxsiwzx (0, test_ui32);
+  j = (vui32_t) vec_permdi ((vui64_t) jd0, (vui64_t)e, 1);
+
+  rc += check_vuint128x ("vec_vlxsiwx 1:", (vui128_t) j, (vui128_t) e);
+
+  e =  (vui32_t) CONST_VINT32_W ( 0, 1, -2, -3 );
+  jd0 = vec_vlxsiwzx (4, test_ui32);
+  j = (vui32_t) vec_permdi ((vui64_t) jd0, (vui64_t)e, 1);
+
+  rc += check_vuint128x ("vec_vlxsiwx 2:", (vui128_t) j, (vui128_t) e);
+
+  e =  (vui32_t) CONST_VINT32_W ( 0, 15, -2, -3 );
+  jd0 = vec_vlxsiwzx (60, test_ui32);
+  j = (vui32_t) vec_permdi ((vui64_t) jd0, (vui64_t)e, 1);
+
+  rc += check_vuint128x ("vec_vlxsiwx 3:", (vui128_t) j, (vui128_t) e);
+
+  i1 = (vi32_t) { 4, 60, 8, 56 };
+  e =  (vui32_t) CONST_VINT32_W ( 0, 1, -2, -3 );
+  jd0 = vec_vlxsiwzx (i1[0], test_ui32);
+  j = (vui32_t) vec_permdi ((vui64_t) jd0, (vui64_t)e, 1);
+
+  rc += check_vuint128x ("vec_vlxsiwx 4:", (vui128_t) j, (vui128_t) e);
+
+  i1 = (vi32_t) { 4, 60, 8, 56 };
+  e =  (vui32_t) CONST_VINT32_W ( 0, 15, -2, -3 );
+  jd1 = vec_vlxsiwzx (i1[1], test_ui32);
+  j = (vui32_t) vec_permdi ((vui64_t) jd1, (vui64_t)e, 1);
+
+  rc += check_vuint128x ("vec_vlxsiwx 5:", (vui128_t) j, (vui128_t) e);
+
+  // This test depends on the merge of scalars from lxsiwzx 4/5
+
+  ed =  (vui64_t) { 1, 15 };
+#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+  jd = vec_permdi ((vui64_t) jd1, (vui64_t) jd0, 0);
+#else
+  jd = vec_permdi ((vui64_t) jd0, (vui64_t) jd1, 0);
+#endif
+  rc += check_vuint128x ("vec_vlxsiwx2 :", (vui128_t) jd, (vui128_t) ed);
+
+  // This test replicates the results of the last 3 tests in single op.
+  ed =  (vui64_t) { 1, 15 };
+  jd = vec_vgluwso (test_ui32, 4, 60);
+
+  rc += check_vuint128x ("vec_vgluwso :", (vui128_t) jd, (vui128_t) ed);
+
+  // This test replicates the results of the last tests with vector offsets.
+  id1 = (vi64_t)  {  4, 60 };
+  jd = vec_vgluwdo (test_ui32, id1);
+
+  rc += check_vuint128x ("vec_vgluwdo :", (vui128_t) jd, (vui128_t) ed);
+
+  // This test replicates the results of the last tests with vector indexes.
+  id1 = (vi64_t)  {  1, 15 };
+  jd = vec_vgluwdx (test_ui32, id1);
+
+  rc += check_vuint128x ("vec_vgluwdx :", (vui128_t) jd, (vui128_t) ed);
+
+  // This test replicates the results of the last tests with vector
+  // scaled indexes.
+  id1 = (vi64_t)  { 1, 3 };
+  ed =  (vui64_t) { 4, 12 };
+  jd = vec_vgluwdsx (test_ui32, id1, 2);
+
+  rc += check_vuint128x ("vec_vgluwdx :", (vui128_t) jd, (vui128_t) ed);
+
+  i1 = (vi32_t) { 8, 72, 16, 80 };
+  e =  (vui32_t) CONST_VINT32_W ( 0, 2, -2, -3 );
+  j0 = (vui32_t) vec_vlxsiwax (i1[0], (signed int *) test_ui32);
+  j = (vui32_t) vec_permdi ((vui64_t) j0, (vui64_t)e, 1);
+
+  rc += check_vuint128x ("vec_vlxsiwax 0:", (vui128_t) j, (vui128_t) e);
+
+  i1 = (vi32_t) { 8, 72, 16, 80 };
+  e =  (vui32_t) CONST_VINT32_W ( -1, -2, -1, -2 );
+  j1 = (vui32_t) vec_vlxsiwax (i1[1], (signed int *) test_ui32);
+  j = (vui32_t) vec_permdi ((vui64_t) j1, (vui64_t)e, 1);
+
+  rc += check_vuint128x ("vec_vlxsiwax 1:", (vui128_t) j, (vui128_t) e);
+
+  // This test depends on the merge of scalars from lxsiwax 0/1
+
+  ed =  (vui64_t) { 2, -2 };
+#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+  jd = vec_permdi ((vui64_t) j1, (vui64_t) j0, 0);
+#else
+  jd = vec_permdi ((vui64_t) j0, (vui64_t) j1, 0);
+#endif
+  rc += check_vuint128x ("vec_vlxsiwax2 :", (vui128_t) jd, (vui128_t) ed);
+
+  // This test replicates the results of the last 3 tests in single op.
+  ed =  (vui64_t) { 2, -2 };
+  id2 = vec_vglswso ((int *)test_ui32, 8, 72);
+
+  rc += check_vuint128x ("vec_vglswso :", (vui128_t) id2, (vui128_t) ed);
+
+  // This test replicates the results of the last tests with vector offsets.
+  ed =  (vui64_t) { 2, -2 };
+  id1 = (vi64_t)  {  8, 72 };
+  id2 = vec_vglswdo ((int *)test_ui32, id1);
+
+  rc += check_vuint128x ("vec_vglswdo :", (vui128_t) id2, (vui128_t) ed);
+
+  // This test replicates the results of the last tests with vector indexes.
+  ed =  (vui64_t) { 2, -2 };
+  id1 = (vi64_t)  {  2, 18 };
+  id2 = vec_vglswdx ((int *)test_ui32, id1);
+
+  rc += check_vuint128x ("vec_vglswdx :", (vui128_t) id2, (vui128_t) ed);
+
+  // This test replicates the results of the last tests with vector
+  // scaled indexes.
+  ed =  (vui64_t) { 2, -2 };
+  id1 = (vi64_t)  {  1, 9 };
+  id2 = vec_vglswdsx ((int *)test_ui32, id1, 1);
+
+  rc += check_vuint128x ("vec_vglswdsx :", (vui128_t) id2, (vui128_t) ed);
+
+  // This test replicates the results of the last 3 tests in single op.
+  e =  (vui32_t) {  1, 15, 2, -2 };
+  j = vec_vgl4wso (test_ui32, 4, 60, 8, 72);
+
+  rc += check_vuint128x ("vec_vgl4wso :", (vui128_t) j, (vui128_t) e);
+
+  // This test replicates the results of the last 3 tests in single op.
+  i1 = (vi32_t) { 4, 60, 8, 72 };
+  e =  (vui32_t) { 1, 15, 2, -2 };
+  j = vec_vgl4wwo (test_ui32, i1);
+
+  rc += check_vuint128x ("vec_vgl4wwo :", (vui128_t) j, (vui128_t) e);
+
+  // This test replicates the results of the last tests with indexed op.
+  i1 = (vi32_t) { 1, 15, 2, 18 };
+  e =  (vui32_t) { 1, 15, 2, -2 };
+  j = vec_vgl4wwx (test_ui32, i1);
+
+  rc += check_vuint128x ("vec_vgl4wwx :", (vui128_t) j, (vui128_t) e);
+
+  // This test replicates the results of the last tests with scaled indexed op.
+  i1 = (vi32_t) { 1, 15, 2, 9 };
+  e =  (vui32_t) { 2, -14, 4, -2 };
+  j = vec_vgl4wwsx (test_ui32, i1, 1);
+
+  rc += check_vuint128x ("vec_vgl4wwsx :", (vui128_t) j, (vui128_t) e);
+
+  return (rc);
+}
+
+static unsigned int test_stui32[16];
+
+int
+test_stvguwx (void)
+{
+  vi32_t i1, i2;
+  vui32_t e, *mem;
+  vui32_t j, j1, j2;
+  vui64_t jd;
+  vi64_t id1;
+  int rc = 0;
+  int i;
+
+  mem = (vui32_t *)& test_stui32;
+
+  for (i=0; i<16; i++)
+    test_stui32[i] = test_ui32[i];
+
+  printf ("\ntest_Vector Scatter-Store Word\n");
+#if 1
+
+  j1 = (vui32_t) CONST_VINT32_W ( 0, 16, 1616, -1616 );
+  j2 = (vui32_t) CONST_VINT32_W ( 0, 31, 3131, -3131 );
+  vec_vstxsiwx (j1, 0, test_stui32);
+  vec_vstxsiwx (j2, 60, test_stui32);
+
+  j = mem [0];
+  e = (vui32_t) { 16, 1, 2, 3 };
+
+  rc += check_vuint128x ("vec_stsudux 1:", (vui128_t) j, (vui128_t) e);
+
+  j = mem [3];
+  e = (vui32_t) { 12, 13, 14, 31 };
+
+  rc += check_vuint128x ("vec_stsudux 2:", (vui128_t) j, (vui128_t) e);
+
+  jd = (vui64_t) { 1616, 3131 };
+  vec_vsstwso (jd, test_stui32, 0, 60);
+
+  j = mem [0];
+  e = (vui32_t) { 1616, 1, 2, 3 };
+
+  rc += check_vuint128x ("vec_vsstwso 1:", (vui128_t) j, (vui128_t) e);
+
+  j = mem [3];
+  e = (vui32_t) { 12, 13, 14, 3131 };
+
+  rc += check_vuint128x ("vec_vsstwso 2:", (vui128_t) j, (vui128_t) e);
+
+  jd = (vui64_t) { 1617, 3132 };
+  id1 = (vi64_t) { 0, 60 };
+  vec_vsstwdo (jd, test_stui32, id1);
+
+  j = mem [0];
+  e = (vui32_t) { 1617, 1, 2, 3 };
+
+  rc += check_vuint128x ("vec_vsstwdo 1:", (vui128_t) j, (vui128_t) e);
+
+  j = mem [3];
+  e = (vui32_t) { 12, 13, 14, 3132 };
+
+  rc += check_vuint128x ("vec_vsstwdo 2:", (vui128_t) j, (vui128_t) e);
+
+  jd = (vui64_t) { 1618, 3133 };
+  id1 = (vi64_t) { 0, 15 };
+  vec_vsstwdx (jd, test_stui32, id1);
+
+  j = mem [0];
+  e = (vui32_t) { 1618, 1, 2, 3 };
+
+  rc += check_vuint128x ("vec_vsstwdx 1:", (vui128_t) j, (vui128_t) e);
+
+  j = mem [3];
+  e = (vui32_t) { 12, 13, 14, 3133 };
+
+  rc += check_vuint128x ("vec_vsstwdx 2:", (vui128_t) j, (vui128_t) e);
+
+  jd = (vui64_t) { 1619, 3134 };
+  id1 = (vi64_t) { 0, 15 };
+  vec_vsstwdsx (jd, test_stui32, id1, 0);
+
+  j = mem [0];
+  e = (vui32_t) { 1619, 1, 2, 3 };
+
+  rc += check_vuint128x ("vec_vsstwdsx 1:", (vui128_t) j, (vui128_t) e);
+
+  j = mem [3];
+  e = (vui32_t) { 12, 13, 14, 3134 };
+
+  rc += check_vuint128x ("vec_vsstwdsx 2:", (vui128_t) j, (vui128_t) e);
+
+
+  j1 = (vui32_t) { 16, 31, 17, 30 };
+  vec_vsst4wso (j1, test_stui32, 0, 60, 4, 56);
+
+  j = mem [0];
+  e = (vui32_t) { 16, 17, 2, 3 };
+
+  rc += check_vuint128x ("vec_vsst4wso 1:", (vui128_t) j, (vui128_t) e);
+
+  j = mem [3];
+  e = (vui32_t) { 12, 13, 30, 31 };
+
+  rc += check_vuint128x ("vec_vsst4wso 2:", (vui128_t) j, (vui128_t) e);
+
+
+  j1 = (vui32_t) { 160, 310, 170, 300 };
+  i1 = (vi32_t) { 0, 60, 4, 56 };
+  vec_vsst4wwo (j1, test_stui32, i1);
+
+  j = mem [0];
+  e = (vui32_t) { 160, 170, 2, 3 };
+
+  rc += check_vuint128x ("vec_vsst4wwo 1:", (vui128_t) j, (vui128_t) e);
+
+  j = mem [3];
+  e = (vui32_t) { 12, 13, 300, 310 };
+
+  rc += check_vuint128x ("vec_vsst4wwo 2:", (vui128_t) j, (vui128_t) e);
+#endif
+
+  j1 = (vui32_t) { 16, 31, 17, 30 };
+  i2 = (vi32_t) { 0, 15, 1, 14 };
+  vec_vsst4wwx (j1, test_stui32, i2);
+
+  j = mem [0];
+  e = (vui32_t) { 16, 17, 2, 3 };
+
+  rc += check_vuint128x ("vec_vsst4wwx 1:", (vui128_t) j, (vui128_t) e);
+
+  j = mem [3];
+  e = (vui32_t) { 12, 13, 30, 31 };
+
+  rc += check_vuint128x ("vec_vsst4wwx 2:", (vui128_t) j, (vui128_t) e);
+
+  j1 = (vui32_t) { 0, 7, 1, 6 };
+  i2 = (vi32_t) { 0, 7, 1, 6 };
+  vec_vsst4wwsx (j1, test_stui32, i2, 1);
+
+  j = mem [0];
+  e = (vui32_t) { 0, 17, 1, 3 };
+
+  rc += check_vuint128x ("vec_vsst4wwsx 1:", (vui128_t) j, (vui128_t) e);
+
+  j = mem [3];
+  e = (vui32_t) { 6, 13, 7, 31 };
+
+  rc += check_vuint128x ("vec_vsst4wwsx 2:", (vui128_t) j, (vui128_t) e);
+
+  return (rc);
+}
+
+int
+test_unpkxw (void)
+{
+  vi32_t ii;
+  vui32_t i;
+  vui64_t e, k;
+  int rc = 0;
+
+  printf ("\ntest_unpk[h|l]w Unpack High/Low Words\n");
+
+  i = (vui32_t) { 10, -1, 2, -3 };
+  e = (vui64_t) { 10, 0xffffffff };
+  k = (vui64_t) vec_vupkhuw ((vui32_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_vupkhuw i=", (vui128_t)i);
+  print_vint128x ("            k=", k);
+#endif
+  rc += check_vuint128x ("vec_vupkhuw 1:", (vui128_t) k, (vui128_t) e);
+
+  e = (vui64_t) { 2, 0xfffffffd };
+  k = (vui64_t) vec_vupkluw ((vui32_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_vupkluw i=", (vui128_t)i);
+  print_vint128x ("            k=", k);
+#endif
+  rc += check_vuint128x ("vec_vupkluw 1:", (vui128_t) k, (vui128_t) e);
+
+  ii = (vi32_t) { -10, 1, 2, -3 };
+  e = (vui64_t) { -10, 1 };
+  k = (vui64_t) vec_vupkhsw ((vi32_t) ii);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_vupkhsw i=", (vui128_t)ii);
+  print_vint128x ("            k=", k);
+#endif
+  rc += check_vuint128x ("vec_vupkhsw 1:", (vui128_t) k, (vui128_t) e);
+
+  e = (vui64_t) { 2, -3 };
+  k = (vui64_t) vec_vupklsw ((vi32_t) ii);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_vupklsw i=", (vui128_t)ii);
+  print_vint128x ("            k=", k);
+#endif
+  rc += check_vuint128x ("vec_vupkluw 1:", (vui128_t) k, (vui128_t) e);
+
+  return (rc);
+}
+
 int
 test_vec_i32 (void)
 {
@@ -1341,6 +1714,9 @@ test_vec_i32 (void)
   rc += test_mrgahlw();
   rc += test_mrgeow();
   rc += test_mulhuw();
+  rc += test_unpkxw ();
+  rc += test_lvguwx ();
+  rc += test_stvguwx ();
 
   return (rc);
 }

--- a/src/testsuite/vec_int32_dummy.c
+++ b/src/testsuite/vec_int32_dummy.c
@@ -22,6 +22,361 @@
 
 #include <pveclib/vec_int128_ppc.h>
 
+#if defined(_ARCH_PWR8)
+vi64_t
+test_vec_unpackh (vi32_t vra)
+{
+  return vec_unpackh (vra);
+}
+
+vi64_t
+test_vec_unpackl (vi32_t vra)
+{
+  return vec_unpackl (vra);
+}
+#endif
+
+vi64_t
+test_vec_vupkhsw (vi32_t vra)
+{
+  return vec_vupkhsw (vra);
+}
+
+vi64_t
+test_vec_vupklsw (vi32_t vra)
+{
+  return vec_vupklsw (vra);
+}
+
+vui64_t
+test_vec_vupkhuw (vui32_t vra)
+{
+  return vec_vupkhuw (vra);
+}
+
+vui64_t
+test_vec_vupkluw (vui32_t vra)
+{
+  return vec_vupkluw (vra);
+}
+
+vui32_t
+test_vlsuwux (const signed long long ra, const unsigned int *rb)
+{
+  vui32_t xt;
+  __VEC_U_128 t;
+
+  unsigned int *p = (unsigned int *)((char *)rb + ra);
+  t.ulong.upper = *p;
+  xt = t.vx4;
+
+  return xt;
+}
+
+#if !defined(_ARCH_PWR8)
+vui64_t
+test_vlxsiwx_PWR7 (const signed long long ra, const unsigned int *rb)
+{
+  const vui32_t zero = {0,0,0,0};
+  vui32_t xte;
+  vui8_t perm;
+
+  perm = vec_lvsl (ra, rb);
+  xte = vec_lde (ra, rb);
+  xte = vec_perm (xte, xte, perm);
+  return (vui64_t) vec_sld (zero, xte, 12);
+}
+
+vi64_t
+test_vlxsiwax_PWR7 (const signed long long ra, const signed int *rb)
+{
+  vui32_t const shb = { 31, 0, 0 ,0 };
+  vi32_t xte;
+  vui8_t perm;
+
+  perm = vec_lvsl (ra, rb);
+  xte = vec_lde (ra, rb);
+  perm = (vui8_t) vec_mergeh ((vui32_t) perm, (vui32_t) perm);
+  xte = vec_perm (xte, xte, perm);
+  return (vi64_t) vec_sra (xte, shb);
+}
+#endif
+
+vui64_t
+test_vec_vlxsiwx (const signed long long ra, const unsigned int *rb)
+{
+  return vec_vlxsiwzx (ra, rb);
+}
+
+vui64_t
+test_vec_vlxsiwx_c0 (const unsigned int *rb)
+{
+  return vec_vlxsiwzx (0, rb);
+}
+
+vui64_t
+test_vec_vlxsiwx_c1 (const unsigned int *rb)
+{
+  return vec_vlxsiwzx (8, rb);
+}
+
+vui64_t
+test_vec_vlxsiwx_c2 (const unsigned int *rb)
+{
+  return vec_vlxsiwzx (32760, rb);
+}
+
+vui64_t
+test_vec_vlxsiwx_c3 (const unsigned int *rb)
+{
+  return vec_vlxsiwzx (32768, rb);
+}
+
+vui64_t
+test_vec_vlxsiwx_c4 (const unsigned int *rb)
+{
+  return vec_vlxsiwzx (-32768, rb);
+}
+
+vui64_t
+test_vec_vgluwso (unsigned int *array, const long long offset0,
+	     const long long offset1)
+{
+  return vec_vgluwso (array, offset0, offset1);
+}
+
+vui64_t
+test_vec_vgluwdo (unsigned int *array, vi64_t offset)
+{
+  return vec_vgluwdo (array, offset);
+}
+
+vui64_t
+test_vec_vgluwdsx (unsigned int *array, vi64_t offset)
+{
+  return vec_vgluwdsx (array, offset, 4);
+}
+
+vui64_t
+test_vec_vgluwdx (unsigned int *array, vi64_t offset)
+{
+  return vec_vgluwdx (array, offset);
+}
+
+vi64_t
+test_vec_vglswso (signed int *array, const long long offset0,
+	     const long long offset1)
+{
+  return vec_vglswso (array, offset0, offset1);
+}
+
+vi64_t
+test_vec_vglswdo (signed int *array, vi64_t offset)
+{
+  return vec_vglswdo (array, offset);
+}
+
+vi64_t
+test_vec_vglswdx (signed int *array, vi64_t offset)
+{
+  return vec_vglswdx (array, offset);
+}
+
+vi64_t
+test_vec_vglswdsx (signed int *array, vi64_t offset)
+{
+  return vec_vglswdsx (array, offset, 4);
+}
+
+vui32_t
+test_vec_vgl4wso (unsigned int *array, const long long offset0,
+	     const long long offset1, const long long offset2,
+	     const long long offset3)
+{
+  return vec_vgl4wso (array, offset0, offset1, offset2, offset3);
+}
+
+vui32_t
+test_vec_vgl4wwo (unsigned int *array, vi32_t vra)
+{
+  return vec_vgl4wwo (array, vra);
+}
+
+vui32_t
+test_vec_vgl4wwx (unsigned int *array, vi32_t vra)
+{
+  return vec_vgl4wwx (array, vra);
+}
+
+vui32_t
+test_vec_vgl4wwsx (unsigned int *array, vi32_t vra)
+{
+  return vec_vgl4wwsx (array, vra, 4);
+}
+
+#ifdef _ARCH_PWR8
+vui32_t
+test_vec_vgl4wwo_1 (unsigned int *array, vi32_t vra)
+{
+  vui32_t r;
+
+  r = vec_vgl4wso (array, vra[0], vra[1], vra[2], vra[3]);
+  return  r;
+}
+
+vui32_t
+test_vec_vgl4wwo_2 (unsigned int *array, vi32_t vra)
+{
+  vui32_t r;
+  vi64_t off01, off23;
+
+  off01 = vec_vupkhsw (vra);
+  off23 = vec_vupklsw (vra);
+
+  r = vec_vgl4wso (array, off01[0], off01[1], off23[0], off23[1]);
+  return  r;
+}
+#endif
+
+vi64_t
+test_vec_vlxsiwax (const signed long long ra, const signed int *rb)
+{
+  return vec_vlxsiwax (ra, rb);
+}
+
+vi64_t
+test_vec_vlxsiwax_c0 (const signed int *rb)
+{
+  return vec_vlxsiwax (0, rb);
+}
+
+vi64_t
+test_vec_vlxsiwax_c1 (const signed int *rb)
+{
+  return vec_vlxsiwax (8, rb);
+}
+
+vi64_t
+test_vec_vlxsiwax_c2 (const signed int *rb)
+{
+  return vec_vlxsiwax (32760, rb);
+}
+
+vi64_t
+test_vec_vlxsiwax_c3 (const signed int *rb)
+{
+  return vec_vlxsiwax (32768, rb);
+}
+
+vi64_t
+test_vec_vlxsiwax_c4 (const signed int *rb)
+{
+  return vec_vlxsiwax (-32768, rb);
+}
+
+void
+test_vstsuwux (vui32_t xs, const signed long long ra, unsigned int *rb)
+{
+  __VEC_U_128 t;
+  unsigned int *p = (unsigned int *)((char *)rb + ra);
+  t.vx4 = xs;
+  *p = t.ulong.upper;
+}
+
+#if !defined(_ARCH_PWR8)
+void
+test_vstsuwux_PWR7 (vui32_t xs, const signed long long ra, unsigned int *rb)
+{
+  vui32_t xss = vec_splat (xs, 1);
+  vec_ste (xss, ra, rb);
+}
+#endif
+
+void
+test_vec_vstxsiwx (vui32_t xs, const signed long long ra, unsigned int *rb)
+{
+  vec_vstxsiwx (xs, ra, rb);
+}
+
+void
+test_vec_vstxsiwx_c0 (vui32_t xs, unsigned int *rb)
+{
+  vec_vstxsiwx (xs, 0, rb);
+}
+
+void
+test_vec_vstxsiwx_c1 (vui32_t xs, unsigned int *rb)
+{
+  vec_vstxsiwx (xs, 8, rb);
+}
+
+void
+test_vec_vstxsiwx_c2 (vui32_t xs, unsigned int *rb)
+{
+  vec_vstxsiwx (xs, 32760, rb);
+}
+
+void
+test_vec_vstxsiwx_c3 (vui32_t xs, unsigned int *rb)
+{
+  vec_vstxsiwx (xs, 32768, rb);
+}
+
+void
+test_vec_vstxsiwx_c4 (vui32_t xs, unsigned int *rb)
+{
+  vec_vstxsiwx (xs, -32768, rb);
+}
+
+void
+test_vec_vsst4wso (vui32_t xs, unsigned int *array,
+		   const long long offset0, const long long offset1,
+		   const long long offset2, const long long offset3)
+{
+  vec_vsst4wso (xs, array, offset0, offset1, offset2, offset3);
+}
+
+void
+test_vec_vsst4wwo (vui32_t xs, unsigned int *array,
+		   vi32_t vra)
+{
+  vec_vsst4wwo (xs, array, vra);
+}
+
+void
+test_vec_vsst4wwx (vui32_t xs, unsigned int *array,
+		   vi32_t vra)
+{
+  vec_vsst4wwx (xs, array, vra);
+}
+
+void
+test_vec_vsstwso (vui64_t xs, unsigned int *array,
+	      const long long offset0, const long long offset1)
+{
+  vec_vsstwso (xs, array, offset0, offset1);
+}
+
+void
+test_vec_vsstwdo (vui64_t xs, unsigned int *array,
+		  vi64_t offset)
+{
+  vec_vsstwdo (xs, array, offset);
+}
+
+void
+test_vec_vsstwdx (vui64_t xs, unsigned int *array,
+		  vi64_t offset)
+{
+  vec_vsstwdx (xs, array, offset);
+}
+
+void
+test_vec_vsstwdsx (vui64_t xs, unsigned int *array,
+		  vi64_t offset)
+{
+  vec_vsstwdsx (xs, array, offset, 4);
+}
 
 vi32_t
 test_vec_sum2s (vi32_t vra, vi32_t vrb)


### PR DESCRIPTION
This is the integer word variant of Gather/Scatter.
The Gathers have three vector result forms:
- Words zero extented to unsigned doubleword integers.
- Words signed extended to signed doubleword integers.
- Words as unsigned word integers.

The doubleword results take signed doubleword offsets/indexes.
The Scatter has two vector source forms;
- Wnsigned Doublewords where only the low order words is stored.
- Unsigned words where all 4 words are stored.

Doubleword sources take vector signed doubleword offsets/indexes,
while word sources take vector signed word offsets/indexes,
There are also forms where offsets are provided as 2/4 const scalar
offsets. These are optimized for const offsets but are also used
in the implementation of the vector offset/index forms.

	* src/pveclib/vec_int32_ppc.h [@cond INTERNAL[_ARCH_PWR8]]:
	Define __pvec_vsld.
	[@cond INTERNAL]: Forward declare; vec_vlxsiwzx,  vec_vlxsiwax,
	vec_vsstwso, vec_vstxsiwx.
	(vec_vgl4wso, vec_vgl4wwo, vec_vgl4wwsx, vec_vgl4wwx,
	vec_vglswso, vec_vglswdo, vec_vglswdsx, vec_vglswdx,
	vec_vgluwso, vec_vgluwdo, vec_vgluwdsx, vec_vgluwdx,
	vec_vlxsiwax, vec_vlxsiwzx): New inline operations.
	(vec_vsst4wso, vec_vsst4wwo, vec_vsst4wwsx, vec_vsst4wwx
	vec_vsstwdo, vec_vsstwdsx, vec_vsstwdx, vec_vsstwso,
	vec_vstxsiwx):  New inline operations.
	(vec_vupkhsw, vec_vupkhuw, vec_vupklsw, vec_vupkluw):
	New inline operations.

	* src/testsuite/arith128_test_i32.c (test_ui32):
	New test array.
	(test_lvguwx): New unit test functions.
	(test_stui32): New test array.
	(test_stvguwx, test_unpkxw): New unit test functions.
	(test_vec_i32): Update test driver to call new unit tests.

	* src/testsuite/vec_int32_dummy.c [_ARCH_PWR8]:
	New compiler tests; test_vec_unpackh, test_vec_unpackl.
	(test_vec_vupkhsw, test_vec_vupklsw, test_vec_vupkhuw,
	test_vec_vupkluw): New compile tests.
	(test_vlsuwux): New compile tests.
	[!_ARCH_PWR8]:: New compile tests; test_vlxsiwx_PWR7,
	test_vlxsiwax_PWR7.
	(test_vec_vlxsiwx test_vec_vlxsiwx_c0, test_vec_vlxsiwx_c1,
	test_vec_vlxsiwx_c2, test_vec_vlxsiwx_c3, test_vec_vlxsiwx_c4):
	New compile tests.
	(test_vec_vgluwso, test_vec_vgluwdo, test_vec_vgluwdsx,
	test_vec_vgluwdx, test_vec_vglswso, test_vec_vglswdo,
	test_vec_vglswdx, test_vec_vglswdsx, test_vec_vgl4wso,
	test_vec_vgl4wwo, test_vec_vgl4wwx, test_vec_vgl4wwsx):
	New compile tests.
	[_ARCH_PWR8]: New compile tests; test_vec_vgl4wwo_1,
	test_vec_vgl4wwo_2.
	(test_vec_vlxsiwax test_vec_vlxsiwax_c0, test_vec_vlxsiwax_c1,
	test_vec_vlxsiwax_c2, test_vec_vlxsiwax_c3,
	test_vec_vlxsiwax_c4, test_vstsuwux): New compile tests.
	[!_ARCH_PWR8]: New compile tests; test_vstsuwux_PWR7
	(test_vec_vstxsiwx, test_vec_vstxsiwx_c0, test_vec_vstxsiwx_c1,
	test_vec_vstxsiwx_c2, test_vec_vstxsiwx_c3,
	test_vec_vstxsiwx_c4): New compile tests.
	(test_vec_vsst4wso, test_vec_vsst4wwo, test_vec_vsst4wwx,
	test_vec_vsstwso, test_vec_vsstwdo, test_vec_vsstwdx,
	test_vec_vsstwdsx): New compile tests.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>