### PR TITLE
Exploit P10 expand mask instructions in existing and new operations.

### DIFF
--- a/src/pveclib/vec_char_ppc.h
+++ b/src/pveclib/vec_char_ppc.h
@@ -753,6 +753,41 @@ vec_popcntb (vui8_t vra)
 #define vec_popcntb __builtin_vec_vpopcntb
 #endif
 
+/*! \brief Vector Set Bool from Signed Byte.
+ *
+ *  For each byte, propagate the sign bit, to all 8-bits of that
+ *  byte. The result is vector bool char reflecting the sign
+ *  bit of each 8-bit byte.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 2-4   | 2/cycle  |
+ *  |power9   | 2-5   | 2/cycle  |
+ *
+ *  @param vra Vector signed char.
+ *  @return vector bool char reflecting the sign bit of each
+ *  byte.
+ */
+
+static inline vb8_t
+vec_setb_sb (vi8_t vra)
+{
+  vb8_t result;
+
+#if defined (_ARCH_PWR10)  && (__GNUC__ >= 10)
+  __asm__(
+      "vexpandbm %0,%1;\n"
+      : "=v" (result)
+      : "v" (vra)
+      : );
+#else
+  const vui8_t rshift =  vec_splat_u8( 7 );
+  // Vector Shift Right Algebraic Bytes 7-bits.
+  result = (vb8_t) vec_sra (vra, rshift);
+#endif
+  return result;
+}
+
 /** \brief Vector Shift left Byte Immediate.
  *
  *  Shift left each byte element [0-15], 0-7 bits,

--- a/src/pveclib/vec_char_ppc.h
+++ b/src/pveclib/vec_char_ppc.h
@@ -755,7 +755,7 @@ vec_popcntb (vui8_t vra)
 
 /*! \brief Vector Set Bool from Signed Byte.
  *
- *  For each byte, propagate the sign bit, to all 8-bits of that
+ *  For each byte, propagate the sign bit to all 8-bits of that
  *  byte. The result is vector bool char reflecting the sign
  *  bit of each 8-bit byte.
  *
@@ -776,7 +776,7 @@ vec_setb_sb (vi8_t vra)
 
 #if defined (_ARCH_PWR10)  && (__GNUC__ >= 10)
   __asm__(
-      "vexpandbm %0,%1;\n"
+      "vexpandbm %0,%1"
       : "=v" (result)
       : "v" (vra)
       : );

--- a/src/pveclib/vec_f128_ppc.h
+++ b/src/pveclib/vec_f128_ppc.h
@@ -1143,12 +1143,11 @@ vec_setb_qp (__binary128 f128)
 #if defined (_ARCH_PWR10)  && (__GNUC__ >= 10)
   vui128_t vra = vec_xfer_bin128_2_vui128t (f128);
   __asm__(
-      "vexpandqm %0,%1;\n"
+      "vexpandqm %0,%1"
       : "=v" (result)
       : "v" (vra)
       : );
-#else
-#if defined (_ARCH_PWR9) && defined (scalar_test_neg) && (__GNUC__ > 7)
+#elif defined (_ARCH_PWR9) && defined (scalar_test_neg) && (__GNUC__ > 7)
   result = (vb128_t) {(__int128) 0};
 
   if (scalar_test_neg (f128))
@@ -1161,7 +1160,6 @@ vec_setb_qp (__binary128 f128)
   vui8_t splat = vec_splat (t128, VEC_BYTE_H);
 
   result = (vb128_t) vec_sra (splat, shift);
-#endif
 #endif
   return result;
 }

--- a/src/pveclib/vec_f32_ppc.h
+++ b/src/pveclib/vec_f32_ppc.h
@@ -1099,7 +1099,7 @@ vec_iszerof32 (vf32_t vf32)
  *  The resulting mask can be used in masking and select operations.
  *
  *  \note This operation will set the sign mask regardless of data
- *  class. while the Vector Test Data Class will not distinguish
+ *  class, while the Vector Test Data Class will not distinguish
  *  between +/- NaN.
  *
  *  |processor|Latency|Throughput|

--- a/src/pveclib/vec_f32_ppc.h
+++ b/src/pveclib/vec_f32_ppc.h
@@ -1090,6 +1090,34 @@ vec_iszerof32 (vf32_t vf32)
   return (result);
 }
 
+/*! \brief Vector Set Bool from Sign, Single Precision.
+ *
+ *  For each float, propagate the sign bit to all 32-bits of that
+ *  word. The result is vector bool int reflecting the sign
+ *  bit of each 32-bit float.
+ *
+ *  The resulting mask can be used in masking and select operations.
+ *
+ *  \note This operation will set the sign mask regardless of data
+ *  class. while the Vector Test Data Class will not distinguish
+ *  between +/- NaN.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 2-9   | 2/cycle  |
+ *  |power9   | 2-8   | 2/cycle  |
+ *
+ *  @param vra Vector float.
+ *  @return vector bool int reflecting the sign bits of each
+ *  float value.
+ */
+
+static inline vb32_t
+vec_setb_sp (vf32_t vra)
+{
+  return vec_setb_sw ((vi32_t) vra);
+}
+
 /** \brief Vector Gather-Load 4 Words from scalar Offsets.
  *
  *  For each scalar offset[0,1,2,3], load the word

--- a/src/pveclib/vec_f64_ppc.h
+++ b/src/pveclib/vec_f64_ppc.h
@@ -1114,6 +1114,35 @@ vec_pack_longdouble (vf64_t lval)
 #endif
 }
 
+/*! \brief Vector Set Bool from Sign, Double Precision.
+ *
+ *  For each double, propagate the sign bit, to all 64-bits of that
+ *  doubleword. The result is vector bool long long reflecting the sign
+ *  bit of each 64-bit double.
+ *
+ *  The resulting mask can be used in vector masking and select
+ *  operations.
+ *
+ *  \note This operation will set the sign mask regardless of data
+ *  class, while the Vector Test Data Class instructions will not
+ *  distinguish between +/- NaN.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 2-4   | 2/cycle  |
+ *  |power9   | 2-5   | 2/cycle  |
+ *
+ *  @param vra Vector double.
+ *  @return vector bool long long reflecting the sign bits of each
+ *  double value.
+ */
+
+static inline vb64_t
+vec_setb_dp (vf64_t vra)
+{
+  return vec_setb_sd ((vi64_t) vra);
+}
+
 /** \brief Copy the pair of doubles from a IBM long double to a vector
  * double.
  *

--- a/src/pveclib/vec_f64_ppc.h
+++ b/src/pveclib/vec_f64_ppc.h
@@ -1116,7 +1116,7 @@ vec_pack_longdouble (vf64_t lval)
 
 /*! \brief Vector Set Bool from Sign, Double Precision.
  *
- *  For each double, propagate the sign bit, to all 64-bits of that
+ *  For each double, propagate the sign bit to all 64-bits of that
  *  doubleword. The result is vector bool long long reflecting the sign
  *  bit of each 64-bit double.
  *

--- a/src/pveclib/vec_int128_ppc.h
+++ b/src/pveclib/vec_int128_ppc.h
@@ -5759,7 +5759,7 @@ vec_setb_sq (vi128_t vra)
 
 #if defined (_ARCH_PWR10)  && (__GNUC__ >= 10)
   __asm__(
-      "vexpandqm %0,%1;\n"
+      "vexpandqm %0,%1"
       : "=v" (result)
       : "v" (vra)
       : );

--- a/src/pveclib/vec_int128_ppc.h
+++ b/src/pveclib/vec_int128_ppc.h
@@ -5755,10 +5755,21 @@ vec_setb_ncq (vui128_t vcy)
 static inline vb128_t
 vec_setb_sq (vi128_t vra)
 {
+  vui128_t result;
+
+#if defined (_ARCH_PWR10)  && (__GNUC__ >= 10)
+  __asm__(
+      "vexpandqm %0,%1;\n"
+      : "=v" (result)
+      : "v" (vra)
+      : );
+#else
   const vui8_t shift = vec_splat_u8 (7);
   vui8_t splat = vec_splat ((vui8_t) vra, VEC_BYTE_H);
 
-  return (vb128_t) vec_sra (splat, shift);
+  result = (vb128_t) vec_sra (splat, shift);
+#endif
+  return result;
 }
 
 /** \brief Vector Shift Left Double Quadword.

--- a/src/pveclib/vec_int16_ppc.h
+++ b/src/pveclib/vec_int16_ppc.h
@@ -993,7 +993,7 @@ vec_revbh (vui16_t vra)
 
 /*! \brief Vector Set Bool from Signed Halfword.
  *
- *  For each halfword, propagate the sign bit, to all 16-bits of that
+ *  For each halfword, propagate the sign bit to all 16-bits of that
  *  halfword. The result is vector bool short reflecting the sign
  *  bit of each 16-bit halfword.
  *
@@ -1014,7 +1014,7 @@ vec_setb_sh (vi16_t vra)
 
 #if defined (_ARCH_PWR10)  && (__GNUC__ >= 10)
   __asm__(
-      "vexpandhm %0,%1;\n"
+      "vexpandhm %0,%1"
       : "=v" (result)
       : "v" (vra)
       : );

--- a/src/pveclib/vec_int16_ppc.h
+++ b/src/pveclib/vec_int16_ppc.h
@@ -991,6 +991,41 @@ vec_revbh (vui16_t vra)
   return (result);
 }
 
+/*! \brief Vector Set Bool from Signed Halfword.
+ *
+ *  For each halfword, propagate the sign bit, to all 16-bits of that
+ *  halfword. The result is vector bool short reflecting the sign
+ *  bit of each 16-bit halfword.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 2-4   | 2/cycle  |
+ *  |power9   | 2-5   | 2/cycle  |
+ *
+ *  @param vra Vector signed short.
+ *  @return vector bool short reflecting the sign bit of each
+ *  halfword.
+ */
+
+static inline vb16_t
+vec_setb_sh (vi16_t vra)
+{
+  vb16_t result;
+
+#if defined (_ARCH_PWR10)  && (__GNUC__ >= 10)
+  __asm__(
+      "vexpandhm %0,%1;\n"
+      : "=v" (result)
+      : "v" (vra)
+      : );
+#else
+  const vui16_t rshift =  vec_splat_u16( 15 );
+  // Vector Shift Right Algebraic Halfwords 15-bits.
+  result = (vb16_t) vec_sra (vra, rshift);
+#endif
+  return result;
+}
+
 /** \brief Vector Shift left Halfword Immediate.
  *
  *  Shift left each halfword element [0-7], 0-15 bits,

--- a/src/pveclib/vec_int32_ppc.h
+++ b/src/pveclib/vec_int32_ppc.h
@@ -1253,6 +1253,41 @@ vec_revbw (vui32_t vra)
   return (result);
 }
 
+/*! \brief Vector Set Bool from Signed Word.
+ *
+ *  For each word, propagate the sign bit, to all 32-bits of that
+ *  word. The result is vector bool int reflecting the sign
+ *  bit of each 32-bit word.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 2-4   | 2/cycle  |
+ *  |power9   | 2-5   | 2/cycle  |
+ *
+ *  @param vra Vector signed int.
+ *  @return vector bool int reflecting the sign bits of each
+ *  word.
+ */
+
+static inline vb32_t
+vec_setb_sw (vi32_t vra)
+{
+  vb32_t result;
+
+#if defined (_ARCH_PWR10)  && (__GNUC__ >= 10)
+  __asm__(
+      "vexpandwm %0,%1;\n"
+      : "=v" (result)
+      : "v" (vra)
+      : );
+#else
+  // Compare signed word less than zero
+  const vi32_t zero = {0, 0, 0, 0};
+  result = vec_cmplt (vra, zero);
+#endif
+  return result;
+}
+
 /** \brief Vector Shift left Word Immediate.
  *
  *  Shift left each word element [0-3], 0-31 bits,

--- a/src/pveclib/vec_int32_ppc.h
+++ b/src/pveclib/vec_int32_ppc.h
@@ -1255,7 +1255,7 @@ vec_revbw (vui32_t vra)
 
 /*! \brief Vector Set Bool from Signed Word.
  *
- *  For each word, propagate the sign bit, to all 32-bits of that
+ *  For each word, propagate the sign bit to all 32-bits of that
  *  word. The result is vector bool int reflecting the sign
  *  bit of each 32-bit word.
  *
@@ -1276,7 +1276,7 @@ vec_setb_sw (vi32_t vra)
 
 #if defined (_ARCH_PWR10)  && (__GNUC__ >= 10)
   __asm__(
-      "vexpandwm %0,%1;\n"
+      "vexpandwm %0,%1"
       : "=v" (result)
       : "v" (vra)
       : );

--- a/src/pveclib/vec_int64_ppc.h
+++ b/src/pveclib/vec_int64_ppc.h
@@ -2808,7 +2808,7 @@ static inline vi64_t vec_vsrad (vi64_t vra, vui64_t vrb);
 
 /*! \brief Vector Set Bool from Signed Doubleword.
  *
- *  For each doubleword, propagate the sign bit, to all 64-bits of that
+ *  For each doubleword, propagate the sign bit to all 64-bits of that
  *  doubleword. The result is vector bool long long reflecting the sign
  *  bit of each 64-bit doubleword.
  *
@@ -2833,8 +2833,7 @@ vec_setb_sd (vi64_t vra)
       : "=v" (result)
       : "v" (vra)
       : );
-#else
-#ifdef _ARCH_PWR8
+#elif defined (_ARCH_PWR8)
   // Compare signed doubleword less than zero
   const vi64_t zero = {0, 0};
   result = vec_cmpltsd (vra, zero);
@@ -2845,7 +2844,6 @@ vec_setb_sd (vi64_t vra)
   vui8_t splat = vec_perm ((vui8_t) vra, (vui8_t) vra, sperm);
   // Vector Shift Right Algebraic Bytes 7-bits.
   result = (vb64_t) vec_sra (splat, rshift);
-#endif
 #endif
   return result;
 }

--- a/src/testsuite/arith128_test_char.c
+++ b/src/testsuite/arith128_test_char.c
@@ -633,6 +633,45 @@ test_mulubm (void)
   return (rc);
 }
 
+//#define __DEBUG_PRINT__ 1
+int
+test_setbb (void)
+{
+  vi8_t i;
+  vui8_t e, k;
+  int rc = 0;
+
+  printf ("\ntest_setbb Vector Set Bool Byte\n");
+
+  i = (vi8_t)CONST_VINT8_B(0xff, 0x7f, 0x3f, 0x1f,
+			   0x0f, 0x07, 0x03, 0x01,
+			   0x01, 0x02, 0x04, 0x08,
+			   0x10, 0x20, 0x40, 0x80);
+  k = (vui8_t) vec_setb_sb ( i );
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_setb ", (vui128_t) i);
+  print_vint128x ("        =", (vui128_t) k);
+#endif
+  e = (vui8_t)CONST_VINT8_B( -1, 0, 0, 0, 0, 0, 0, 0,
+			      0, 0, 0, 0, 0, 0, 0,-1);
+  rc += check_vuint128x ("vec_setb_sh:", (vui128_t) k, (vui128_t) e);
+
+  i = (vi8_t)CONST_VINT8_B(-1, -1, -1, -1, -1, -1, -1, -1,
+			   -1, -1, -1, -1, -1, -1, -1, -1);
+  k = (vui8_t) vec_setb_sb ( i );
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_setb ", (vui128_t) i);
+  print_vint128x ("        =", (vui128_t) k);
+#endif
+  e = (vui8_t)CONST_VINT8_B(-1, -1, -1, -1, -1, -1, -1, -1,
+			    -1, -1, -1, -1, -1, -1, -1, -1);
+  rc += check_vuint128x ("vec_setb_sb:", (vui128_t) k, (vui128_t) e);
+
+  return (rc);
+}
+
 int
 test_vec_char (void)
 {
@@ -649,6 +688,7 @@ test_vec_char (void)
   rc += test_mulhub ();
   rc += test_mulhsb ();
   rc += test_mulubm ();
+  rc += test_setbb ();
 #endif
   return (rc);
 }

--- a/src/testsuite/arith128_test_f32.c
+++ b/src/testsuite/arith128_test_f32.c
@@ -2406,6 +2406,87 @@ test_time_f32 (void)
 }
 
 int
+test_setb_sp (void)
+{
+  const vf32_t f32_zero_one = (vf32_t)
+      CONST_VINT32_W(0.0, -0.0, 1.0, -1.0);
+
+  const vf32_t f32_max_min = (vf32_t)
+      CONST_VINT128_W(0x7f000000, 0xff000000,
+                      0x00400000, 0x80400000);
+
+  const vf32_t f32_sub_inf = (vf32_t)
+      CONST_VINT128_W(0x007fffff, 0x807fffff,
+		       __FLOAT_INF, __FLOAT_NINF);
+
+  const vf32_t f32_nan_snan = (vf32_t)
+      CONST_VINT128_W(__FLOAT_NAN, __FLOAT_NNAN,
+		       __FLOAT_SNAN, __FLOAT_NSNAN);
+
+  const vb32_t f32_FTFT = (vb32_t)
+      CONST_VINT128_W(0, -1, 0, -1);
+
+  vf32_t x;
+  vb32_t test, expt;
+  long tests_count = 0;
+  int rc = 0;
+
+  printf ("\ntest_setb_sp f32 -> vector bool , ...\n");
+
+#if 1
+  tests_count++;
+  x = (vf32_t) f32_zero_one;
+#ifdef __DEBUG_PRINT__
+  print_v4f32 (" x=  ", x);
+  print_v4b32x(" t=  ", test);
+#endif
+  test = vec_setb_sp (x);
+  expt = f32_FTFT;
+  rc += check_v4b32x ("check vec_setb_sp 1", test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (vf32_t) f32_max_min;
+#ifdef __DEBUG_PRINT__
+  print_v4f32 (" x=  ", x);
+  print_v4b32x(" t=  ", test);
+#endif
+  test = vec_setb_sp (x);
+  expt = f32_FTFT;
+  rc += check_v4b32x ("check vec_setb_sp 2", test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (vf32_t) f32_sub_inf;
+  test = vec_setb_sp (x);
+#ifdef __DEBUG_PRINT__
+  print_v4f32 (" x=  ", x);
+  print_v4b32x(" t=  ", test);
+#endif
+  expt = f32_FTFT;
+  rc += check_v4b32x ("check vec_setb_sp 3", test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (vf32_t) f32_nan_snan;
+  test = vec_setb_sp (x);
+#ifdef __DEBUG_PRINT__
+  print_v4f32 (" x=  ", x);
+  print_v4b32x(" t=  ", test);
+#endif
+  expt = f32_FTFT;
+  rc += check_v4b32x ("check vec_setb_sp 4", test, expt);
+#endif
+
+  /* accumulate the number of values tested, in case we are doing
+   * detail timing and want to compute function averages.  */
+  tcount += tests_count;
+  printf ("\ntest_setb_sp, tests=%ld fails=%d\n", tests_count, rc);
+
+  return (rc);
+}
+
+int
 test_vec_f32 (void)
 {
   int rc = 0;
@@ -2422,6 +2503,7 @@ test_vec_f32 (void)
   rc += test_float_issubnormal ();
   rc += test_float_iszero ();
   rc += test_float_isfinite ();
+  rc += test_setb_sp ();
   rc += test_lvgfsx ();
   rc += test_stvgfsx ();
   rc += test_f32_indentity_array ();

--- a/src/testsuite/arith128_test_f64.c
+++ b/src/testsuite/arith128_test_f64.c
@@ -2457,6 +2457,140 @@ test_double_iszero (void)
 }
 //#undef __DEBUG_PRINT__
 
+int
+test_setb_dp (void)
+{
+  const vf64_t f64_zero = (vf64_t)
+      CONST_VINT128_DW(0x0000000000000000, 0x8000000000000000);
+
+  const vf64_t f64_one = (vf64_t)
+      CONST_VINT128_DW(0x3ff0000000000000, 0xbff0000000000000);
+
+  const vf64_t f64_max = (vf64_t)
+      CONST_VINT128_DW(0x7fefffffffffffff, 0xffefffffffffffff);
+
+  const vf64_t f64_min = (vf64_t)
+      CONST_VINT128_DW(0x0010000000000000, 0x8010000000000000);
+
+  const vf64_t f64_sub = (vf64_t)
+      CONST_VINT128_DW(0x000ffffffffffff, 0x800fffffffffffff);
+
+  const vf64_t f64_inf = (vf64_t)
+      CONST_VINT128_DW(__DOUBLE_INF, __DOUBLE_NINF);
+
+  const vf64_t f64_nan = (vf64_t)
+      CONST_VINT128_DW(__DOUBLE_NAN, __DOUBLE_NNAN);
+
+  const vf64_t f64_snan = (vf64_t)
+      CONST_VINT128_DW(__DOUBLE_SNAN, __DOUBLE_NSNAN);
+
+  const vb64_t f64_FT = (vb64_t)
+      CONST_VINT128_DW(0x0000000000000000, 0xffffffffffffffff);
+
+  vf64_t x;
+  vb64_t test, expt;
+  long tests_count = 0;
+  int rc = 0;
+
+  printf ("\ntest_setb_dp f64 -> vector bool , ...\n");
+
+#if 1
+  tests_count++;
+  x = (vf64_t) f64_zero;
+#ifdef __DEBUG_PRINT__
+  print_v2f64 (" x=  ", x);
+  print_v2b64x(" t=  ", test);
+#endif
+  test = vec_setb_dp (x);
+  expt = f64_FT;
+  rc += check_v2b64x ("check vec_setb_dp 1", test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (vf64_t) f64_one;
+#ifdef __DEBUG_PRINT__
+  print_v2f64 (" x=  ", x);
+  print_v2b64x(" t=  ", test);
+#endif
+  test = vec_setb_dp (x);
+  expt = f64_FT;
+  rc += check_v2b64x ("check vec_setb_dp 2", test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (vf64_t) f64_max;
+#ifdef __DEBUG_PRINT__
+  print_v2f64 (" x=  ", x);
+  print_v2b64x(" t=  ", test);
+#endif
+  test = vec_setb_dp (x);
+  expt = f64_FT;
+  rc += check_v2b64x ("check vec_setb_dp 3", test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (vf64_t) f64_min;
+#ifdef __DEBUG_PRINT__
+  print_v2f64 (" x=  ", x);
+  print_v2b64x(" t=  ", test);
+#endif
+  test = vec_setb_dp (x);
+  expt = f64_FT;
+  rc += check_v2b64x ("check vec_setb_dp 4", test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (vf64_t) f64_sub;
+#ifdef __DEBUG_PRINT__
+  print_v2f64 (" x=  ", x);
+  print_v2b64x(" t=  ", test);
+#endif
+  test = vec_setb_dp (x);
+  expt = f64_FT;
+  rc += check_v2b64x ("check vec_setb_dp 5", test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (vf64_t) f64_inf;
+#ifdef __DEBUG_PRINT__
+  print_v2f64 (" x=  ", x);
+  print_v2b64x(" t=  ", test);
+#endif
+  test = vec_setb_dp (x);
+  expt = f64_FT;
+  rc += check_v2b64x ("check vec_setb_dp 6", test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (vf64_t) f64_nan;
+#ifdef __DEBUG_PRINT__
+  print_v2f64 (" x=  ", x);
+  print_v2b64x(" t=  ", test);
+#endif
+  test = vec_setb_dp (x);
+  expt = f64_FT;
+  rc += check_v2b64x ("check vec_setb_dp 7", test, expt);
+#endif
+#if 1
+  tests_count++;
+  x = (vf64_t) f64_snan;
+#ifdef __DEBUG_PRINT__
+  print_v2f64 (" x=  ", x);
+  print_v2b64x(" t=  ", test);
+#endif
+  test = vec_setb_dp (x);
+  expt = f64_FT;
+  rc += check_v2b64x ("check vec_setb_dp 8", test, expt);
+#endif
+
+  /* accumulate the number of values tested, in case we are doing
+   * detail timing and want to compute function averages.  */
+  tcount += tests_count;
+  printf ("\ntest_setb_dp, tests=%ld fails=%d\n", tests_count, rc);
+
+  return (rc);
+}
+
 static double test_f64[] =
     {
 	0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0,
@@ -3018,6 +3152,8 @@ test_vec_f64 (void)
   rc += test_double_issubnormal ();
   rc += test_double_iszero ();
   rc += test_double_isfinite ();
+  rc += test_setb_dp ();
+
   rc += test_lvgdfdx ();
   rc += test_stvgdfdx ();
   rc += test_indentity_array ();

--- a/src/testsuite/arith128_test_i16.c
+++ b/src/testsuite/arith128_test_i16.c
@@ -573,6 +573,51 @@ test_vmadduh (void)
   return (rc);
 }
 
+//#define __DEBUG_PRINT__ 1
+int
+test_setbh (void)
+{
+  vi16_t i;
+  vui16_t e, k;
+  int rc = 0;
+
+  printf ("\ntest_setbh Vector Set Bool Halfword\n");
+
+  i = (vi16_t)CONST_VINT16_H(0xffff, 0x7fff, 0x3fff, 0x1fff,
+			     0x0fff, 0x07ff, 0x03ff, 0x01ff);
+  k = (vui16_t) vec_setb_sh ( i );
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_setb ", (vui128_t) i);
+  print_vint128x ("        =", (vui128_t) k);
+#endif
+  e = (vui16_t)CONST_VINT16_H( -1, 0, 0, 0, 0, 0, 0, 0);
+  rc += check_vuint128x ("vec_setb_sh:", (vui128_t) k, (vui128_t) e);
+
+  i = (vi16_t)CONST_VINT16_H(0x0100, 0x0200, 0x0400, 0x0800,
+			     0x1000, 0x2000, 0x4000, 0x8000);
+  k = (vui16_t) vec_setb_sh ( i );
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_setb ", (vui128_t) i);
+  print_vint128x ("        =", (vui128_t) k);
+#endif
+  e = (vui16_t)CONST_VINT16_H(0, 0, 0, 0, 0, 0, 0, -1);
+  rc += check_vuint128x ("vec_setb_sh:", (vui128_t) k, (vui128_t) e);
+
+  i = (vi16_t)CONST_VINT16_H(-1, -1, -1, -1, -1, -1, -1, -1);
+  k = (vui16_t) vec_setb_sh ( i );
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_setb ", (vui128_t) i);
+  print_vint128x ("        =", (vui128_t) k);
+#endif
+  e = (vui16_t)CONST_VINT16_H(-1, -1, -1, -1, -1, -1, -1, -1);
+  rc += check_vuint128x ("vec_setb_sh:", (vui128_t) k, (vui128_t) e);
+
+  return (rc);
+}
+
 int
 test_vec_i16 (void)
 {
@@ -590,6 +635,7 @@ test_vec_i16 (void)
   rc += test_mulhsh();
   rc += test_muluhm();
   rc += test_vmadduh();
+  rc += test_setbh();
 #endif
   return (rc);
 }

--- a/src/testsuite/arith128_test_i32.c
+++ b/src/testsuite/arith128_test_i32.c
@@ -1693,6 +1693,49 @@ test_unpkxw (void)
   return (rc);
 }
 
+//#define __DEBUG_PRINT__ 1
+int
+test_setbw (void)
+{
+  vi32_t i;
+  vui32_t e, k;
+  int rc = 0;
+
+  printf ("\ntest_setbw Vector Set Bool Word\n");
+
+  i = (vi32_t)CONST_VINT32_W(0x7fffffff, 0xff, 0xff000000, 0);
+  k = (vui32_t) vec_setb_sw ( i );
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_setb ", (vui128_t) i);
+  print_vint128x ("        =", (vui128_t) k);
+#endif
+  e = (vui32_t)CONST_VINT32_W( 0, 0, -1, 0);
+  rc += check_vuint128x ("vec_setb_sw:", (vui128_t) k, (vui128_t) e);
+
+  i = (vi32_t)CONST_VINT32_W(0x80000000, 0x7fffffff, 0, 1);
+  k = (vui32_t) vec_setb_sw ( i );
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_setb ", (vui128_t) i);
+  print_vint128x ("        =", (vui128_t) k);
+#endif
+  e = (vui32_t)CONST_VINT32_W(-1, 0, 0, 0);
+  rc += check_vuint128x ("vec_setb_sw:", (vui128_t) k, (vui128_t) e);
+
+  i = (vi32_t)CONST_VINT32_W(-1, -1, -1, -1);
+  k = (vui32_t) vec_setb_sw ( i );
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_setb ", (vui128_t) i);
+  print_vint128x ("        =", (vui128_t) k);
+#endif
+  e = (vui32_t)CONST_VINT32_W(-1, -1, -1, -1);
+  rc += check_vuint128x ("vec_setb_sw:", (vui128_t) k, (vui128_t) e);
+
+  return (rc);
+}
+
 int
 test_vec_i32 (void)
 {
@@ -1717,6 +1760,7 @@ test_vec_i32 (void)
   rc += test_unpkxw ();
   rc += test_lvguwx ();
   rc += test_stvguwx ();
+  rc += test_setbw ();
 
   return (rc);
 }

--- a/src/testsuite/arith128_test_i64.c
+++ b/src/testsuite/arith128_test_i64.c
@@ -12155,6 +12155,49 @@ test_cmpsd_any (void)
   return (rc);
 }
 
+//#define __DEBUG_PRINT__ 1
+int
+test_setbd (void)
+{
+  vui32_t i, k;
+  vui32_t e;
+  int rc = 0;
+
+  printf ("\ntest_setbd Vector set bool doubleword\n");
+
+  i = (vui32_t)CONST_VINT32_W(0x7fffffff, 0xff, 0xff000000, 0);
+  k = (vui32_t) vec_setb_sd ((vi64_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_setb ", (vui128_t) i);
+  print_vint128x ("        =", (vui128_t) k);
+#endif
+  e = (vui32_t)CONST_VINT32_W(0, 0, -1, -1);
+  rc += check_vuint128x ("vec_setb_sd:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(0x80000000, 0, 0, 1);
+  k = (vui32_t) vec_setb_sd ((vi64_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_setb ", (vui128_t) i);
+  print_vint128x ("        =", (vui128_t) k);
+#endif
+  e = (vui32_t)CONST_VINT32_W(-1, -1, 0, 0);
+  rc += check_vuint128x ("vec_setb_sd:", (vui128_t) k, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(-1, -1, -1, -1);
+  k = (vui32_t) vec_setb_sd ((vi64_t) i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("vec_setb ", (vui128_t) i);
+  print_vint128x ("        =", (vui128_t) k);
+#endif
+  e = (vui32_t)CONST_VINT32_W(-1, -1, -1, -1);
+  rc += check_vuint128x ("vec_setb_sd:", (vui128_t) k, (vui128_t) e);
+
+  return (rc);
+}
+
 int
 test_vec_i64 (void)
 {
@@ -12200,6 +12243,7 @@ test_vec_i64 (void)
   rc += test_vmaddoud ();
   rc += test_lvgudx ();
   rc += test_stvgudx ();
+  rc += test_setbd ();
 
   return (rc);
 }

--- a/src/testsuite/vec_char_dummy.c
+++ b/src/testsuite/vec_char_dummy.c
@@ -11,6 +11,12 @@
 
 #include <pveclib/vec_char_ppc.h>
 
+vb8_t
+test_setb_sb (vi8_t vra)
+{
+  return vec_setb_sb (vra);
+}
+
 vui8_t
 test_ctzb_v1 (vui8_t vra)
 {

--- a/src/testsuite/vec_f128_dummy.c
+++ b/src/testsuite/vec_f128_dummy.c
@@ -40,6 +40,28 @@
 //#define __DEBUG_PRINT__
 #include <pveclib/vec_f128_ppc.h>
 
+#ifndef PVECLIB_DISABLE_F128MATH
+#ifdef __FLOAT128__
+__float128
+test_scalar_add128 (__float128 vra, __float128 vrb)
+{
+  return (vra + vrb);
+}
+
+__float128
+test_scalar_mul128 (__float128 vra, __float128 vrb)
+{
+  return (vra * vrb);
+}
+#endif
+#endif
+
+vb128_t
+test_setb_qp (__binary128 f128)
+{
+  return vec_setb_qp (f128);
+}
+
 __binary128
 test_vec_absf128 (__binary128 f128)
 {

--- a/src/testsuite/vec_f32_dummy.c
+++ b/src/testsuite/vec_f32_dummy.c
@@ -33,6 +33,12 @@
 //#define __DEBUG_PRINT__
 #include <pveclib/vec_f32_ppc.h>
 
+vb32_t
+__test_setb_sp (vf32_t f)
+{
+  return vec_setb_sp (f);
+}
+
 #if (__GNUC__ > 7) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
 vf32_t
 test_vec_pack_dpsp (vf64_t a, vf64_t b)

--- a/src/testsuite/vec_f64_dummy.c
+++ b/src/testsuite/vec_f64_dummy.c
@@ -34,6 +34,12 @@
 
 #include <pveclib/vec_f64_ppc.h>
 
+vb64_t
+__test_setb_dp (vf64_t d)
+{
+  return vec_setb_dp (d);
+}
+
 void
 test_stvsfso (vf64_t data, double *array, const long long offset0,
 		     const long long offset1)

--- a/src/testsuite/vec_int16_dummy.c
+++ b/src/testsuite/vec_int16_dummy.c
@@ -22,6 +22,12 @@
 
 #include <pveclib/vec_int16_ppc.h>
 
+vb16_t
+test_setb_sh (vi16_t vra)
+{
+  return vec_setb_sh (vra);
+}
+
 vui16_t
 test_ctzh_v1 (vui16_t vra)
 {

--- a/src/testsuite/vec_int32_dummy.c
+++ b/src/testsuite/vec_int32_dummy.c
@@ -22,6 +22,12 @@
 
 #include <pveclib/vec_int128_ppc.h>
 
+vb32_t
+test_setb_sw (vi32_t vra)
+{
+  return vec_setb_sw (vra);
+}
+
 #if defined(_ARCH_PWR8)
 vi64_t
 test_vec_unpackh (vi32_t vra)

--- a/src/testsuite/vec_int64_dummy.c
+++ b/src/testsuite/vec_int64_dummy.c
@@ -22,6 +22,11 @@
 
 #include <pveclib/vec_int128_ppc.h>
 
+vb64_t
+test_vec_setb_sd (vi64_t vra)
+{
+  return vec_setb_sd (vra);
+}
 
 // Shift Left Double immediate for P7
 vui64_t

--- a/src/testsuite/vec_pwr10_dummy.c
+++ b/src/testsuite/vec_pwr10_dummy.c
@@ -38,6 +38,36 @@
 #include <pveclib/vec_f32_ppc.h>
 #include <pveclib/vec_bcd_ppc.h>
 
+vb128_t
+test_setb_qp_PWR10 (__binary128 f128)
+{
+  return vec_setb_qp (f128);
+}
+
+vb8_t
+test_setb_sb_PWR10 (vi8_t vra)
+{
+  return vec_setb_sb (vra);
+}
+
+vb16_t
+test_setb_sh_PWR10 (vi16_t vra)
+{
+  return vec_setb_sh (vra);
+}
+
+vb32_t
+test_setb_sw_PWR10 (vi32_t vra)
+{
+  return vec_setb_sw (vra);
+}
+
+vb64_t
+test_setb_sd_PWR10 (vi64_t vra)
+{
+  return vec_setb_sd (vra);
+}
+
 vui128_t
 test_setb_sq_PWR10 (vi128_t vcy)
 {

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -39,6 +39,36 @@
 #include <pveclib/vec_f32_ppc.h>
 #include <pveclib/vec_bcd_ppc.h>
 
+vb128_t
+test_setb_qp_PWR9 (__binary128 f128)
+{
+  return vec_setb_qp (f128);
+}
+
+vb8_t
+test_setb_sb_PWR9 (vi8_t vra)
+{
+  return vec_setb_sb (vra);
+}
+
+vb16_t
+test_setb_sh_PWR9 (vi16_t vra)
+{
+  return vec_setb_sh (vra);
+}
+
+vb32_t
+test_setb_sw_PWR9 (vi32_t vra)
+{
+  return vec_setb_sw (vra);
+}
+
+vb64_t
+test_setb_sd_PWR9 (vi64_t vra)
+{
+  return vec_setb_sd (vra);
+}
+
 vui128_t
 __test_msumcud_PWR9 (vui64_t a, vui64_t b, vui128_t c)
 {


### PR DESCRIPTION
Use P10's expand mask instructions for set bool (setb) from sign for
P10 specific implementations of existing and new vec_setb_* operations.
This includes the existing vec_setb_sq (__int128) and vec_setb_qp
(float128) operations, plus new operations for integer signed
long long, int, short and char and floating-point single and double.

	* src/pveclib/vec_char_ppc.h (vec_setb_sb): New operation.
	* src/pveclib/vec_f128_ppc.h (vec_setb_qp [_ARCH_PWR10]):
	Use vexpandqm for POWER10.
	* src/pveclib/vec_f32_ppc.h (vec_setb_sp): New operation.
	* src/pveclib/vec_f64_ppc.h (vec_setb_dp): New operation.
	* src/pveclib/vec_int128_ppc.h (vec_setb_sq [_ARCH_PWR10]):
	Use vexpandqm for POWER10.
	* src/pveclib/vec_int16_ppc.h (vec_setb_sh): New operation.
	* src/pveclib/vec_int32_ppc.h (vec_setb_sw): New operation.
	* src/pveclib/vec_int64_ppc.h (vec_setb_sd): New operation.

	* src/testsuite/arith128_test_char.c (test_setbb):
	New unit test.
	(test_vec_char): Add test_setbb to driver function.

	* src/testsuite/arith128_test_f32.c (test_setb_sp):
	New unit test.
	(test_vec_f32): Add test_setb_sp to driver function.

	* src/testsuite/arith128_test_f64.c (test_setb_dp):
	New unit test.
	(test_vec_f64): Add test_setb_dp to driver function.

	* src/testsuite/arith128_test_i16.c  (test_setbh):
	New unit test.
	(test_vec_i16): Add test_setbh to driver function.

	* src/testsuite/arith128_test_i32.c  (test_setbw):
	New unit test.
	(test_vec_i32): Add test_setbw to driver function.

	* src/testsuite/arith128_test_i64.c  (test_setbd):
	New unit test.
	(test_vec_i64): Add test_setdh to driver function.

	* src/testsuite/vec_char_dummy.c (test_setb_sb)
	New compile test.
	* src/testsuite/vec_f128_dummy.c [PVECLIB_DISABLE_F128MATH]
	Add test_scalar_add128 and test_scalar_mul128.
	(test_setb_qp): New compile test.
	* src/testsuite/vec_f32_dummy.c (__test_setb_sp)
	New compile test.
	* src/testsuite/vec_f64_dummy.c (__test_setb_dp)
	New compile test.
	* src/testsuite/vec_int16_dummy.c (test_setb_sh)
	New compile test.
	* src/testsuite/vec_int32_dummy.c (test_setb_sw)
	New compile test.
	* src/testsuite/vec_int64_dummy.c (test_setb_sd)
	New compile test.

	src/testsuite/vec_pwr10_dummy.c (test_setb_qp_PWR10,
	test_setb_sb_PWR10, test_setb_sh_PWR10, test_setb_sw_PWR10,
	test_setb_sd_PWR10): New compile test.
	src/testsuite/vec_pwr9_dummy.c (test_setb_qp_PWR9,
	test_setb_sb_PWR9, test_setb_sh_PWR9, test_setb_sw_PWR9,
	test_setb_sd_PWR9): New compile test.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>