### PR TITLE
Add support for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,64 @@
+language: c
+
+matrix:
+  include:
+    - name: "linux-ppc64le-gcc-8"
+      os: linux
+      dist: focal
+      arch: ppc64le
+      compiler: gcc-8
+      env:
+        - CFLAGS="-O3 -g"
+        - PKG_CC="gcc-8"
+    - name: "linux-ppc64le-gcc-9"
+      os: linux
+      dist: focal
+      arch: ppc64le
+      compiler: gcc-9
+      env:
+        - CFLAGS="-O3 -g"
+        - PKG_CC="gcc-9"
+    - name: "linux-ppc64le-at14.0"
+      os: linux
+      dist: bionic
+      arch: ppc64le
+      compiler: /opt/at14.0/bin/gcc
+      env:
+        - CFLAGS="-O3 -g"
+        - PKG_CC="advance-toolchain-at14.0-devel"
+    - name: "linux-ppc64le-clang-8"
+      os: linux
+      dist: bionic
+      arch: ppc64le
+      compiler: clang-8
+      env:
+        - CFLAGS="-O3 -g"
+        - PKG_CC="clang-8"
+    - name: "linux-ppc64le-clang-9"
+      os: linux
+      dist: bionic
+      arch: ppc64le
+      compiler: clang-9
+      env:
+        - CFLAGS="-O3 -g"
+        - PKG_CC="clang-9"
+    - name: "linux-ppc64le-clang-10"
+      os: linux
+      dist: bionic
+      arch: ppc64le
+      compiler: clang-10
+      env:
+        - CFLAGS="-O3 -g"
+        - PKG_CC="clang-10"
+
+before_install:
+  - sudo add-apt-repository universe
+  - sudo apt-get update
+  - sudo apt-get -y install ${PKG_CC} doxygen graphviz
+
+script:
+  - mkdir $(pwd)/install
+  - ./configure $CONFIGURE_OPTS --prefix=$(pwd)/install
+  - make -j $(nproc)
+  - make -j $(nproc) check
+  - make install

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # pveclib
 
+[![Build Status](https://travis-ci.org/open-power-sdk/pveclib.svg?branch=master)](https://travis-ci.org/open-power-sdk/pveclib)
+
 ## Power Vector Library
 
 Header files that contain useful functions leveraging the PowerISA


### PR DESCRIPTION
Test on Ubuntu 20.04, using GCC 8, 9, AT 14.0 (GCC 10) and clang 10.

Notice this patch alone will not enable Travis CI on this project.
It also requires the owner of the repository to enable the tests on
https://travis-ci.org/github/open-power-sdk/pveclib

Signed-off-by: Tulio Magno Quites Machado Filho <tuliom@linux.ibm.com>