### PR TITLE
Exploit P10 instructions in existing operations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ matrix:
 before_install:
   - sudo add-apt-repository universe
   - sudo apt-get update
-  - travis_wait 60 sudo apt-get -y install ${PKG_CC} doxygen graphviz
+  - travis_wait 45 sudo apt-get -y install ${PKG_CC} doxygen graphviz
 
 script:
   - mkdir $(pwd)/install

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ matrix:
 before_install:
   - sudo add-apt-repository universe
   - sudo apt-get update
-  - sudo travis_wait 30 apt-get -y install ${PKG_CC} doxygen graphviz
+  - travis_wait 60 sudo apt-get -y install ${PKG_CC} doxygen graphviz
 
 script:
   - mkdir $(pwd)/install

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ matrix:
 before_install:
   - sudo add-apt-repository universe
   - sudo apt-get update
-  - travis_wait 30 sudo apt-get -y install ${PKG_CC} doxygen graphviz
+  - sudo travis_wait 30 apt-get -y install ${PKG_CC} doxygen graphviz
 
 script:
   - mkdir $(pwd)/install

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ matrix:
 before_install:
   - sudo add-apt-repository universe
   - sudo apt-get update
-  - sudo apt-get -y install ${PKG_CC} doxygen graphviz
+  - travis_wait 30 sudo apt-get -y install ${PKG_CC} doxygen graphviz
 
 script:
   - mkdir $(pwd)/install

--- a/src/pveclib/vec_int128_ppc.h
+++ b/src/pveclib/vec_int128_ppc.h
@@ -4373,26 +4373,26 @@ vec_cmul100ecuq (vui128_t *cout, vui128_t a, vui128_t cin)
   return ((vui128_t) t);
 }
 
-/** \brief Vector Multiply-Sum and Write Carry-out Unsigned Doubleword.
+/** \brief Vector Multiply-Sum and Write Carryout Unsigned Doubleword.
  *
  *  Compute the even and odd 128-bit products of doubleword 64-bit
  *  element values from a, b.
  *  Then compute the carry-out of the low order 128-bits of the sum of
  *  (a<SUB>even</SUB> * b<SUB>even</SUB>) +
  *  (a<SUB>odd</SUB> * b<SUB>odd</SUB>) + c.
- *  Only the high order 128 bits of the Multiply-Sum are returned and
- *  the low order 128-bits of the sum is ignored/lost.
- *  ResultS are in the range 0-2.
+ *  Only the high order 2 bits of the 130-bit Multiply-Sum are
+ *  returned and the low order 128-bits of the sum is ignored/lost.
+ *  Results are in the range 0-2.
  *
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
  *  |power8   | 30-32 | 1/cycle  |
  *  |power9   | 5-7   | 2/cycle  |
  *
- *  @param a 128-bit __vector unsigned long int.
- *  @param b 128-bit __vector unsigned long int.
+ *  @param a 128-bit __vector unsigned long long.
+ *  @param b 128-bit __vector unsigned long long.
  *  @param c 128-bit __vector unsigned __int128.
- *  @return The carry-out of the __vector unsigned multiply Sum.
+ *  @return The Carryout of the __vector unsigned Multiply-Sum.
  */
 static inline vui128_t
 vec_msumcud (vui64_t a, vui64_t b, vui128_t c)
@@ -7048,7 +7048,7 @@ vec_vsldbi (vui128_t vra, vui128_t vrb, const unsigned int shb)
 	  const vui8_t zero = vec_splat_u8 (0);
 	  vui8_t lowbits, highbits;
 
-	  /* Left double shift by 1 octet 'zero' || vrb to isolate the
+	  /* Shift left double by 15 octet vra || 'zero' to isolate the
 	   * high order byte of vrb in to the low 8-bits. Then right
 	   * shift this (8-shb) bits. This provides (128-shb) bits of
 	   * leading '0's. */
@@ -7056,7 +7056,7 @@ vec_vsldbi (vui128_t vra, vui128_t vrb, const unsigned int shb)
 	  lowbits = vec_vsrb (lowbits, vshr);
 	  /* Left shift the quadword vra shifting in shb '0' bits.  */
 	  highbits = vec_sll ((vui8_t) vra, vshl);
-	  /* Combines left shifted bits from vra, vrb.  */
+	  /* Combine left shifted bits from vra, vrb.  */
 	  result = (vui128_t) vec_or (highbits, lowbits);
 	}
       else
@@ -7113,7 +7113,7 @@ vec_vsrdbi (vui128_t vra, vui128_t vrb, const unsigned int shb)
 	  const vui8_t zero = vec_splat_u8 (0);
 	  vui8_t lowbits, highbits;
 
-	  /* Left double shift by 15 octet vra || 'zero' to isolate the
+	  /* Shift left double by 15 octet vra || 'zero' to isolate the
 	   * low order byte of vra in to the high 8-bits. Then left
 	   * shift this (8-shb) bits. This provides (128-shb) bits of
 	   * trailing '0's. */
@@ -7121,7 +7121,7 @@ vec_vsrdbi (vui128_t vra, vui128_t vrb, const unsigned int shb)
 	  highbits = vec_vslb (highbits, vshl);
 	  /* right shift the quadword vrb shifting in shb '0' bits.  */
 	  lowbits = vec_srl ((vui8_t) vrb, vshr);
-	  /* Combines right shifted bits from vra, vrb.  */
+	  /* Combine right shifted bits from vra, vrb.  */
 	  result = (vui128_t) vec_or (highbits, lowbits);
 	}
       else
@@ -7133,7 +7133,7 @@ vec_vsrdbi (vui128_t vra, vui128_t vrb, const unsigned int shb)
 #if defined (__clang__) && (__clang_major__ < 6)
       // A workaround for a constant propagation bug in clang-5
       if (shb == 0)
-	result = vrb;
+        result = vrb;
       else
 #endif
       result = vec_sldqi (vra, vrb, (128 - (shb & 7)));

--- a/src/pveclib/vec_int128_ppc.h
+++ b/src/pveclib/vec_int128_ppc.h
@@ -7130,6 +7130,12 @@ vec_vsrdbi (vui128_t vra, vui128_t vrb, const unsigned int shb)
     }
   else
     {
+#if defined (__clang__) && (__clang_major__ < 6)
+      // A workaround for a constant propagation bug in clang-5
+      if (shb == 0)
+	result = vrb;
+      else
+#endif
       result = vec_sldqi (vra, vrb, (128 - (shb & 7)));
     }
 

--- a/src/pveclib/vec_int128_ppc.h
+++ b/src/pveclib/vec_int128_ppc.h
@@ -4381,7 +4381,7 @@ vec_cmul100ecuq (vui128_t *cout, vui128_t a, vui128_t cin)
  *  (a<SUB>even</SUB> * b<SUB>even</SUB>) +
  *  (a<SUB>odd</SUB> * b<SUB>odd</SUB>) + c.
  *  Only the high order 2 bits of the 130-bit Multiply-Sum are
- *  returned and the low order 128-bits of the sum is ignored/lost.
+ *  returned and the low order 128-bits of the sum are ignored/lost.
  *  Results are in the range 0-2.
  *
  *  |processor|Latency|Throughput|
@@ -7036,7 +7036,7 @@ vec_vsldbi (vui128_t vra, vui128_t vrb, const unsigned int shb)
 	  : "v" (vra), "v" (vrb), "K" (shb)
 	  : );
 #else
-      /* For Power7/8/9 the quadword shift left/right instructions
+      /* For Power7/8/9 the quadword bit shift left/right instructions
        * only handle 128-bits.
        * So shift vra and vrb separately then combine those into
        * a single 128-bit result.
@@ -7048,8 +7048,8 @@ vec_vsldbi (vui128_t vra, vui128_t vrb, const unsigned int shb)
 	  const vui8_t zero = vec_splat_u8 (0);
 	  vui8_t lowbits, highbits;
 
-	  /* Shift left double by 15 octet vra || 'zero' to isolate the
-	   * high order byte of vrb in to the low 8-bits. Then right
+	  /* Shift left double (vra || 'zero') by 15 octet  to isolate
+	   * the high order byte of vrb in to the low 8-bits. Then right
 	   * shift this (8-shb) bits. This provides (128-shb) bits of
 	   * leading '0's. */
 	  lowbits = vec_sld (zero, (vui8_t) vrb, 1);
@@ -7101,7 +7101,7 @@ vec_vsrdbi (vui128_t vra, vui128_t vrb, const unsigned int shb)
 	  : "v" (vra), "v" (vrb), "K" (shb)
 	  : );
 #else
-      /* For Power7/8/9 the quadword shift left/right instructions
+      /* For Power7/8/9 the quadword bit shift left/right instructions
        * only handle 128-bits.
        * So shift vra and vrb separately then combine those into
        * a single 128-bit result.
@@ -7113,8 +7113,8 @@ vec_vsrdbi (vui128_t vra, vui128_t vrb, const unsigned int shb)
 	  const vui8_t zero = vec_splat_u8 (0);
 	  vui8_t lowbits, highbits;
 
-	  /* Shift left double by 15 octet vra || 'zero' to isolate the
-	   * low order byte of vra in to the high 8-bits. Then left
+	  /* Shift left double (vra || 'zero') by 15 octet to isolate
+	   * the low order byte of vra in to the high 8-bits. Then left
 	   * shift this (8-shb) bits. This provides (128-shb) bits of
 	   * trailing '0's. */
 	  highbits = vec_sld ((vui8_t) vra, zero, 15);

--- a/src/testsuite/arith128_test_i128.c
+++ b/src/testsuite/arith128_test_i128.c
@@ -2296,6 +2296,69 @@ test_msumudm (void)
 #endif
   rc += check_vuint128x ("vec_mmsumudm:", (vui128_t)l, (vui128_t) e);
 
+  i = (vui64_t){-1UL, -1UL};
+  j = (vui64_t){-1UL, -1UL};
+  k = (vui128_t)CONST_VINT128_DW128(0x0UL, 0x0UL);
+  e = (vui128_t)CONST_VINT128_DW128(0xfffffffffffffffcUL, 2UL);
+
+  l = vec_msumudm(i, j, k);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("msumudm({-1, -1}, {-1, -1}, 0) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_msumudm:", (vui128_t)l, (vui128_t) e);
+
+  e = (vui128_t)CONST_VINT128_DW128(0UL, 1UL);
+
+  l = vec_msumcud(i, j, k);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("msumcud({-1, -1}, {-1, -1}, 0) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_msumcud:", (vui128_t)l, (vui128_t) e);
+
+  i = (vui64_t){-1UL, -1UL};
+  j = (vui64_t){0UL, -1UL};
+  k = (vui128_t)CONST_VINT128_DW128(-1UL, -1UL);
+  e = (vui128_t)CONST_VINT128_DW128(0xfffffffffffffffeUL, 0UL);
+
+  l = vec_msumudm(i, j, k);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("msumudm({-1, -1}, {0, -1}, -1) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_msumudm:", (vui128_t)l, (vui128_t) e);
+
+  e = (vui128_t)CONST_VINT128_DW128(0UL, 1UL);
+
+  l = vec_msumcud(i, j, k);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("msumcud({-1, -1}, {-1, -1}, 0) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_msumcud:", (vui128_t)l, (vui128_t) e);
+
+  i = (vui64_t){-1UL, -1UL};
+  j = (vui64_t){-1UL, -1UL};
+  k = (vui128_t)CONST_VINT128_DW128(-1UL, -1UL);
+  e = (vui128_t)CONST_VINT128_DW128(0xfffffffffffffffcUL, 1UL);
+
+  l = vec_msumudm(i, j, k);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("msumudm({-1, -1}, {-1, -1}, -1) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_msumudm:", (vui128_t)l, (vui128_t) e);
+
+  e = (vui128_t)CONST_VINT128_DW128(0UL, 2UL);
+
+  l = vec_msumcud(i, j, k);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("msumcud({-1, -1}, {-1, -1}, -1) ", (vui128_t)k);
+#endif
+  rc += check_vuint128x ("vec_msumcud:", (vui128_t)l, (vui128_t) e);
+
   return (rc);
 }
 
@@ -5553,6 +5616,126 @@ test_vsldqi (void)
   return (rc);
 }
 #undef __DEBUG_PRINT__
+
+int
+test_sldbi (void)
+{
+  vui32_t i, j, e;
+  vui128_t l;
+  int rc = 0;
+
+  printf ("\n%s Vector Shift Left Double Quadword by Bit Immediate\n", __FUNCTION__);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 0);
+  l = vec_vsldbi ((vui128_t) i, (vui128_t) j, 0);
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" w ", (vui128_t) i);
+  print_vint128x (" x ", (vui128_t) j);
+  print_vint128x (" = ", l);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  rc += check_vuint128x ("vec_vsldbi (  0):", (vui128_t) l, (vui128_t) e);
+
+  l = vec_vsldbi ((vui128_t) i, (vui128_t) j, 4);
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" w ", (vui128_t) i);
+  print_vint128x (" x ", (vui128_t) j);
+  print_vint128x (" = ", l);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xfffffff0);
+  rc += check_vuint128x ("vec_vsldbi (  4):", (vui128_t) l, (vui128_t) e);
+
+  l = vec_vsldbi ((vui128_t) i, (vui128_t) j, 7);
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" w ", (vui128_t) i);
+  print_vint128x (" x ", (vui128_t) j);
+  print_vint128x (" = ", l);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xffffff80);
+  rc += check_vuint128x ("vec_vsldbi (  7):", (vui128_t) l, (vui128_t) e);
+
+  j = (vui32_t) CONST_VINT32_W(0x55555555, 0, 0, 0);
+  l = vec_vsldbi ((vui128_t) i, (vui128_t) j, 7);
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" w ", (vui128_t) i);
+  print_vint128x (" x ", (vui128_t) j);
+  print_vint128x (" = ", l);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xffffffaa);
+  rc += check_vuint128x ("vec_vsldbi ( 7a):", (vui128_t) l, (vui128_t) e);
+
+  return (rc);
+}
+
+int
+test_srdbi (void)
+{
+  vui32_t i, j, e;
+  vui128_t l;
+  int rc = 0;
+
+  printf ("\n%s Vector Shift Right Double Quadword by Bit Immediate\n", __FUNCTION__);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   __UINT32_MAX__);
+  j = (vui32_t) CONST_VINT32_W(0, 0, 0, 0);
+  l = vec_vsrdbi ((vui128_t) i, (vui128_t) j, 0);
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" w ", (vui128_t) i);
+  print_vint128x (" x ", (vui128_t) j);
+  print_vint128x (" = ", l);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0, 0, 0, 0);
+  rc += check_vuint128x ("vec_vsrdbi (  0):", (vui128_t) l, (vui128_t) e);
+
+  l = vec_vsrdbi ((vui128_t) i, (vui128_t) j, 4);
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" w ", (vui128_t) i);
+  print_vint128x (" x ", (vui128_t) j);
+  print_vint128x (" = ", l);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0xf0000000, 0, 0, 0);
+  rc += check_vuint128x ("vec_vsrdbi (  4):", (vui128_t) l, (vui128_t) e);
+
+  l = vec_vsrdbi ((vui128_t) i, (vui128_t) j, 7);
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" w ", (vui128_t) i);
+  print_vint128x (" x ", (vui128_t) j);
+  print_vint128x (" = ", l);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0xfe000000, 0, 0, 0);
+  rc += check_vuint128x ("vec_vsrdbi (  7):", (vui128_t) l, (vui128_t) e);
+
+  i = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xaaaaaaaa);
+  l = vec_vsrdbi ((vui128_t) i, (vui128_t) j, 7);
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" w ", (vui128_t) i);
+  print_vint128x (" x ", (vui128_t) j);
+  print_vint128x (" = ", l);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(0x54000000, 0, 0, 0);
+  rc += check_vuint128x ("vec_vsrdbi ( 7a):", (vui128_t) l, (vui128_t) e);
+
+  return (rc);
+}
 
 //#define __DEBUG_PRINT__ 1
 int
@@ -10124,6 +10307,8 @@ test_vec_i128 (void)
   rc += test_vsraqi ();
   rc += test_vsldq ();
   rc += test_vsldqi ();
+  rc += test_sldbi ();
+  rc += test_srdbi ();
 
   rc += test_addq();
 

--- a/src/testsuite/vec_int128_dummy.c
+++ b/src/testsuite/vec_int128_dummy.c
@@ -26,6 +26,30 @@
 #include "arith128.h"
 #include <testsuite/arith128_print.h>
 
+vui128_t
+__test_msumcud (vui64_t a, vui64_t b, vui128_t c)
+{
+  return vec_msumcud ( a, b, c);
+}
+
+vui128_t
+__test_cmsumudm (vui128_t * carry, vui64_t a, vui64_t b, vui128_t c)
+{
+  *carry = vec_msumcud ( a, b, c);
+  return vec_msumudm ( a, b, c);
+}
+
+vui128_t
+test_vec_sldbi_7  (vui128_t a, vui128_t b)
+{
+  return (vec_vsldbi (a, b, 7));
+}
+
+vui128_t
+test_vec_srdbi_7  (vui128_t a, vui128_t b)
+{
+  return (vec_vsrdbi (a, b, 7));
+}
 
 unsigned __int128
 test_xfer_vui128t_2_uint128 (vui128_t vra)

--- a/src/testsuite/vec_int128_dummy.c
+++ b/src/testsuite/vec_int128_dummy.c
@@ -40,6 +40,18 @@ __test_cmsumudm (vui128_t * carry, vui64_t a, vui64_t b, vui128_t c)
 }
 
 vui128_t
+test_vec_sldbi_0  (vui128_t a, vui128_t b)
+{
+  return (vec_vsldbi (a, b, 0));
+}
+
+vui128_t
+test_vec_srdbi_0  (vui128_t a, vui128_t b)
+{
+  return (vec_vsrdbi (a, b, 0));
+}
+
+vui128_t
 test_vec_sldbi_7  (vui128_t a, vui128_t b)
 {
   return (vec_vsldbi (a, b, 7));

--- a/src/testsuite/vec_pwr10_dummy.c
+++ b/src/testsuite/vec_pwr10_dummy.c
@@ -39,6 +39,139 @@
 #include <pveclib/vec_bcd_ppc.h>
 
 vui128_t
+__test_msumcud_PWR10 (vui64_t a, vui64_t b, vui128_t c)
+{
+  return vec_msumcud ( a, b, c);
+}
+
+vui128_t
+__test_cmsumudm_PWR10 (vui128_t * carry, vui64_t a, vui64_t b, vui128_t c)
+{
+  *carry = vec_msumcud ( a, b, c);
+  return vec_msumudm ( a, b, c);
+}
+
+vui128_t
+test_vec_srdbi_PWR10  (vui128_t a, vui128_t b, const unsigned int  sh)
+{
+  return (vec_vsrdbi (a, b, sh));
+}
+
+vui128_t
+test_vec_srdbi_PWR10_0  (vui128_t a, vui128_t b)
+{
+  return (vec_vsrdbi (a, b, 0));
+}
+
+vui128_t
+test_vec_srdbi_PWR10_7  (vui128_t a, vui128_t b)
+{
+  return (vec_vsrdbi (a, b, 7));
+}
+
+vui128_t
+test_vec_sldbi_PWR10  (vui128_t a, vui128_t b, const unsigned int  sh)
+{
+  return (vec_vsldbi (a, b, sh));
+}
+
+vui128_t
+test_vec_sldbi_PWR10_0  (vui128_t a, vui128_t b)
+{
+  return (vec_vsldbi (a, b, 0));
+}
+
+vui128_t
+test_vec_sldbi_PWR10_7  (vui128_t a, vui128_t b)
+{
+  return (vec_vsldbi (a, b, 7));
+}
+
+vui128_t
+test_vec_sldbi_PWR10_8  (vui128_t a, vui128_t b)
+{
+  return (vec_vsldbi (a, b, 8));
+}
+
+vui128_t
+test_vec_rlqi_PWR10  (vui128_t a, const unsigned int  sh)
+{
+  return (vec_rlqi (a, sh));
+}
+
+vui128_t
+test_vec_rlqi_7_PWR10  (vui128_t a)
+{
+  return (vec_rlqi (a, 7));
+}
+
+vui128_t
+test_vec_rlqi_15_PWR10  (vui128_t a)
+{
+  return (vec_rlqi (a, 15));
+}
+
+vui128_t
+test_vec_slqi_PWR10  (vui128_t a, const unsigned int  sh)
+{
+  return (vec_slqi (a, sh));
+}
+
+vui128_t
+test_vec_slqi_7_PWR10  (vui128_t a)
+{
+  return (vec_slqi (a, 7));
+}
+
+vi128_t
+test_vec_sraqi_PWR10  (vi128_t a, const unsigned int  sh)
+{
+  return (vec_sraqi (a, sh));
+}
+
+vi128_t
+test_vec_sraqi_7_PWR10  (vi128_t a)
+{
+  return (vec_sraqi (a, 7));
+}
+
+vui128_t
+test_vec_srqi_PWR10  (vui128_t a, const unsigned int  sh)
+{
+  return (vec_srqi (a, sh));
+}
+
+vui128_t
+test_vec_srqi_7_PWR10  (vui128_t a)
+{
+  return (vec_srqi (a, 7));
+}
+
+vui128_t
+test_vec_rlq_PWR10  (vui128_t a, vui128_t sh)
+{
+  return (vec_rlq (a, sh));
+}
+
+vui128_t
+test_vec_slq_PWR10  (vui128_t a, vui128_t sh)
+{
+  return (vec_slq (a, sh));
+}
+
+vi128_t
+test_vec_sraq_PWR10  (vi128_t a, vui128_t sh)
+{
+  return (vec_sraq (a, sh));
+}
+
+vui128_t
+test_vec_srq_PWR10  (vui128_t a, vui128_t sh)
+{
+  return (vec_srq (a, sh));
+}
+
+vui128_t
 __test_muloud_PWR10 (vui64_t a, vui64_t b)
 {
   return vec_muloud (a, b);
@@ -120,5 +253,95 @@ vui128_t
 __test_muludq_PWR10 (vui128_t *mulh, vui128_t a, vui128_t b)
 {
   return vec_muludq (mulh, a, b);
+}
+
+vui128_t
+test_vec_rlqi_128_PWR10  (vui128_t a)
+{
+  return (vec_rlqi (a, 128));
+}
+
+vui128_t
+test_vec_slqi_128_PWR10  (vui128_t a)
+{
+  return (vec_slqi (a, 128));
+}
+
+vi128_t
+test_vec_sraqi_128_PWR10  (vi128_t a)
+{
+  return (vec_sraqi (a, 128));
+}
+
+vui128_t
+test_vec_srqi_128_PWR10  (vui128_t a)
+{
+  return (vec_srqi (a, 128));
+}
+
+vui128_t
+test_vec_rlqi_127_PWR10  (vui128_t a)
+{
+  return (vec_rlqi (a, 127));
+}
+
+vui128_t
+test_vec_slqi_127_PWR10  (vui128_t a)
+{
+  return (vec_slqi (a, 127));
+}
+
+vi128_t
+test_vec_sraqi_127_PWR10  (vi128_t a)
+{
+  return (vec_sraqi (a, 127));
+}
+
+vui128_t
+test_vec_srqi_127_PWR10  (vui128_t a)
+{
+  return (vec_srqi (a, 127));
+}
+
+vui128_t
+test_vec_slqi_15_PWR10  (vui128_t a)
+{
+  return (vec_slqi (a, 15));
+}
+
+vi128_t
+test_vec_sraqi_15_PWR10  (vi128_t a)
+{
+  return (vec_sraqi (a, 15));
+}
+
+vui128_t
+test_vec_srqi_15_PWR10  (vui128_t a)
+{
+  return (vec_srqi (a, 15));
+}
+
+vui128_t
+test_vec_rlqi_0_PWR10  (vui128_t a)
+{
+  return (vec_rlqi (a, 0));
+}
+
+vui128_t
+test_vec_slqi_0_PWR10  (vui128_t a)
+{
+  return (vec_slqi (a, 0));
+}
+
+vi128_t
+test_vec_sraqi_0_PWR10  (vi128_t a)
+{
+  return (vec_sraqi (a, 0));
+}
+
+vui128_t
+test_vec_srqi_0_PWR10  (vui128_t a)
+{
+  return (vec_srqi (a, 0));
 }
 #endif

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -39,6 +39,35 @@
 #include <pveclib/vec_f32_ppc.h>
 #include <pveclib/vec_bcd_ppc.h>
 
+vui128_t
+__test_msumcud_PWR9 (vui64_t a, vui64_t b, vui128_t c)
+{
+  return vec_msumcud ( a, b, c);
+}
+
+vui128_t
+__test_cmsumudm_PWR9 (vui128_t * carry, vui64_t a, vui64_t b, vui128_t c)
+{
+  *carry = vec_msumcud ( a, b, c);
+  return vec_msumudm ( a, b, c);
+}
+
+#ifndef PVECLIB_DISABLE_F128MATH
+#if defined (_ARCH_PWR9) &&(__GNUC__ > 7)
+__float128
+test_scalar_add128_PWR9 (__float128 vra, __float128 vrb)
+{
+  return __builtin_addf128_round_to_odd (vra, vrb);
+}
+
+__float128
+test_scalar_mul128_PWR9 (__float128 vra, __float128 vrb)
+{
+  return __builtin_mulf128_round_to_odd (vra, vrb);
+}
+#endif
+#endif
+
 vui64_t
 test_vslsudux_PWR9 (unsigned long long int *array, unsigned long offset)
 {


### PR DESCRIPTION
Use P10 instructions for P10 specific implementations of existing
operations.  Add new operations based on P10 instructions as needed.
Add associated compile and unit tests.

	* src/pveclib/vec_int128_ppc.h (vec_vsldbi): Forward ref.
	(vec_msumcud): New inline operation.
	(vec_mulhud [_ARCH_PWR10]): Add P10 specific implementation.
	(vec_muludm): Update Doxygen comments.
	[_ARCH_PWR10]: Add P10 specific implementation.
	(vec_rlq [_ARCH_PWR10]): Add P10 specific implementation.
	(vec_rlqi [_ARCH_PWR10]): Add P10 specific implementation.
	(vec_slq [_ARCH_PWR10]): Add P10 specific implementation.
	(vec_slqi [_ARCH_PWR10]): Add P10 specific implementation.
	(vec_sraq [_ARCH_PWR10]): Add P10 specific implementation.
	(vec_sraqi [_ARCH_PWR10]): Add P10 specific implementation.
	(vec_srq [_ARCH_PWR10]): Add P10 specific implementation.
	(vec_srqi [_ARCH_PWR10]): Add P10 specific implementation.
	(vec_vmuleud [_ARCH_PWR10]): Add P10 specific implementation.
	(vec_vmuloud [_ARCH_PWR10]): Add P10 specific implementation.
	(vec_vsldbi): New inline operation.
	(vec_vsrdbi): New inline operation.

	*src/testsuite/arith128_test_i128.c (test_msumudm): Add new
	msumudm/msumcud tests with carry/overflow.
	(test_sldbi, test_srdbi): New unit test.
	(test_vec_i128): Call test_sldbi and test_srdbi from driver.

	* src/testsuite/vec_int128_dummy.c (__test_msumcud,
	__test_cmsumudm, test_vec_sldbi_7, test_vec_srdbi_7):
	Add new inline compile tests.

	* src/testsuite/vec_pwr10_dummy.c (__test_msumcud_PWR10,
	__test_cmsumudm_PWR10): Add new inline compile tests.
	(test_vec_srdbi_PWR10, test_vec_srdbi_PWR10_0,
	test_vec_srdbi_PWR10_7, test_vec_sldbi_PWR10,
	test_vec_sldbi_PWR10_0, test_vec_sldbi_PWR10_7.
	test_vec_sldbi_PWR10_8): Add new inline compile tests.
	(test_vec_rlqi_PWR10, test_vec_rlqi_7_PWR10,
	test_vec_rlqi_15_PWR10): Add new inline compile tests.
	(test_vec_slqi_PWR10, test_vec_slqi_7_PWR10):
	Add new inline compile tests.
	(test_vec_sraqi_PWR10, test_vec_sraqi_7_PWR10,
	test_vec_srqi_PWR10, test_vec_srqi_7_PWR10):
	Add new inline compile tests.
	(test_vec_rlq_PWR10, test_vec_slq_PWR10,
	test_vec_sraq_PWR10, test_vec_srq_PWR10):
	Add new inline compile tests.
	(test_vec_rlqi_128_PWR10, test_vec_slqi_128_PWR10,
	test_vec_sraqi_128_PWR10, test_vec_srqi_128_PWR10):
	Add new inline compile tests.
	(test_vec_rlqi_127_PWR10, test_vec_slqi_127_PWR10,
	test_vec_sraqi_127_PWR10, test_vec_srqi_127_PWR10):
	Add new inline compile tests.
	(test_vec_slqi_15_PWR10, test_vec_sraqi_15_PWR10,
	test_vec_srqi_15_PWR10):
	Add new inline compile tests.
	(test_vec_rlqi_0_PWR10, test_vec_slqi_0_PWR10,
	test_vec_sraqi_0_PWR10, test_vec_srqi_0_PWR10):
	Add new inline compile tests.

	* src/testsuite/vec_pwr9_dummy.c (__test_msumcud_PWR9,
	__test_cmsumudm_PWR9): Add new inline compile tests.
	[!PVECLIB_DISABLE_F128MATH && _ARCH_PWR9 &&(__GNUC__ > 7)]
	(test_scalar_add128_PWR9, test_scalar_mul128_PWR9):
	Add new inline compile tests.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>