### PR TITLE
Exploit P10 instructions in existing and new quad shift operations.

### DIFF
--- a/src/pveclib/vec_int128_ppc.h
+++ b/src/pveclib/vec_int128_ppc.h
@@ -5836,16 +5836,16 @@ vec_sldqi (vui128_t vrw, vui128_t vrx, const unsigned int shb)
 	else
 	  {
 #if defined (_ARCH_PWR10)  && (__GNUC__ >= 10)
-	    // Special case of P10.
-	    vui8_t h, l;
-	    // Shift left double quad (256-bits) by Octet
+            // Special case of P10.
+            vui8_t h, l;
+            // Shift left double quad (256-bits) by Octet
             h = vec_sld ((vui8_t) vrw, (vui8_t) vrx, (shb / 8));
             l = vec_sld ((vui8_t) vrx, (vui8_t) vrx, (shb / 8));
             // Then Shift Left Double by Bit to complete the shift.
-  	    result = vec_vsldbi ((vui128_t) h, (vui128_t) l, (shb % 8));
+            result = vec_vsldbi ((vui128_t) h, (vui128_t) l, (shb % 8));
 #else       // Load shb as vector and use general vec_sldq case.
-	    const vui8_t vrb = vec_splats ((unsigned char) shb);
-	    result = vec_sldq (vrw, vrx, (vui128_t) vrb);
+            const vui8_t vrb = vec_splats ((unsigned char) shb);
+            result = vec_sldq (vrw, vrx, (vui128_t) vrb);
 #endif
 	  }
     }

--- a/src/testsuite/arith128_test_i128.c
+++ b/src/testsuite/arith128_test_i128.c
@@ -5558,6 +5558,39 @@ test_vsldqi (void)
 			   0xfffffffe);
   rc += check_vuint128 ("vec_sldq (  1):", (vui128_t) l, (vui128_t) e);
 
+  l = vec_sldqi ((vui128_t) i, (vui128_t) j, 7);
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" w ", (vui128_t) i);
+  print_vint128x (" x ", (vui128_t) j);
+  print_vint128x (" = ", l);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xffffff80);
+  rc += check_vuint128x ("vec_sldq (  7):", (vui128_t) l, (vui128_t) e);
+
+  l = vec_sldqi ((vui128_t) i, (vui128_t) j, 8);
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" w ", (vui128_t) i);
+  print_vint128x (" x ", (vui128_t) j);
+  print_vint128x (" = ", l);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xffffff00);
+  rc += check_vuint128x ("vec_sldq (  8):", (vui128_t) l, (vui128_t) e);
+
+  l = vec_sldqi ((vui128_t) i, (vui128_t) j, 15);
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" w ", (vui128_t) i);
+  print_vint128x (" x ", (vui128_t) j);
+  print_vint128x (" = ", l);
+#endif
+  e = (vui32_t)
+	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
+			   0xffff8000);
+  rc += check_vuint128x ("vec_sldq ( 15):", (vui128_t) l, (vui128_t) e);
+
   l = vec_sldqi ((vui128_t) i, (vui128_t) j, 127);
 #ifdef __DEBUG_PRINT__
   print_vint128x (" w ", (vui128_t) i);
@@ -5582,6 +5615,24 @@ test_vsldqi (void)
   e = (vui32_t) CONST_VINT32_W (0, 0, 0, 1);
   rc += check_vuint128 ("vec_sldqi (  1):", (vui128_t) l, (vui128_t) e);
 
+  l = vec_sldqi ((vui128_t) i, (vui128_t) j, 8);
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" w ", (vui128_t) i);
+  print_vint128x (" x ", (vui128_t) j);
+  print_vint128x (" = ", l);
+#endif
+  e = (vui32_t) CONST_VINT32_W (0, 0, 0, 0xff);
+  rc += check_vuint128 ("vec_sldqi (  8):", (vui128_t) l, (vui128_t) e);
+
+  l = vec_sldqi ((vui128_t) i, (vui128_t) j, 15);
+#ifdef __DEBUG_PRINT__
+  print_vint128x (" w ", (vui128_t) i);
+  print_vint128x (" x ", (vui128_t) j);
+  print_vint128x (" = ", l);
+#endif
+  e = (vui32_t) CONST_VINT32_W (0, 0, 0, 0x7fff);
+  rc += check_vuint128 ("vec_sldqi ( 15):", (vui128_t) l, (vui128_t) e);
+
   l = vec_sldqi ((vui128_t) i, (vui128_t) j, 127);
 #ifdef __DEBUG_PRINT__
   print_vint128x (" w ", (vui128_t) i);
@@ -5592,15 +5643,6 @@ test_vsldqi (void)
 	CONST_VINT32_W( 0x7fffffff, __UINT32_MAX__, __UINT32_MAX__,
 	    __UINT32_MAX__);
   rc += check_vuint128 ("vec_sldqi (127):", (vui128_t) l, (vui128_t) e);
-
-  l = vec_sldqi ((vui128_t) i, (vui128_t) j, 8);
-#ifdef __DEBUG_PRINT__
-  print_vint128x (" w ", (vui128_t) i);
-  print_vint128x (" x ", (vui128_t) j);
-  print_vint128x (" = ", l);
-#endif
-  e = (vui32_t) CONST_VINT32_W (0, 0, 0, 0xff);
-  rc += check_vuint128 ("vec_sldqi (  8):", (vui128_t) l, (vui128_t) e);
 
   l = vec_sldqi ((vui128_t) i, (vui128_t) j, 120);
 #ifdef __DEBUG_PRINT__

--- a/src/testsuite/vec_int128_dummy.c
+++ b/src/testsuite/vec_int128_dummy.c
@@ -891,6 +891,12 @@ test_vec_sldqi_0 (vui128_t a, vui128_t b)
 }
 
 vui128_t
+test_vec_sldqi_7 (vui128_t a, vui128_t b)
+{
+  return (vec_sldqi (a, b, 7));
+}
+
+vui128_t
 test_vec_sldqi_15 (vui128_t a, vui128_t b)
 {
   return (vec_sldqi (a, b, 15));

--- a/src/testsuite/vec_pwr10_dummy.c
+++ b/src/testsuite/vec_pwr10_dummy.c
@@ -39,6 +39,36 @@
 #include <pveclib/vec_bcd_ppc.h>
 
 vui128_t
+test_setb_sq_PWR10 (vi128_t vcy)
+{
+  return vec_setb_sq (vcy);
+}
+
+vui128_t
+test_vec_sldqi_7_PWR10 (vui128_t a, vui128_t b)
+{
+  return (vec_sldqi (a, b, 7));
+}
+
+vui128_t
+test_vec_sldqi_15_PWR10 (vui128_t a, vui128_t b)
+{
+  return (vec_sldqi (a, b, 15));
+}
+
+vui128_t
+test_vec_sldqi_16_PWR10 (vui128_t a, vui128_t b)
+{
+  return (vec_sldqi (a, b, 16));
+}
+
+vui128_t
+test_vec_sldqi_127_PWR10 (vui128_t a, vui128_t b)
+{
+  return (vec_sldqi (a, b, 127));
+}
+
+vui128_t
 __test_msumcud_PWR10 (vui64_t a, vui64_t b, vui128_t c)
 {
   return vec_msumcud ( a, b, c);


### PR DESCRIPTION
Use P10 instructions for P10 specific implementations of existing
shift left double quadword and new shift left/right by bits immediate
operations.

Found that the new vrlq, vslq, vsraw, vsrq instructions use vector
bits 57:63 for shift count where original Altivec Octet and Bit shifts
used bits 121:127.  So P10 needs shift count adjusted (xxsplatd)
for P10.  Also updated vec_sldqi to leverage vsldbi for P10.

Add associated compile and unit tests.

	* src/pveclib/vec_int128_ppc.h (vec_rlq [_ARCH_PWR10]):
	Use vec_splatd() to adjust shift count for P10.
	* (vec_sldqi): Add code to special case Octet, (shb < 8),
	and (shb > 7) cases for P10 using vsldbi.
	(vec_slq [_ARCH_PWR10]): Use vec_splatd() to adjust shift
	count for P10.
	(vec_sraq [_ARCH_PWR10]): Use vec_splatd() to adjust shift
	count for P10.
	(vec_srq [_ARCH_PWR10]): Use vec_splatd() to adjust shift
	count for P10.

	* src/testsuite/arith128_test_i128.c (test_vsldqi): Add tests
	for boundary conditions specific to new implementation and P10.

	* src/testsuite/vec_int128_dummy.c (test_vec_sldqi_7):
	New compiler test.

	* src/testsuite/vec_pwr10_dummy.c (test_setb_sq_PWR10,
	test_vec_sldqi_7_PWR10, test_vec_sldqi_15_PWR10,
	test_vec_sldqi_16_PWR10, test_vec_sldqi_127_PWR10):
	New compiler tests.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>