### PR TITLE
Fixes for issue #129.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -47,7 +47,7 @@ PVECCOMPILE = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 	$(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) \
 	$(AM_CFLAGS)
 
-vec_dynrt_PWR10.lo: vec_runtime_PWR10.c $(pveclibinclude_HEADERS)
+vec_dynrt_PWR10.lo: vec_runtime_PWR10.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
 if am__fastdepCC
 	$(PVECCOMPILE) -fpic $(PVECLIB_POWER10_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR10.c
 	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
@@ -59,19 +59,19 @@ endif
 	$(PVECCOMPILE) -fpic $(PVECLIB_POWER10_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR10.c
 endif
 
-vec_staticrt_PWR10.lo: vec_runtime_PWR10.c $(pveclibinclude_HEADERS)
+vec_staticrt_PWR10.lo: vec_runtime_PWR10.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
 if am__fastdepCC
-	$(PVECCOMPILE) $(PVECLIB_POWER10_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR10.c
+	$(PVECCOMPILE) -fpie $(PVECLIB_POWER10_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR10.c
 	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
 else
 if AMDEP
 	source='vec_runtime_PWR10.c' object='$@' libtool=yes @AMDEPBACKSLASH@
 	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 endif
-	$(PVECCOMPILE) $(PVECLIB_POWER10_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR10.c
+	$(PVECCOMPILE) -fpie $(PVECLIB_POWER10_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR10.c
 endif
 
-vec_dynrt_PWR9.lo: vec_runtime_PWR9.c $(pveclibinclude_HEADERS)
+vec_dynrt_PWR9.lo: vec_runtime_PWR9.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
 if am__fastdepCC
 	$(PVECCOMPILE) -fpic $(PVECLIB_POWER9_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR9.c
 	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
@@ -83,19 +83,19 @@ endif
 	$(PVECCOMPILE) -fpic $(PVECLIB_POWER9_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR9.c
 endif
 
-vec_staticrt_PWR9.lo: vec_runtime_PWR9.c $(pveclibinclude_HEADERS)
+vec_staticrt_PWR9.lo: vec_runtime_PWR9.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
 if am__fastdepCC
-	$(PVECCOMPILE) $(PVECLIB_POWER9_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR9.c
+	$(PVECCOMPILE) -fpie $(PVECLIB_POWER9_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR9.c
 	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
 else
 if AMDEP
 	source='vec_runtime_PWR9.c' object='$@' libtool=yes @AMDEPBACKSLASH@
 	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 endif
-	$(PVECCOMPILE) $(PVECLIB_POWER9_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR9.c
+	$(PVECCOMPILE) -fpie $(PVECLIB_POWER9_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR9.c
 endif
 
-vec_dynrt_PWR8.lo: vec_runtime_PWR8.c $(pveclibinclude_HEADERS)
+vec_dynrt_PWR8.lo: vec_runtime_PWR8.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
 if am__fastdepCC
 	$(PVECCOMPILE) -fpic $(PVECLIB_POWER8_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR8.c
 	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
@@ -107,19 +107,19 @@ endif
 	$(PVECCOMPILE) -fpic $(PVECLIB_POWER8_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR8.c
 endif
 
-vec_staticrt_PWR8.lo: vec_runtime_PWR8.c $(pveclibinclude_HEADERS)
+vec_staticrt_PWR8.lo: vec_runtime_PWR8.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
 if am__fastdepCC
-	$(PVECCOMPILE) $(PVECLIB_POWER8_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR8.c
+	$(PVECCOMPILE) -fpie $(PVECLIB_POWER8_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR8.c
 	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
 else
 if AMDEP
 	source='vec_runtime_PWR8.c' object='$@' libtool=yes @AMDEPBACKSLASH@
 	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 endif
-	$(PVECCOMPILE) $(PVECLIB_POWER8_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR8.c
+	$(PVECCOMPILE) -fpie $(PVECLIB_POWER8_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR8.c
 endif
 
-vec_dynrt_PWR7.lo: vec_runtime_PWR7.c $(pveclibinclude_HEADERS)
+vec_dynrt_PWR7.lo: vec_runtime_PWR7.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
 if am__fastdepCC
 	$(PVECCOMPILE) -fpic $(PVECLIB_POWER7_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR7.c
 	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
@@ -131,16 +131,16 @@ endif
 	$(PVECCOMPILE) -fpic $(PVECLIB_POWER7_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR7.c
 endif
 
-vec_staticrt_PWR7.lo: vec_runtime_PWR7.c $(pveclibinclude_HEADERS)
+vec_staticrt_PWR7.lo: vec_runtime_PWR7.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
 if am__fastdepCC
-	$(PVECCOMPILE) $(PVECLIB_POWER7_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR7.c
+	$(PVECCOMPILE) -fpie $(PVECLIB_POWER7_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR7.c
 	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
 else
 if AMDEP
 	source='vec_runtime_PWR7.c' object='$@' libtool=yes @AMDEPBACKSLASH@
 	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 endif
-	$(PVECCOMPILE) $(PVECLIB_POWER7_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR7.c
+	$(PVECCOMPILE) -fpie $(PVECLIB_POWER7_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR7.c
 endif
 
 vec_dynrt_common.lo: vec_runtime_common.c $(pveclibinclude_HEADERS)
@@ -172,6 +172,7 @@ distclean-local:
 .libs/libpvecstatic.a: libpvecstatic.la
 .libs/libpvecdummy.a: libpvecdummy.la
 .libs/libpvecdummyPWR9.a: libpvecdummyPWR9.la
+.libs/libpvecdummyPWR10.a: libpvecdummyPWR10.la
 
 # libpvec definitions.
 # libpvec_la already includes vec_runtime_DYN.c compiled compiled -fpic
@@ -179,9 +180,9 @@ distclean-local:
 # Now adding the -fpic -mcpu= target built runtimes.
 libpvec_la_LDFLAGS = -version-info $(PVECLIB_SO_VERSION)
 libpvec_la_LIBADD = vec_dynrt_PWR9.lo
-libpvec_la_LIBADD += vec_dynrt_PWR10.lo
 libpvec_la_LIBADD += vec_dynrt_PWR8.lo
 libpvec_la_LIBADD += vec_dynrt_PWR7.lo
+libpvec_la_LIBADD += vec_dynrt_PWR10.lo
 libpvec_la_LIBADD += vec_dynrt_common.lo
 libpvec_la_LIBADD += -lc
 
@@ -189,9 +190,9 @@ libpvec_la_LIBADD += -lc
 # libpvecstatic_la already includes tipowof10.c decpowof2.c.
 # Now adding the name qualified -mcpu= target built runtimes.
 libpvecstatic_la_LIBADD = vec_staticrt_PWR9.lo
-libpvecstatic_la_LIBADD += vec_staticrt_PWR10.lo
 libpvecstatic_la_LIBADD += vec_staticrt_PWR8.lo
 libpvecstatic_la_LIBADD += vec_staticrt_PWR7.lo
+libpvecstatic_la_LIBADD += vec_staticrt_PWR10.lo
 
 # pveclib definitions
 pveclibincludedir = $(includedir)/pveclib
@@ -269,5 +270,6 @@ vec_dummy_SOURCES = testsuite/vec_dummy_main.c
 vec_dummy_CFLAGS = $(AM_CPPFLAGS) $(PVECLIB_DEFAULT_CFLAGS) $(AM_CFLAGS)
 
 vec_dummy_LDADD   = libpvecstatic.la libvecdummy.la libvecdummyPWR9.la
+vec_dummy_LDADD   += libvecdummyPWR10.la
 
 check_PROGRAMS = $(TESTS)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -179,9 +179,9 @@ distclean-local:
 # for IFUNC resolvers.
 # Now adding the -fpic -mcpu= target built runtimes.
 libpvec_la_LDFLAGS = -version-info $(PVECLIB_SO_VERSION)
-libpvec_la_LIBADD = vec_dynrt_PWR9.lo
+libpvec_la_LIBADD = vec_dynrt_PWR7.lo
 libpvec_la_LIBADD += vec_dynrt_PWR8.lo
-libpvec_la_LIBADD += vec_dynrt_PWR7.lo
+libpvec_la_LIBADD += vec_dynrt_PWR9.lo
 libpvec_la_LIBADD += vec_dynrt_PWR10.lo
 libpvec_la_LIBADD += vec_dynrt_common.lo
 libpvec_la_LIBADD += -lc
@@ -189,9 +189,9 @@ libpvec_la_LIBADD += -lc
 # libpvecstatic definitions, compiled without -fpic
 # libpvecstatic_la already includes tipowof10.c decpowof2.c.
 # Now adding the name qualified -mcpu= target built runtimes.
-libpvecstatic_la_LIBADD = vec_staticrt_PWR9.lo
+libpvecstatic_la_LIBADD = vec_staticrt_PWR7.lo
 libpvecstatic_la_LIBADD += vec_staticrt_PWR8.lo
-libpvecstatic_la_LIBADD += vec_staticrt_PWR7.lo
+libpvecstatic_la_LIBADD += vec_staticrt_PWR9.lo
 libpvecstatic_la_LIBADD += vec_staticrt_PWR10.lo
 
 # pveclib definitions
@@ -269,7 +269,8 @@ vec_dummy_SOURCES = testsuite/vec_dummy_main.c
 
 vec_dummy_CFLAGS = $(AM_CPPFLAGS) $(PVECLIB_DEFAULT_CFLAGS) $(AM_CFLAGS)
 
-vec_dummy_LDADD   = libpvecstatic.la libvecdummy.la libvecdummyPWR9.la
+vec_dummy_LDADD   = libpvecstatic.la libvecdummy.la 
+vec_dummy_LDADD   += libvecdummyPWR9.la
 vec_dummy_LDADD   += libvecdummyPWR10.la
 
 check_PROGRAMS = $(TESTS)

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -137,8 +137,8 @@ am__uninstall_files_from_dir = { \
 am__installdirs = "$(DESTDIR)$(libdir)" \
 	"$(DESTDIR)$(pveclibincludedir)"
 LTLIBRARIES = $(lib_LTLIBRARIES) $(noinst_LTLIBRARIES)
-libpvec_la_DEPENDENCIES = vec_dynrt_PWR9.lo vec_dynrt_PWR8.lo \
-	vec_dynrt_PWR7.lo vec_dynrt_PWR10.lo vec_dynrt_common.lo
+libpvec_la_DEPENDENCIES = vec_dynrt_PWR7.lo vec_dynrt_PWR8.lo \
+	vec_dynrt_PWR9.lo vec_dynrt_PWR10.lo vec_dynrt_common.lo
 am_libpvec_la_OBJECTS = libpvec_la-vec_runtime_DYN.lo
 libpvec_la_OBJECTS = $(am_libpvec_la_OBJECTS)
 AM_V_lt = $(am__v_lt_@AM_V@)
@@ -148,8 +148,8 @@ am__v_lt_1 =
 libpvec_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 	$(LIBTOOLFLAGS) --mode=link $(CCLD) $(libpvec_la_CFLAGS) \
 	$(CFLAGS) $(libpvec_la_LDFLAGS) $(LDFLAGS) -o $@
-libpvecstatic_la_DEPENDENCIES = vec_staticrt_PWR9.lo \
-	vec_staticrt_PWR8.lo vec_staticrt_PWR7.lo \
+libpvecstatic_la_DEPENDENCIES = vec_staticrt_PWR7.lo \
+	vec_staticrt_PWR8.lo vec_staticrt_PWR9.lo \
 	vec_staticrt_PWR10.lo
 am_libpvecstatic_la_OBJECTS = libpvecstatic_la-tipowof10.lo \
 	libpvecstatic_la-decpowof2.lo
@@ -682,14 +682,14 @@ EXTRA_DIST = vec_runtime_PWR7.c vec_runtime_PWR8.c vec_runtime_PWR9.c \
 # for IFUNC resolvers.
 # Now adding the -fpic -mcpu= target built runtimes.
 libpvec_la_LDFLAGS = -version-info $(PVECLIB_SO_VERSION)
-libpvec_la_LIBADD = vec_dynrt_PWR9.lo vec_dynrt_PWR8.lo \
-	vec_dynrt_PWR7.lo vec_dynrt_PWR10.lo vec_dynrt_common.lo -lc
+libpvec_la_LIBADD = vec_dynrt_PWR7.lo vec_dynrt_PWR8.lo \
+	vec_dynrt_PWR9.lo vec_dynrt_PWR10.lo vec_dynrt_common.lo -lc
 
 # libpvecstatic definitions, compiled without -fpic
 # libpvecstatic_la already includes tipowof10.c decpowof2.c.
 # Now adding the name qualified -mcpu= target built runtimes.
-libpvecstatic_la_LIBADD = vec_staticrt_PWR9.lo vec_staticrt_PWR8.lo \
-	vec_staticrt_PWR7.lo vec_staticrt_PWR10.lo
+libpvecstatic_la_LIBADD = vec_staticrt_PWR7.lo vec_staticrt_PWR8.lo \
+	vec_staticrt_PWR9.lo vec_staticrt_PWR10.lo
 
 # pveclib definitions
 pveclibincludedir = $(includedir)/pveclib

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -137,8 +137,8 @@ am__uninstall_files_from_dir = { \
 am__installdirs = "$(DESTDIR)$(libdir)" \
 	"$(DESTDIR)$(pveclibincludedir)"
 LTLIBRARIES = $(lib_LTLIBRARIES) $(noinst_LTLIBRARIES)
-libpvec_la_DEPENDENCIES = vec_dynrt_PWR9.lo vec_dynrt_PWR10.lo \
-	vec_dynrt_PWR8.lo vec_dynrt_PWR7.lo vec_dynrt_common.lo
+libpvec_la_DEPENDENCIES = vec_dynrt_PWR9.lo vec_dynrt_PWR8.lo \
+	vec_dynrt_PWR7.lo vec_dynrt_PWR10.lo vec_dynrt_common.lo
 am_libpvec_la_OBJECTS = libpvec_la-vec_runtime_DYN.lo
 libpvec_la_OBJECTS = $(am_libpvec_la_OBJECTS)
 AM_V_lt = $(am__v_lt_@AM_V@)
@@ -149,8 +149,8 @@ libpvec_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 	$(LIBTOOLFLAGS) --mode=link $(CCLD) $(libpvec_la_CFLAGS) \
 	$(CFLAGS) $(libpvec_la_LDFLAGS) $(LDFLAGS) -o $@
 libpvecstatic_la_DEPENDENCIES = vec_staticrt_PWR9.lo \
-	vec_staticrt_PWR10.lo vec_staticrt_PWR8.lo \
-	vec_staticrt_PWR7.lo
+	vec_staticrt_PWR8.lo vec_staticrt_PWR7.lo \
+	vec_staticrt_PWR10.lo
 am_libpvecstatic_la_OBJECTS = libpvecstatic_la-tipowof10.lo \
 	libpvecstatic_la-decpowof2.lo
 libpvecstatic_la_OBJECTS = $(am_libpvecstatic_la_OBJECTS)
@@ -218,7 +218,7 @@ pveclib_test_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 am_vec_dummy_OBJECTS = testsuite/vec_dummy-vec_dummy_main.$(OBJEXT)
 vec_dummy_OBJECTS = $(am_vec_dummy_OBJECTS)
 vec_dummy_DEPENDENCIES = libpvecstatic.la libvecdummy.la \
-	libvecdummyPWR9.la
+	libvecdummyPWR9.la libvecdummyPWR10.la
 vec_dummy_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 	$(LIBTOOLFLAGS) --mode=link $(CCLD) $(vec_dummy_CFLAGS) \
 	$(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $@
@@ -682,14 +682,14 @@ EXTRA_DIST = vec_runtime_PWR7.c vec_runtime_PWR8.c vec_runtime_PWR9.c \
 # for IFUNC resolvers.
 # Now adding the -fpic -mcpu= target built runtimes.
 libpvec_la_LDFLAGS = -version-info $(PVECLIB_SO_VERSION)
-libpvec_la_LIBADD = vec_dynrt_PWR9.lo vec_dynrt_PWR10.lo \
-	vec_dynrt_PWR8.lo vec_dynrt_PWR7.lo vec_dynrt_common.lo -lc
+libpvec_la_LIBADD = vec_dynrt_PWR9.lo vec_dynrt_PWR8.lo \
+	vec_dynrt_PWR7.lo vec_dynrt_PWR10.lo vec_dynrt_common.lo -lc
 
 # libpvecstatic definitions, compiled without -fpic
 # libpvecstatic_la already includes tipowof10.c decpowof2.c.
 # Now adding the name qualified -mcpu= target built runtimes.
-libpvecstatic_la_LIBADD = vec_staticrt_PWR9.lo vec_staticrt_PWR10.lo \
-	vec_staticrt_PWR8.lo vec_staticrt_PWR7.lo
+libpvecstatic_la_LIBADD = vec_staticrt_PWR9.lo vec_staticrt_PWR8.lo \
+	vec_staticrt_PWR7.lo vec_staticrt_PWR10.lo
 
 # pveclib definitions
 pveclibincludedir = $(includedir)/pveclib
@@ -754,7 +754,8 @@ pveclib_test_LDADD = .libs/libpvecstatic.a .libs/libvecdummy.a
 #Dummy main to force generation of vec_dummy_* codes
 vec_dummy_SOURCES = testsuite/vec_dummy_main.c 
 vec_dummy_CFLAGS = $(AM_CPPFLAGS) $(PVECLIB_DEFAULT_CFLAGS) $(AM_CFLAGS)
-vec_dummy_LDADD = libpvecstatic.la libvecdummy.la libvecdummyPWR9.la
+vec_dummy_LDADD = libpvecstatic.la libvecdummy.la libvecdummyPWR9.la \
+	libvecdummyPWR10.la
 all: all-am
 
 .SUFFIXES:
@@ -1756,61 +1757,61 @@ uninstall-am: uninstall-libLTLIBRARIES uninstall-pveclibincludeHEADERS
 .PRECIOUS: Makefile
 
 
-vec_dynrt_PWR10.lo: vec_runtime_PWR10.c $(pveclibinclude_HEADERS)
+vec_dynrt_PWR10.lo: vec_runtime_PWR10.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
 @am__fastdepCC_TRUE@	$(PVECCOMPILE) -fpic $(PVECLIB_POWER10_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR10.c
 @am__fastdepCC_TRUE@	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	source='vec_runtime_PWR10.c' object='$@' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(PVECCOMPILE) -fpic $(PVECLIB_POWER10_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR10.c
 
-vec_staticrt_PWR10.lo: vec_runtime_PWR10.c $(pveclibinclude_HEADERS)
-@am__fastdepCC_TRUE@	$(PVECCOMPILE) $(PVECLIB_POWER10_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR10.c
+vec_staticrt_PWR10.lo: vec_runtime_PWR10.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
+@am__fastdepCC_TRUE@	$(PVECCOMPILE) -fpie $(PVECLIB_POWER10_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR10.c
 @am__fastdepCC_TRUE@	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	source='vec_runtime_PWR10.c' object='$@' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(PVECCOMPILE) $(PVECLIB_POWER10_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR10.c
+@am__fastdepCC_FALSE@	$(PVECCOMPILE) -fpie $(PVECLIB_POWER10_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR10.c
 
-vec_dynrt_PWR9.lo: vec_runtime_PWR9.c $(pveclibinclude_HEADERS)
+vec_dynrt_PWR9.lo: vec_runtime_PWR9.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
 @am__fastdepCC_TRUE@	$(PVECCOMPILE) -fpic $(PVECLIB_POWER9_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR9.c
 @am__fastdepCC_TRUE@	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	source='vec_runtime_PWR9.c' object='$@' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(PVECCOMPILE) -fpic $(PVECLIB_POWER9_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR9.c
 
-vec_staticrt_PWR9.lo: vec_runtime_PWR9.c $(pveclibinclude_HEADERS)
-@am__fastdepCC_TRUE@	$(PVECCOMPILE) $(PVECLIB_POWER9_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR9.c
+vec_staticrt_PWR9.lo: vec_runtime_PWR9.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
+@am__fastdepCC_TRUE@	$(PVECCOMPILE) -fpie $(PVECLIB_POWER9_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR9.c
 @am__fastdepCC_TRUE@	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	source='vec_runtime_PWR9.c' object='$@' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(PVECCOMPILE) $(PVECLIB_POWER9_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR9.c
+@am__fastdepCC_FALSE@	$(PVECCOMPILE) -fpie $(PVECLIB_POWER9_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR9.c
 
-vec_dynrt_PWR8.lo: vec_runtime_PWR8.c $(pveclibinclude_HEADERS)
+vec_dynrt_PWR8.lo: vec_runtime_PWR8.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
 @am__fastdepCC_TRUE@	$(PVECCOMPILE) -fpic $(PVECLIB_POWER8_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR8.c
 @am__fastdepCC_TRUE@	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	source='vec_runtime_PWR8.c' object='$@' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(PVECCOMPILE) -fpic $(PVECLIB_POWER8_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR8.c
 
-vec_staticrt_PWR8.lo: vec_runtime_PWR8.c $(pveclibinclude_HEADERS)
-@am__fastdepCC_TRUE@	$(PVECCOMPILE) $(PVECLIB_POWER8_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR8.c
+vec_staticrt_PWR8.lo: vec_runtime_PWR8.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
+@am__fastdepCC_TRUE@	$(PVECCOMPILE) -fpie $(PVECLIB_POWER8_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR8.c
 @am__fastdepCC_TRUE@	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	source='vec_runtime_PWR8.c' object='$@' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(PVECCOMPILE) $(PVECLIB_POWER8_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR8.c
+@am__fastdepCC_FALSE@	$(PVECCOMPILE) -fpie $(PVECLIB_POWER8_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR8.c
 
-vec_dynrt_PWR7.lo: vec_runtime_PWR7.c $(pveclibinclude_HEADERS)
+vec_dynrt_PWR7.lo: vec_runtime_PWR7.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
 @am__fastdepCC_TRUE@	$(PVECCOMPILE) -fpic $(PVECLIB_POWER7_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR7.c
 @am__fastdepCC_TRUE@	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	source='vec_runtime_PWR7.c' object='$@' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(PVECCOMPILE) -fpic $(PVECLIB_POWER7_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR7.c
 
-vec_staticrt_PWR7.lo: vec_runtime_PWR7.c $(pveclibinclude_HEADERS)
-@am__fastdepCC_TRUE@	$(PVECCOMPILE) $(PVECLIB_POWER7_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR7.c
+vec_staticrt_PWR7.lo: vec_runtime_PWR7.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
+@am__fastdepCC_TRUE@	$(PVECCOMPILE) -fpie $(PVECLIB_POWER7_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR7.c
 @am__fastdepCC_TRUE@	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	source='vec_runtime_PWR7.c' object='$@' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(PVECCOMPILE) $(PVECLIB_POWER7_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR7.c
+@am__fastdepCC_FALSE@	$(PVECCOMPILE) -fpie $(PVECLIB_POWER7_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR7.c
 
 vec_dynrt_common.lo: vec_runtime_common.c $(pveclibinclude_HEADERS)
 @am__fastdepCC_TRUE@	$(PVECCOMPILE) -fpic $(PVECLIB_DEFAULT_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_common.c
@@ -1828,6 +1829,7 @@ distclean-local:
 .libs/libpvecstatic.a: libpvecstatic.la
 .libs/libpvecdummy.a: libpvecdummy.la
 .libs/libpvecdummyPWR9.a: libpvecdummyPWR9.la
+.libs/libpvecdummyPWR10.a: libpvecdummyPWR10.la
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.

--- a/src/vec_int512_runtime.c
+++ b/src/vec_int512_runtime.c
@@ -199,6 +199,11 @@ __VEC_PWR_IMP (vec_madd512x128a128) (__VEC_U_512 m1, vui128_t m2,
   return vec_madd512x128a128_inline (m1, m2, a1);
 }
 
+/* The core implementation of vec_madd512x128a512 with platform
+ * specific tuning.
+ * This static version can be in-lined (via __attribute__((flatten)))
+ * for the extern implementation for the library and as needed internal to
+ * the implementations of wider quadword integer multiples */
 static __VEC_U_640
 __VEC_PWR_IMP (vec_madd512x128a512_static) (__VEC_U_512 m1, vui128_t m2,
                                      __VEC_U_512 a2)
@@ -265,6 +270,10 @@ __VEC_PWR_IMP (vec_madd512x128a128a512) (__VEC_U_512 m1, vui128_t m2,
   return vec_madd512x128a128a512_inline (m1, m2, a1, a2);
 }
 
+/* The core implementation of vec_mul512x512 with platform specific tuning.
+ * This static version can be in-lined (via __attribute__((flatten)))
+ * for the extern implementation for the library and as needed internal to
+ * the implementations of wider quadword integer multiples */
 static __VEC_U_1024 __attribute__((flatten))
 __VEC_PWR_IMP (vec_mul512x512_static) (__VEC_U_512 m1, __VEC_U_512 m2)
 {
@@ -336,6 +345,11 @@ __VEC_PWR_IMP (vec_mul512x512) (__VEC_U_512 m1, __VEC_U_512 m2)
 #endif
 }
 
+/* The core implementation of vec_madd512x512a512 with platform
+ * specific tuning.
+ * This static version can be in-lined (via __attribute__((flatten)))
+ * for the extern implementation for the library and as needed internal to
+ * the implementations of wider quadword integer multiples */
 static __VEC_U_1024 __attribute__((flatten))
 __VEC_PWR_IMP (vec_madd512x512a512_static) (__VEC_U_512 m1, __VEC_U_512 m2,
                                      __VEC_U_512 a1)


### PR DESCRIPTION
GCC does not honor __attribute__((flatten)) for fpic or fpie.
In effect the inlining is disabled for extern functions and PIC style
function calls are generated. For example; vec_mul512x128 and vec_madd512x128a512 
are used in the implementation of vec_mul512x512. vec_mul512x512 and
vec_madd512x512a512 are used in the implementations of vec_mul1024x1024
and vec_mul2048x2048.

If these calls are not fully inlined, the result is;
- parameters are restricted to the ABI defined VRs,
- register allocation is more restricted,
  - all volatile VRs/VSRs are killed across calls,
  - volitile VSRs can not be effectively used as temporaries.
- non-volitile VSRs may be saved to the register save-area and are
exposed to cache based side channel attack.

This hurts performance and can expose intermediate results.
This is a problem for compiling vec_dynrt_PWR[7-10].o for DSO libpvec.
While the resulting library is functional, the implementations are
not as optimized as they should be.

The work around is to provide local **static** implementations for
internal (vec_int512_runtime.c) use. These will be inlined via
__attribute__((flatten)) independent for fpic/fpie. As a result the
**extern** implementations of vec_mul512x512, vec_mul1024x1024, and
vec_mul2048x2048 will be generated as straight line code that makes
full utilization of all 64 VSRs.

	* /src/Makefile.am (vec_dynrt_PWR10.lo):
	Add vec_int512_runtime.c as a dependency.
	(vec_staticrt_PWR10.lo): Add vec_int512_runtime.c as
	dependency. Add compile option -fpie.
	(vec_dynrt_PWR9.lo):
	Add vec_int512_runtime.c as a dependency.
	(vec_staticrt_PWR9.lo): Add vec_int512_runtime.c as
	dependency. Add compile option -fpie.
	(vec_dynrt_PWR8.lo):
	Add vec_int512_runtime.c as a dependency.
	(vec_staticrt_PWR8.lo): Add vec_int512_runtime.c as
	dependency. Add compile option -fpie.
	(vec_dynrt_PWR7.lo):
	Add vec_int512_runtime.c as a dependency.
	(vec_staticrt_PWR7.lo): Add vec_int512_runtime.c as
	dependency. Add compile option -fpie.
	(.libs/libpvecdummyPWR10.a): Add rule.
	(libpvec_la_LIBADD): Move vec_dynrt_PWR10.lo.
	(libpvecstatic_la_LIBADD): Move vec_staticrt_PWR10.lo
	(vec_dummy_LDADD): Add libvecdummyPWR10.la.

	* src/Makefile.in: Regenerated.

	* src/vec_int512_runtime.c
	(vec_mul512x128_static): New static implementation,
	Renamed from vec_mul512x128.
	(vec_mul512x128): Extern function using vec_mul512x128_static
	via __attribute__((flatten)).
	(vec_madd512x128a512_static): New static implementation,
	Renamed from vec_madd512x128a512.
	(vec_madd512x128a512): Extern function using
	vec_madd512x128a512_static via __attribute__((flatten)).
	(vec_mul512x512_static): New static implementation,
	Renamed from vec_madd512x128a512.
	Replace calls to vec_mul512x128 with vec_mul512x128_static.
	Replace calls to vec_madd512x128a512 with
	vec_madd512x128a512_static.
	(vec_mul512x512): Extern function using vec_mul512x512_static
	via __attribute__((flatten)).
	(vec_madd512x512a512_static): New static implementation,
	Renamed from vec_madd512x512a512.
	Replace calls to vec_madd512x128a512 with
	vec_madd512x128a512_static.
	(vec_madd512x512a512): Extern function using
	vec_madd512x512a512_static via __attribute__((flatten)).
	(vec_mul1024x1024): Replace calls to vec_mul512x512 with
	vec_mul512x512_static. Replace calls to vec_madd512x512a512
	with vec_madd512x512a512_static.
	(vec_mul2048x2048): Replace calls to vec_mul512x512 with
	vec_mul512x512_static. Replace calls to vec_madd512x512a512
	with vec_madd512x512a512_static.
	(vec_mul128_byMN): Fix comments. Replace calls to
	vec_mul512x512 with vec_mul512x512_static. Replace calls to
	vec_madd512x512a512 with vec_madd512x512a512_static.
	(vec_mul512_byMN): Fix comments. Replace calls to
	vec_mul512x512 with vec_mul512x512_static. Replace calls to
	vec_madd512x512a512 with vec_madd512x512a512_static.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>