### PR TITLE
Exploit P9 extract/insert instructions operations. Update

### DIFF
--- a/src/pveclib/vec_f32_ppc.h
+++ b/src/pveclib/vec_f32_ppc.h
@@ -2047,12 +2047,15 @@ vec_xviexpsp (vui32_t sig, vui32_t exp)
 {
   vf32_t result;
 #if defined (_ARCH_PWR9) && defined (__VSX__) && (__GNUC__ > 7)
+#if defined (vec_insert_exp)
+  result = vec_insert_exp (sig, exp);
+#else
   __asm__(
       "xviexpsp %x0,%x1,%x2"
       : "=wa" (result)
       : "wa" (sig), "wa" (exp)
       : );
-
+#endif
 #else
   vui32_t tmp;
   const vui32_t expmask = CONST_VINT128_W(0x7f800000, 0x7f800000,
@@ -2072,7 +2075,7 @@ vec_xviexpsp (vui32_t sig, vui32_t exp)
  *  The result is returned as vector unsigned integer value.
  *
  *  \note This operation is equivalent to the POWER9 xvxexpsp
- *  instruction and the built-in vector_extract_exp. These require a
+ *  instruction and the built-in vec_extract_exp. These require a
  *  POWER9-enabled compiler targeting -mcpu=power9 and are not
  *  available for older compilers nor POWER8 and earlier.
  *  This function provides this operation for all VSX-enabled
@@ -2093,13 +2096,15 @@ vec_xvxexpsp (vf32_t vrb)
 {
   vui32_t result;
 #if defined (_ARCH_PWR9) && defined (__VSX__) && (__GNUC__ > 7)
-
+#if defined (vec_extract_exp)
+  result = vec_extract_exp (vrb);
+#else
   __asm__(
       "xvxexpsp %x0,%x1"
       : "=wa" (result)
       : "wa" (vrb)
       : );
-
+#endif
 #else
   vui32_t tmp;
   const vui32_t expmask = CONST_VINT128_W(0x7f800000, 0x7f800000,
@@ -2122,7 +2127,7 @@ vec_xvxexpsp (vf32_t vrb)
  *  up to 24 bits of significance.
  *
  *  \note This operation is equivalent to the POWER9 xvxsigsp
- *  instruction and the built-in vector_extract_sig. These require a
+ *  instruction and the built-in vec_extract_sig. These require a
  *  POWER9-enabled compiler targeting -mcpu=power9 and are not
  *  available for older compilers nor POWER8 and earlier.
  *  This function provides this operation for all VSX-enabled
@@ -2142,13 +2147,15 @@ vec_xvxsigsp (vf32_t vrb)
 {
   vui32_t result;
 #if defined (_ARCH_PWR9) && defined (__VSX__) && (__GNUC__ > 7)
-
+#if defined (vec_extract_sig)
+  result = vec_extract_sig (vrb);
+#else
   __asm__(
       "xvxsigsp %x0,%x1"
       : "=wa" (result)
       : "wa" (vrb)
       : );
-
+#endif
 #else
   vui32_t t128, tmp;
   vui32_t normal;

--- a/src/pveclib/vec_f64_ppc.h
+++ b/src/pveclib/vec_f64_ppc.h
@@ -1644,12 +1644,15 @@ vec_xviexpdp (vui64_t sig, vui64_t exp)
 {
   vf64_t result;
 #if defined (_ARCH_PWR9) && defined (__VSX__) && (__GNUC__ > 7)
+#if defined (vec_insert_exp)
+  result = vec_insert_exp (sig, exp);
+#else
   __asm__(
       "xviexpdp %x0,%x1,%x2"
       : "=wa" (result)
       : "wa" (sig), "wa" (exp)
       : );
-
+#endif
 #else
   vui32_t tmp, t128;
   const vui32_t expmask = CONST_VINT128_W(0x7ff00000, 0, 0x7ff00000, 0);
@@ -1668,7 +1671,7 @@ vec_xviexpdp (vui64_t sig, vui64_t exp)
  *  The result is returned as vector long long integer value.
  *
  *  \note This operation is equivalent to the POWER9 xvxexpdp
- *  instruction and the built-in vector_extract_exp. These require a
+ *  instruction and the built-in vec_extract_exp. These require a
  *  POWER9-enabled compiler targeting -mcpu=power9 and are not
  *  available for older compilers nor POWER8 and earlier.
  *  This function provides this operation for all VSX-enabled
@@ -1689,13 +1692,15 @@ vec_xvxexpdp (vf64_t vrb)
 {
   vui64_t result;
 #if defined (_ARCH_PWR9) && defined (__VSX__) && (__GNUC__ > 7)
-
+#if defined (vec_extract_exp)
+  result = vec_extract_exp (vrb);
+#else
   __asm__(
       "xvxexpdp %x0,%x1"
       : "=wa" (result)
       : "wa" (vrb)
       : );
-
+#endif
 #else
   vui32_t tmp;
   const vui32_t expmask = CONST_VINT128_W(0x7ff00000, 0, 0x7ff00000, 0);
@@ -1717,7 +1722,7 @@ vec_xvxexpdp (vf64_t vrb)
  *  up to 53 bits of significance.
  *
  *  \note This operation is equivalent to the POWER9 xvxsigdp
- *  instruction and the built-in vector_extract_sig. These require a
+ *  instruction and the built-in vec_extract_sig. These require a
  *  POWER9-enabled compiler targeting -mcpu=power9 and are not
  *  available for older compilers nor POWER8 and earlier.
  *  This function provides this operation for all VSX-enabled
@@ -1737,13 +1742,15 @@ vec_xvxsigdp (vf64_t vrb)
 {
   vui64_t result;
 #if defined (_ARCH_PWR9) && defined (__VSX__) && (__GNUC__ > 7)
-
+#if defined (vec_extract_sig)
+  result = vec_extract_sig (vrb);
+#else
   __asm__(
       "xvxsigdp %x0,%x1"
       : "=wa" (result)
       : "wa" (vrb)
       : );
-
+#endif
 #else
   vui32_t t128, tmp;
   vui32_t normal;


### PR DESCRIPTION
Use P9's built-ins; vec_insert_exp, vec_extract_exp, vec_extract_sig
if available.

	* src/pveclib/vec_f32_ppc.h (vec_xviexpsp [vec_insert_exp]):
	Use built-in vec_insert_exp if available.
	(vec_xvxexpsp): Correct doxygen text.
	[vec_extract_exp]: Use built-in vec_extract_exp if available.
	(vec_xvxsigsp): Correct doxygen text.
	[vec_extract_sig]: Use built-in vec_extract_sig if available.

	* src/pveclib/vec_f64_ppc.h (vec_xviexpdp [vec_insert_exp]):
	Use built-in vec_insert_exp if available.
	(vec_xvxexpdp): Correct doxygen text.
	[vec_extract_exp]: Use built-in vec_extract_exp if available.
	(vec_xvxsigdp): Correct doxygen text.
	[vec_extract_sig]: Use built-in vec_extract_sig if available.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>