### PR TITLE
Initial support for Gather/Scatter ops, 1st pass for f32.

### DIFF
--- a/src/testsuite/arith128_test_f32.c
+++ b/src/testsuite/arith128_test_f32.c
@@ -1796,6 +1796,514 @@ test_float_iszero (void)
 #define __DEBUG_PRINT__ 1
 #undef __DEBUG_PRINT__
 
+static float test_f32[] =
+    {
+	0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0,
+	8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0,
+	0.0, -1.0, -2.0, -3.0, -4.0, -5.0, -6.0, -7.0,
+	-8.0, -9.0, -10.0, -11.0, -12.0, -13.0, -14.0, -15.0
+    };
+
+int
+test_lvgfsx (void)
+{
+  vi32_t i1;
+  vf32_t e, j;
+  vi64_t id1;
+  vf64_t ed;
+  vf64_t jd, jd0, jd1;
+  int rc = 0;
+
+  printf ("\ntest_Vector Gather-Load Single Float\n");
+
+  ed =  (vf64_t) CONST_VINT64_DW ( 0.0, -2.0);
+  jd0 = vec_vlxsspx (0, test_f32);
+  jd =  (vf64_t) vec_permdi ((vui64_t) jd0, (vui64_t)ed, 1);
+
+  rc += check_v2f64 ("vec_vlxsspx 1:", (vf64_t) jd, (vf64_t) ed);
+
+  ed =  (vf64_t) CONST_VINT64_DW ( 1.0, -2.0 );
+  jd0 = vec_vlxsspx (4, test_f32);
+  jd =  (vf64_t) vec_permdi ((vui64_t) jd0, (vui64_t)ed, 1);
+
+  rc += check_v2f64 ("vec_vlxsspx 2:", (vf64_t) jd, (vf64_t) ed);
+
+  ed =  (vf64_t) CONST_VINT64_DW ( 15.0, -2.0 );
+  jd0 = vec_vlxsspx (60, test_f32);
+  jd =  (vf64_t) vec_permdi ((vui64_t) jd0, (vui64_t)ed, 1);
+
+  rc += check_v2f64 ("vec_vlxsspx 3:", (vf64_t) jd, (vf64_t) ed);
+
+  i1 = (vi32_t) { 4, 60, 8, 56 };
+  ed =  (vf64_t) CONST_VINT64_DW ( 1.0, -2.0 );
+  jd0 = vec_vlxsspx (i1[0], test_f32);
+  jd =  (vf64_t) vec_permdi ((vui64_t) jd0, (vui64_t)ed, 1);
+
+  rc += check_v2f64 ("vec_vlxsspx 4:", (vf64_t) jd, (vf64_t) ed);
+
+  ed = (vf64_t) CONST_VINT64_DW ( 15.0, -2.0 );
+  jd1 = vec_vlxsspx (i1[1], test_f32);
+  jd = (vf64_t) vec_permdi ((vui64_t) jd1, (vui64_t)ed, 1);
+
+  rc += check_v2f64 ("vec_vlxsspx 5:", (vf64_t) jd, (vf64_t) ed);
+
+  // This test depends on the merge of scalars from lxsiwzx 4/5
+
+  ed =  (vf64_t) { 1.0, 15.0 };
+#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+  jd = (vf64_t) vec_permdi ((vui64_t) jd1, (vui64_t) jd0, 0);
+#else
+  jd = (vf64_t) vec_permdi ((vui64_t) jd0, (vui64_t) jd1, 0);
+#endif
+  rc += check_v2f64 ("vec_vlxsspx2 :", (vf64_t) jd, (vf64_t) ed);
+
+  // This test replicates the results of the last 3 tests in single op.
+  ed =  (vf64_t) { 1.0, 15.0 };
+  jd = vec_vglfsso (test_f32, 4, 60);
+
+  rc += check_v2f64 ("vec_vglfsso :", (vf64_t) jd, (vf64_t) ed);
+
+  // This test replicates the results of the last tests with vector offsets.
+  id1 = (vi64_t)  {  4, 60 };
+  jd = vec_vglfsdo (test_f32, id1);
+
+  rc += check_v2f64 ("vec_vglfsdo :", (vf64_t) jd, (vf64_t) ed);
+
+  // This test replicates the results of the last tests with vector indexes.
+  id1 = (vi64_t)  {  1, 15 };
+  jd = vec_vglfsdx (test_f32, id1);
+
+  rc += check_v2f64 ("vec_vglfsdx :", (vf64_t) jd, (vf64_t) ed);
+
+  // This test replicates the results of the last tests with vector
+  // scaled indexes.
+  id1 = (vi64_t)  { 1, 3 };
+  ed =  (vf64_t) { 4.0, 12.0 };
+  jd = vec_vglfsdsx (test_f32, id1, 2);
+
+  rc += check_v2f64 ("vec_vglfsdsx :", (vf64_t) jd, (vf64_t) ed);
+
+
+  // This test replicates the results of the last 3 tests in single op.
+  e =  (vf32_t) { 1.0, 15.0, 2.0, -2.0 };
+  j = vec_vgl4fsso (test_f32, 4, 60, 8, 72);
+
+  rc += check_v4f32 ("vec_vgl4fsso :", j, e);
+
+  // This test replicates the results of the last 3 tests in single op.
+  i1 = (vi32_t) { 4, 60, 8, 72 };
+  e =  (vf32_t) { 1.0, 15.0, 2.0, -2.0 };
+  j = vec_vgl4fswo (test_f32, i1);
+
+  rc += check_v4f32 ("vec_vgl4fswo :", j, e);
+
+  // This test replicates the results of the last tests with indexed op.
+  i1 = (vi32_t) { 1, 15, 2, 18 };
+  e =  (vf32_t) { 1.0, 15.0, 2.0, -2.0 };
+  j = vec_vgl4fswx (test_f32, i1);
+
+  rc += check_v4f32 ("vec_vgl4fswx :", j, e);
+
+  // This test replicates the results of the last tests with scaled indexed op.
+  i1 = (vi32_t) { 1, 15, 2, 9 };
+  e =  (vf32_t) { 2.0, -14.0, 4.0, -2.0 };
+  j = vec_vgl4fswsx (test_f32, i1, 1);
+
+  rc += check_v4f32 ("vec_vgl4fswsx :", j, e);
+  return (rc);
+}
+
+static float test_stf32[16];
+
+int
+test_stvgfsx (void)
+{
+  vi32_t i1, i2;
+  vf32_t e, *mem;
+  vf32_t j, j1;
+  vf64_t jd, jd1, jd2;
+  vi64_t id1;
+  int rc = 0;
+  int i;
+
+  mem = (vf32_t *)& test_stf32;
+
+  for (i=0; i<16; i++)
+    test_stf32[i] = test_f32[i];
+
+  printf ("\ntest_Vector Scatter-Store Single Float\n");
+
+  jd1 = (vf64_t) CONST_VINT64_DW ( 16.0, 1616.0 );
+  jd2 = (vf64_t) CONST_VINT64_DW ( 31.0, 3131.0 );
+  vec_vstxsspx (jd1, 0, test_stf32);
+  vec_vstxsspx (jd2, 60, test_stf32);
+
+  j = mem [0];
+  e = (vf32_t) { 16.0, 1.0, 2.0, 3.0 };
+
+  rc += check_v4f32 ("vec_vstxsspx 1:", j, e);
+
+  j = mem [3];
+  e = (vf32_t) { 12.0, 13.0, 14.0, 31.0 };
+
+  rc += check_v4f32 ("vec_vstxsspx 2:", j, e);
+
+  jd = (vf64_t) { 0.5, 31.5 };
+  vec_vsstfsso (jd, test_stf32, 0, 60);
+
+  j = mem [0];
+  e = (vf32_t) { 0.5, 1.0, 2.0, 3.0 };
+
+  rc += check_v4f32 ("vec_vsstfsso 1:", j, e);
+
+  j = mem [3];
+  e = (vf32_t) { 12.0, 13.0, 14.0, 31.5 };
+
+  rc += check_v4f32 ("vec_vsstfsso 2:", j, e);
+
+  jd = (vf64_t) { 0.75, 31.75 };
+  id1 = (vi64_t) { 0, 60 };
+  vec_vsstfsdo (jd, test_stf32, id1);
+
+  j = mem [0];
+  e = (vf32_t) { 0.75, 1.0, 2.0, 3.0 };
+
+  rc += check_v4f32 ("vec_vsstfsdo 1:", j, e);
+
+  j = mem [3];
+  e = (vf32_t) { 12.0, 13.0, 14.0, 31.75 };
+
+  rc += check_v4f32 ("vec_vsstfsdo 2:", j, e);
+
+  jd = (vf64_t) { 0.25, 31.25 };
+  id1 = (vi64_t) { 0, 15 };
+  vec_vsstfsdx (jd, test_stf32, id1);
+
+  j = mem [0];
+  e = (vf32_t) { 0.25, 1.0, 2.0, 3.0 };
+
+  rc += check_v4f32 ("vec_vsstfsdx 1:", j, e);
+
+  j = mem [3];
+  e = (vf32_t) { 12.0, 13.0, 14.0, 31.25 };
+
+  rc += check_v4f32 ("vec_vsstfsdx 2:", j, e);
+
+  jd = (vf64_t) { 0.125, 31.125 };
+  id1 = (vi64_t) { 0, 15 };
+  vec_vsstfsdsx (jd, test_stf32, id1, 0);
+
+  j = mem [0];
+  e = (vf32_t) { 0.125, 1.0, 2.0, 3.0 };
+
+  rc += check_v4f32 ("vec_vsstfsdsx 1:", j, e);
+
+  j = mem [3];
+  e = (vf32_t) { 12.0, 13.0, 14.0, 31.125 };
+
+  rc += check_v4f32 ("vec_vsstfsdsx 2:", j, e);
+
+
+  j1 = (vf32_t) { 16.0, 31.0, 17.0, 30.0 };
+  vec_vsst4fsso (j1, test_stf32, 0, 60, 4, 56);
+
+  j = mem [0];
+  e = (vf32_t) { 16.0, 17.0, 2.0, 3.0 };
+
+  rc += check_v4f32 ("vec_vsst4fsso 1:", j, e);
+
+  j = mem [3];
+  e = (vf32_t) { 12.0, 13.0, 30.0, 31.0 };
+
+  rc += check_v4f32 ("vec_vsst4fsso 2:", j, e);
+
+
+  j1 = (vf32_t) { 16.5, 31.5, 17.5, 30.5 };
+  i1 = (vi32_t) { 0, 60, 4, 56 };
+  vec_vsst4fswo (j1, test_stf32, i1);
+
+  j = mem [0];
+  e = (vf32_t) { 16.5, 17.5, 2.0, 3.0 };
+
+  rc += check_v4f32 ("vec_vsst4fswo 1:", j, e);
+
+  j = mem [3];
+  e = (vf32_t) { 12.0, 13.0, 30.5, 31.5 };
+
+  rc += check_v4f32 ("vec_vsst4fswo 2:", j, e);
+
+  j1 = (vf32_t) { 16.75, 31.75, 17.75, 30.75 };
+  i2 = (vi32_t) { 0, 15, 1, 14 };
+  vec_vsst4fswx (j1, test_stf32, i2);
+
+  j = mem [0];
+  e = (vf32_t) { 16.75, 17.75, 2.0, 3.0 };
+
+
+  rc += check_v4f32 ("vec_vsst4fswx 1:", j, e);
+
+  j = mem [3];
+  e = (vf32_t) { 12.0, 13.0, 30.75, 31.75 };
+
+  rc += check_v4f32 ("vec_vsst4fswx 2:", j, e);
+
+  j1 = (vf32_t) { 0.0, 7.0, 1.0, 6.0 };
+  i2 = (vi32_t) { 0, 7, 1, 6 };
+  vec_vsst4fswsx (j1, test_stf32, i2, 1);
+
+  j = mem [0];
+  e = (vf32_t) { 0.0, 17.75, 1.0, 3.0 };
+
+  rc += check_v4f32 ("vec_vsst4fswsx 1:", j, e);
+
+  j = mem [3];
+  e = (vf32_t) { 6.0, 13.0, 7.0, 31.75 };
+
+  rc += check_v4f32 ("vec_vsst4fswsx 2:", j, e);
+
+  return (rc);
+}
+
+float matrix_f32 [MN][MN] __attribute__ ((aligned (128)));
+
+void
+test_f32_Imatrix_init (float * array)
+{
+  long i, j, k;
+  long rows, columns;
+
+  rows = columns = MN;
+
+#ifdef __DEBUG_PRINT__
+  printf ("init_indentity array[%d,%d]\n",
+	  rows, columns);
+#endif
+
+  for ( i=0; i<rows; i++ )
+  {
+    for ( j=0; j<columns; j++ )
+      {
+	k = (i * columns) + j;
+	if (i == j)
+	  {
+	    array [k] = 1.0;
+#ifdef __DEBUG_PRINT__
+	    printf ("init_indentity array[%d,%d] is %f\n",
+			i, j, array [k]);
+#endif
+	  }
+	else
+	  {
+	    array [k] = 0.0;
+	  }
+      }
+  }
+}
+
+int
+#if !defined(__clang__)
+__attribute__ ((optimize ("unroll-loops")))
+#endif
+test_f32_Imatrix_check (float * array)
+{
+  long i, j, k;
+  long rows, columns;
+  int rc = 0;
+
+  rows = columns = MN;
+
+  for ( i=0; i<rows; i++ )
+  {
+    for ( j=0; j<columns; j++ )
+      {
+	k = (i * columns) + j;
+	if (i == j)
+	  {
+	    if ( array [k] != 1.0 )
+	      {
+		printf ("check_indentity array[%ld,%ld] !=1.0 is %f\n",
+			i, j, array [k]);
+		rc++;
+	      }
+	  }
+	else
+	  {
+	    if ( array [k] != 0.0 )
+	      {
+		printf ("check_indentity array[%ld,%ld] !=0.0 is %f\n",
+			i, j, array [k]);
+		rc++;
+	      }
+	  }
+      }
+  }
+  if (rc)
+    {
+      printf ("check_indentity array failed rc=%d\n",
+		rc);
+
+    }
+  return rc;
+}
+
+void
+#if !defined(__clang__)
+__attribute__ ((optimize ("unroll-loops")))
+#endif
+test_f32_matrix_transpose (float * tm, float * m)
+{
+  long i, j, k, l;
+  long rows, columns;
+
+  rows = columns = MN;
+
+  for ( i=0; i<rows; i++ )
+  {
+    for ( j=0; j<columns; j++ )
+      {
+	k = (i * columns) + j;
+	l = (j * columns) + i;
+	tm[l] = m[k];
+      }
+  }
+}
+
+void
+//__attribute__ ((optimize ("unroll-loops")))
+test_f32_matrix_gather_transpose (float * tm, float * m)
+{
+  vi32_t vra_init = { 0, MN*4, (MN*2)*4, (MN*3)*4 };
+  vi32_t vra;
+  vi32_t stride = { MN * 4 * 4, MN * 4 * 4, MN * 4 * 4, MN * 4 * 4 };
+  long i, j;
+  long rows, columns;
+
+  rows = columns = MN;
+  vra = vra_init;
+#ifdef __DEBUG_PRINT__
+  printf ("test_f32_matrix_gather_transpose (%p, %p)\n", tm, m);
+  printf ("vra    = {%d, %d, %d, %d}\n",
+	  vra[0], vra[1], vra[2], vra[3]);
+  printf ("stride = {%d, %d, %d, %d}\n",
+	  stride[0], stride[1], stride[2], stride[3]);
+#endif
+  for (i = 0; i < rows; i++)
+    {
+      float *cadr = &m[i];
+      vf32_t *radr = (vf32_t*)&tm[(i * columns)];
+      vra = vra_init;
+      for (j = 0; j < columns/4; j++)
+	{
+	  radr[j] = vec_vgl4fswo (cadr, vra);
+	  vra = vec_add ( vra, stride);
+	}
+    }
+}
+
+void
+//__attribute__ ((optimize ("unroll-loops")))
+test_f32_matrix_gatherx2_transpose (float * tm, float * m)
+{
+  vi32_t vra_init = { 0, MN*4, (MN*2)*4, (MN*3)*4 };
+  vi32_t vra;
+  vi32_t stride = { MN * 4 * 4, MN * 4 * 4, MN * 4 * 4, MN * 4 * 4 };
+  long i, j;
+  long rows, columns;
+
+  rows = columns = MN;
+
+  for (i = 0; i < rows; i+=2)
+    {
+      float *cadr = &m[i];
+      float *cadr1 = &m[i+1];
+      vf32_t *radr = (vf32_t*)&tm[(i * columns)];
+      vf32_t *radr1 = (vf32_t*)&tm[((i+1) * columns)];
+
+      vra = vra_init;
+      for (j = 0; j < columns/4; j++)
+	{
+	  vf32_t vrow0, vrow1;
+	  vrow0 = vec_vgl4fswo (cadr, vra);
+	  vrow1 = vec_vgl4fswo (cadr1, vra);
+	  radr[j] = vrow0;
+	  radr1[j] = vrow1;
+	  vra = vec_add ( vra, stride);
+	}
+    }
+}
+
+#if 1
+void
+//__attribute__ ((optimize ("unroll-loops")))
+test_f32_matrix_gatherx4_transpose (float * tm, float * m)
+{
+  vi32_t vra_init = { 0, MN*4, (MN*2)*4, (MN*3)*4 };
+  vi32_t vra;
+  vi32_t stride = { MN * 4 * 4, MN * 4 * 4, MN * 4 * 4, MN * 4 * 4 };
+  long i, j;
+  long rows, columns;
+
+  rows = columns = MN;
+
+  for (i = 0; i < rows; i+=4)
+    {
+      float *cadr = &m[i];
+      float *cadr1 = &m[i+1];
+      float *cadr2 = &m[i+2];
+      float *cadr3 = &m[i+3];
+      vf32_t *radr = (vf32_t*)&tm[(i * columns)];
+      vf32_t *radr1 = (vf32_t*)&tm[((i+1) * columns)];
+      vf32_t *radr2 = (vf32_t*)&tm[((i+2) * columns)];
+      vf32_t *radr3 = (vf32_t*)&tm[((i+3) * columns)];
+
+      vra = vra_init;
+      for (j = 0; j < columns/4; j++)
+	{
+	  vf32_t vrow0, vrow1, vrow2, vrow3;
+	  vrow0 = vec_vgl4fswo (cadr, vra);
+	  vrow1 = vec_vgl4fswo (cadr1, vra);
+	  vrow2 = vec_vgl4fswo (cadr2, vra);
+	  vrow3 = vec_vgl4fswo (cadr3, vra);
+	  radr[j] = vrow0;
+	  radr1[j] = vrow1;
+	  radr2[j] = vrow2;
+	  radr3[j] = vrow3;
+	  vra = vec_add ( vra, stride);
+	}
+    }
+}
+#endif
+int
+test_f32_indentity_array ()
+{
+  float tmatrix[MN][MN] __attribute__ ((aligned (128)));
+  int rc = 0;
+
+  printf ("\ntest_indentity_array\n");
+
+  test_f32_Imatrix_init  (&matrix_f32[0][0]);
+
+  rc += test_f32_Imatrix_check (&matrix_f32[0][0]);
+
+  test_f32_matrix_transpose (&tmatrix[0][0], &matrix_f32[0][0]);
+
+  rc += test_f32_Imatrix_check (&tmatrix[0][0]);
+
+  test_f32_matrix_gather_transpose (&tmatrix[0][0], &matrix_f32[0][0]);
+
+  rc += test_f32_Imatrix_check (&tmatrix[0][0]);
+
+  test_f32_matrix_gatherx2_transpose (&tmatrix[0][0], &matrix_f32[0][0]);
+
+  rc += test_f32_Imatrix_check (&tmatrix[0][0]);
+
+#if 1
+  test_f32_matrix_gatherx4_transpose (&tmatrix[0][0], &matrix_f32[0][0]);
+
+  rc += test_f32_Imatrix_check (&tmatrix[0][0]);
+#endif
+  return rc;
+}
 
 #define TIMING_ITERATIONS 10
 
@@ -1835,6 +2343,65 @@ test_time_f32 (void)
   printf ("\n%s fpclassify_f32  tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
 	  t_delta, delta_sec);
 
+  // initialize the test array to the Identity matrix
+  test_f32_Imatrix_init  (&matrix_f32[0][0]);
+
+  printf ("\n%s scalar_transpose_f32 start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_scalar_f32_transpose ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s scalar_transpose_f32 end", __FUNCTION__);
+  printf ("\n%s scalar_transpose_f32  tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+	  t_delta, delta_sec);
+
+  printf ("\n%s gather_transpose_f32 start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_gather_f32_transpose ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s gather_transpose_f32 end", __FUNCTION__);
+  printf ("\n%s gather_transpose_f32  tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+	  t_delta, delta_sec);
+
+  printf ("\n%s gatherx2_transpose_f32 start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_gatherx2_f32_transpose ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s gatherx2_transpose_f32 end", __FUNCTION__);
+  printf ("\n%s gatherx2_transpose_f32  tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+	  t_delta, delta_sec);
+
+  printf ("\n%s gatherx4_transpose_f32 start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_gatherx4_f32_transpose ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s gatherx4_transpose_f32 end", __FUNCTION__);
+  printf ("\n%s gatherx4_transpose_f32  tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+	  t_delta, delta_sec);
+
   return (rc);
 }
 
@@ -1855,6 +2422,9 @@ test_vec_f32 (void)
   rc += test_float_issubnormal ();
   rc += test_float_iszero ();
   rc += test_float_isfinite ();
+  rc += test_lvgfsx ();
+  rc += test_stvgfsx ();
+  rc += test_f32_indentity_array ();
 
   rc += test_time_f32 ();
 

--- a/src/testsuite/arith128_test_f32.h
+++ b/src/testsuite/arith128_test_f32.h
@@ -26,4 +26,26 @@
 extern int
 test_vec_f32 (void);
 
+#define MN 64
+
+extern float matrix_f32 [MN][MN];
+
+extern void
+test_f32_Imatrix_init (float * array);
+
+extern int
+test_f32_Imatrix_check (float * array);
+
+extern void
+test_f32_matrix_transpose (float * tm, float * m);
+
+extern void
+test_f32_matrix_gather_transpose (float * tm, float * m);
+
+extern void
+test_f32_matrix_gatherx2_transpose (float * tm, float * m);
+
+extern void
+test_f32_matrix_gatherx4_transpose (float * tm, float * m);
+
 #endif /* TESTSUITE_ARITH128_TEST_F32_H_ */

--- a/src/testsuite/vec_f32_dummy.c
+++ b/src/testsuite/vec_f32_dummy.c
@@ -292,18 +292,6 @@ test_veclfgux_v1 (float *array, vui32_t idx)
   return res;
 }
 
-vf32_t
-test_veclfgux_v2 (float *array, vui32_t idx)
-{
-  __VEC_U_128 vidx, vflt;
-  vidx.vx4 = idx;
-  vflt.vf4[0] = array[vidx.uint.ix0];
-  vflt.vf4[1] = array[vidx.uint.ix1];
-  vflt.vf4[2] = array[vidx.uint.ix2];
-  vflt.vf4[3] = array[vidx.uint.ix3];
-  return vflt.vf4;
-}
-
 #if defined __GNUC__ && (__GNUC__ > 7) && defined(_ARCH_PWR8)
 vf32_t
 test_veclfgux_v3 (float *array, vui32_t idx)

--- a/src/testsuite/vec_f32_dummy.c
+++ b/src/testsuite/vec_f32_dummy.c
@@ -33,6 +33,304 @@
 //#define __DEBUG_PRINT__
 #include <pveclib/vec_f32_ppc.h>
 
+#if (__GNUC__ > 7) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+vf32_t
+test_vec_pack_dpsp (vf64_t a, vf64_t b)
+{
+  return vec_pack (a,b);
+}
+#endif
+
+void
+test_vec_vsst4fsso (vf32_t xs, float *array,
+		   const long long offset0, const long long offset1,
+		   const long long offset2, const long long offset3)
+{
+  vec_vsst4fsso (xs, array, offset0, offset1, offset2, offset3);
+}
+
+void
+test_vec_vsstfswwo (vf32_t xs, float *array,
+		   vi32_t vra)
+{
+  vec_vsst4fswo (xs, array, vra);
+}
+
+void
+test_vec_vsst4fswsx (vf32_t xs, float *array,
+		   vi32_t vra)
+{
+  vec_vsst4fswsx (xs, array, vra, 4);
+}
+
+void
+test_vec_vsst4fswx (vf32_t xs, float *array,
+		   vi32_t vra)
+{
+  vec_vsst4fswx (xs, array, vra);
+}
+
+vf32_t
+test_vec_vgl4fswsx (float *array, vi32_t vra)
+{
+  return vec_vgl4fswsx (array, vra, 4);
+}
+
+vf32_t
+test_vec_vgl4fswx (float *array, vi32_t vra)
+{
+  return vec_vgl4fswx (array, vra);
+}
+
+vf32_t
+test_vec_vgl4fswo (float *array, vi32_t vra)
+{
+  return vec_vgl4fswo (array, vra);
+}
+
+vf32_t
+test_vec_vgl4fsso (float *array, const long long offset0,
+	     const long long offset1, const long long offset2,
+	     const long long offset3)
+{
+  return vec_vgl4fsso (array, offset0, offset1, offset2, offset3);
+}
+
+void
+test_vec_vsstfsdsx (vf64_t xs, float *array, vi64_t vra)
+{
+  vec_vsstfsdsx (xs, array, vra, 4);
+}
+
+void
+test_vec_vsstfsdx (vf64_t xs, float *array, vi64_t vra)
+{
+  vec_vsstfsdx (xs, array, vra);
+}
+
+void
+test_vec_vsstfsdo (vf64_t xs, float *array, vi64_t vra)
+{
+  vec_vsstfsdo (xs, array, vra);
+}
+
+void
+test_vec_vsstfsso (vf64_t xs, float *array,
+	      const long long offset0, const long long offset1)
+{
+  vec_vsstfsso (xs, array, offset0, offset1);
+}
+
+void
+test_vec_vsstfsso_032 (vf64_t xs, float *array)
+{
+  vec_vsstfsso (xs, array, 0, 32);
+}
+
+vf64_t
+test_vec_vglfsdsx (float *array, vi64_t vra)
+{
+  return vec_vglfsdsx (array, vra, 4);
+}
+
+vf64_t
+test_vec_vglfsdx (float *array, vi64_t vra)
+{
+  return vec_vglfsdx (array, vra);
+}
+
+vf64_t
+test_vec_vglfsdo (float *array, vi64_t vra)
+{
+  return vec_vglfsdo (array, vra);
+}
+
+vf64_t
+test_vec_vglfsso (float *array, const long long offset0,
+		     const long long offset1)
+{
+  return vec_vglfsso (array, offset0, offset1);
+}
+
+vf64_t
+test_vec_vglfsso_032 (float *array)
+{
+  return vec_vglfsso (array, 0, 32);
+}
+
+vf64_t
+test_vec_vlxsspx (const signed long long ra, const float *rb)
+{
+  return vec_vlxsspx (ra, rb);
+}
+
+vf64_t
+test_vec_vlxsspx_c0 (const float *rb)
+{
+  return vec_vlxsspx (0, rb);
+}
+
+vf64_t
+test_vec_vlxsspx_c1 (const float *rb)
+{
+  return vec_vlxsspx (8, rb);
+}
+
+vf64_t
+test_vec_vlxsspx_c2 (const float *rb)
+{
+  return vec_vlxsspx (32760, rb);
+}
+
+vf64_t
+test_vec_vlxsspx_c3 (const float *rb)
+{
+  return vec_vlxsspx (32768, rb);
+}
+
+vf64_t
+test_vec_vlxsspx_c4 (const float *rb)
+{
+  return vec_vlxsspx (-32768, rb);
+}
+
+vf64_t
+test_vlxsspx_v0 (const signed long long ra, const float *rb)
+{
+  vf64_t xt;
+  __VEC_U_128 t;
+
+  float *p = (float *)((char *)rb + ra);
+  t.vf2[0] = t.vf2[1] = *p;
+  xt = t.vf2;
+  return xt;
+}
+
+void
+test_vstxsspx (vf64_t data, float *array, signed long offset)
+{
+  vec_vstxsspx (data, offset, array);
+}
+
+void
+test_vstxsspx_c0 (vf64_t data, float *array)
+{
+  vec_vstxsspx (data, 0, array);
+}
+
+void
+test_vstxsspx_c1 (vf64_t data, float *array)
+{
+  vec_vstxsspx (data, 8, array);
+}
+
+void
+test_vstxsspx_c2 (vf64_t data, float *array)
+{
+  vec_vstxsspx (data, 32760, array);
+}
+
+void
+test_vstxsspx_c3 (vf64_t data, float *array)
+{
+  vec_vstxsspx (data, 32768, array);
+}
+
+void
+test_vstxsspx_c4 (vf64_t data, float *array)
+{
+  vec_vstxsspx (data, -32768, array);
+}
+
+void
+test_vstxsspx_v1 (vf64_t data, float *array, signed long offset)
+{
+  __VEC_U_128 t;
+  float *p = (float *)((char *)array + offset);
+  t.vf2 = data;
+  *p = t.vf2[0];
+}
+
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+vf32_t
+test_vlxsspx_v1 (float *array, unsigned long offset)
+{
+  vf32_t res, rese;
+  vui8_t resp;
+
+  rese = vec_lvewx (offset, array);
+  resp = vec_lvsr (offset, array);
+  res = vec_perm (rese, rese, resp);
+  return res;
+}
+
+vf32_t
+test_vglssfso_v2 (float *array, unsigned long offset0, unsigned long offset1)
+{
+  vf32_t res, rese0, rese1;
+  vui8_t resp0, resp1;
+
+  rese0 = vec_lvewx (offset0, array);
+  rese1 = vec_lvewx (offset1, array);
+  resp0 = vec_lvsl (offset0, array);
+  resp1 = vec_lvsl (offset1, array);
+  rese0 = vec_perm (rese0, rese0, resp0);
+  rese1 = vec_perm (rese1, rese1, resp1);
+  res = vec_mergeh (rese0, rese1);
+  return res;
+}
+#endif
+
+vf32_t
+test_veclfgux_v1 (float *array, vui32_t idx)
+{
+  vf32_t res;
+  res[0] = array[idx[0]];
+  res[1] = array[idx[1]];
+  res[2] = array[idx[2]];
+  res[3] = array[idx[3]];
+  return res;
+}
+
+vf32_t
+test_veclfgux_v2 (float *array, vui32_t idx)
+{
+  __VEC_U_128 vidx, vflt;
+  vidx.vx4 = idx;
+  vflt.vf4[0] = array[vidx.uint.ix0];
+  vflt.vf4[1] = array[vidx.uint.ix1];
+  vflt.vf4[2] = array[vidx.uint.ix2];
+  vflt.vf4[3] = array[vidx.uint.ix3];
+  return vflt.vf4;
+}
+
+#if defined __GNUC__ && (__GNUC__ > 7) && defined(_ARCH_PWR8)
+vf32_t
+test_veclfgux_v3 (float *array, vui32_t idx)
+{
+  __VEC_U_128 vidx0, vidx1, vflt0, vflt1;
+  vui64_t idxh, idxl;
+  const vui32_t vzero = { 0, 0, 0, 0 };
+  const vui64_t vsl2 = { 2, 2 };
+  vf32_t res0, res1, res;
+  idxh = (vui64_t) vec_mergeh (vzero, idx);
+  idxl = (vui64_t) vec_mergel (vzero, idx);
+  idxh = vec_sl (idxh, vsl2);
+  idxl = vec_sl (idxl, vsl2);
+
+  vidx0.vx2 = idxh;
+  vidx1.vx2 = idxl;
+  vflt0.vf2[0] = array[vidx0.ulong.lower];
+  vflt0.vf2[1] = array[vidx0.ulong.upper];
+  vflt1.vf2[0] = array[vidx1.ulong.lower];
+  vflt1.vf2[1] = array[vidx1.ulong.upper];
+  res0 = vec_floate (vflt0.vf2);
+  res1 = vec_floato (vflt1.vf2);
+  res  = vec_mergee (res0, res1);
+  return res;
+}
+#endif
+
 vf32_t
 test_vec_f32_abs (vf32_t value)
 {

--- a/src/testsuite/vec_perf_f32.c
+++ b/src/testsuite/vec_perf_f32.c
@@ -37,6 +37,7 @@
 
 #include <testsuite/arith128_print.h>
 #include <testsuite/vec_perf_f32.h>
+#include <testsuite/arith128_test_f32.h>
 
 #define N 10
 static const vf32_t data0 =
@@ -87,3 +88,49 @@ int timed_fpclassify_f32 (void)
 #endif
    return 0;
 }
+
+int
+timed_scalar_f32_transpose ()
+{
+  float tmatrix[MN][MN] __attribute__ ((aligned (128)));
+  int rc = 0;
+
+  test_f32_matrix_transpose (&tmatrix[0][0], &matrix_f32[0][0]);
+
+  return rc;
+}
+
+int
+timed_gather_f32_transpose ()
+{
+  float tmatrix[MN][MN] __attribute__ ((aligned (128)));
+  int rc = 0;
+
+  test_f32_matrix_gather_transpose (&tmatrix[0][0], &matrix_f32[0][0]);
+
+  return rc;
+}
+
+int
+timed_gatherx2_f32_transpose ()
+{
+  float tmatrix[MN][MN] __attribute__ ((aligned (128)));
+  int rc = 0;
+
+  test_f32_matrix_gatherx2_transpose (&tmatrix[0][0], &matrix_f32[0][0]);
+
+  return rc;
+}
+
+#if 1
+int
+timed_gatherx4_f32_transpose ()
+{
+  float tmatrix[MN][MN] __attribute__ ((aligned (128)));
+  int rc = 0;
+
+  test_f32_matrix_gatherx4_transpose (&tmatrix[0][0], &matrix_f32[0][0]);
+
+  return rc;
+}
+#endif

--- a/src/testsuite/vec_perf_f32.h
+++ b/src/testsuite/vec_perf_f32.h
@@ -25,5 +25,9 @@
 
 extern int timed_is_f32 (void);
 extern int timed_fpclassify_f32 (void);
+extern int timed_scalar_f32_transpose ();
+extern int timed_gather_f32_transpose ();
+extern int timed_gatherx2_f32_transpose ();
+extern int timed_gatherx4_f32_transpose ();
 
 #endif /* TESTSUITE_VEC_PERF_F32_H_ */


### PR DESCRIPTION
This is the Single Precision Float variant of Gather/Scatter.
The Gathers have three vector result forms:
- Float single words expanded to Float Double as vector double.
- Float single words as vector float.

The doubleword results take signed doubleword offsets/indexes.
The word results take signed word offsets/indexes.
The Scatter has two vector source forms;
- Vector Double rounded and converted to float single stored as words.
- Vector Float where all 4 words are stored are float single.

Doubleword sources take vector signed doubleword offsets/indexes,
while word sources take vector signed word offsets/indexes,
There are also forms where offsets are provided as 2/4 const scalar
offsets. These are optimized for const offsets but are also used
in the implementation of the vector offset/index forms.

	* src/pveclib/vec_f32_ppc.h [@cond INTERNAL]: Forward declare;
	vec_vglfsso, vec_vlxsspx, vec_vsstfsso, vec_vstxsspx;
	(vec_vgl4fsso, vec_vgl4fswo, vec_vgl4fswsx, vec_vgl4fswx,
	vec_vglfsdo, vec_vglfsdsx, vec_vglfsdx, vec_vglfsso,
	vec_vlxsspx):  New inline operations.
	(vec_vsst4fsso, vec_vsst4fswo, vec_vsst4fswsx, vec_vsst4fswx,
	vec_vsstfsso, vec_vsstfsdsx, vec_vsstfsdx, vec_vsstfsso,
	vec_vstxsspx):  New inline operations.

	* src/testsuite/arith128_test_f32.c (test_f32):
	New test array.
	(test_lvgfsx): New unit test functions.
	(test_stf32): New test array.
	(test_stvgfsx): New unit test functions.
	(matrix_f32): New matrix for column vector tests.
	(test_f32_Imatrix_init, test_f32_Imatrix_check,
	test_f32_matrix_transpose, test_f32_matrix_gather_transpose,
	test_f32_matrix_gatherx2_transpose,
	test_f32_matrix_gatherx4_transpose): New unit/perf tests.
	(test_indentity_array): New unit test.
	(test_time_f32): Add timed tests for timed_scalar_f32_transpose,
	test_f32_matrix_gather_transpose,
	test_f32_matrix_gatherx2_transpose,
	test_f32_matrix_gatherx4_transpose.
	(test_vec_f32): Add test_lvgdfdx, test_stvgdfdx,
	test_indentity_array calls to unit test driver.

	* src/testsuite/arith128_test_f32.h (matrix_f32,
	test_f32_Imatrix_init, test_f32_Imatrix_check,
	test_f32_matrix_transpose, test_f32_matrix_gather_transpose,
	test_f32_matrix_gatherx2_transpose,
	test_f32_matrix_gatherx4_transpose): New externs.

	* src/testsuite/vec_f32_dummy.c
	[ (__GNUC__ > 7) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)]:
	New compile test test_vec_pack_dpsp.
	(test_vec_vsst4fsso test_vec_vsstfswwo, test_vec_vsst4fswsx,
	test_vec_vsst4fswx): New compile tests.
	(test_vec_vgl4fswsx, test_vec_vgl4fswx, test_vec_vgl4fswo,
	test_vec_vgl4fsso): New compile tests.
	(test_vec_vsstfsdsx, test_vec_vsstfsdx, test_vec_vsstfsdo,
	test_vec_vsstfsso, test_vec_vsstfsso_032): New compile tests.
	(test_vec_vglfsdsx, test_vec_vglfsdx, test_vec_vglfsdo,
	test_vec_vglfsso, test_vec_vglfsso_032): New compile tests.
	(test_vec_vlxsspx test_vec_vlxsspx_c0, test_vec_vlxsspx_c1,
	test_vec_vlxsspx_c2, test_vec_vlxsspx_c3, test_vec_vlxsspx_c4,
	test_vlxsspx_v0): New compile tests.
	(test_vstxsspx, test_vstxsspx_c0, test_vstxsspx_c1,
	test_vstxsspx_c2, test_vstxsspx_c3, test_vstxsspx_c4,
	test_vstxsspx_v1): New compile tests.
	[__ORDER_BIG_ENDIAN__} (test_vlxsspx_v1, test_vglssfso_v2):
	(test_veclfgux_v1, test_veclfgux_v2): New compile tests.
	[__GNUC__ && (__GNUC__ > 7) && defined(_ARCH_PWR8)]
	(test_veclfgux_v3): New compile test.

	* src/testsuite/vec_perf_f32.c: Include
	<testsuite/arith128_test_f32.h>.
	(timed_scalar_f32_transpose, timed_gather_f32_transpose,
	timed_gatherx2_f32_transpose, timed_gatherx4_f32_transpose):
	New timed test functions.

	* src/testsuite/vec_perf_f32.h (timed_scalar_f32_transpose,
	timed_gather_f32_transpose, timed_gatherx2_f32_transpose,
	timed_gatherx4_f32_transpose): New externs.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>