### PR TITLE
Part2 P9/10 Float128 compare instructions plus P8 equivalants.

### DIFF
--- a/src/pveclib/vec_f128_ppc.h
+++ b/src/pveclib/vec_f128_ppc.h
@@ -1763,6 +1763,229 @@ vec_cmpequqp (__binary128 vfa, __binary128 vfb)
   return result;
 }
 
+/** \brief Vector Compare Greater Than or Equal (Total-order) Quad-Precision.
+ *
+ *  Compare Binary-float 128-bit values and return all '1's,
+ *  if vfa >= vfb, otherwise all '0's.
+ *  Zeros, Infinities and NaNs are compared as signed values.
+ *  Infinities and NaNs have the highest/lowest magnitudes.
+ *
+ *  For POWER9 (PowerISA 3.0B) or later, use a VSX Scalar Compare
+ *  Unordered Quad-Precision or (POWER10) VSX Scalar Compare Greater
+ *  Than Quad-Precision instruction.
+ *  Otherwise comparands are converted to unsigned integer magnitudes
+ *  before using vector __int128 comparison to implement the equivalent
+ *  Quad-precision floating-point operation. This leverages operations
+ *  from vec_int128_ppc.h.
+ *
+ *  \note This operation <I>may not</I> follow the IEEE standard
+ *  relative to signed zero, or NaN comparison.
+ *  However if the hardware target includes an instruction that does
+ *  implement the IEEE standard, the implementation may use that.
+ *  This relaxed implementation may be useful for implementations on
+ *  POWER8 and earlier. Especially for soft-float implementations
+ *  where it is known these special cases do not occur.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 26-35 | 2/cycle  |
+ *  |power9   | 3     | 2/cycle  |
+ *
+ *  @param vfa 128-bit vector treated as a scalar __binary128.
+ *  @param vfb 128-bit vector treated as a scalar __binary128.
+ *  @return 128-bit vector boolean reflecting __binary128
+ *  compare greater than or equal.
+ */
+static inline vb128_t
+vec_cmpgetoqp (__binary128 vfa, __binary128 vfb)
+{
+  vb128_t result;
+#if defined (_ARCH_PWR10) && defined (__FLOAT128__)  && (__GNUC__ >= 10)
+  __asm__(
+      "xscmpgtqp %0,%2,%1;\n"
+      : "=v" (result)
+      : "v" (vfa), "v" (vfb)
+      : );
+  result = (vb128_t) vec_nor ((vui32_t) result, (vui32_t) result);
+#elif defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  result= (vb128_t) vec_splat_u32 (0);
+  if (vfa >= vfb)
+    result= (vb128_t) vec_splat_s32 (-1);
+#else // defined( _ARCH_PWR8 )
+  vui128_t vfa128, vfb128;
+  vb128_t altb, agtb;
+  vb128_t signbool;
+  const vui8_t shift = vec_splat_u8 (7);
+  vui8_t splatvfa;
+
+  vfa128 = vec_xfer_bin128_2_vui128t (vfa);
+  vfb128 = vec_xfer_bin128_2_vui128t (vfb);
+
+  // Replace (vfa >= 0) with (vfa < 0) == vec_setb_qp (vfa)
+  splatvfa = vec_splat ((vui8_t) vfa128, VEC_BYTE_H);
+  signbool = (vb128_t) vec_sra (splatvfa, shift);
+
+  agtb = vec_cmpgesq ((vi128_t) vfa128, (vi128_t) vfb128);
+  altb = vec_cmpleuq ((vui128_t) vfa128, (vui128_t) vfb128);
+  result = (vb128_t) vec_sel ((vui32_t)agtb, (vui32_t)altb, (vui32_t)signbool);
+#endif
+  return result;
+}
+
+/** \brief Vector Compare Greater Than Or Equal (Zero-unordered) Quad-Precision.
+ *
+ *  Compare Binary-float 128-bit values and return all '1's,
+ *  if vfa >= vfb, otherwise all '0's.
+ *  Zeros of either sign are converted to +0.
+ *  Infinities and NaNs are compared as signed values.
+ *  Infinities and NaNs have the highest/lowest magnitudes.
+ *
+ *  For POWER9 (PowerISA 3.0B) or later, use a VSX Scalar Compare
+ *  Unordered Quad-Precision or (POWER10) VSX Scalar Compare Greater
+ *  Than Quad-Precision instruction.
+ *  Otherwise comparands are converted to unsigned integer magnitudes
+ *  before using vector __int128 comparison to implement the equivalent
+ *  Quad-precision floating-point operation. This leverages operations
+ *  from vec_int128_ppc.h.
+ *
+ *  \note This operation <I>may not</I> follow the IEEE standard
+ *  relative to NaN comparison.
+ *  However if the hardware target includes an instruction that does
+ *  implement the IEEE standard, the implementation may use that.
+ *  This relaxed implementation may be useful for implementations on
+ *  POWER8 and earlier. Especially for soft-float implementations
+ *  where it is known these special cases do not occur.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 28-37 | 2/cycle  |
+ *  |power9   | 3     | 2/cycle  |
+ *
+ *  @param vfa 128-bit vector treated as a scalar __binary128.
+ *  @param vfb 128-bit vector treated as a scalar __binary128.
+ *  @return 128-bit vector boolean reflecting __binary128
+ *  compare greater than or equal.
+ */
+static inline vb128_t
+vec_cmpgeuzqp (__binary128 vfa, __binary128 vfb)
+{
+  vb128_t result;
+#if defined (_ARCH_PWR10) && defined (__FLOAT128__)  && (__GNUC__ >= 10)
+  __asm__(
+      "xscmpgtqp %0,%2,%1;\n"
+      : "=v" (result)
+      : "v" (vfa), "v" (vfb)
+      : );
+  result = (vb128_t) vec_nor ((vui32_t) result, (vui32_t) result);
+#elif defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  result = (vb128_t) vec_splat_u32 (0);
+  if (vfa >= vfb)
+    result = (vb128_t) vec_splat_s32 (-1);
+#else // defined( _ARCH_PWR8 )
+  const vui32_t zero = CONST_VINT128_W(0, 0, 0, 0);
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
+  vui128_t vra, vrb;
+  vb128_t age0, bge0;
+  vui128_t vrap, vran;
+  vui128_t vrbp, vrbn;
+  vui8_t splatvfa, splatvfb;
+
+  vra = vec_xfer_bin128_2_vui128t (vfa);
+  vrb = vec_xfer_bin128_2_vui128t (vfb);
+
+  age0 = vec_setb_qp (vfa);
+  vrap = (vui128_t) vec_xor ((vui32_t) vra, signmask);
+  vran = (vui128_t) vec_subuqm ((vui128_t) zero, (vui128_t) vra);
+  vra  = (vui128_t) vec_sel ((vui32_t)vrap, (vui32_t)vran, (vui32_t)age0);
+
+  bge0 = vec_setb_qp (vfb);
+  vrbp = (vui128_t) vec_xor ((vui32_t) vrb, signmask);
+  vrbn = (vui128_t) vec_subuqm ((vui128_t) zero, (vui128_t) vrb);
+  vrb  = (vui128_t) vec_sel ((vui32_t)vrbp, (vui32_t)vrbn, (vui32_t)bge0);
+
+  result = vec_cmpgeuq ((vui128_t) vra, (vui128_t) vrb);
+#endif
+  return result;
+}
+
+/** \brief Vector Compare Greater Than or Equal (Unordered) Quad-Precision.
+ *
+ *  Compare Binary-float 128-bit values and return all '1's,
+ *  if vfa >= vfb, otherwise all '0's.
+ *  Zeros of either sign are converted to +0.
+ *  Infinities of different signs compare ordered.
+ *  A NaN in either or both operands compare unordered.
+ *
+ *  For POWER9 (PowerISA 3.0B) or later, use a VSX Scalar Compare
+ *  Unordered Quad-Precision or (POWER10) VSX Scalar Compare Greater Than
+ *  Quad-Precision instruction.
+ *  Otherwise comparands are converted to unsigned integer magnitudes
+ *  before using vector __int128 comparison to implement the equivalent
+ *  Quad-precision floating-point operation. This leverages operations
+ *  from vec_int128_ppc.h.
+ *
+ *  \note This operation <I>may not</I> follow the IEEE standard
+ *  relative to NaN comparison.
+ *  However if the hardware target includes an instruction that does
+ *  implement the IEEE standard, the implementation may use that.
+ *  This relaxed implementation may be useful for implementations on
+ *  POWER8 and earlier. Especially for soft-float implementations
+ *  where it is known these special cases do not occur.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 28-37 | 2/cycle  |
+ *  |power9   | 3     | 2/cycle  |
+ *
+ *  @param vfa 128-bit vector treated as a scalar __binary128.
+ *  @param vfb 128-bit vector treated as a scalar __binary128.
+ *  @return 128-bit vector boolean reflecting __binary128
+ *  compare greater than or equal.
+ */
+static inline vb128_t
+vec_cmpgeuqp (__binary128 vfa, __binary128 vfb)
+{
+  vb128_t result;
+#if defined (_ARCH_PWR10) && defined (__FLOAT128__)  && (__GNUC__ >= 10)
+  __asm__(
+      "xscmpgtqp %0,%2,%1;\n"
+      : "=v" (result)
+      : "v" (vfa), "v" (vfb)
+      : );
+  result = (vb128_t) vec_nor ((vui32_t) result, (vui32_t) result);
+#elif defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  result= (vb128_t) vec_splat_u32 (0);
+  if (vfa >= vfb)
+    result= (vb128_t) vec_splat_s32 (-1);
+#else // defined( _ARCH_PWR8 )
+  const vui32_t zero = CONST_VINT128_W(0, 0, 0, 0);
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
+  vui128_t vra, vrb;
+  vb128_t age0, bge0;
+  vui128_t vrap, vran;
+  vui128_t vrbp, vrbn;
+
+  if (__builtin_expect ((vec_all_isnanf128 (vfa) || vec_all_isnanf128 (vfb)), 0))
+    return (vb128_t) vec_splat_u32 (0);
+
+  vra = vec_xfer_bin128_2_vui128t (vfa);
+  vrb = vec_xfer_bin128_2_vui128t (vfb);
+
+  age0 = vec_setb_qp (vfa);
+  vrap = (vui128_t) vec_xor ((vui32_t) vra, signmask);
+  vran = (vui128_t) vec_subuqm ((vui128_t) zero, (vui128_t) vra);
+  vra  = (vui128_t) vec_sel ((vui32_t)vrap, (vui32_t)vran, (vui32_t)age0);
+
+  bge0 = vec_setb_qp (vfb);
+  vrbp = (vui128_t) vec_xor ((vui32_t) vrb, signmask);
+  vrbn = (vui128_t) vec_subuqm ((vui128_t) zero, (vui128_t) vrb);
+  vrb  = (vui128_t) vec_sel ((vui32_t)vrbp, (vui32_t)vrbn, (vui32_t)bge0);
+
+  result = vec_cmpgeuq ((vui128_t) vra, (vui128_t) vrb);
+#endif
+  return result;
+}
+
 /** \brief Vector Compare Greater Than (Total-order) Quad-Precision.
  *
  *  Compare Binary-float 128-bit values and return all '1's,
@@ -1794,7 +2017,7 @@ vec_cmpequqp (__binary128 vfa, __binary128 vfb)
  *  @param vfa 128-bit vector treated as a scalar __binary128.
  *  @param vfb 128-bit vector treated as a scalar __binary128.
  *  @return 128-bit vector boolean reflecting __binary128
- *  compare equal.
+ *  compare greater than.
  */
 static inline vb128_t
 vec_cmpgttoqp (__binary128 vfa, __binary128 vfb)
@@ -1863,7 +2086,7 @@ vec_cmpgttoqp (__binary128 vfa, __binary128 vfb)
  *  @param vfa 128-bit vector treated as a scalar __binary128.
  *  @param vfb 128-bit vector treated as a scalar __binary128.
  *  @return 128-bit vector boolean reflecting __binary128
- *  compare equal.
+ *  compare greater than.
  */
 static inline vb128_t
 vec_cmpgtuzqp (__binary128 vfa, __binary128 vfb)
@@ -1938,7 +2161,7 @@ vec_cmpgtuzqp (__binary128 vfa, __binary128 vfb)
  *  @param vfa 128-bit vector treated as a scalar __binary128.
  *  @param vfb 128-bit vector treated as a scalar __binary128.
  *  @return 128-bit vector boolean reflecting __binary128
- *  compare equal.
+ *  compare greater than.
  */
 static inline vb128_t
 vec_cmpgtuqp (__binary128 vfa, __binary128 vfb)
@@ -1979,6 +2202,635 @@ vec_cmpgtuqp (__binary128 vfa, __binary128 vfb)
   vrb  = (vui128_t) vec_sel ((vui32_t)vrbp, (vui32_t)vrbn, (vui32_t)bge0);
 
   result = vec_cmpgtuq ((vui128_t) vra, (vui128_t) vrb);
+#endif
+  return result;
+}
+
+/** \brief Vector Compare Less Than or Equal (Total-order) Quad-Precision.
+ *
+ *  Compare Binary-float 128-bit values and return all '1's,
+ *  if vfa <= vfb, otherwise all '0's.
+ *  Zeros, Infinities and NaNs are compared as signed values.
+ *  Infinities and NaNs have the highest/lowest magnitudes.
+ *
+ *  For POWER9 (PowerISA 3.0B) or later, use a VSX Scalar Compare
+ *  Unordered Quad-Precision or (POWER10) VSX Scalar Compare Greater
+ *  Than Quad-Precision instruction.
+ *  Otherwise comparands are converted to unsigned integer magnitudes
+ *  before using vector __int128 comparison to implement the equivalent
+ *  Quad-precision floating-point operation. This leverages operations
+ *  from vec_int128_ppc.h.
+ *
+ *  \note This operation <I>may not</I> follow the IEEE standard
+ *  relative to signed zero, or NaN comparison.
+ *  However if the hardware target includes an instruction that does
+ *  implement the IEEE standard, the implementation may use that.
+ *  This relaxed implementation may be useful for implementations on
+ *  POWER8 and earlier. Especially for soft-float implementations
+ *  where it is known these special cases do not occur.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 26-35 | 2/cycle  |
+ *  |power9   | 3     | 2/cycle  |
+ *
+ *  @param vfa 128-bit vector treated as a scalar __binary128.
+ *  @param vfb 128-bit vector treated as a scalar __binary128.
+ *  @return 128-bit vector boolean reflecting __binary128
+ *  compare less than or equal.
+ */
+static inline vb128_t
+vec_cmpletoqp (__binary128 vfa, __binary128 vfb)
+{
+  vb128_t result;
+#if defined (_ARCH_PWR10) && defined (__FLOAT128__)  && (__GNUC__ >= 10)
+  __asm__(
+      "xscmpgtqp %0,%1,%2;\n"
+      : "=v" (result)
+      : "v" (vfa), "v" (vfb)
+      : );
+  result = (vb128_t) vec_nor ((vui32_t) result, (vui32_t) result);
+#elif defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  result= (vb128_t) vec_splat_u32 (0);
+  if (vfa <= vfb)
+    result= (vb128_t) vec_splat_s32 (-1);
+#else // defined( _ARCH_PWR8 )
+  vui128_t vfa128, vfb128;
+  vb128_t altb, agtb;
+  vb128_t signbool;
+  const vui8_t shift = vec_splat_u8 (7);
+  vui8_t splatvfa;
+
+  vfa128 = vec_xfer_bin128_2_vui128t (vfa);
+  vfb128 = vec_xfer_bin128_2_vui128t (vfb);
+
+  // Replace (vfa >= 0) with (vfa < 0) == vec_setb_qp (vfa)
+  splatvfa = vec_splat ((vui8_t) vfa128, VEC_BYTE_H);
+  signbool = (vb128_t) vec_sra (splatvfa, shift);
+
+  altb = vec_cmplesq ((vi128_t) vfa128, (vi128_t) vfb128);
+  agtb = vec_cmpgeuq ((vui128_t) vfa128, (vui128_t) vfb128);
+  result = (vb128_t) vec_sel ((vui32_t)altb, (vui32_t)agtb, (vui32_t)signbool);
+#endif
+  return result;
+}
+
+/** \brief Vector Compare Less Than or Equal (Zero-unordered) Quad-Precision.
+ *
+ *  Compare Binary-float 128-bit values and return all '1's,
+ *  if vfa <= vfb, otherwise all '0's.
+ *  Zeros of either sign are converted to +0.
+ *  Infinities and NaNs are compared as signed values.
+ *  Infinities and NaNs have the highest/lowest magnitudes.
+ *
+ *  For POWER9 (PowerISA 3.0B) or later, use a VSX Scalar Compare
+ *  Unordered Quad-Precision or (POWER10) VSX Scalar Compare Greater
+ *  Than Quad-Precision instruction.
+ *  Otherwise comparands are converted to unsigned integer magnitudes
+ *  before using vector __int128 comparison to implement the equivalent
+ *  Quad-precision floating-point operation. This leverages operations
+ *  from vec_int128_ppc.h.
+ *
+ *  \note This operation <I>may not</I> follow the IEEE standard
+ *  relative to NaN comparison.
+ *  However if the hardware target includes an instruction that does
+ *  implement the IEEE standard, the implementation may use that.
+ *  This relaxed implementation may be useful for implementations on
+ *  POWER8 and earlier. Especially for soft-float implementations
+ *  where it is known these special cases do not occur.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 28-37 | 2/cycle  |
+ *  |power9   | 3     | 2/cycle  |
+ *
+ *  @param vfa 128-bit vector treated as a scalar __binary128.
+ *  @param vfb 128-bit vector treated as a scalar __binary128.
+ *  @return 128-bit vector boolean reflecting __binary128
+ *  compare less than or equal.
+ */
+static inline vb128_t
+vec_cmpleuzqp (__binary128 vfa, __binary128 vfb)
+{
+  vb128_t result;
+#if defined (_ARCH_PWR10) && defined (__FLOAT128__)  && (__GNUC__ >= 10)
+  __asm__(
+      "xscmpgtqp %0,%1,%2;\n"
+      : "=v" (result)
+      : "v" (vfa), "v" (vfb)
+      : );
+  result = (vb128_t) vec_nor ((vui32_t) result, (vui32_t) result);
+#elif defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  result = (vb128_t) vec_splat_u32 (0);
+  if (vfa <= vfb)
+    result = (vb128_t) vec_splat_s32 (-1);
+#else // defined( _ARCH_PWR8 )
+  const vui32_t zero = CONST_VINT128_W(0, 0, 0, 0);
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
+  vui128_t vra, vrb;
+  vb128_t age0, bge0;
+  vui128_t vrap, vran;
+  vui128_t vrbp, vrbn;
+  vui8_t splatvfa, splatvfb;
+
+  vra = vec_xfer_bin128_2_vui128t (vfa);
+  vrb = vec_xfer_bin128_2_vui128t (vfb);
+
+  age0 = vec_setb_qp (vfa);
+  vrap = (vui128_t) vec_xor ((vui32_t) vra, signmask);
+  vran = (vui128_t) vec_subuqm ((vui128_t) zero, (vui128_t) vra);
+  vra  = (vui128_t) vec_sel ((vui32_t)vrap, (vui32_t)vran, (vui32_t)age0);
+
+  bge0 = vec_setb_qp (vfb);
+  vrbp = (vui128_t) vec_xor ((vui32_t) vrb, signmask);
+  vrbn = (vui128_t) vec_subuqm ((vui128_t) zero, (vui128_t) vrb);
+  vrb  = (vui128_t) vec_sel ((vui32_t)vrbp, (vui32_t)vrbn, (vui32_t)bge0);
+
+  result = vec_cmpleuq ((vui128_t) vra, (vui128_t) vrb);
+#endif
+  return result;
+}
+
+/** \brief Vector Compare Less Than or Equal (Unordered) Quad-Precision.
+ *
+ *  Compare Binary-float 128-bit values and return all '1's,
+ *  if vfa <= vfb, otherwise all '0's.
+ *  Zeros of either sign are converted to +0.
+ *  Infinities of different signs compare ordered.
+ *  A NaN in either or both operands compare unordered.
+ *
+ *  For POWER9 (PowerISA 3.0B) or later, use a VSX Scalar Compare
+ *  Unordered Quad-Precision or (POWER10) VSX Scalar Compare Greater Than
+ *  Quad-Precision instruction.
+ *  Otherwise comparands are converted to unsigned integer magnitudes
+ *  before using vector __int128 comparison to implement the equivalent
+ *  Quad-precision floating-point operation. This leverages operations
+ *  from vec_int128_ppc.h.
+ *
+ *  \note This operation <I>may not</I> follow the IEEE standard
+ *  relative to NaN comparison.
+ *  However if the hardware target includes an instruction that does
+ *  implement the IEEE standard, the implementation may use that.
+ *  This relaxed implementation may be useful for implementations on
+ *  POWER8 and earlier. Especially for soft-float implementations
+ *  where it is known these special cases do not occur.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 28-37 | 2/cycle  |
+ *  |power9   | 3     | 2/cycle  |
+ *
+ *  @param vfa 128-bit vector treated as a scalar __binary128.
+ *  @param vfb 128-bit vector treated as a scalar __binary128.
+ *  @return 128-bit vector boolean reflecting __binary128
+ *  compare less than or equal.
+ */
+static inline vb128_t
+vec_cmpleuqp (__binary128 vfa, __binary128 vfb)
+{
+  vb128_t result;
+#if defined (_ARCH_PWR10) && defined (__FLOAT128__)  && (__GNUC__ >= 10)
+  __asm__(
+      "xscmpgtqp %0,%1,%2;\n"
+      : "=v" (result)
+      : "v" (vfa), "v" (vfb)
+      : );
+  result = (vb128_t) vec_nor ((vui32_t) result, (vui32_t) result);
+#elif defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  result= (vb128_t) vec_splat_u32 (0);
+  if (vfa <= vfb)
+    result= (vb128_t) vec_splat_s32 (-1);
+#else // defined( _ARCH_PWR8 )
+  const vui32_t zero = CONST_VINT128_W(0, 0, 0, 0);
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
+  vui128_t vra, vrb;
+  vb128_t age0, bge0;
+  vui128_t vrap, vran;
+  vui128_t vrbp, vrbn;
+
+  if (__builtin_expect ((vec_all_isnanf128 (vfa) || vec_all_isnanf128 (vfb)), 0))
+    return (vb128_t) vec_splat_u32 (0);
+
+  vra = vec_xfer_bin128_2_vui128t (vfa);
+  vrb = vec_xfer_bin128_2_vui128t (vfb);
+
+  age0 = vec_setb_qp (vfa);
+  vrap = (vui128_t) vec_xor ((vui32_t) vra, signmask);
+  vran = (vui128_t) vec_subuqm ((vui128_t) zero, (vui128_t) vra);
+  vra  = (vui128_t) vec_sel ((vui32_t)vrap, (vui32_t)vran, (vui32_t)age0);
+
+  bge0 = vec_setb_qp (vfb);
+  vrbp = (vui128_t) vec_xor ((vui32_t) vrb, signmask);
+  vrbn = (vui128_t) vec_subuqm ((vui128_t) zero, (vui128_t) vrb);
+  vrb  = (vui128_t) vec_sel ((vui32_t)vrbp, (vui32_t)vrbn, (vui32_t)bge0);
+
+  result = vec_cmpleuq ((vui128_t) vra, (vui128_t) vrb);
+#endif
+  return result;
+}
+
+/** \brief Vector Compare Less Than (Total-order) Quad-Precision.
+ *
+ *  Compare Binary-float 128-bit values and return all '1's,
+ *  if vfa < vfb, otherwise all '0's.
+ *  Zeros, Infinities and NaNs are compared as signed values.
+ *  Infinities and NaNs have the highest/lowest magnitudes.
+ *
+ *  For POWER9 (PowerISA 3.0B) or later, use a VSX Scalar Compare
+ *  Unordered Quad-Precision or (POWER10) VSX Scalar Compare Greater
+ *  Than Quad-Precision instruction.
+ *  Otherwise comparands are converted to unsigned integer magnitudes
+ *  before using vector __int128 comparison to implement the equivalent
+ *  Quad-precision floating-point operation. This leverages operations
+ *  from vec_int128_ppc.h.
+ *
+ *  \note This operation <I>may not</I> follow the IEEE standard
+ *  relative to signed zero, or NaN comparison.
+ *  However if the hardware target includes an instruction that does
+ *  implement the IEEE standard, the implementation may use that.
+ *  This relaxed implementation may be useful for implementations on
+ *  POWER8 and earlier. Especially for soft-float implementations
+ *  where it is known these special cases do not occur.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 26-35 | 2/cycle  |
+ *  |power9   | 3     | 2/cycle  |
+ *
+ *  @param vfa 128-bit vector treated as a scalar __binary128.
+ *  @param vfb 128-bit vector treated as a scalar __binary128.
+ *  @return 128-bit vector boolean reflecting __binary128
+ *  compare less than.
+ */
+static inline vb128_t
+vec_cmplttoqp (__binary128 vfa, __binary128 vfb)
+{
+  vb128_t result;
+#if defined (_ARCH_PWR10) && defined (__FLOAT128__)  && (__GNUC__ >= 10)
+  __asm__(
+      "xscmpgtqp %0,%2,%1;\n"
+      : "=v" (result)
+      : "v" (vfa), "v" (vfb)
+      : );
+#elif defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  result= (vb128_t) vec_splat_u32 (0);
+  if (vfa < vfb)
+    result= (vb128_t) vec_splat_s32 (-1);
+#else // defined( _ARCH_PWR8 )
+  vui128_t vfa128, vfb128;
+  vb128_t altb, agtb;
+  vb128_t signbool;
+  const vui8_t shift = vec_splat_u8 (7);
+  vui8_t splatvfa;
+
+  vfa128 = vec_xfer_bin128_2_vui128t (vfa);
+  vfb128 = vec_xfer_bin128_2_vui128t (vfb);
+
+  // Replace (vfa >= 0) with (vfa < 0) == vec_setb_qp (vfa)
+  splatvfa = vec_splat ((vui8_t) vfa128, VEC_BYTE_H);
+  signbool = (vb128_t) vec_sra (splatvfa, shift);
+
+  altb = vec_cmpltsq ((vi128_t) vfa128, (vi128_t) vfb128);
+  agtb = vec_cmpgtuq ((vui128_t) vfa128, (vui128_t) vfb128);
+  result = (vb128_t) vec_sel ((vui32_t)altb, (vui32_t)agtb, (vui32_t)signbool);
+#endif
+  return result;
+}
+
+/** \brief Vector Compare Less Than (Zero-unordered) Quad-Precision.
+ *
+ *  Compare Binary-float 128-bit values and return all '1's,
+ *  if vfa < vfb, otherwise all '0's.
+ *  Zeros of either sign are converted to +0.
+ *  Infinities and NaNs are compared as signed values.
+ *  Infinities and NaNs have the highest/lowest magnitudes.
+ *
+ *  For POWER9 (PowerISA 3.0B) or later, use a VSX Scalar Compare
+ *  Unordered Quad-Precision or (POWER10) VSX Scalar Compare Greater
+ *  Than Quad-Precision instruction.
+ *  Otherwise comparands are converted to unsigned integer magnitudes
+ *  before using vector __int128 comparison to implement the equivalent
+ *  Quad-precision floating-point operation. This leverages operations
+ *  from vec_int128_ppc.h.
+ *
+ *  \note This operation <I>may not</I> follow the IEEE standard
+ *  relative to NaN comparison.
+ *  However if the hardware target includes an instruction that does
+ *  implement the IEEE standard, the implementation may use that.
+ *  This relaxed implementation may be useful for implementations on
+ *  POWER8 and earlier. Especially for soft-float implementations
+ *  where it is known these special cases do not occur.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 28-37 | 2/cycle  |
+ *  |power9   | 3     | 2/cycle  |
+ *
+ *  @param vfa 128-bit vector treated as a scalar __binary128.
+ *  @param vfb 128-bit vector treated as a scalar __binary128.
+ *  @return 128-bit vector boolean reflecting __binary128
+ *  compare less than.
+ */
+static inline vb128_t
+vec_cmpltuzqp (__binary128 vfa, __binary128 vfb)
+{
+  vb128_t result;
+#if defined (_ARCH_PWR10) && defined (__FLOAT128__)  && (__GNUC__ >= 10)
+  __asm__(
+      "xscmpgtqp %0,%2,%1;\n"
+      : "=v" (result)
+      : "v" (vfa), "v" (vfb)
+      : );
+#elif defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  result = (vb128_t) vec_splat_u32 (0);
+  if (vfa < vfb)
+    result = (vb128_t) vec_splat_s32 (-1);
+#else // defined( _ARCH_PWR8 )
+  const vui32_t zero = CONST_VINT128_W(0, 0, 0, 0);
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
+  vui128_t vra, vrb;
+  vb128_t age0, bge0;
+  vui128_t vrap, vran;
+  vui128_t vrbp, vrbn;
+  vui8_t splatvfa, splatvfb;
+
+  vra = vec_xfer_bin128_2_vui128t (vfa);
+  vrb = vec_xfer_bin128_2_vui128t (vfb);
+
+  age0 = vec_setb_qp (vfa);
+  vrap = (vui128_t) vec_xor ((vui32_t) vra, signmask);
+  vran = (vui128_t) vec_subuqm ((vui128_t) zero, (vui128_t) vra);
+  vra  = (vui128_t) vec_sel ((vui32_t)vrap, (vui32_t)vran, (vui32_t)age0);
+
+  bge0 = vec_setb_qp (vfb);
+  vrbp = (vui128_t) vec_xor ((vui32_t) vrb, signmask);
+  vrbn = (vui128_t) vec_subuqm ((vui128_t) zero, (vui128_t) vrb);
+  vrb  = (vui128_t) vec_sel ((vui32_t)vrbp, (vui32_t)vrbn, (vui32_t)bge0);
+
+  result = vec_cmpltuq ((vui128_t) vra, (vui128_t) vrb);
+#endif
+  return result;
+}
+
+/** \brief Vector Compare Less Than (Unordered) Quad-Precision.
+ *
+ *  Compare Binary-float 128-bit values and return all '1's,
+ *  if vfa < vfb, otherwise all '0's.
+ *  Zeros of either sign are converted to +0.
+ *  Infinities of different signs compare ordered.
+ *  A NaN in either or both operands compare unordered.
+ *
+ *  For POWER9 (PowerISA 3.0B) or later, use a VSX Scalar Compare
+ *  Unordered Quad-Precision or (POWER10) VSX Scalar Compare Greater Than
+ *  Quad-Precision instruction.
+ *  Otherwise comparands are converted to unsigned integer magnitudes
+ *  before using vector __int128 comparison to implement the equivalent
+ *  Quad-precision floating-point operation. This leverages operations
+ *  from vec_int128_ppc.h.
+ *
+ *  \note This operation <I>may not</I> follow the IEEE standard
+ *  relative to NaN comparison.
+ *  However if the hardware target includes an instruction that does
+ *  implement the IEEE standard, the implementation may use that.
+ *  This relaxed implementation may be useful for implementations on
+ *  POWER8 and earlier. Especially for soft-float implementations
+ *  where it is known these special cases do not occur.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 28-37 | 2/cycle  |
+ *  |power9   | 3     | 2/cycle  |
+ *
+ *  @param vfa 128-bit vector treated as a scalar __binary128.
+ *  @param vfb 128-bit vector treated as a scalar __binary128.
+ *  @return 128-bit vector boolean reflecting __binary128
+ *  compare less than.
+ */
+static inline vb128_t
+vec_cmpltuqp (__binary128 vfa, __binary128 vfb)
+{
+  vb128_t result;
+#if defined (_ARCH_PWR10) && defined (__FLOAT128__)  && (__GNUC__ >= 10)
+  __asm__(
+      "xscmpgtqp %0,%2,%1;\n"
+      : "=v" (result)
+      : "v" (vfa), "v" (vfb)
+      : );
+#elif defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  result= (vb128_t) vec_splat_u32 (0);
+  if (vfa < vfb)
+    result= (vb128_t) vec_splat_s32 (-1);
+#else // defined( _ARCH_PWR8 )
+  const vui32_t zero = CONST_VINT128_W(0, 0, 0, 0);
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
+  vui128_t vra, vrb;
+  vb128_t age0, bge0;
+  vui128_t vrap, vran;
+  vui128_t vrbp, vrbn;
+
+  if (__builtin_expect ((vec_all_isnanf128 (vfa) || vec_all_isnanf128 (vfb)), 0))
+    return (vb128_t) vec_splat_u32 (0);
+
+  vra = vec_xfer_bin128_2_vui128t (vfa);
+  vrb = vec_xfer_bin128_2_vui128t (vfb);
+
+  age0 = vec_setb_qp (vfa);
+  vrap = (vui128_t) vec_xor ((vui32_t) vra, signmask);
+  vran = (vui128_t) vec_subuqm ((vui128_t) zero, (vui128_t) vra);
+  vra  = (vui128_t) vec_sel ((vui32_t)vrap, (vui32_t)vran, (vui32_t)age0);
+
+  bge0 = vec_setb_qp (vfb);
+  vrbp = (vui128_t) vec_xor ((vui32_t) vrb, signmask);
+  vrbn = (vui128_t) vec_subuqm ((vui128_t) zero, (vui128_t) vrb);
+  vrb  = (vui128_t) vec_sel ((vui32_t)vrbp, (vui32_t)vrbn, (vui32_t)bge0);
+
+  result = vec_cmpltuq ((vui128_t) vra, (vui128_t) vrb);
+#endif
+  return result;
+}
+
+/** \brief Vector Compare Not Equal (Total-order) Quad-Precision.
+ *
+ *  Compare Binary-float 128-bit values and return all '1's,
+ *  if vfa != vfb, otherwise all '0's.
+ *  Zeros, Infinities and NaN of the same sign compare equal.
+ *
+ *  For POWER9 (PowerISA 3.0B) or later, use a VSX Scalar Compare
+ *  Unordered Quad-Precision or a VSX Scalar Compare Equal
+ *  Quad-Precision instruction.
+ *  Otherwise use vector __int128 arithmetic and logical operations
+ *  to implement the equivalent Quad-precision floating-point
+ *  operation. This leverages operations from vec_int128_ppc.h.
+ *
+ *  \note This operation <I>may not</I> follow the IEEE standard
+ *  relative to signed zero, or NaN comparison.
+ *  However if the hardware target includes an instruction that does
+ *  implement the IEEE standard, the implementation may use that.
+ *  This relaxed implementation may be useful for implementations on
+ *  POWER8 and earlier. Especially for soft-float implementations
+ *  where it is known these special cases do not occur.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 6     | 2/cycle  |
+ *  |power9   | 3     | 2/cycle  |
+ *
+ *  @param vfa 128-bit vector treated as a scalar __binary128.
+ *  @param vfb 128-bit vector treated as a scalar __binary128.
+ *  @return 128-bit vector boolean reflecting __binary128
+ *  compare not equal.
+ */
+static inline vb128_t
+vec_cmpnetoqp (__binary128 vfa, __binary128 vfb)
+{
+  vb128_t result;
+#if defined (_ARCH_PWR10) && defined (__FLOAT128__)  && (__GNUC__ >= 10)
+  __asm__(
+      "xscmpeqqp %0,%1,%2;\n"
+      : "=v" (result)
+      : "v" (vfa), "v" (vfb)
+      : );
+  result = (vb128_t) vec_nor ((vui32_t) result, (vui32_t) result);
+#elif defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  result= (vb128_t) vec_splat_u32 (0);
+  if (vfa != vfb)
+    result= (vb128_t) vec_splat_s32 (-1);
+#else // defined( _ARCH_PWR8 )
+  vui128_t vra, vrb;
+  vra = vec_xfer_bin128_2_vui128t (vfa);
+  vrb = vec_xfer_bin128_2_vui128t (vfb);
+  result = vec_cmpneuq ( vra,  vrb );
+#endif
+  return result;
+}
+
+/** \brief Vector Compare Not Equal (Zero-unordered) Quad-Precision.
+ *
+ *  Compare Binary-float 128-bit values and return all '1's,
+ *  if vfa != vfb, otherwise all '0's.
+ *  Zeros of either sign compare equal.
+ *  Infinities and NaNs of the same sign compare equal.
+ *
+ *  For POWER9 (PowerISA 3.0B) or later, use a VSX Scalar Compare
+ *  Unordered Quad-Precision or a VSX Scalar Compare Equal
+ *  Quad-Precision instruction.
+ *  Otherwise use vector __int128 arithmetic and logical operations
+ *  to implement the equivalent Quad-precision floating-point
+ *  operation. This leverages operations from vec_int128_ppc.h.
+ *
+ *  \note This operation <I>may not</I> follow the IEEE standard
+ *  relative to signed zero, or NaN comparison.
+ *  However if the hardware target includes an instruction that does
+ *  implement the IEEE standard, the implementation may use that.
+ *  This relaxed implementation may be useful for implementations on
+ *  POWER8 and earlier. Especially for soft-float implementations
+ *  where it is known these special cases do not occur.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 10    | 1/cycle  |
+ *  |power9   | 3     | 2/cycle  |
+ *
+ *  @param vfa 128-bit vector treated as a scalar __binary128.
+ *  @param vfb 128-bit vector treated as a scalar __binary128.
+ *  @return 128-bit vector boolean reflecting __binary128
+ *  compare not equal.
+ */
+static inline vb128_t
+vec_cmpneuzqp (__binary128 vfa, __binary128 vfb)
+{
+  vb128_t result;
+#if defined (_ARCH_PWR10) && defined (__FLOAT128__)  && (__GNUC__ >= 10)
+  __asm__(
+      "xscmpeqqp %0,%1,%2;\n"
+      : "=v" (result)
+      : "v" (vfa), "v" (vfb)
+      : );
+  result = (vb128_t) vec_nor ((vui32_t) result, (vui32_t) result);
+#elif defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  result = (vb128_t) vec_splat_u32 (0);
+  if (vfa != vfb)
+    result = (vb128_t) vec_splat_s32 (-1);
+#else // defined( _ARCH_PWR8 )
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
+  vb128_t cmps, or_ab, eq_s;
+  vui64_t vra, vrb;
+
+  vra = vec_xfer_bin128_2_vui64t (vfa);
+  vrb = vec_xfer_bin128_2_vui64t (vfb);
+
+  or_ab = (vb128_t) vec_or ( vra, vrb );
+  eq_s = vec_cmpequq ((vui128_t) or_ab, (vui128_t) signmask);
+  cmps = vec_cmpequq ((vui128_t) vra, (vui128_t)vrb);
+  result = (vb128_t) vec_nor ((vui32_t) cmps, (vui32_t) eq_s);
+#endif
+  return result;
+}
+
+/** \brief Vector Compare Equal (Unordered) Quad-Precision.
+ *
+ *  Compare Binary-float 128-bit values and return all '1's,
+ *  if vfa == vfb, otherwise all '0's.
+ *  Zeros of either sign compare equal.
+ *  Infinities of the same sign compare equal.
+ *  A NaN in either or both operands compare unequal.
+ *
+ *  For POWER9 (PowerISA 3.0B) or later, use a VSX Scalar Compare
+ *  Unordered Quad-Precision or (POWER10) VSX Scalar Compare Equal
+ *  Quad-Precision instruction.
+ *  Otherwise use vector __int128 arithmetic and logical operations
+ *  to implement the equivalent Quad-precision floating-point
+ *  operation. This leverages operations from vec_int128_ppc.h.
+ *
+ *  \note This operation <I>may not</I> follow the IEEE standard
+ *  relative to signed zero, or NaN comparison.
+ *  However if the hardware target includes an instruction that does
+ *  implement the IEEE standard, the implementation may use that.
+ *  This relaxed implementation may be useful for implementations on
+ *  POWER8 and earlier. Especially for soft-float implementations
+ *  where it is known these special cases do not occur.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 18-30 | 1/cycle  |
+ *  |power9   | 3     | 2/cycle  |
+ *
+ *  @param vfa 128-bit vector treated as a scalar __binary128.
+ *  @param vfb 128-bit vector treated as a scalar __binary128.
+ *  @return 128-bit vector boolean reflecting __binary128
+ *  compare equal.
+ */
+static inline vb128_t
+vec_cmpneuqp (__binary128 vfa, __binary128 vfb)
+{
+  vb128_t result;
+#if defined (_ARCH_PWR10) && defined (__FLOAT128__)  && (__GNUC__ >= 10)
+  __asm__(
+      "xscmpeqqp %0,%1,%2;\n"
+      : "=v" (result)
+      : "v" (vfa), "v" (vfb)
+      : );
+  result = (vb128_t) vec_nor ((vui32_t) result, (vui32_t) result);
+#elif defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  result = (vb128_t) vec_splat_u32 (0);
+  if (vfa != vfb)
+    result = (vb128_t) vec_splat_s32 (-1);
+#else // defined( _ARCH_PWR8 )
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
+  vb128_t cmps, or_ab, eq_s;
+  vui64_t vra, vrb;
+
+  result = (vb128_t) vec_splat_u32 (0);
+  if (vec_all_isnanf128 (vfa) || vec_all_isnanf128 (vfb))
+    return result;
+
+  vra = vec_xfer_bin128_2_vui64t (vfa);
+  vrb = vec_xfer_bin128_2_vui64t (vfb);
+
+  or_ab = (vb128_t) vec_or ( vra, vrb );
+  eq_s = vec_cmpequq ((vui128_t) or_ab, (vui128_t) signmask);
+  cmps = vec_cmpequq ((vui128_t) vra, (vui128_t) vrb);
+  result = (vb128_t) vec_nor ((vui32_t) cmps, (vui32_t) eq_s);
 #endif
   return result;
 }

--- a/src/pveclib/vec_f128_ppc.h
+++ b/src/pveclib/vec_f128_ppc.h
@@ -1649,7 +1649,7 @@ vec_cmpeqtoqp (__binary128 vfa, __binary128 vfb)
  *  operation. This leverages operations from vec_int128_ppc.h.
  *
  *  \note This operation <I>may not</I> follow the IEEE standard
- *  relative to signed zero, or NaN comparison.
+ *  relative NaN comparison.
  *  However if the hardware target includes an instruction that does
  *  implement the IEEE standard, the implementation may use that.
  *  This relaxed implementation may be useful for implementations on
@@ -1711,8 +1711,8 @@ vec_cmpequzqp (__binary128 vfa, __binary128 vfb)
  *  to implement the equivalent Quad-precision floating-point
  *  operation. This leverages operations from vec_int128_ppc.h.
  *
- *  \note This operation <I>may not</I> follow the IEEE standard
- *  relative to signed zero, or NaN comparison.
+ *  \note This operation <I>may not</I> follow the PowerISA
+ *  relative to NaN comparison and setting the FPSCR.
  *  However if the hardware target includes an instruction that does
  *  implement the IEEE standard, the implementation may use that.
  *  This relaxed implementation may be useful for implementations on
@@ -1924,8 +1924,8 @@ vec_cmpgeuzqp (__binary128 vfa, __binary128 vfb)
  *  Quad-precision floating-point operation. This leverages operations
  *  from vec_int128_ppc.h.
  *
- *  \note This operation <I>may not</I> follow the IEEE standard
- *  relative to NaN comparison.
+ *  \note This operation <I>may not</I> follow the PowerISA
+ *  relative to NaN comparison and setting the FPSCR.
  *  However if the hardware target includes an instruction that does
  *  implement the IEEE standard, the implementation may use that.
  *  This relaxed implementation may be useful for implementations on
@@ -2145,8 +2145,8 @@ vec_cmpgtuzqp (__binary128 vfa, __binary128 vfb)
  *  Quad-precision floating-point operation. This leverages operations
  *  from vec_int128_ppc.h.
  *
- *  \note This operation <I>may not</I> follow the IEEE standard
- *  relative to NaN comparison.
+ *  \note This operation <I>may not</I> follow the PowerISA
+ *  relative to NaN comparison and setting the FPSCR.
  *  However if the hardware target includes an instruction that does
  *  implement the IEEE standard, the implementation may use that.
  *  This relaxed implementation may be useful for implementations on
@@ -2367,8 +2367,8 @@ vec_cmpleuzqp (__binary128 vfa, __binary128 vfb)
  *  Quad-precision floating-point operation. This leverages operations
  *  from vec_int128_ppc.h.
  *
- *  \note This operation <I>may not</I> follow the IEEE standard
- *  relative to NaN comparison.
+ *  \note This operation <I>may not</I> follow the PowerISA
+ *  relative to NaN comparison and setting the FPSCR.
  *  However if the hardware target includes an instruction that does
  *  implement the IEEE standard, the implementation may use that.
  *  This relaxed implementation may be useful for implementations on
@@ -2588,8 +2588,8 @@ vec_cmpltuzqp (__binary128 vfa, __binary128 vfb)
  *  Quad-precision floating-point operation. This leverages operations
  *  from vec_int128_ppc.h.
  *
- *  \note This operation <I>may not</I> follow the IEEE standard
- *  relative to NaN comparison.
+ *  \note This operation <I>may not</I> follow the PowerISA
+ *  relative to NaN comparison and setting the FPSCR.
  *  However if the hardware target includes an instruction that does
  *  implement the IEEE standard, the implementation may use that.
  *  This relaxed implementation may be useful for implementations on
@@ -2782,8 +2782,8 @@ vec_cmpneuzqp (__binary128 vfa, __binary128 vfb)
  *  to implement the equivalent Quad-precision floating-point
  *  operation. This leverages operations from vec_int128_ppc.h.
  *
- *  \note This operation <I>may not</I> follow the IEEE standard
- *  relative to signed zero, or NaN comparison.
+ *  \note This operation <I>may not</I> follow the PowerISA
+ *  relative to NaN comparison and setting the FPSCR.
  *  However if the hardware target includes an instruction that does
  *  implement the IEEE standard, the implementation may use that.
  *  This relaxed implementation may be useful for implementations on

--- a/src/pveclib/vec_f128_ppc.h
+++ b/src/pveclib/vec_f128_ppc.h
@@ -2820,7 +2820,7 @@ vec_cmpneuqp (__binary128 vfa, __binary128 vfb)
   vb128_t cmps, or_ab, eq_s;
   vui64_t vra, vrb;
 
-  result = (vb128_t) vec_splat_u32 (0);
+  result = (vb128_t) vec_splat_u32 (-1);
   if (vec_all_isnanf128 (vfa) || vec_all_isnanf128 (vfb))
     return result;
 

--- a/src/testsuite/arith128_test_f128.c
+++ b/src/testsuite/arith128_test_f128.c
@@ -5722,7 +5722,7 @@ test_cmpge_f128 ()
 #if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
   // Don't expect to detect this case for P8 but should on P9
   exp = vec_cmpgetoqp (x, y);
-  expt = (vb128_t) vf128_false;
+  expt = (vb128_t) vf128_true;
   rc += check_vuint128x ("check vec_cmpgetoqp 1b", (vui128_t) exp, (vui128_t) expt);
 #endif
 #endif
@@ -6090,7 +6090,7 @@ test_cmple_f128 ()
 #if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
   // Don't expect to detect this case for P8 but should on P9
   exp = vec_cmpletoqp (x, y);
-  expt = (vb128_t) vf128_false;
+  expt = (vb128_t) vf128_true;
   rc += check_vuint128x ("check vec_cmpletoqp 1b", (vui128_t) exp, (vui128_t) expt);
 #endif
 #endif
@@ -6525,7 +6525,7 @@ test_cmpne_f128 ()
   print_vfloat128x(" y=  ", y);
 #endif
   exp = vec_cmpneuqp (x, y);
-  expt = (vb128_t) vf128_false;
+  expt = (vb128_t) vf128_true;
   rc += check_vuint128x ("check vec_cmpneuqp 7", (vui128_t) exp, (vui128_t) expt);
 
   // P8 should detect these because absolute magnitudes are different
@@ -6546,17 +6546,17 @@ test_cmpne_f128 ()
   print_vfloat128x(" y=  ", y);
 #endif
   exp = vec_cmpneuqp (x, y);
-  expt = (vb128_t) vf128_false;
+  expt = (vb128_t) vf128_true;
   rc += check_vuint128x ("check vec_cmpneuqp 8", (vui128_t) exp, (vui128_t) expt);
 
 #if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
   // Don't expect to detect this case for P8 but should on P9
   exp = vec_cmpneuzqp (x, y);
-  expt = (vb128_t) vf128_false;
+  expt = (vb128_t) vf128_true;
   rc += check_vuint128x ("check vec_cmpneuzqp 8", (vui128_t) exp, (vui128_t) expt);
 
   exp = vec_cmpnetoqp (x, y);
-  expt = (vb128_t) vf128_false;
+  expt = (vb128_t) vf128_true;
   rc += check_vuint128x ("check vec_cmpnetoqp 8", (vui128_t) exp, (vui128_t) expt);
 #endif
 #endif
@@ -6569,7 +6569,7 @@ test_cmpne_f128 ()
   print_vfloat128x(" y=  ", y);
 #endif
   exp = vec_cmpneuqp (x, y);
-  expt = (vb128_t) vf128_false;
+  expt = (vb128_t) vf128_true;
   rc += check_vuint128x ("check vec_cmpneuqp 9", (vui128_t) exp, (vui128_t) expt);
 
   // P8 should detect these because absolute magnitudes are different

--- a/src/testsuite/arith128_test_f128.c
+++ b/src/testsuite/arith128_test_f128.c
@@ -5150,6 +5150,46 @@ test_cmpgt_f128 ()
 #endif
 
 #if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_none );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_one );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpgtuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpgtuqp 3c", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgtuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpgtuzqp 3c", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgttoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpgttoqp 3c", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_one );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_none );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpgtuqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgtuqp 3d", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgtuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgtuzqp 3d", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgttoqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgttoqp 3d", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
   x = vec_xfer_vui64t_2_bin128 ( vf128_max );
   y = vec_xfer_vui64t_2_bin128 ( vf128_one );
 #ifdef __DEBUG_PRINT__
@@ -5288,6 +5328,1326 @@ test_cmpgt_f128 ()
 }
 
 int
+test_cmplt_f128 ()
+{
+  __binary128 x, y;
+  vb128_t exp, expt;
+  int rc = 0;
+
+  printf ("\n%s\n", __FUNCTION__);
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_zero );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_zero );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpltuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpltuqp 0", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpltuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpltuzqp 0", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmplttoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmplttoqp 0", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_zero );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_nzero );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpltuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpltuqp 1", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpltuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpltuzqp 1", (vui128_t) exp, (vui128_t) expt);
+
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  // Don't expect to detect this case for P8 but should on P9
+  exp = vec_cmplttoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmplttoqp 1", (vui128_t) exp, (vui128_t) expt);
+#endif
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_nzero );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_zero );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpltuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpltuqp 1b", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpltuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpltuzqp 1b", (vui128_t) exp, (vui128_t) expt);
+
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  // Don't expect to detect this case for P8 but should on P9
+  exp = vec_cmplttoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmplttoqp 1b", (vui128_t) exp, (vui128_t) expt);
+#endif
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_sub );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_zero );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpltuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpltuqp 2", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpltuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpltuzqp 2", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmplttoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmplttoqp 2", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_nsub );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_nzero );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpltuqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpltuqp 2b", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpltuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpltuzqp 2b", (vui128_t) exp, (vui128_t) expt);
+
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  // Don't expect to detect this case for P8 but should on P9
+  exp = vec_cmplttoqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmplttoqp 2b", (vui128_t) exp, (vui128_t) expt);
+#endif
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_one );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_sub );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpltuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpltuqp 3", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpltuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpltuzqp 3", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmplttoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmplttoqp 3", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_none );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_nsub );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpltuqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpltuqp 3b", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpltuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpltuzqp 3b", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmplttoqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmplttoqp 3b", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_none );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_one );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpltuqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpltuqp 3c", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpltuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpltuzqp 3c", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmplttoqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmplttoqp 3c", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_one );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_none );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpltuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpltuqp 3d", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpltuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpltuzqp 3d", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmplttoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmplttoqp 3d", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_max );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_one );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpltuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpltuqp 4", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpltuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpltuzqp 4", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmplttoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmplttoqp 4", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_nmax );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_none );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpltuqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpltuqp 4b", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpltuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpltuzqp 4b", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmplttoqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmplttoqp 4b", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_inf );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_max );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpltuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpltuqp 5", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpltuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpltuzqp 5", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmplttoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmplttoqp 5", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_ninf );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_nmax );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpltuqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpltuqp 5b", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpltuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpltuzqp 5b", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmplttoqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmplttoqp 5b", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_nan );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_nmax );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpltuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpltuqp 6", (vui128_t) exp, (vui128_t) expt);
+
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  // Don't expect to detect this case for P8 but should on P9
+  exp = vec_cmpltuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpltuzqp 6", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmplttoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmplttoqp 6", (vui128_t) exp, (vui128_t) expt);
+#endif
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_nan );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_nnan );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpltuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpltuqp 6b", (vui128_t) exp, (vui128_t) expt);
+
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  // Don't expect to detect this case for P8 but should on P9
+  exp = vec_cmpltuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpltuzqp 6b", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmplttoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmplttoqp 6b", (vui128_t) exp, (vui128_t) expt);
+#endif
+#endif
+
+  return (rc);
+}
+
+int
+test_cmpge_f128 ()
+{
+  __binary128 x, y;
+  vb128_t exp, expt;
+  int rc = 0;
+
+  printf ("\n%s\n", __FUNCTION__);
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_zero );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_zero );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpgeuqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgeuqp 0", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgeuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgeuzqp 0", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgetoqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgetoqp 0", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_zero );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_nzero );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpgeuqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgeuqp 1", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgeuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgeuzqp 1", (vui128_t) exp, (vui128_t) expt);
+
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  // Don't expect to detect this case for P8 but should on P9
+  exp = vec_cmpgetoqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgetoqp 1", (vui128_t) exp, (vui128_t) expt);
+#endif
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_nzero );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_zero );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpgeuqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgeuqp 1b", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgeuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgeuzqp 1b", (vui128_t) exp, (vui128_t) expt);
+
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  // Don't expect to detect this case for P8 but should on P9
+  exp = vec_cmpgetoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpgetoqp 1b", (vui128_t) exp, (vui128_t) expt);
+#endif
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_sub );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_zero );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpgeuqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgeuqp 2", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgeuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgeuzqp 2", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgetoqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgetoqp 2", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_nsub );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_nzero );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpgeuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpgeuqp 2b", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgeuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpgeuzqp 2b", (vui128_t) exp, (vui128_t) expt);
+
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  // Don't expect to detect this case for P8 but should on P9
+  exp = vec_cmpgetoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpgetoqp 2b", (vui128_t) exp, (vui128_t) expt);
+#endif
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_nsub );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_nsub );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpgeuqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgeuqp 2c", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgeuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgeuzqp 2c", (vui128_t) exp, (vui128_t) expt);
+
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  // Don't expect to detect this case for P8 but should on P9
+  exp = vec_cmpgetoqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgetoqp 2c", (vui128_t) exp, (vui128_t) expt);
+#endif
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_one );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_sub );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpgeuqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgeuqp 3", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgeuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgeuzqp 3", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgetoqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgetoqp 3", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_none );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_nsub );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpgeuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpgeuqp 3b", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgeuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpgeuzqp 3b", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgetoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpgetoqp 3b", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_none );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_one );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpgeuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpgeuqp 3c", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgeuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpgeuzqp 3c", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgetoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpgetoqp 3c", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_one );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_none );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpgeuqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgeuqp 3d", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgeuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgeuzqp 3d", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgetoqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgetoqp 3d", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_one );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_one );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpgeuqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgeuqp 3e", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgeuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgeuzqp 3e", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgetoqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgetoqp 3e", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_max );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_one );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpgeuqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgeuqp 4", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgeuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgeuzqp 4", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgetoqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgetoqp 4", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_nmax );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_none );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpgeuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpgeuqp 4b", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgeuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpgeuzqp 4b", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgetoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpgetoqp 4b", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_inf );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_max );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpgeuqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgeuqp 5", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgeuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgeuzqp 5", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgetoqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpgetoqp 5", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_ninf );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_nmax );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpgeuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpgeuqp 5b", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgeuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpgeuzqp 5b", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgetoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpgetoqp 5b", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_nan );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_nmax );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpgeuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpgeuqp 6", (vui128_t) exp, (vui128_t) expt);
+
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  // Don't expect to detect this case for P8 but should on P9
+  exp = vec_cmpgeuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpgeuzqp 6", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgetoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpgetoqp 6", (vui128_t) exp, (vui128_t) expt);
+#endif
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_nan );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_nnan );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpgeuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpgeuqp 6b", (vui128_t) exp, (vui128_t) expt);
+
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  // Don't expect to detect this case for P8 but should on P9
+  exp = vec_cmpgeuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpgeuzqp 6b", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpgetoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpgetoqp 6b", (vui128_t) exp, (vui128_t) expt);
+#endif
+#endif
+
+  return (rc);
+}
+int
+test_cmple_f128 ()
+{
+  __binary128 x, y;
+  vb128_t exp, expt;
+  int rc = 0;
+
+  printf ("\n%s\n", __FUNCTION__);
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_zero );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_zero );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpleuqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpleuqp 0", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpleuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpleuzqp 0", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpletoqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpletoqp 0", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_zero );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_nzero );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpleuqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpleuqp 1", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpleuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpleuzqp 1", (vui128_t) exp, (vui128_t) expt);
+
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  // Don't expect to detect this case for P8 but should on P9
+  exp = vec_cmpletoqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpletoqp 1", (vui128_t) exp, (vui128_t) expt);
+#endif
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_nzero );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_zero );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpleuqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpleuqp 1b", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpleuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpleuzqp 1b", (vui128_t) exp, (vui128_t) expt);
+
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  // Don't expect to detect this case for P8 but should on P9
+  exp = vec_cmpletoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpletoqp 1b", (vui128_t) exp, (vui128_t) expt);
+#endif
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_sub );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_zero );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpleuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpleuqp 2", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpleuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpleuzqp 2", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpletoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpletoqp 2", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_nsub );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_nzero );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpleuqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpleuqp 2b", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpleuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpleuzqp 2b", (vui128_t) exp, (vui128_t) expt);
+
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  // Don't expect to detect this case for P8 but should on P9
+  exp = vec_cmpletoqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpletoqp 2b", (vui128_t) exp, (vui128_t) expt);
+#endif
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_nsub );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_nsub );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpleuqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpleuqp 2c", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpleuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpleuzqp 2c", (vui128_t) exp, (vui128_t) expt);
+
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  // Don't expect to detect this case for P8 but should on P9
+  exp = vec_cmpletoqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpletoqp 2c", (vui128_t) exp, (vui128_t) expt);
+#endif
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_one );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_sub );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpleuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpleuqp 3", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpleuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpleuzqp 3", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpletoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpletoqp 3", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_none );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_nsub );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpleuqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpleuqp 3b", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpleuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpleuzqp 3b", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpletoqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpletoqp 3b", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_none );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_one );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpleuqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpleuqp 3c", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpleuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpleuzqp 3c", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpletoqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpletoqp 3c", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_one );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_none );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpleuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpleuqp 3d", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpleuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpleuzqp 3d", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpletoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpletoqp 3d", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_one );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_one );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpleuqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpleuqp 3e", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpleuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpleuzqp 3e", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpletoqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpletoqp 3e", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_max );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_one );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpleuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpleuqp 4", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpleuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpleuzqp 4", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpletoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpletoqp 4", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_nmax );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_none );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpleuqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpleuqp 4b", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpleuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpleuzqp 4b", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpletoqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpletoqp 4b", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_inf );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_max );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpleuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpleuqp 5", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpleuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpleuzqp 5", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpletoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpletoqp 5", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_ninf );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_nmax );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpleuqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpleuqp 5b", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpleuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpleuzqp 5b", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpletoqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpletoqp 5b", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_nan );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_nmax );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpleuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpleuqp 6", (vui128_t) exp, (vui128_t) expt);
+
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  // Don't expect to detect this case for P8 but should on P9
+  exp = vec_cmpleuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpleuzqp 6", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpletoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpletoqp 6", (vui128_t) exp, (vui128_t) expt);
+#endif
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_nan );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_nnan );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpleuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpleuqp 6b", (vui128_t) exp, (vui128_t) expt);
+
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  // Don't expect to detect this case for P8 but should on P9
+  exp = vec_cmpleuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpleuzqp 6b", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpletoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpletoqp 6b", (vui128_t) exp, (vui128_t) expt);
+#endif
+#endif
+
+  return (rc);
+}
+
+int
+test_cmpne_f128 ()
+{
+  __binary128 x, y;
+  vb128_t exp, expt;
+  int rc = 0;
+
+  printf ("\ntest_cmpne_f128 ...\n");
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_zero );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_zero );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpneuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpneuqp 1", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpneuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpneuzqp 1", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpnetoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpnetoqp 1", (vui128_t) exp, (vui128_t) expt);
+#endif
+  x = vec_xfer_vui64t_2_bin128 ( vf128_zero );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_nzero );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpneuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpneuqp 2", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpneuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpneuzqp 2", (vui128_t) exp, (vui128_t) expt);
+
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  // Don't expect to detect this case for P8 but should on P9
+  exp = vec_cmpnetoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpnetoqp 2", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_nzero );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpneuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpneuqp 3", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpneuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpneuzqp 3", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpnetoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpnetoqp 3", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_max );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_max );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpneuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpneuqp 4", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpneuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpneuzqp 4", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpnetoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpnetoqp 4", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_max );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_nmax );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpneuqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpneuqp 5", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpneuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpneuzqp 5", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpnetoqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpnetoqp 5", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_nmax );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_nmax );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpneuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpneuqp 6", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpneuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpneuzqp 6", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpnetoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpnetoqp 6", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_nan );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_nmax );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpneuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpneuqp 7", (vui128_t) exp, (vui128_t) expt);
+
+  // P8 should detect these because absolute magnitudes are different
+  exp = vec_cmpneuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpneuzqp 7", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpnetoqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpnetoqp 7", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_nan );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_nan );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpneuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpneuqp 8", (vui128_t) exp, (vui128_t) expt);
+
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+  // Don't expect to detect this case for P8 but should on P9
+  exp = vec_cmpneuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpneuzqp 8", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpnetoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpnetoqp 8", (vui128_t) exp, (vui128_t) expt);
+#endif
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_max );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_nan );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpneuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpneuqp 9", (vui128_t) exp, (vui128_t) expt);
+
+  // P8 should detect these because absolute magnitudes are different
+  exp = vec_cmpneuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpneuzqp 9", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpnetoqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpnetoqp 9", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_max );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_inf );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpneuqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpneuqp 10", (vui128_t) exp, (vui128_t) expt);
+
+  // P8 should detect these because absolute magnitudes are different
+  exp = vec_cmpneuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpneuzqp 10", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpnetoqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpnetoqp 10", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_inf );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_inf );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpneuqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpneuqp 11", (vui128_t) exp, (vui128_t) expt);
+
+  // P8 should detect these because absolute magnitudes are different
+  exp = vec_cmpneuzqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpneuzqp 11", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpnetoqp (x, y);
+  expt = (vb128_t) vf128_false;
+  rc += check_vuint128x ("check vec_cmpnetoqp 11", (vui128_t) exp, (vui128_t) expt);
+#endif
+
+#if 1
+  x = vec_xfer_vui64t_2_bin128 ( vf128_ninf );
+  y = vec_xfer_vui64t_2_bin128 ( vf128_inf );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+  print_vfloat128x(" y=  ", y);
+#endif
+  exp = vec_cmpneuqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpneuqp 12", (vui128_t) exp, (vui128_t) expt);
+
+  // P8 should detect these because absolute magnitudes are different
+  exp = vec_cmpneuzqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpneuzqp 12", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_cmpnetoqp (x, y);
+  expt = (vb128_t) vf128_true;
+  rc += check_vuint128x ("check vec_cmpnetoqp 12", (vui128_t) exp, (vui128_t) expt);
+#endif
+  return (rc);
+}
+
+int
 test_vec_f128 (void)
 {
   int rc = 0;
@@ -5301,6 +6661,10 @@ test_vec_f128 (void)
   rc += test_extract_insert_f128 ();
   rc += test_cmpeq_f128 ();
   rc += test_cmpgt_f128 ();
+  rc += test_cmplt_f128 ();
+  rc += test_cmpge_f128 ();
+  rc += test_cmple_f128 ();
+  rc += test_cmpne_f128 ();
 #ifndef PVECLIB_DISABLE_F128MATH
 #ifdef __FLOAT128__
   rc += test_time_f128 ();

--- a/src/testsuite/vec_f128_dummy.c
+++ b/src/testsuite/vec_f128_dummy.c
@@ -40,6 +40,64 @@
 //#define __DEBUG_PRINT__
 #include <pveclib/vec_f128_ppc.h>
 
+int
+test_scalar_test_neg (__binary128 vfa)
+{
+  return vec_signbitf128 (vfa);
+}
+
+int
+test_scalar_cmpto_exp_gt (__binary128 vfa, __binary128 vfb)
+{
+#if defined (_ARCH_PWR9) && defined (scalar_cmp_exp_gt) && defined (__FLOAT128__) && (__GNUC__ > 9)
+  return scalar_cmp_exp_gt (vfa, vfb);
+#else
+  vui32_t vra, vrb;
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
+  const vui32_t expmask = CONST_VINT128_W(0x7fff0000, 0, 0, 0);
+
+  vra = vec_and_bin128_2_vui32t (vfa, expmask);
+  vrb = vec_and_bin128_2_vui32t (vfb, expmask);
+  return vec_any_gt (vra, vrb);
+#endif
+}
+
+int
+test_scalar_cmp_exp_gt (__binary128 vfa, __binary128 vfb)
+{
+#if defined (_ARCH_PWR9) && defined (scalar_cmp_exp_gt) && defined (__FLOAT128__) && (__GNUC__ > 9)
+  return scalar_cmp_exp_gt (vfa, vfb);
+#else
+  vui32_t vra, vrb;
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
+  const vui32_t expmask = CONST_VINT128_W(0x7fff0000, 0, 0, 0);
+
+  if (__builtin_expect ((vec_all_isnanf128 (vfa) || vec_all_isnanf128 (vfb)), 0))
+    return 0;
+
+  vra = vec_and_bin128_2_vui32t (vfa, expmask);
+  vrb = vec_and_bin128_2_vui32t (vfb, expmask);
+  return vec_any_gt (vra, vrb);
+#endif
+}
+
+int
+test_scalar_cmp_exp_unordered (__binary128 vfa, __binary128 vfb)
+{
+#if defined (_ARCH_PWR9) && defined (scalar_cmp_exp_gt) && defined (__FLOAT128__) && (__GNUC__ > 9)
+  return scalar_cmp_exp_unordered (vfa, vfb);
+#else
+  return (vec_all_isnanf128 (vfa) || vec_all_isnanf128 (vfb));
+#endif
+}
+
+vb128_t
+test_bool_cmp_exp_unordered (__binary128 vfa, __binary128 vfb)
+{
+  return (vb128_t) vec_or ((vui32_t) vec_isnanf128 (vfa),
+			   (vui32_t) vec_isnanf128 (vfb));
+}
+
 __binary128
 test_sel_bin128_2_bin128 (__binary128 vfa, __binary128 vfb, vb128_t mask)
 {
@@ -464,6 +522,78 @@ vb128_t
 test_vec_cmpeqtoqp (__binary128 vfa, __binary128 vfb)
 {
   return vec_cmpeqtoqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpneuqp (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpneuqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpneuzqp (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpneuzqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpnetoqp (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpnetoqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpleuzqp (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpleuzqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpleuqp (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpleuqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpletoqp (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpletoqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpgeuzqp (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpgeuzqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpgeuqp (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpgeuqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpgetoqp (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpgetoqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpltuzqp (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpltuzqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpltuqp (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpltuqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmplttoqp (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmplttoqp (vfa, vfb);
 }
 
 vb128_t

--- a/src/testsuite/vec_pwr10_dummy.c
+++ b/src/testsuite/vec_pwr10_dummy.c
@@ -38,6 +38,124 @@
 #include <pveclib/vec_f32_ppc.h>
 #include <pveclib/vec_bcd_ppc.h>
 
+#if defined (_ARCH_PWR10) && (__GNUC__ > 10)
+// New support defined in Power Vector Intrinsic Programming Reference.
+// Waiting for GCC 11.2?
+int
+test_gcc_cmpsq_all_gt_PWR10 (vi128_t a, vi128_t b)
+{
+  return vec_all_gt (a, b);
+}
+
+vb128_t
+test_gcc_cmpsq_gt_PWR10 (vi128_t a, vi128_t b)
+{
+  return vec_cmpgt (a, b);
+}
+#endif
+
+vi128_t
+test_min_ui128_PWR10  (vi128_t a, vi128_t b)
+{
+  if (vec_cmpsq_all_lt (a, b))
+    return a;
+  else
+    return b;
+}
+
+vi128_t
+test_max_ui128_PWR10  (vi128_t a, vi128_t b)
+{
+  if (vec_cmpsq_all_gt (a, b))
+    return a;
+  else
+    return b;
+}
+
+int
+test_cmpsq_all_lt_PWR10 (vi128_t a, vi128_t b)
+{
+  return vec_cmpsq_all_lt (a, b);
+}
+
+int
+test_cmpsq_all_gt_PWR10 (vi128_t a, vi128_t b)
+{
+  return vec_cmpsq_all_gt (a, b);
+}
+
+vb128_t
+test_vec_cmpnetoqp_PWR10 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpnetoqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpneuzqp_PWR10 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpneuzqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpneuqp_PWR10 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpneuqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpletoqp_PWR10 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpletoqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpleuzqp_PWR10 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpleuzqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpleuqp_PWR10 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpleuqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpgetoqp_PWR10 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpgetoqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpgeuzqp_PWR10 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpgeuzqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpgeuqp_PWR10 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpgeuqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmplttoqp_PWR10 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmplttoqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpltuzqp_PWR10 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpltuzqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpltuqp_PWR10 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpltuqp (vfa, vfb);
+}
+
 vb128_t
 test_vec_cmpgttoqp_PWR10 (__binary128 vfa, __binary128 vfb)
 {

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -40,6 +40,40 @@
 #include <pveclib/vec_f32_ppc.h>
 #include <pveclib/vec_bcd_ppc.h>
 
+int
+test_scalar_test_neg_PWR9 (__binary128 vfa)
+{
+  return vec_signbitf128 (vfa);
+}
+
+int
+test_scalar_cmpto_exp_gt_PWR9 (__binary128 vfa, __binary128 vfb)
+{
+#if defined (_ARCH_PWR9) && defined (scalar_cmp_exp_gt) \
+  && defined (__FLOAT128__) && (__GNUC__ >= 9)
+  return scalar_cmp_exp_gt (vfa, vfb);
+#else
+  vui32_t vra, vrb;
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
+  const vui32_t expmask = CONST_VINT128_W(0x7fff0000, 0, 0, 0);
+
+  vra = vec_and_bin128_2_vui32t (vfa, expmask);
+  vrb = vec_and_bin128_2_vui32t (vfb, expmask);
+  return vec_any_gt (vra, vrb);
+#endif
+}
+
+int
+test_scalar_cmp_exp_unordered_PWR9 (__binary128 vfa, __binary128 vfb)
+{
+#if defined (_ARCH_PWR9) && defined (scalar_cmp_exp_gt) \
+  && defined (__FLOAT128__) && (__GNUC__ >= 9)
+  return scalar_cmp_exp_unordered (vfa, vfb);
+#else
+  return (vec_all_isnanf128 (vfa) || vec_all_isnanf128 (vfb));
+#endif
+}
+
 __binary128
 test_vec_max8_f128_PWR9 (__binary128 vf1, __binary128 vf2,
 		    __binary128 vf3, __binary128 vf4,
@@ -65,6 +99,78 @@ test_vec_max8_f128_PWR9 (__binary128 vf1, __binary128 vf2,
   maxres = vec_self128 (vf8, maxres, bool);
 
   return maxres;
+}
+
+vb128_t
+test_vec_cmpnetoqp_PWR9 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpnetoqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpneuzqp_PWR9 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpneuzqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpneuqp_PWR9 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpneuqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpletoqp_PWR9 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpletoqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpleuzqp_PWR9 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpleuzqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpleuqp_PWR9 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpleuqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpgetoqp_PWR9 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpgetoqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpgeuzqp_PWR9 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpgeuzqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpgeuqp_PWR9 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpgeuqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmplttoqp_PWR9 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmplttoqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpltuzqp_PWR9 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpltuzqp (vfa, vfb);
+}
+
+vb128_t
+test_vec_cmpltuqp_PWR9 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpltuqp (vfa, vfb);
 }
 
 vb128_t


### PR DESCRIPTION
Complete the remaining boolian compares (ge, le, lt, ne).

	* src/pveclib/vec_f128_ppc.h (vec_cmpgetoqp, vec_cmpgeuzqp,
	vec_cmpgeuqp): New inline operations.
	(vec_cmpgetoqp, vec_cmpgeuzqp, vec_cmpgeuqp):
	New inline operations.
	(vec_cmpgttoqp, vec_cmpgtuzqp, vec_cmpgtuqp):
	Fix doxygen text.
	(vec_cmpletoqp, vec_cmpleuzqp, vec_cmpleuqp):
	New inline operations.
	(vec_cmplttoqp, vec_cmpltuzqp, vec_cmpltuqp):
	New inline operations.
	(vec_cmpnetoqp, vec_cmpneuzqp, vec_cmpneuqp):
	New inline operations.

	* src/testsuite/arith128_test_f128.c (test_cmpgt_f128):
	Add new unit tests.
	(test_cmplt_f128, test_cmpge_f128, test_cmple_f128,
	test_cmpne_f128): Add new unit test functions.
	(test_vec_f128): Call new unit test functions.

	* src/testsuite/vec_f128_dummy.c (test_scalar_test_neg,
	test_scalar_cmpto_exp_gt, test_scalar_cmp_exp_gt,
	test_scalar_cmp_exp_unordered, test_bool_cmp_exp_unordered):
	New compile tests.
	(test_vec_cmpneuqp, test_vec_cmpneuzqp, test_vec_cmpnetoqp,
	test_vec_cmpleuzqp, test_vec_cmpleuqp, test_vec_cmpletoqp,
	test_vec_cmpgeuzqp, test_vec_cmpgeuqp, test_vec_cmpgetoqp,
	test_vec_cmpltuzqp, test_vec_cmpltuqp. test_vec_cmplttoqp):
	New compile tests.

	* src/testsuite/vec_pwr10_dummy.c (test_gcc_cmpsq_all_gt_PWR10,
	test_gcc_cmpsq_gt_PWR10, test_min_ui128_PWR10,
	test_max_ui128_PWR10, test_cmpsq_all_lt_PWR10,
	test_cmpsq_all_gt_PWR10):
	New compile tests.
	(test_vec_cmpnetoqp_PWR10, test_vec_cmpneuzqp_PWR10,
	test_vec_cmpneuqp_PWR10, test_vec_cmpletoqp_PWR10,
	test_vec_cmpleuzqp_PWR10, test_vec_cmpleuqp_PWR10,
	test_vec_cmpgetoqp_PWR10, test_vec_cmpgeuzqp_PWR10,
	test_vec_cmpgeuqp_PWR10, test_vec_cmplttoqp_PWR10,
	test_vec_cmpltuzqp_PWR10, test_vec_cmpltuqp_PWR10):
	New compile tests.

	* src/testsuite/vec_pwr9_dummy.c (test_scalar_test_neg_PWR9,
	test_scalar_cmpto_exp_gt_PWR9,
	test_scalar_cmp_exp_unordered_PWR9): New compile tests.
	(test_vec_cmpnetoqp_PWR9, test_vec_cmpneuzqp_PWR9,
	test_vec_cmpneuqp_PWR9, test_vec_cmpletoqp_PWR9,
	test_vec_cmpleuzqp_PWR9, test_vec_cmpleuqp_PWR9,
	test_vec_cmpgetoqp_PWR9,test_vec_cmpgeuzqp_PWR9,
	test_vec_cmpgeuqp_PWR9test_vec_cmplttoqp_PWR9.
	test_vec_cmpltuzqp_PWR9. test_vec_cmpltuqp_PWR9):
	New compile tests.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>