### PR TITLE
Exploit P9 extract/insert instructions operations.

### DIFF
--- a/src/pveclib/vec_f128_ppc.h
+++ b/src/pveclib/vec_f128_ppc.h
@@ -247,6 +247,142 @@ typedef union
        __binary128 vf1;
      } __VF_128;
 
+
+ /** \brief Transfer a quadword from a __binary128 scalar to a vector int
+  * and logical AND with a mask.
+ *
+ *  The compiler does not allow direct transfer (assignment or type
+ *  cast) between __binary128 (__float128) scalars and vector types.
+ *  This despite the fact the the ABI and ISA require __binary128 in
+ *  vector registers (VRs).
+ *
+ *  \note this function uses a union to effect the (logical) transfer.
+ *  The compiler should not generate any code for this.
+ *
+ *  @param f128 a __binary128 floating point scalar value.
+ *  @param mask a vector unsigned int
+ *  @return The original value ANDed with mask as a 128-bit vector int.
+ */
+ static inline vui32_t
+ vec_and_bin128_2_vui32t (__binary128 f128, vui32_t mask)
+ {
+   vui32_t result;
+ #if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) && (__GNUC__ > 7) \
+      && !defined (_ARCH_PWR9)
+   // Work around for GCC PR 100085
+ #ifdef __VSX__
+   __asm__(
+       "xxland %x0,%x1,%x2"
+       : "=wa" (result)
+       : "wa" (f128), "wa" (mask)
+       : );
+ #else
+   __asm__(
+       "vand %0,%1,%2"
+       : "=v" (result)
+       : "v" (f128), "v" (mask)
+       : );
+ #endif
+ #else
+   __VF_128 vunion;
+
+   vunion.vf1 = f128;
+
+   result = (vec_and (vunion.vx4, mask));
+ #endif
+   return result;
+ }
+
+ /** \brief Transfer a quadword from a __binary128 scalar to a vector int
+  * and logical AND Compliment with mask.
+ *
+ *  The compiler does not allow direct transfer (assignment or type
+ *  cast) between __binary128 (__float128) scalars and vector types.
+ *  This despite the fact the the ABI and ISA require __binary128 in
+ *  vector registers (VRs).
+ *
+ *  \note this function uses a union to effect the (logical) transfer.
+ *  The compiler should not generate any code for this.
+ *
+ *  @param f128 a __binary128 floating point scalar value.
+ *  @param mask a vector unsigned int
+ *  @return The original value ANDed with mask as a 128-bit vector int.
+ */
+ static inline vui32_t
+ vec_andc_bin128_2_vui32t (__binary128 f128, vui32_t mask)
+ {
+   vui32_t result;
+ #if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) && (__GNUC__ > 7) \
+    && !defined (_ARCH_PWR9)
+   // Work around for GCC PR 100085
+ #ifdef __VSX__
+   __asm__(
+       "xxlandc %x0,%x1,%x2"
+       : "=wa" (result)
+       : "wa" (f128), "wa" (mask)
+       : );
+ #else
+   __asm__(
+       "vandc %0,%1,%2"
+       : "=v" (result)
+       : "v" (f128), "v" (mask)
+       : );
+ #endif
+ #else
+   __VF_128 vunion;
+
+   vunion.vf1 = f128;
+
+   result = (vec_andc (vunion.vx4, mask));
+ #endif
+   return result;
+ }
+
+ /** \brief Transfer a quadword from a __binary128 scalar to a vector __int128
+  * and logical AND Compliment with mask.
+ *
+ *  The compiler does not allow direct transfer (assignment or type
+ *  cast) between __binary128 (__float128) scalars and vector types.
+ *  This despite the fact the the ABI and ISA require __binary128 in
+ *  vector registers (VRs).
+ *
+ *  \note this function uses a union to effect the (logical) transfer.
+ *  The compiler should not generate any code for this.
+ *
+ *  @param f128 a __binary128 floating point scalar value.
+ *  @param mask a vector unsigned __int128
+ *  @return The original value ANDed with mask as a 128-bit vector int.
+ */
+ static inline vui128_t
+ vec_andc_bin128_2_vui128t (__binary128 f128, vui128_t mask)
+ {
+   vui128_t result;
+ #if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) && (__GNUC__ > 7) \
+    && !defined (_ARCH_PWR9)
+   // Work around for GCC PR 100085
+ #ifdef __VSX__
+   __asm__(
+       "xxlandc %x0,%x1,%x2"
+       : "=wa" (result)
+       : "wa" (f128), "wa" (mask)
+       : );
+ #else
+   __asm__(
+       "vandc %0,%1,%2"
+       : "=v" (result)
+       : "v" (f128), "v" (mask)
+       : );
+ #endif
+ #else
+   __VF_128 vunion;
+
+   vunion.vf1 = f128;
+   // vec_andc does not accept vector __int128 type
+   result = (vui128_t) vec_andc (vunion.vx4, (vui32_t) mask);
+ #endif
+   return result;
+ }
+
 /** \brief Transfer function from a __binary128 scalar to a vector char.
 *
 *  The compiler does not allow direct transfer (assignment or type
@@ -263,11 +399,31 @@ typedef union
 static inline vui8_t
 vec_xfer_bin128_2_vui8t (__binary128 f128)
 {
+  vui8_t result;
+#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) && (__GNUC__ > 7) \
+    && !defined (_ARCH_PWR9)
+  // Work around for GCC PR 100085
+#ifdef __VSX__
+  __asm__(
+      "xxlor %x0,%x1,%x1"
+      : "=wa" (result)
+      : "wa" (f128)
+      : );
+#else
+  __asm__(
+      "vor %0,%1,%1"
+      : "=v" (result)
+      : "v" (f128)
+      : );
+#endif
+#else
   __VF_128 vunion;
 
   vunion.vf1 = f128;
 
-  return (vunion.vx16);
+  result = (vunion.vx16);
+#endif
+  return result;
 }
 
 /** \brief Transfer function from a __binary128 scalar to a vector short int.
@@ -309,11 +465,31 @@ vec_xfer_bin128_2_vui16t (__binary128 f128)
 static inline vui32_t
 vec_xfer_bin128_2_vui32t (__binary128 f128)
 {
+  vui32_t result;
+#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) && (__GNUC__ > 7) \
+    && !defined (_ARCH_PWR9)
+  // Work around for GCC PR 100085
+#ifdef __VSX__
+  __asm__(
+      "xxlor %x0,%x1,%x1"
+      : "=wa" (result)
+      : "wa" (f128)
+      : );
+#else
+  __asm__(
+      "vor %0,%1,%1"
+      : "=v" (result)
+      : "v" (f128)
+      : );
+#endif
+#else
   __VF_128 vunion;
 
   vunion.vf1 = f128;
 
-  return (vunion.vx4);
+  result = (vunion.vx4);
+#endif
+  return result;
 }
 
 /** \brief Transfer function from a __binary128 scalar to a vector long long int.
@@ -355,11 +531,31 @@ vec_xfer_bin128_2_vui64t (__binary128 f128)
 static inline vui128_t
 vec_xfer_bin128_2_vui128t (__binary128 f128)
 {
+  vui128_t result;
+#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) && (__GNUC__ > 7) \
+    && !defined (_ARCH_PWR9)
+  // Work around for GCC PR 100085
+#ifdef __VSX__
+  __asm__(
+      "xxlor %x0,%x1,%x1"
+      : "=wa" (result)
+      : "wa" (f128)
+      : );
+#else
+  __asm__(
+      "vor %0,%1,%1"
+      : "=v" (result)
+      : "v" (f128)
+      : );
+#endif
+#else
   __VF_128 vunion;
 
   vunion.vf1 = f128;
 
-  return (vunion.vx1);
+  result = (vunion.vx1);
+#endif
+  return result;
 }
 
 /** \brief Transfer a vector unsigned char to __binary128 scalar.
@@ -502,8 +698,8 @@ vec_absf128 (__binary128 f128)
 #else
   vui32_t tmp;
   const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
-  tmp = vec_xfer_bin128_2_vui32t (f128);
-  tmp = vec_andc (tmp, signmask);
+
+  tmp = vec_andc_bin128_2_vui32t (f128, signmask);
   result = vec_xfer_vui32t_2_bin128 (tmp);
 #endif
   return (result);
@@ -536,11 +732,10 @@ vec_all_isfinitef128 (__binary128 f128)
 #if defined (_ARCH_PWR9) && defined (scalar_test_data_class) && defined (__FLOAT128__) && (__GNUC__ > 7)
   return !scalar_test_data_class (f128, 0x70);
 #else
-  vui32_t tmp, t128;
+  vui32_t tmp;
   const vui32_t expmask = CONST_VINT128_W(0x7fff0000, 0, 0, 0);
 
-  t128 = vec_xfer_bin128_2_vui32t (f128);
-  tmp = vec_and (t128, expmask);
+  tmp = vec_and_bin128_2_vui32t (f128, expmask);
   return !vec_all_eq(tmp, expmask);
 #endif
 }
@@ -573,8 +768,7 @@ vec_all_isinff128 (__binary128 f128)
   const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
   const vui32_t expmask = CONST_VINT128_W(0x7fff0000, 0, 0, 0);
 
-  tmp = vec_xfer_bin128_2_vui32t (f128);
-  tmp = vec_andc (tmp, signmask);
+  tmp = vec_andc_bin128_2_vui32t (f128, signmask);
   return vec_all_eq(tmp, expmask);
 #endif
 }
@@ -604,13 +798,12 @@ vec_all_isnanf128 (__binary128 f128)
 #if defined (_ARCH_PWR9) && defined (scalar_test_data_class) && defined (__FLOAT128__) && (__GNUC__ > 7)
   return scalar_test_data_class (f128, 0x40);
 #else
-  vui32_t tmp, tmp2, t128;
+  vui32_t tmp, tmp2;
   const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
   const vui32_t expmask = CONST_VINT128_W(0x7fff0000, 0, 0, 0);
 
-  t128 = vec_xfer_bin128_2_vui32t (f128);
-  tmp = vec_andc (t128, signmask);
-  tmp2 = vec_and (t128, expmask);
+  tmp  = vec_andc_bin128_2_vui32t (f128, signmask);
+  tmp2 = vec_and_bin128_2_vui32t (f128, expmask);
   return (vec_all_eq (tmp2, expmask) && vec_any_gt(tmp, expmask));
 #endif
 }
@@ -642,13 +835,11 @@ vec_all_isnormalf128 (__binary128 f128)
 #if defined (_ARCH_PWR9) && defined (scalar_test_data_class) && defined (__FLOAT128__) && (__GNUC__ > 7)
   return !scalar_test_data_class (f128, 0x7f);
 #else
-  vui32_t tmp, t128;
+  vui32_t tmp;
   const vui32_t expmask = CONST_VINT128_W(0x7fff0000, 0, 0, 0);
   const vui32_t vec_zero = CONST_VINT128_W(0, 0, 0, 0);
 
-  t128 = vec_xfer_bin128_2_vui32t (f128);
-  tmp = vec_and (t128, expmask);
-
+  tmp = vec_and_bin128_2_vui32t (f128, expmask);
   return !(vec_all_eq (tmp, expmask) || vec_all_eq(tmp, vec_zero));
 #endif
 }
@@ -680,9 +871,12 @@ vec_all_issubnormalf128 (__binary128 f128)
 #else
   const vui64_t minnorm = CONST_VINT128_DW(0x0001000000000000UL, 0UL);
   const vui64_t vec_zero = CONST_VINT128_DW(0, 0);
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
   vui128_t tmp1;
 
-  tmp1 = vec_xfer_bin128_2_vui128t (vec_absf128 (f128));
+  // Equivalent to vec_absf128 (f128)
+  tmp1 = (vui128_t) vec_andc_bin128_2_vui32t (f128, signmask);
+
   return vec_cmpuq_all_gt ((vui128_t) minnorm, tmp1)
       && !vec_cmpuq_all_eq (tmp1, (vui128_t) vec_zero);
 #endif
@@ -715,8 +909,10 @@ vec_all_iszerof128 (__binary128 f128)
 #else
   vui64_t tmp2;
   const vui64_t vec_zero = CONST_VINT128_DW(0, 0);
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
 
-  tmp2 = vec_xfer_bin128_2_vui64t (vec_absf128 (f128));
+  // Equivalent to vec_absf128 (f128)
+  tmp2 = (vui64_t) vec_andc_bin128_2_vui32t (f128, signmask);
 #if _ARCH_PWR8
   return vec_all_eq(tmp2, vec_zero);
 #else
@@ -841,11 +1037,10 @@ vec_isfinitef128 (__binary128 f128)
   return (vb128_t)result;
 #else
   const vui32_t expmask = CONST_VINT128_W(0x7fff0000, 0, 0, 0);
-  vui32_t tmp, t128;
+  vui32_t tmp;
   vb128_t tmp2, tmp3;
 
-  t128 = vec_xfer_bin128_2_vui32t (f128);
-  tmp = vec_and (t128, expmask);
+  tmp = vec_and_bin128_2_vui32t (f128, expmask);
   tmp2 = (vb128_t) vec_cmpeq (tmp, expmask);
   tmp3 = (vb128_t) vec_splat ((vui32_t) tmp2, VEC_W_H);
   return (vb128_t) vec_nor ((vui32_t) tmp3, (vui32_t) tmp3); // vec_not
@@ -892,7 +1087,7 @@ vec_isinf_signf128 (__binary128 f128)
   const vui32_t expmask = CONST_VINT128_W(0x7fff0000, 0, 0, 0);
 
   t128 = vec_xfer_bin128_2_vui32t (f128);
-  tmp = vec_andc (t128, signmask);
+  tmp = vec_andc_bin128_2_vui32t (f128, signmask);
 
   if (vec_all_eq(tmp, expmask))
     {
@@ -936,12 +1131,11 @@ vec_isinff128 (__binary128 f128)
 
   return (vb128_t)result;
 #else
-  vui32_t tmp, t128;
+  vui32_t tmp;
   const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
   const vui32_t expmask = CONST_VINT128_W(0x7fff0000, 0, 0, 0);
 
-  t128 = vec_xfer_bin128_2_vui32t (f128);
-  tmp = vec_andc (t128, signmask);
+  tmp = vec_andc_bin128_2_vui32t (f128, signmask);
   return vec_cmpequq ((vui128_t)tmp , (vui128_t)expmask);
 #endif
 }
@@ -979,12 +1173,11 @@ vec_isnanf128 (__binary128 f128)
 
   return (vb128_t)result;
 #else
-  vui32_t tmp, t128;
+  vui32_t tmp;
   const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
   const vui32_t expmask = CONST_VINT128_W(0x7fff0000, 0, 0, 0);
 
-  t128 = vec_xfer_bin128_2_vui32t (f128);
-  tmp = vec_andc (t128, signmask);
+  tmp = vec_andc_bin128_2_vui32t (f128, signmask);
   return vec_cmpgtuq ((vui128_t)tmp , (vui128_t)expmask);
 #endif
 }
@@ -1019,18 +1212,15 @@ vec_isnormalf128 (__binary128 f128)
 
   return (vb128_t)result;
 #else
-  vui32_t tmp, t128;
+  vui32_t tmp;
   const vui32_t expmask = CONST_VINT128_W(0x7fff0000, 0, 0, 0);
   const vui32_t vec_zero = CONST_VINT128_W(0, 0, 0, 0);
   vb128_t result;
 
-  t128 = vec_xfer_bin128_2_vui32t (f128);
-  tmp = vec_and (t128, expmask);
+  tmp = vec_and_bin128_2_vui32t (f128, expmask);
   result = (vb128_t) vec_nor (vec_cmpeq (tmp, expmask),
 			      vec_cmpeq (tmp, vec_zero));
-  result = (vb128_t) vec_splat ((vui32_t) result, VEC_W_H);
-
-  return (result);
+  return (vb128_t) vec_splat ((vui32_t) result, VEC_W_H);
 #endif
 }
 
@@ -1064,13 +1254,14 @@ vec_issubnormalf128 (__binary128 f128)
 
   return (vb128_t)result;
 #else
-  vui32_t tmp, tmpz, tmp2, t128;
+  vui32_t tmp, tmpz, tmp2;
   const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
   const vui32_t vec_zero = CONST_VINT128_W(0, 0, 0, 0);
   const vui32_t minnorm = CONST_VINT128_W(0x00010000, 0, 0, 0);
 
-  t128 = vec_xfer_bin128_2_vui32t (f128);
-  tmp = vec_andc (t128, signmask);
+  // Equivalent to vec_absf128 (f128)
+  tmp = vec_andc_bin128_2_vui32t (f128, signmask);
+
   tmp2 = (vui32_t) vec_cmpltuq ((vui128_t)tmp, (vui128_t)minnorm);
   tmpz = (vui32_t) vec_cmpequq ((vui128_t)tmp, (vui128_t)vec_zero);
   return (vb128_t) vec_andc (tmp2, tmpz);
@@ -1109,8 +1300,10 @@ vec_iszerof128 (__binary128 f128)
 #else
   vui128_t t128;
   const vui64_t vec_zero = CONST_VINT128_DW(0, 0);
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
 
-  t128 = vec_xfer_bin128_2_vui128t (vec_absf128(f128));
+  // Equivalent to vec_absf128 (f128)
+  t128 = (vui128_t) vec_andc_bin128_2_vui32t (f128, signmask);
   return  (vb128_t)vec_cmpequq (t128, (vui128_t)vec_zero);
 #endif
 }
@@ -1184,13 +1377,162 @@ vec_signbitf128 (__binary128 f128)
 #if defined (_ARCH_PWR9) && defined (scalar_test_neg) && (__GNUC > 7)
   return (scalar_test_neg (f128);
 #else
-  vui32_t tmp, t128;
+  vui32_t tmp;
   const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
 
-  t128 = vec_xfer_bin128_2_vui32t (f128);
-  tmp = vec_and (t128, signmask);
+  tmp = vec_and_bin128_2_vui32t (f128, signmask);
   return vec_all_eq(tmp, signmask);
 #endif
+}
+
+/** \brief Scalar Insert Exponent Quad-Precision
+ *
+ *  Merge the sign (bit 0) and significand (bits 16:127) from sig
+ *  with the 15-bit exponent from exp (bits 49:63). The exponent is
+ *  moved to bits 1:15 of the final result.
+ *  The result is return as a Quad_precision floating point value.
+ *
+ *  \note This operation is equivalent to the POWER9 xsiexpqp
+ *  instruction and the built-in scalar_insert_exp. These require a
+ *  POWER9 enables compiler targeting -mcpu=power9 and are not
+ *  available for older compilers and POWER8 and earlier.
+ *  This operation provides this operation for all VSX enabled
+ *  platforms.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   |  2-11 | 2/cycle  |
+ *  |power9   |   2   | 4/cycle  |
+ *
+ *  @param sig Vector __int128 containing the Sign Bit and 112-bit significand.
+ *  @param exp Vector long long containing the 15-bit exponent.
+ *  @return a __binary128 value where the exponent bits (1:15) of sig
+ *  are replaced from bits 49:63 of exp.
+ *
+ */
+static inline __binary128
+vec_xsiexpqp (vui128_t sig, vui64_t exp)
+{
+  __binary128 result;
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  __asm__(
+      "xsiexpqp %0,%1,%2"
+      : "=v" (result)
+      : "v" (sig), "v" (exp)
+      : );
+
+#else
+  vui32_t tmp, t128;
+  const vui32_t expmask = CONST_VINT128_W(0x7fff0000, 0, 0, 0);
+
+  tmp = vec_sld ((vui32_t) exp, (vui32_t) exp, 6);
+  t128 =  vec_sel ((vui32_t) sig, tmp, expmask);
+  result = vec_xfer_vui32t_2_bin128 (t128);
+#endif
+  return result;
+}
+
+/** \brief Scalar Extract Exponent Quad-Precision
+ *
+ *  Extract the quad-precision exponent (bits 1:15) and right justify
+ *  it to (bits 49:63 of) doubleword 0 of the result vector.
+ *  The result is return as vector long long integer value.
+ *
+ *  \note This operation is equivalent to the POWER9 xsxexpqp
+ *  instruction and the built-in scalar_extract_exp. These require a
+ *  POWER9 enables compiler targeting -mcpu=power9 and are not
+ *  available for older compilers and POWER8 and earlier.
+ *  This operation provides this operation for all VSX enabled
+ *  platforms.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   |  4-13 | 2/cycle  |
+ *  |power9   |   2   | 4/cycle  |
+ *
+ *  @param f128 __binary128 value.
+ *  @return _Vector long long containing the 15-bit exponent in doubleword 0
+ *
+ */
+static inline vui64_t
+vec_xsxexpqp (__binary128 f128)
+{
+  vui64_t result;
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+
+  vui128_t vrb = vec_xfer_bin128_2_vui128t (f128);
+  __asm__(
+      "xsxexpqp %0,%1"
+      : "=v" (result)
+      : "v" (vrb)
+      : );
+
+#else
+  vui32_t tmp;
+  const vui32_t expmask = CONST_VINT128_W(0x7fff0000, 0, 0, 0);
+  const vui32_t zero = CONST_VINT128_W(0, 0, 0, 0);
+
+  tmp = vec_and_bin128_2_vui32t (f128, expmask);
+  result = (vui64_t) vec_sld (zero, tmp, 10);
+#endif
+  return result;
+}
+
+/** \brief Scalar Extract Significand Quad-Precision
+ *
+ *  Extract the quad-precision significand (bits 16:127) and
+ *  restore the implied (hidden) bit (bit 15) if the quad-precition
+ *  value is normal (not zero, subnormal, Infinity or NaN).
+ *  The result is return as vector __int128 integer value with
+ *  up to 113 bits of significance.
+ *
+ *  \note This operation is equivalent to the POWER9 xsxsigqp
+ *  instruction and the built-in scalar_extract_sig. These require a
+ *  POWER9 enables compiler targeting -mcpu=power9 and are not
+ *  available for older compilers and POWER8 and earlier.
+ *  This operation provides this operation for all VSX enabled
+ *  platforms.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 10-19 | 2/cycle  |
+ *  |power9   |   3   | 2/cycle  |
+ *
+ *  @param f128 __binary128 value.
+ *  @return Vector __int128 containing the significand.
+ *
+ */
+static inline vui128_t
+vec_xsxsigqp (__binary128 f128)
+{
+  vui128_t result;
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+
+  vui128_t vrb = vec_xfer_bin128_2_vui128t (f128);
+  __asm__(
+      "xsxsigqp %0,%1"
+      : "=v" (result)
+      : "v" (vrb)
+      : );
+
+#else
+  vui32_t t128, tmp;
+  vui32_t normal;
+  const vui32_t zero = CONST_VINT128_W(0, 0, 0, 0);
+  const vui32_t sigmask = CONST_VINT128_W(0x0000ffff, -1, -1, -1);
+  const vui32_t expmask = CONST_VINT128_W(0x7fff0000, 0, 0, 0);
+  const vui32_t hidden = CONST_VINT128_W(0x00010000, 0, 0, 0);
+
+  // Check if f128 is normal. Normal values need the hidden bit
+  // restored to the significand. We use a simpler sequence here as
+  // vec_isnormalf128 does more then we need.
+  tmp = vec_and_bin128_2_vui32t (f128, expmask);
+  normal = (vui32_t) vec_nor (vec_cmpeq (tmp, expmask),
+		              vec_cmpeq (tmp, zero));
+  t128 = vec_and_bin128_2_vui32t (f128, sigmask);
+  result = (vui128_t) vec_sel (t128, normal, hidden);
+#endif
+  return result;
 }
 
 #endif /* VEC_F128_PPC_H_ */

--- a/src/pveclib/vec_f128_ppc.h
+++ b/src/pveclib/vec_f128_ppc.h
@@ -1390,13 +1390,13 @@ vec_signbitf128 (__binary128 f128)
  *  Merge the sign (bit 0) and significand (bits 16:127) from sig
  *  with the 15-bit exponent from exp (bits 49:63). The exponent is
  *  moved to bits 1:15 of the final result.
- *  The result is return as a Quad_precision floating point value.
+ *  The result is returned as a Quad_precision floating point value.
  *
  *  \note This operation is equivalent to the POWER9 xsiexpqp
  *  instruction and the built-in scalar_insert_exp. These require a
- *  POWER9 enables compiler targeting -mcpu=power9 and are not
- *  available for older compilers and POWER8 and earlier.
- *  This operation provides this operation for all VSX enabled
+ *  POWER9-enabled compiler targeting -mcpu=power9 and are not
+ *  available for older compilers nor POWER8 and earlier.
+ *  This function provides this operation for all VSX-enabled
  *  platforms.
  *
  *  |processor|Latency|Throughput|
@@ -1404,8 +1404,8 @@ vec_signbitf128 (__binary128 f128)
  *  |power8   |  2-11 | 2/cycle  |
  *  |power9   |   2   | 4/cycle  |
  *
- *  @param sig Vector __int128 containing the Sign Bit and 112-bit significand.
- *  @param exp Vector long long containing the 15-bit exponent.
+ *  @param sig vector __int128 containing the Sign Bit and 112-bit significand.
+ *  @param exp vector unsigned long long element 0 containing the 15-bit exponent.
  *  @return a __binary128 value where the exponent bits (1:15) of sig
  *  are replaced from bits 49:63 of exp.
  *
@@ -1436,13 +1436,13 @@ vec_xsiexpqp (vui128_t sig, vui64_t exp)
  *
  *  Extract the quad-precision exponent (bits 1:15) and right justify
  *  it to (bits 49:63 of) doubleword 0 of the result vector.
- *  The result is return as vector long long integer value.
+ *  The result is returned as vector long long integer value.
  *
  *  \note This operation is equivalent to the POWER9 xsxexpqp
  *  instruction and the built-in scalar_extract_exp. These require a
- *  POWER9 enables compiler targeting -mcpu=power9 and are not
- *  available for older compilers and POWER8 and earlier.
- *  This operation provides this operation for all VSX enabled
+ *  POWER9-enabled compiler targeting -mcpu=power9 and are not
+ *  available for older compilers nor POWER8 and earlier.
+ *  This function provides this operation for all VSX-enabled
  *  platforms.
  *
  *  |processor|Latency|Throughput|
@@ -1451,7 +1451,8 @@ vec_xsiexpqp (vui128_t sig, vui64_t exp)
  *  |power9   |   2   | 4/cycle  |
  *
  *  @param f128 __binary128 value.
- *  @return _Vector long long containing the 15-bit exponent in doubleword 0
+ *  @return vector unsigned long long element 0 containing the 15-bit
+ *  exponent
  *
  */
 static inline vui64_t
@@ -1483,14 +1484,14 @@ vec_xsxexpqp (__binary128 f128)
  *  Extract the quad-precision significand (bits 16:127) and
  *  restore the implied (hidden) bit (bit 15) if the quad-precition
  *  value is normal (not zero, subnormal, Infinity or NaN).
- *  The result is return as vector __int128 integer value with
+ *  The result is returned as vector __int128 integer value with
  *  up to 113 bits of significance.
  *
  *  \note This operation is equivalent to the POWER9 xsxsigqp
  *  instruction and the built-in scalar_extract_sig. These require a
- *  POWER9 enables compiler targeting -mcpu=power9 and are not
- *  available for older compilers and POWER8 and earlier.
- *  This operation provides this operation for all VSX enabled
+ *  POWER9-enabled compiler targeting -mcpu=power9 and are not
+ *  available for older compilers nor POWER8 and earlier.
+ *  This function provides this operation for all VSX-enabled
  *  platforms.
  *
  *  |processor|Latency|Throughput|
@@ -1499,7 +1500,7 @@ vec_xsxexpqp (__binary128 f128)
  *  |power9   |   3   | 2/cycle  |
  *
  *  @param f128 __binary128 value.
- *  @return Vector __int128 containing the significand.
+ *  @return vector __int128 containing the significand.
  *
  */
 static inline vui128_t

--- a/src/testsuite/arith128_test_f128.c
+++ b/src/testsuite/arith128_test_f128.c
@@ -4219,6 +4219,350 @@ test_vec_f128_f128 (void)
     return (rc);
 }
 
+#ifndef PVECLIB_DISABLE_F128MATH
+#ifdef __FLOAT128__
+extern __float128
+test_scalar_add128 (__float128 vra, __float128 vrb);
+
+extern __float128
+test_scalar_div128 (__float128 vra, __float128 vrb);
+
+extern __float128
+test_scalar_mul128 (__float128 vra, __float128 vrb);
+
+extern __float128
+test_scalar_sub128 (__float128 vra, __float128 vrb);
+
+extern __float128
+test_scalarCC_expxsuba_128 (__float128 x, __float128 a, __float128 expa);
+
+const __float128 f128_one = 1.0Q;
+const __float128 f128_e = 2.71828182845904523536028747135266249775724709369996Q;
+const __float128 inv_fact2 = (1.0Q / 2.0Q);
+const __float128 inv_fact3 = (1.0Q / 6.0Q);
+const __float128 inv_fact4 = (1.0Q / 24.0Q);
+const __float128 inv_fact5 = (1.0Q / 120.0Q);
+const __float128 inv_fact6 = (1.0Q / 720.0Q);
+const __float128 inv_fact7 = (1.0Q / 5040.0Q);
+const __float128 inv_fact8 = (1.0Q / 40320.0Q);
+
+__float128
+test_scalarLib_expxsuba_128 (__float128 x, __float128 a, __float128 expa)
+{
+  __float128 term, xma, xma2, xmaf2;
+  __float128 xma3, xmaf3, xma4, xmaf4, xma5, xmaf5;
+  __float128 xma6, xmaf6, xma7, xmaf7, xma8, xmaf8;
+
+  // 1st 8 terms of e**x = e**a * taylor( x-a )
+  xma = test_scalar_sub128 (x, a);
+  term = test_scalar_add128 (f128_one, xma);
+  xma2 = test_scalar_mul128 (xma, xma);
+  xmaf2 = test_scalar_mul128 (xma2, inv_fact2);
+  term = test_scalar_add128 (term, xmaf2);
+  xma3 = test_scalar_mul128 (xma2, xma);
+  xmaf3 = test_scalar_mul128 (xma3, inv_fact3);
+  term = test_scalar_add128 (term, xmaf3);
+  xma4 = test_scalar_mul128 (xma3, xma);
+  xmaf4 = test_scalar_mul128 (xma4, inv_fact4);
+  term = test_scalar_add128 (term, xmaf4);
+  xma5 = test_scalar_mul128 (xma4, xma);
+  xmaf5 = test_scalar_mul128 (xma5, inv_fact5);
+  term = test_scalar_add128 (term, xmaf5);
+  xma6 = test_scalar_mul128 (xma5, xma);
+  xmaf6 = test_scalar_mul128 (xma6, inv_fact6);
+  term = test_scalar_add128 (term, xmaf6);
+  xma7 = test_scalar_mul128 (xma6, xma);
+  xmaf7 = test_scalar_mul128 (xma7, inv_fact7);
+  term = test_scalar_add128 (term, xmaf7);
+  xma8 = test_scalar_mul128 (xma7, xma);
+  xmaf8 = test_scalar_mul128 (xma8, inv_fact8);
+  term = test_scalar_add128 (term, xmaf8);
+  return test_scalar_mul128(expa, term);;
+}
+
+#define N 10
+#define TIMING_ITERATIONS 10
+
+int timed_expxsuba_v1_f128 (void)
+{
+#ifndef PVECLIB_DISABLE_F128MATH
+  __float128 accum = 0.0Q;
+  int i;
+
+  for (i=0; i<N; i++)
+    {
+      accum += test_scalarCC_expxsuba_128 (f128_one, f128_one, f128_e);
+    }
+#endif
+   return 0;
+}
+
+int timed_expxsuba_v2_f128 (void)
+{
+#ifndef PVECLIB_DISABLE_F128MATH
+  __float128 accum = 0.0Q;
+  int i;
+
+  for (i=0; i<N; i++)
+    {
+      accum += test_scalarLib_expxsuba_128 (f128_one, f128_one, f128_e);
+    }
+#endif
+   return 0;
+}
+
+int
+test_time_f128 (void)
+{
+  long i;
+  uint64_t t_start, t_end, t_delta;
+  double delta_sec;
+  int rc = 0;
+
+  printf ("\n%s f128 CC start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_expxsuba_v1_f128 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s f128 CC end", __FUNCTION__);
+  printf ("\n%s f128 CC  tb delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
+	  delta_sec);
+
+  printf ("\n%s f128_LIB start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_expxsuba_v2_f128 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s f128_LIB end", __FUNCTION__);
+  printf ("\n%s f128_LIB  tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+	  t_delta, delta_sec);
+
+  return (rc);
+}
+#endif
+#endif
+
+int
+test_extract_insert_f128 ()
+{
+  __binary128 x, xp, xpt;
+  vui128_t sig, sigt, sigs;
+  vui64_t exp, expt;
+  int rc = 0;
+
+  printf ("\ntest_extract_insert_f128 ...\n");
+
+  x = vec_xfer_vui64t_2_bin128 ( vf128_zero );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  exp = vec_xsxexpqp (x);
+  expt =  CONST_VINT128_DW(0x0000000000000000, 0);
+  rc += check_vuint128x ("check vec_xsxexpqp 1", (vui128_t) exp, (vui128_t) expt);
+
+  sig = vec_xsxsigqp (x);
+  sigt =  (vui128_t) CONST_VINT128_DW(0x0000000000000000, 0);
+  rc += check_vuint128x ("check vec_xsxsigqp 1", (vui128_t) sig, (vui128_t) sigt);
+
+  xp = vec_xsiexpqp (sig, exp);
+  xpt = vec_xfer_vui64t_2_bin128 ( vf128_zero );
+  rc += check_f128 ("check vec_xsiexpqp 1", x, xpt, xp);
+
+  x = vec_xfer_vui64t_2_bin128 ( vf128_nzero );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  exp = vec_xsxexpqp (x);
+  expt =  CONST_VINT128_DW(0x0000000000000000, 0);
+  rc += check_vuint128x ("check vec_xsxexpqp 2", (vui128_t) exp, (vui128_t) expt);
+
+  sig = vec_xsxsigqp (x);
+  sigt =  (vui128_t) CONST_VINT128_DW(0x0000000000000000, 0);
+  rc += check_vuint128x ("check vec_xsxsigqp 2", (vui128_t) sig, (vui128_t) sigt);
+
+  sigs = (vui128_t) vec_or ((vui64_t) sig, vf128_nzero);
+  xp = vec_xsiexpqp (sigs, exp);
+  xpt = vec_xfer_vui64t_2_bin128 ( vf128_nzero );
+  rc += check_f128 ("check vec_xsiexpqp 2", x, xp, xpt);
+
+  x = vec_xfer_vui64t_2_bin128 ( vf128_one );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  exp = vec_xsxexpqp (x);
+  expt =  CONST_VINT128_DW(0x0000000000003fff, 0);
+  rc += check_vuint128x ("check vec_xsxexpqp 3", (vui128_t) exp, (vui128_t) expt);
+
+  sig = vec_xsxsigqp (x);
+  sigt =  (vui128_t) CONST_VINT128_DW(0x0001000000000000, 0);
+  rc += check_vuint128x ("check vec_xsxsigqp 3", (vui128_t) sig, (vui128_t) sigt);
+
+  xp = vec_xsiexpqp (sig, exp);
+  xpt = vec_xfer_vui64t_2_bin128 ( vf128_one );
+  rc += check_f128 ("check vec_xsiexpqp 3", x, xpt, xp);
+
+  x = vec_xfer_vui64t_2_bin128 ( vf128_none );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  exp = vec_xsxexpqp (x);
+  expt =  CONST_VINT128_DW(0x0000000000003fff, 0);
+  rc += check_vuint128x ("check vec_xsxexpqp 4", (vui128_t) exp, (vui128_t) expt);
+
+  sig = vec_xsxsigqp (x);
+  sigt =  (vui128_t) CONST_VINT128_DW(0x0001000000000000, 0);
+  rc += check_vuint128x ("check vec_xsxsigqp 4", (vui128_t) sig, (vui128_t) sigt);
+
+  sigs = (vui128_t) vec_or ((vui64_t) sig, vf128_nzero);
+  xp = vec_xsiexpqp (sigs, exp);
+  xpt = vec_xfer_vui64t_2_bin128 ( vf128_none );
+  rc += check_f128 ("check vec_xsiexpqp 4", x, xpt, xp);
+
+  x = vec_xfer_vui64t_2_bin128 ( vf128_max );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  exp = vec_xsxexpqp (x);
+  expt =  CONST_VINT128_DW(0x0000000000007ffe, 0);
+  rc += check_vuint128x ("check vec_xsxexpqp 5", (vui128_t) exp, (vui128_t) expt);
+
+  sig = vec_xsxsigqp (x);
+  sigt =  (vui128_t) CONST_VINT128_DW(0x0001ffffffffffff, 0xffffffffffffffff);
+  rc += check_vuint128x ("check vec_xsxsigqp 5", (vui128_t) sig, (vui128_t) sigt);
+
+  xp = vec_xsiexpqp (sig, exp);
+  xpt = vec_xfer_vui64t_2_bin128 ( vf128_max );
+  rc += check_f128 ("check vec_xsiexpqp 5", x, xpt, xp);
+
+  x = vec_xfer_vui64t_2_bin128 ( vf128_nmax );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  exp = vec_xsxexpqp (x);
+  expt =  CONST_VINT128_DW(0x0000000000007ffe, 0);
+  rc += check_vuint128x ("check vec_xsxexpqp 6", (vui128_t) exp, (vui128_t) expt);
+
+  sig = vec_xsxsigqp (x);
+  sigt =  (vui128_t) CONST_VINT128_DW(0x0001ffffffffffff, 0xffffffffffffffff);
+  rc += check_vuint128x ("check vec_xsxsigqp 6", (vui128_t) sig, (vui128_t) sigt);
+
+  sigs = (vui128_t) vec_or ((vui64_t) sig, vf128_nzero);
+  xp = vec_xsiexpqp (sigs, exp);
+  xpt = vec_xfer_vui64t_2_bin128 ( vf128_nmax );
+  rc += check_f128 ("check vec_xsiexpqp 6", x, xpt, xp);
+
+  x = vec_xfer_vui64t_2_bin128 ( vf128_sub );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  exp = vec_xsxexpqp (x);
+  expt =  CONST_VINT128_DW(0x0000000000000000, 0);
+  rc += check_vuint128x ("check vec_xsxexpqp 7", (vui128_t) exp, (vui128_t) expt);
+
+  sig = vec_xsxsigqp (x);
+  sigt =  (vui128_t) CONST_VINT128_DW(0x0000ffffffffffff, 0xffffffffffffffff);
+  rc += check_vuint128x ("check vec_xsxsigqp 7", (vui128_t) sig, (vui128_t) sigt);
+
+  xp = vec_xsiexpqp (sig, exp);
+  xpt = vec_xfer_vui64t_2_bin128 ( vf128_sub );
+  rc += check_f128 ("check vec_xsiexpqp 7", x, xpt, xp);
+
+  x = vec_xfer_vui64t_2_bin128 ( vf128_nsub );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  exp = vec_xsxexpqp (x);
+  expt =  CONST_VINT128_DW(0x0000000000000000, 0);
+  rc += check_vuint128x ("check vec_xsxexpqp 8", (vui128_t) exp, (vui128_t) expt);
+
+  sig = vec_xsxsigqp (x);
+  sigt =  (vui128_t) CONST_VINT128_DW(0x0000ffffffffffff, 0xffffffffffffffff);
+  rc += check_vuint128x ("check vec_xsxsigqp 8", (vui128_t) sig, (vui128_t) sigt);
+
+  sigs = (vui128_t) vec_or ((vui64_t) sig, vf128_nzero);
+  xp = vec_xsiexpqp (sigs, exp);
+  xpt = vec_xfer_vui64t_2_bin128 ( vf128_nsub );
+  rc += check_f128 ("check vec_xsiexpqp 8", x, xpt, xp);
+
+  x = vec_xfer_vui64t_2_bin128 ( vf128_inf );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  exp = vec_xsxexpqp (x);
+  expt =  CONST_VINT128_DW(0x0000000000007fff, 0);
+  rc += check_vuint128x ("check vec_xsxexpqp 9", (vui128_t) exp, (vui128_t) expt);
+
+  sig = vec_xsxsigqp (x);
+  sigt =  (vui128_t) CONST_VINT128_DW(0x0000000000000000, 0);
+  rc += check_vuint128x ("check vec_xsxsigqp 9", (vui128_t) sig, (vui128_t) sigt);
+
+  xp = vec_xsiexpqp (sig, exp);
+  xpt = vec_xfer_vui64t_2_bin128 ( vf128_inf);
+  rc += check_f128 ("check vec_xsiexpqp 9", x, xpt, xp);
+
+  x = vec_xfer_vui64t_2_bin128 ( vf128_ninf );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  exp = vec_xsxexpqp (x);
+  expt =  CONST_VINT128_DW(0x0000000000007fff, 0);
+  rc += check_vuint128x ("check vec_xsxexpqp 10", (vui128_t) exp, (vui128_t) expt);
+
+  sig = vec_xsxsigqp (x);
+  sigt =  (vui128_t) CONST_VINT128_DW(0x0000000000000000, 0);
+  rc += check_vuint128x ("check vec_xsxsigqp 10", (vui128_t) sig, (vui128_t) sigt);
+
+  sigs = (vui128_t) vec_or ((vui64_t) sig, vf128_nzero);
+  xp = vec_xsiexpqp (sigs, exp);
+  xpt = vec_xfer_vui64t_2_bin128 ( vf128_ninf );
+  rc += check_f128 ("check vec_xsiexpqp 10", x, xp, xpt);
+
+  x = vec_xfer_vui64t_2_bin128 ( vf128_nan );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  exp = vec_xsxexpqp (x);
+  expt =  CONST_VINT128_DW(0x0000000000007fff, 0);
+  rc += check_vuint128x ("check vec_xsxexpqp 11", (vui128_t) exp, (vui128_t) expt);
+
+  sig = vec_xsxsigqp (x);
+  sigt =  (vui128_t) CONST_VINT128_DW(0x0000800000000000, 0);
+  rc += check_vuint128x ("check vec_xsxsigqp 11", (vui128_t) sig, (vui128_t) sigt);
+
+  xp = vec_xsiexpqp (sig, exp);
+  xpt = vec_xfer_vui64t_2_bin128 ( vf128_nan);
+  rc += check_f128 ("check vec_xsiexpqp 11", x, xpt, xp);
+
+  x = vec_xfer_vui64t_2_bin128 ( vf128_nnan );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  exp = vec_xsxexpqp (x);
+  expt =  CONST_VINT128_DW(0x0000000000007fff, 0);
+  rc += check_vuint128x ("check vec_xsxexpqp 12", (vui128_t) exp, (vui128_t) expt);
+
+  sig = vec_xsxsigqp (x);
+  sigt =  (vui128_t) CONST_VINT128_DW(0x0000800000000000, 0);
+  rc += check_vuint128x ("check vec_xsxsigqp 12", (vui128_t) sig, (vui128_t) sigt);
+
+  sigs = (vui128_t) vec_or ((vui64_t) sig, vf128_nzero);
+  xp = vec_xsiexpqp (sigs, exp);
+  xpt = vec_xfer_vui64t_2_bin128 ( vf128_nnan );
+  rc += check_f128 ("check vec_xsiexpqp 12", x, xp, xpt);
+
+  return (rc);
+}
+
 int
 test_vec_f128 (void)
 {
@@ -4230,5 +4574,11 @@ test_vec_f128 (void)
   rc += test_all_is_f128 ();
   rc += test_vec_bool_f128 ();
   rc += test_vec_f128_f128 ();
+  rc += test_extract_insert_f128 ();
+#ifndef PVECLIB_DISABLE_F128MATH
+#ifdef __FLOAT128__
+  rc += test_time_f128 ();
+#endif
+#endif
   return (rc);
 }

--- a/src/testsuite/vec_f128_dummy.c
+++ b/src/testsuite/vec_f128_dummy.c
@@ -40,24 +40,177 @@
 //#define __DEBUG_PRINT__
 #include <pveclib/vec_f128_ppc.h>
 
+vui32_t
+test_and_bin128_2_vui32t (__binary128 f128, vui32_t mask)
+{
+  return vec_and_bin128_2_vui32t (f128, mask);
+}
+
+vui32_t
+test_andc_bin128_2_vui32t (__binary128 f128, vui32_t mask)
+{
+  return vec_andc_bin128_2_vui32t (f128, mask);
+}
+
+vui32_t
+test_xfer_bin128_2_vui32t (__binary128 f128)
+{
+  return vec_xfer_bin128_2_vui32t (f128);
+}
+
+vui128_t
+test_xfer_bin128_2_vui128t (__binary128 f128)
+{
+  return vec_xfer_bin128_2_vui128t (f128);
+}
+
+__binary128
+test_xfer_vui32t_2_bin128 (vui32_t f128)
+{
+  return vec_xfer_vui32t_2_bin128 (f128);
+}
+
 #ifndef PVECLIB_DISABLE_F128MATH
 #ifdef __FLOAT128__
+// TBD will sub-in pveclib softfloat for P8 when available
+
 __float128
 test_scalar_add128 (__float128 vra, __float128 vrb)
 {
-  return (vra + vrb);
+  if (__builtin_cpu_supports("ieee128"))
+    {
+      __float128 result;
+      __asm__(
+	      "xsaddqp %0,%1,%2"
+	      : "=v" (result)
+	      : "v" (vra), "v" (vrb)
+	      : );
+      return result;
+    }
+  else
+    // Generate call to __addkf3
+    return (vra + vrb);
+}
+
+__float128
+test_scalar_div128 (__float128 vra, __float128 vrb)
+{
+  if (__builtin_cpu_supports("ieee128"))
+    {
+      __float128 result;
+      __asm__(
+	      "xsdivqp %0,%1,%2"
+	      : "=v" (result)
+	      : "v" (vra), "v" (vrb)
+	      : );
+      return result;
+    }
+  else
+    // Generate call to __divkf3
+    return (vra / vrb);
 }
 
 __float128
 test_scalar_mul128 (__float128 vra, __float128 vrb)
 {
-  return (vra * vrb);
+  if (__builtin_cpu_supports("ieee128"))
+    {
+      __float128 result;
+      __asm__(
+	      "xsmulqp %0,%1,%2"
+	      : "=v" (result)
+	      : "v" (vra), "v" (vrb)
+	      : );
+      return result;
+    }
+  else
+    // Generate call to __mulkf3
+    return (vra * vrb);
+}
+
+__float128
+test_scalar_sub128 (__float128 vra, __float128 vrb)
+{
+  if (__builtin_cpu_supports("ieee128"))
+    {
+      __float128 result;
+      __asm__(
+	      "xssubqp %0,%1,%2"
+	      : "=v" (result)
+	      : "v" (vra), "v" (vrb)
+	      : );
+      return result;
+    }
+  else
+    // Generate call to __subkf3
+    return (vra - vrb);
+}
+
+__float128
+test_scalarCC_expxsuba_128 (__float128 x, __float128 a, __float128 expa)
+{
+  const __float128 f128_one = 1.0Q;
+  const __float128 inv_fact2 = (1.0Q / 2.0Q);
+  const __float128 inv_fact3 = (1.0Q / 6.0Q);
+  const __float128 inv_fact4 = (1.0Q / 24.0Q);
+  const __float128 inv_fact5 = (1.0Q / 120.0Q);
+  const __float128 inv_fact6 = (1.0Q / 720.0Q);
+  const __float128 inv_fact7 = (1.0Q / 5040.0Q);
+  const __float128 inv_fact8 = (1.0Q / 40320.0Q);
+
+  __float128 term, xma, xma2, xmaf2;
+  __float128 xma3, xmaf3, xma4, xmaf4, xma5, xmaf5;
+  __float128 xma6, xmaf6, xma7, xmaf7, xma8, xmaf8;
+
+  // 1st 8 terms of e**x = e**a * taylor( x-a )
+  xma = (x - a);
+  term = (f128_one + xma);
+  xma2 = (xma * xma);
+  xmaf2 = (xma2 * inv_fact2);
+  term = (term + xmaf2);
+  xma3 = (xma2 * xma);
+  xmaf3 = (xma3 * inv_fact3);
+  term =  (term + xmaf3);
+  xma4 = (xma3 * xma);
+  xmaf4 = (xma4 * inv_fact4);
+  term = (term + xmaf4);
+  xma5 = (xma4 * xma);
+  xmaf5 = (xma5 * inv_fact5);
+  term = (term + xmaf5);
+  xma6 = (xma5 * xma);
+  xmaf6 = (xma6 * inv_fact6);
+  term = (term + xmaf6);
+  xma7 = (xma6 * xma);
+  xmaf7 = (xma7 * inv_fact7);
+  term = (term + xmaf7);
+  xma8 = (xma7 * xma);
+  xmaf8 = (xma8 * inv_fact8);
+  term = (term + xmaf8);
+  return (expa * term);
 }
 #endif
 #endif
 
+__binary128
+test_vec_xsiexpqp (vui128_t sig, vui64_t exp)
+{
+  return vec_xsiexpqp (sig, exp);
+}
+
+vui64_t
+test_vec_xsxexpqp (__binary128 f128)
+{
+  return vec_xsxexpqp (f128);
+}
+
+vui128_t
+test_vec_xsxsigqp (__binary128 f128)
+{
+  return vec_xsxsigqp (f128);
+}
+
 vb128_t
-test_setb_qp (__binary128 f128)
+__test_setb_qp (__binary128 f128)
 {
   return vec_setb_qp (f128);
 }

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -39,6 +39,54 @@
 #include <pveclib/vec_f32_ppc.h>
 #include <pveclib/vec_bcd_ppc.h>
 
+vui32_t
+test_and_bin128_2_vui32t_PWR9 (__binary128 f128, vui32_t mask)
+{
+  return vec_and_bin128_2_vui32t (f128, mask);
+}
+
+vui32_t
+test_andc_bin128_2_vui32t_PWR9 (__binary128 f128, vui32_t mask)
+{
+  return vec_andc_bin128_2_vui32t (f128, mask);
+}
+
+vui32_t
+test_xfer_bin128_2_vui32t_PWR9 (__binary128 f128)
+{
+  return vec_xfer_bin128_2_vui32t (f128);
+}
+
+vui128_t
+test_xfer_bin128_2_vui128t_PWR9 (__binary128 f128)
+{
+  return vec_xfer_bin128_2_vui128t (f128);
+}
+
+__binary128
+test_xfer_vui32t_2_bin128_PWR9 (vui32_t f128)
+{
+  return vec_xfer_vui32t_2_bin128 (f128);
+}
+
+__binary128
+test_vec_xsiexpqp_PWR9 (vui128_t sig, vui64_t exp)
+{
+  return vec_xsiexpqp (sig, exp);
+}
+
+vui64_t
+test_vec_xsxexpqp_PWR9 (__binary128 f128)
+{
+  return vec_xsxexpqp (f128);
+}
+
+vui128_t
+test_vec_xsxsigqp_PWR9 (__binary128 f128)
+{
+  return vec_xsxsigqp (f128);
+}
+
 vb128_t
 test_setb_qp_PWR9 (__binary128 f128)
 {


### PR DESCRIPTION
Also work around GCC PR 100085.

Use P9's xsiexpqp, xsxexpqp, xsxsigqp instructions plus provide
equivalent P8 implementations. In the process noticed code gen issues
document in https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100085.
So updated and augmented the vec_xfer_bin128_2_ operations with
in-line asm to work around the bad code generated for power8/LE.
In some case combined the xfer with logical operations to avoid
redundent instructions.

	* src/pveclib/vec_f128_ppc.h (vec_and_bin128_2_vui32t,
	vec_andc_bin128_2_vui32t, vec_andc_bin128_2_vui128t):
	New transfer with logical and operations.
	(vec_xfer_bin128_2_vui8t [!defined (_ARCH_PWR9)]):
	Add inline xfer (xxlor/vmr).
	(vec_xfer_bin128_2_vui32t [!defined (_ARCH_PWR9)]):
	Add inline xfer (xxlor/vmr).
	(vec_xfer_bin128_2_vui128t [!defined (_ARCH_PWR9)]):
	Add inline xfer (xxlor/vmr).
	(vec_absf128 [!defined (_ARCH_PWR9)]):
	Combine xfer/andc into vec_andc_bin128_2_vui32t.
	(vec_all_isfinitef128 [!defined (_ARCH_PWR9)]):
	Combine xfer/and into vec_and_bin128_2_vui32t.
	(vec_all_isinff128 [!defined (_ARCH_PWR9)]):
	Combine xfer/andc into vec_andc_bin128_2_vui32t.
	(vec_all_isnanf128 [!defined (_ARCH_PWR9)]):
	Combine xfer/andc/and into vec_andc_bin128_2_vui32t,
	vec_and_bin128_2_vui32t.
	(vec_all_isnormalf128 [!defined (_ARCH_PWR9)]):
	Combine xfer/and into vec_and_bin128_2_vui32t.
	(vec_all_issubnormalf128 [!defined (_ARCH_PWR9)]):
	Expand vec_absf128 manually to avoid redundent operations.
	(vec_all_iszerof128 [!defined (_ARCH_PWR9)]):
	Combine xfer/andc into vec_andc_bin128_2_vui32t.
	(vec_isfinitef128 [!defined (_ARCH_PWR9)]):
	Combine xfer/and into vec_and_bin128_2_vui32t.
	(vec_isinf_signf128 [!defined (_ARCH_PWR9)]):
	Combine xfer/andc into vec_andc_bin128_2_vui32t.
	(vec_isinff128 [!defined (_ARCH_PWR9)]):
	Combine xfer/andc into vec_andc_bin128_2_vui32t.
	(vec_isnanf128 [!defined (_ARCH_PWR9)]):
	Combine xfer/andc into vec_andc_bin128_2_vui32t.
	(vec_isnormalf128 [!defined (_ARCH_PWR9)]):
	Combine xfer/and into vec_and_bin128_2_vui32t.
	(vec_issubnormalf128 [!defined (_ARCH_PWR9)]):
	Expand vec_absf128 manually to avoid redundent operations.
	(vec_iszerof128 [!defined (_ARCH_PWR9)]):
	Combine xfer/andc into vec_andc_bin128_2_vui32t.
	(vec_signbitf128 [!defined (_ARCH_PWR9)]):
	Combine xfer/and into vec_and_bin128_2_vui32t.
	(vec_xsiexpqp, vec_xsxexpqp, vec_xsxsigqp): New operations.

	* src/testsuite/arith128_test_f128.c (test_scalar_add128,
	test_scalar_div128, test_scalar_mul128, test_scalar_sub128):
	Define externs.
	(f128_one, f128_e, inv_fact2, inv_fact3, inv_fact4, inv_fact5,
	inv_fact6, inv_fact7, inv_fact8): Define QP constants.
	(test_scalarLib_expxsuba_128): New function.
	(timed_expxsuba_v1_f128, timed_expxsuba_v2_f128): New timed
	functions.
	(test_time_f128): New timed tests driver.
	(test_extract_insert_f128): New unit test.
	(test_vec_f128): Add test_extract_insert_f128 and
	test_time_f128 calls to test driver.

	* src/testsuite/vec_f128_dummy.c (test_and_bin128_2_vui32t,
	test_andc_bin128_2_vui32t, test_xfer_bin128_2_vui32t,
	test_xfer_bin128_2_vui128t, test_xfer_vui32t_2_bin128):
	New compile tests.
	([!PVECLIB_DISABLE_F128MATH] test_scalar_add128,
	test_scalar_mul128): Add __builtin_cpu_supports for power9.
	(test_scalar_div128, test_scalar_sub128,
	test_scalarCC_expxsuba_128): New timed functions.
	(test_vec_xsiexpqp, test_vec_xsxexpqp, test_vec_xsxsigqp):
	New compile tests.
	(__test_setb_qp): renamed from test_setb_qp to avoid naming
	conflict.

	* src/testsuite/vec_pwr9_dummy.c
	(test_and_bin128_2_vui32t_PWR9, test_andc_bin128_2_vui32t_PWR9,
	test_xfer_bin128_2_vui32t_PWR9,
	test_xfer_bin128_2_vui128t_PWR9,test_xfer_vui32t_2_bin128_PWR9,
	test_vec_xsiexpqp_PWR9, test_vec_xsxexpqp_PWR9
	test_vec_xsxsigqp_PWR9): New compile tests.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>