### PR TITLE
P9/10 Float128 convert instructions plus P8 equivalants. P1

### DIFF
--- a/src/pveclib/vec_f128_ppc.h
+++ b/src/pveclib/vec_f128_ppc.h
@@ -1743,7 +1743,7 @@ vec_all_isnanf128 (__binary128 f128)
 #if defined (_ARCH_PWR9) && defined (scalar_test_data_class) && defined (__FLOAT128__) && (__GNUC__ > 7)
   return scalar_test_data_class (f128, 0x40);
 #elif defined (_ARCH_PWR8)
-  vui32_t tmp, tmp2;
+  vui32_t tmp;
   const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
   const vui32_t expmask = CONST_VINT128_W(0x7fff0000, 0, 0, 0);
 
@@ -2288,7 +2288,6 @@ vec_cmpgeuzqp (__binary128 vfa, __binary128 vfb)
   vb128_t age0, bge0;
   vui128_t vrap, vran;
   vui128_t vrbp, vrbn;
-  vui8_t splatvfa, splatvfb;
 
   vra = vec_xfer_bin128_2_vui128t (vfa);
   vrb = vec_xfer_bin128_2_vui128t (vfb);
@@ -2509,7 +2508,6 @@ vec_cmpgtuzqp (__binary128 vfa, __binary128 vfb)
   vb128_t age0, bge0;
   vui128_t vrap, vran;
   vui128_t vrbp, vrbn;
-  vui8_t splatvfa, splatvfb;
 
   vra = vec_xfer_bin128_2_vui128t (vfa);
   vrb = vec_xfer_bin128_2_vui128t (vfb);
@@ -2730,7 +2728,6 @@ vec_cmpleuzqp (__binary128 vfa, __binary128 vfb)
   vb128_t age0, bge0;
   vui128_t vrap, vran;
   vui128_t vrbp, vrbn;
-  vui8_t splatvfa, splatvfb;
 
   vra = vec_xfer_bin128_2_vui128t (vfa);
   vrb = vec_xfer_bin128_2_vui128t (vfb);
@@ -2951,7 +2948,6 @@ vec_cmpltuzqp (__binary128 vfa, __binary128 vfb)
   vb128_t age0, bge0;
   vui128_t vrap, vran;
   vui128_t vrbp, vrbn;
-  vui8_t splatvfa, splatvfb;
 
   vra = vec_xfer_bin128_2_vui128t (vfa);
   vrb = vec_xfer_bin128_2_vui128t (vfb);
@@ -3317,7 +3313,7 @@ vec_cmpqp_all_uzeq (__binary128 vfa, __binary128 vfb)
   result = (vfa == vfb);
 #else // defined( _ARCH_PWR8 )
   const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
-  vb128_t cmps, or_ab, eq_s;
+  vb128_t or_ab;
   vui64_t vra, vrb;
 
   vra = vec_xfer_bin128_2_vui64t (vfa);
@@ -3369,7 +3365,7 @@ vec_cmpqp_all_eq (__binary128 vfa, __binary128 vfb)
   result = (vfa == vfb);
 #else // defined( _ARCH_PWR8 )
   const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
-  vb128_t cmps, or_ab, eq_s;
+  vb128_t or_ab;
   vui64_t vra, vrb;
 
   vra = vec_xfer_bin128_2_vui64t (vfa);
@@ -3489,7 +3485,6 @@ vec_cmpqp_all_uzge (__binary128 vfa, __binary128 vfb)
   vb128_t age0, bge0;
   vui128_t vrap, vran;
   vui128_t vrbp, vrbn;
-  vui8_t splatvfa, splatvfb;
 
   vra = vec_xfer_bin128_2_vui128t (vfa);
   vrb = vec_xfer_bin128_2_vui128t (vfb);
@@ -3680,7 +3675,6 @@ vec_cmpqp_all_uzgt (__binary128 vfa, __binary128 vfb)
   vb128_t age0, bge0;
   vui128_t vrap, vran;
   vui128_t vrbp, vrbn;
-  vui8_t splatvfa, splatvfb;
 
   vra = vec_xfer_bin128_2_vui128t (vfa);
   vrb = vec_xfer_bin128_2_vui128t (vfb);
@@ -3870,7 +3864,6 @@ vec_cmpqp_all_uzle (__binary128 vfa, __binary128 vfb)
   vb128_t age0, bge0;
   vui128_t vrap, vran;
   vui128_t vrbp, vrbn;
-  vui8_t splatvfa, splatvfb;
 
   vra = vec_xfer_bin128_2_vui128t (vfa);
   vrb = vec_xfer_bin128_2_vui128t (vfb);
@@ -4061,7 +4054,6 @@ vec_cmpqp_all_uzlt (__binary128 vfa, __binary128 vfb)
   vb128_t age0, bge0;
   vui128_t vrap, vran;
   vui128_t vrbp, vrbn;
-  vui8_t splatvfa, splatvfb;
 
   vra = vec_xfer_bin128_2_vui128t (vfa);
   vrb = vec_xfer_bin128_2_vui128t (vfb);
@@ -4228,7 +4220,7 @@ vec_cmpqp_all_uzne (__binary128 vfa, __binary128 vfb)
   result = (vfa != vfb);
 #else // defined( _ARCH_PWR8 )
   const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
-  vb128_t cmps, or_ab, eq_s;
+  vb128_t or_ab;
   vui64_t vra, vrb;
 
   vra = vec_xfer_bin128_2_vui64t (vfa);
@@ -4280,7 +4272,7 @@ vec_cmpqp_all_ne (__binary128 vfa, __binary128 vfb)
   result = (vfa != vfb);
 #else // defined( _ARCH_PWR8 )
   const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
-  vb128_t cmps, or_ab, eq_s;
+  vb128_t or_ab;
   vui64_t vra, vrb;
 
   vra = vec_xfer_bin128_2_vui64t (vfa);
@@ -4799,7 +4791,7 @@ static inline vec_xscvdpqp (vf64_t f64)
 	      vui64_t q_denorm = (vui64_t) CONST_VINT64_DW( (0x3fff - (1023 - 12)), 0 );
 	      vui64_t f64_clz;
 	      f64_clz = vec_clzd (d_sig);
-	      d_sig = vec_vsld (d_sig, f64_clz);;
+	      d_sig = vec_vsld (d_sig, f64_clz);
 	      q_exp = vec_subudm (q_denorm, f64_clz);
 	      q_sig = vec_srqi ((vui128_t) d_sig, 15);
 	    }
@@ -4860,7 +4852,7 @@ static inline vec_xscvsdqp (vi64_t int64)
       : );
 #endif
 #elif  defined (_ARCH_PWR8)
-  vui64_t d_exp, d_sig, q_exp, d_sign, d_neg;
+  vui64_t d_sig, q_exp, d_sign, d_neg;
   vui128_t q_sig;
   vui32_t q_sign;
   const vui64_t d_zero = (vui64_t) CONST_VINT64_DW( 0, 0 );
@@ -4896,7 +4888,7 @@ static inline vec_xscvsdqp (vi64_t int64)
       result = vec_xsiexpqp (q_sig, q_exp);
     }
 #else
-  result = f64[VEC_DW_H];
+  result = int64[VEC_DW_H];
 #endif
   return result;
 }
@@ -4940,7 +4932,7 @@ static inline vec_xscvudqp (vui64_t int64)
       : );
 #endif
 #elif  defined (_ARCH_PWR8)
-  vui64_t d_exp, d_sig, q_exp;
+  vui64_t d_sig, q_exp;
   vui128_t q_sig;
   const vui64_t d_zero = (vui64_t) CONST_VINT64_DW( 0, 0 );
 

--- a/src/testsuite/pveclib_perf.c
+++ b/src/testsuite/pveclib_perf.c
@@ -566,7 +566,7 @@ test_time_f128 (void)
   delta_sec = TimeDeltaSec (t_delta);
 
   printf ("\n%s f128 CC end", __FUNCTION__);
-  printf ("\n%s f128 CC  tb delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
+  printf ("\n%s f128 CC tb delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
 	  delta_sec);
 
   printf ("\n%s f128_LIB start, ...\n", __FUNCTION__);
@@ -580,7 +580,7 @@ test_time_f128 (void)
   delta_sec = TimeDeltaSec (t_delta);
 
   printf ("\n%s f128_LIB end", __FUNCTION__);
-  printf ("\n%s f128_LIB  tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+  printf ("\n%s f128_LIB tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
 	  t_delta, delta_sec);
 
   printf ("\n%s cmpgtuqp_gcc start, ...\n", __FUNCTION__);
@@ -594,7 +594,7 @@ test_time_f128 (void)
   delta_sec = TimeDeltaSec (t_delta);
 
   printf ("\n%s cmpgtuqp_gcc end", __FUNCTION__);
-  printf ("\n%s cmpgtuqp_gcc  tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+  printf ("\n%s cmpgtuqp_gcc tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
 	  t_delta, delta_sec);
 
   printf ("\n%s cmpgtuqp_lib start, ...\n", __FUNCTION__);
@@ -608,7 +608,7 @@ test_time_f128 (void)
   delta_sec = TimeDeltaSec (t_delta);
 
   printf ("\n%s cmpgtuqp_lib end", __FUNCTION__);
-  printf ("\n%s cmpgtuqp_lib  tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+  printf ("\n%s cmpgtuqp_lib tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
 	  t_delta, delta_sec);
 
   printf ("\n%s cmpgtuqp_vec start, ...\n", __FUNCTION__);
@@ -622,21 +622,63 @@ test_time_f128 (void)
   delta_sec = TimeDeltaSec (t_delta);
 
   printf ("\n%s cmpgtuqp_vec end", __FUNCTION__);
-  printf ("\n%s cmpgtuqp_vec  tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+  printf ("\n%s cmpgtuqp_vec tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
 	  t_delta, delta_sec);
 
   printf ("\n%s cmpgtuzqp_vec start, ...\n", __FUNCTION__);
   t_start = __builtin_ppc_get_timebase ();
   for (i = 0; i < TIMING_ITERATIONS; i++)
     {
-      rc += timed_vec_max8_f128 ();
+      rc += timed_vec_max8_f128uz ();
     }
   t_end = __builtin_ppc_get_timebase ();
   t_delta = t_end - t_start;
   delta_sec = TimeDeltaSec (t_delta);
 
   printf ("\n%s cmpgtuzqp_vec end", __FUNCTION__);
-  printf ("\n%s cmpgtuzqp_vec  tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+  printf ("\n%s cmpgtuzqp_vec tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+	  t_delta, delta_sec);
+
+  printf ("\n%s cvt_dpqp_gcc start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_gcc_dpqp_f128 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s cvt_dpqp_gcc end", __FUNCTION__);
+  printf ("\n%s cvt_dpqp_gcc tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+	  t_delta, delta_sec);
+
+  printf ("\n%s cvt_dpqp_lib start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_gcc_dpqp_f128 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s cvt_dpqp_lib end", __FUNCTION__);
+  printf ("\n%s cvt_dpqp_lib tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+	  t_delta, delta_sec);
+
+  printf ("\n%s cvt_dpqp_vec start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_gcc_dpqp_f128 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s cvt_dpqp_vec end", __FUNCTION__);
+  printf ("\n%s cvt_dpqp_vec tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
 	  t_delta, delta_sec);
 
   return (rc);

--- a/src/testsuite/pveclib_perf.c
+++ b/src/testsuite/pveclib_perf.c
@@ -555,6 +555,7 @@ test_time_f128 (void)
   double delta_sec;
   int rc = 0;
 
+#if 0
   printf ("\n%s f128 CC start, ...\n", __FUNCTION__);
   t_start = __builtin_ppc_get_timebase ();
   for (i = 0; i < TIMING_ITERATIONS; i++)
@@ -582,7 +583,7 @@ test_time_f128 (void)
   printf ("\n%s f128_LIB end", __FUNCTION__);
   printf ("\n%s f128_LIB tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
 	  t_delta, delta_sec);
-
+#endif
   printf ("\n%s cmpgtuqp_gcc start, ...\n", __FUNCTION__);
   t_start = __builtin_ppc_get_timebase ();
   for (i = 0; i < TIMING_ITERATIONS; i++)
@@ -657,7 +658,7 @@ test_time_f128 (void)
   t_start = __builtin_ppc_get_timebase ();
   for (i = 0; i < TIMING_ITERATIONS; i++)
     {
-      rc += timed_gcc_dpqp_f128 ();
+      rc += timed_lib_dpqp_f128 ();
     }
   t_end = __builtin_ppc_get_timebase ();
   t_delta = t_end - t_start;
@@ -671,7 +672,7 @@ test_time_f128 (void)
   t_start = __builtin_ppc_get_timebase ();
   for (i = 0; i < TIMING_ITERATIONS; i++)
     {
-      rc += timed_gcc_dpqp_f128 ();
+      rc += timed_vec_dpqp_f128 ();
     }
   t_end = __builtin_ppc_get_timebase ();
   t_delta = t_end - t_start;

--- a/src/testsuite/vec_f128_dummy.c
+++ b/src/testsuite/vec_f128_dummy.c
@@ -168,6 +168,219 @@ test_scalar_test_neg (__binary128 vfa)
 
 // Convert Float DP to QP
 __binary128
+test_vec_xscvdpqp (vf64_t f64)
+{
+  return vec_xscvdpqp (f64);
+}
+
+__binary128
+test_convert_udqp (vui64_t int64)
+{
+  __binary128 result;
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 9)
+  result = int64[VEC_DW_H];
+#elif  defined (_ARCH_PWR8)
+  vui64_t d_exp, d_sig, q_exp;
+  vui128_t q_sig;
+  vui32_t q_sign;
+  const vui64_t d_zero = (vui64_t) CONST_VINT64_DW( 0, 0 );
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
+
+  int64[VEC_DW_L] = 0UL; // clear the right most element to zero.
+  d_sig = int64;
+  // Quick test for 0UL as this case requires a special exponent.
+  if (vec_cmpud_all_eq (d_sig, d_zero))
+    {
+      result = vec_xfer_vui64t_2_bin128 (d_zero);
+    }
+  else
+    { // We need to produce a normal QP, so we treat the integer like a
+      // denormal, then normalize it.
+      // Start with the quad exponent bias + 63 then subtract the count of
+      // leading '0's. The 64-bit sig can have 0-63 leading '0's.
+      vui64_t q_expm = (vui64_t) CONST_VINT64_DW((0x3fff + 63), 0 );
+      vui64_t i64_clz = vec_clzd (d_sig);
+      d_sig = vec_vsld (d_sig, i64_clz);
+      q_exp = vec_subudm (q_expm, i64_clz);
+      q_sig = vec_srqi ((vui128_t) d_sig, 15);
+      result = vec_xsiexpqp (q_sig, q_exp);
+    }
+  // Insert exponent into significand to complete conversion to QP
+  // result = vec_xsiexpqp (q_sig, q_exp);
+#else
+  result = int64[VEC_DW_H];
+#endif
+  return result;
+}
+
+__binary128
+test_convert_sdqp (vi64_t int64)
+{
+  __binary128 result;
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 9)
+  result = int64[VEC_DW_H];
+#elif  defined (_ARCH_PWR8)
+  vui64_t d_exp, d_sig, q_exp, d_sign, d_inv;
+  vui128_t q_sig;
+  vui32_t q_sign;
+  const vui64_t d_zero = (vui64_t) CONST_VINT64_DW( 0, 0 );
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
+
+  int64[VEC_DW_L] = 0UL; // clear the right most element to zero.
+
+  if (vec_cmpud_all_eq ((vui64_t) int64, d_zero))
+    {
+      result = vec_xfer_vui64t_2_bin128 (d_zero);
+    }
+  else
+    {
+      q_sign = vec_and ((vui32_t) int64, signmask);
+      d_inv  = vec_subudm (d_zero, (vui64_t)int64);
+      d_sign = (vui64_t) vec_cmpequd ((vui64_t) q_sign, (vui64_t) signmask);
+      d_sig = (vui64_t) vec_sel ((vui32_t) int64, (vui32_t) d_inv, (vui32_t) d_sign);
+      // We need to produce a normal QP, so we treat the integer as
+      // denormal, Then normalize it.
+      // Start with the quad exponent bias + 63 then subtract the count of
+      // leading '0's. The 64-bit sig will have at 0-63 leading '0's
+      vui64_t q_expm = (vui64_t) CONST_VINT64_DW((0x3fff + 63), 0 );
+      vui64_t i64_clz = vec_clzd (d_sig);
+      d_sig = vec_vsld (d_sig, i64_clz);
+      q_exp = vec_subudm (q_expm, i64_clz);
+      q_sig = vec_srqi ((vui128_t) d_sig, 15);
+      // Copy Sign-bit to QP significand before insert.
+      q_sig = (vui128_t) vec_or ((vui32_t) q_sig, q_sign);
+      // Insert exponent into significand to complete conversion to QP
+      result = vec_xsiexpqp (q_sig, q_exp);
+    }
+#else
+  result = int64[VEC_DW_H];
+#endif
+  return result;
+}
+
+__binary128
+test_convert_dpqp_v3 (vf64_t f64)
+{
+  __binary128 result;
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 9)
+  result = f64[VEC_DW_H];
+#elif  defined (_ARCH_PWR8)
+  vui64_t d_exp, d_sig, q_exp;
+  vui128_t q_sig;
+  vui32_t q_sign;
+  const vui64_t exp_delta = (vui64_t) CONST_VINT64_DW( (0x3fff - 0x3ff), 0 );
+  const vui64_t d_naninf = (vui64_t) CONST_VINT64_DW( 0x7ff, 0 );
+  const vui64_t d_denorm = (vui64_t) CONST_VINT64_DW( 0, 0 );
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
+
+  f64[VEC_DW_L] = 0.0; // clear the right most element to zero.
+  // Extract the exponent, significand, and sign bit.
+  d_exp = vec_xvxexpdp (f64);
+  d_sig = vec_xvxsigdp (f64);
+  q_sign = vec_and ((vui32_t) f64, signmask);
+  // The extract sig operation has already tested for finite/subnormal.
+  // So avoid testing isfinite/issubnormal again by simply testing
+  // the extracted exponent.
+  if (__builtin_expect (!vec_cmpud_all_eq (d_exp, d_naninf), 1))
+    {
+      if (__builtin_expect (!vec_cmpud_all_eq (d_exp, d_denorm), 1))
+	{
+	  q_sig = vec_srqi ((vui128_t) d_sig, 4);
+	  q_exp = vec_addudm (d_exp, exp_delta);
+	}
+      else
+	{ // We can simplify iszero by comparing the sig to 0
+	  if (vec_cmpud_all_eq (d_sig, d_denorm))
+	    {
+	      q_sig = (vui128_t) d_sig;
+	      q_exp = (vui64_t) d_exp;
+	    }
+	  else
+	    { // Must be subnormal but we need to produce a normal QP
+	      // Need to adjust the quad exponent by the f64 denormal exponent
+	      // (-1023) and that the f64 sig will have at least 12 leading '0's
+	      vui64_t q_denorm = (vui64_t) CONST_VINT64_DW( (0x3fff - (1023 -12)), 0 );
+	      vui64_t f64_clz;
+	      //d_sig = vec_sldi (d_sig, 12);
+	      f64_clz = vec_clzd (d_sig);
+	      d_sig = vec_vsld (d_sig, f64_clz);
+	      q_exp = vec_subudm (q_denorm, f64_clz);
+	      q_sig = vec_srqi ((vui128_t) d_sig, 15);
+	    }
+	}
+    }
+  else
+    { // isinf or isnan.
+      q_sig = vec_srqi ((vui128_t) d_sig, 4);
+      q_exp = (vui64_t) CONST_VINT64_DW(0x7fff, 0);
+    }
+
+  // Copy Sign-bit to QP significand before insert.
+  q_sig = (vui128_t) vec_or ((vui32_t) q_sig, q_sign);
+  // Insert exponent into significand to complete conversion to QP
+  result = vec_xsiexpqp (q_sig, q_exp);
+#else
+  result = f64[VEC_DW_H];
+#endif
+  return result;
+}
+
+__binary128
+test_convert_dpqp_v2 (vf64_t f64)
+{
+  __binary128 result;
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 9)
+  result = f64[VEC_DW_H];
+#elif  defined (_ARCH_PWR8)
+  f64[VEC_DW_L] = 0.0;
+  vui64_t d_exp, d_sig, q_exp;
+  vui128_t q_sig;
+  const vui64_t exp_delta = (vui64_t) CONST_VINT64_DW( (0x3fff - 0x3ff), 0 );
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
+
+  d_exp = vec_xvxexpdp (f64);
+  d_sig = vec_xvxsigdp (f64);
+  if (__builtin_expect (vec_all_isfinitef64 (f64), 1))
+    {
+      if (__builtin_expect (vec_all_isnormalf64 (vec_splat (f64, VEC_DW_H)), 1))
+	{
+	  q_sig = vec_srqi ((vui128_t) d_sig, 4);
+	  q_exp = vec_addudm (d_exp, exp_delta);
+	}
+      else
+	{
+	  if (vec_all_iszerof64 (f64))
+	    {
+	      q_sig = (vui128_t) d_sig;
+	      q_exp = (vui64_t) d_exp;
+	    }
+	  else
+	    { // Must be subnormal
+	      vui64_t q_denorm = (vui64_t) CONST_VINT64_DW( (0x3fff - 1023), 0 );
+	      vui64_t f64_clz;
+	      d_sig = vec_sldi (d_sig, 12);
+	      f64_clz = vec_clzd (d_sig);
+	      d_sig = vec_sl (d_sig, f64_clz);
+	      q_exp = vec_subudm (q_denorm, f64_clz);
+	      q_sig = vec_srqi ((vui128_t) d_sig, 15);
+	    }
+	}
+    }
+  else
+    { // isinf or isnan.
+      q_sig = vec_srqi ((vui128_t) d_sig, 4);
+      q_exp = (vui64_t) CONST_VINT64_DW(0x7fff, 0);
+    }
+
+  q_sig = (vui128_t) vec_sel ((vui32_t) q_sig, (vui32_t) f64, signmask);
+  result = vec_xsiexpqp (q_sig, q_exp);
+#else
+  result = f64[VEC_DW_H];
+#endif
+  return result;
+}
+
+__binary128
 test_convert_dpqp (vf64_t f64)
 {
   __binary128 result;
@@ -195,7 +408,7 @@ test_convert_dpqp (vf64_t f64)
 	  {
 	    if (vec_all_issubnormalf64 (vec_splat (f64, VEC_DW_H)))
 	      {
-		vui64_t q_denorm = { (0x3fff - 1022), 0 };
+		vui64_t q_denorm = { (0x3fff - 1023), 0 };
 		vui64_t f64_clz;
 		d_sig = vec_sldi ( d_sig, 12);
 		f64_clz = vec_clzd (d_sig);
@@ -204,7 +417,7 @@ test_convert_dpqp (vf64_t f64)
 		q_sig = vec_srqi ((vui128_t) d_sig, 15);
 	      } else {
 		q_sig = vec_srqi ((vui128_t) d_sig, 4);
-		q_exp = (vui64_t) CONST_VINT64_DW(0x7fff000000000000, 0);
+		q_exp = (vui64_t) CONST_VINT64_DW(0x7fff, 0);
 	      }
 	  }
     }
@@ -663,6 +876,51 @@ test_vec_max8_f128 (__binary128 vf1, __binary128 vf2,
 
 #ifndef PVECLIB_DISABLE_F128ARITH
 #ifdef __FLOAT128__
+
+void
+test_vec_dpqp_f128 (__binary128 * vf128,
+		    vf64_t vf1, vf64_t vf2,
+		    vf64_t vf3, vf64_t vf4,
+		    vf64_t vf5)
+{
+  vf128[0] = vec_xscvdpqp (vf1);
+  vf1[VEC_DW_H] = vf1[VEC_DW_L];
+  vf128[1] = vec_xscvdpqp (vf1);
+
+  vf128[2] = vec_xscvdpqp (vf2);
+  vf2[VEC_DW_H] = vf2[VEC_DW_L];
+  vf128[3] = vec_xscvdpqp (vf2);
+
+  vf128[4] = vec_xscvdpqp (vf3);
+  vf3[VEC_DW_H] = vf3[VEC_DW_L];
+  vf128[5] = vec_xscvdpqp (vf3);
+
+  vf128[6] = vec_xscvdpqp (vf4);
+  vf4[VEC_DW_H] = vf4[VEC_DW_L];
+  vf128[7] = vec_xscvdpqp (vf4);
+
+  vf128[8] = vec_xscvdpqp (vf5);
+  vf5[VEC_DW_H] = vf5[VEC_DW_L];
+  vf128[8] = vec_xscvdpqp (vf5);
+}
+
+void
+test_gcc_dpqp_f128 (__binary128 * vf128,
+		    vf64_t vf1, vf64_t vf2,
+		    vf64_t vf3, vf64_t vf4,
+		    vf64_t vf5)
+{
+  vf128[0] = vf1[VEC_DW_H];
+  vf128[1] = vf1[VEC_DW_L];
+  vf128[2] = vf2[VEC_DW_H];
+  vf128[3] = vf2[VEC_DW_L];
+  vf128[4] = vf3[VEC_DW_H];
+  vf128[5] = vf3[VEC_DW_L];
+  vf128[6] = vf4[VEC_DW_H];
+  vf128[7] = vf4[VEC_DW_L];
+  vf128[8] = vf5[VEC_DW_H];
+  vf128[9] = vf5[VEC_DW_L];
+}
 
 __binary128
 test_gcc_max8_f128 (__binary128 vf1, __binary128 vf2,

--- a/src/testsuite/vec_f128_dummy.c
+++ b/src/testsuite/vec_f128_dummy.c
@@ -322,9 +322,6 @@ test_convert_dpqp_v3 (vf64_t f64)
   return result;
 }
 
-  if (__builtin_expect (!vec_cmpuq_all_eq ((vui128_t) q_exp, (vui128_t) q_naninf), 1))
-    {
-      if (vec_cmpuq_all_ge ((vui128_t) q_exp, (vui128_t) exp_low))
 __binary128
 test_convert_dpqp_v2 (vf64_t f64)
 {

--- a/src/testsuite/vec_perf_f128.c
+++ b/src/testsuite/vec_perf_f128.c
@@ -56,6 +56,23 @@ const __float128 inv_fact6 = (1.0Q / 720.0Q);
 const __float128 inv_fact7 = (1.0Q / 5040.0Q);
 const __float128 inv_fact8 = (1.0Q / 40320.0Q);
 
+const double f64_one = 1.0;
+const double f64_fact2 = (1.0 / 2.0);
+const double f64_fact3 = (1.0 / 6.0);
+const double f64_fact4 = (1.0 / 24.0);
+const double f64_fact5 = (1.0 / 120.0);
+const double f64_fact6 = (1.0 / 720.0);
+const double f64_fact7 = (1.0 / 5040.0);
+const double f64_fact8 = (1.0 / 40320.0);
+const double f64_fact9 = (1.0 / 362880.0);
+const double f64_fact10 = (1.0 / 3628800.0);
+
+const vf64_t invfact1_2 = {1.0, 2.0};
+const vf64_t invfact3_4 = {6.0, 24.0};
+const vf64_t invfact5_6 = {120.0, 720.0};
+const vf64_t invfact7_8 = {5040.0, 40320.0};
+const vf64_t invfact9_10 = {362880.0, 3628800.0};
+
 __float128
 test_scalarLib_expxsuba_128 (__float128 x, __float128 a, __float128 expa)
 {
@@ -111,8 +128,23 @@ test_gcc_max8_f128 (__binary128 vf1, __binary128 vf2,
 		    __binary128 vf5, __binary128 vf6,
 		    __binary128 vf7, __binary128 vf8);
 
+extern void
+test_gcc_dpqp_f128 (__binary128 * vf128,
+		    vf64_t vf1, vf64_t vf2,
+		    vf64_t vf3, vf64_t vf4,
+		    vf64_t vf5);
+
+extern void
+test_vec_dpqp_f128 (__binary128 * vf128,
+		    vf64_t vf1, vf64_t vf2,
+		    vf64_t vf3, vf64_t vf4,
+		    vf64_t vf5);
+
 extern vb128_t
 test_vec_cmpgtuqp (__binary128 vfa, __binary128 vfb);
+
+extern __binary128
+test_vec_xscvdpqp (vf64_t f64);
 
 __binary128
 test_lib_max8_f128 (__binary128 vf1, __binary128 vf2,
@@ -139,6 +171,81 @@ test_lib_max8_f128 (__binary128 vf1, __binary128 vf2,
   maxres = vec_self128 (vf8, maxres, bool);
 
   return maxres;
+}
+
+void
+test_lib_dpqp_f128 (__binary128 * vf128,
+		    vf64_t vf1, vf64_t vf2,
+		    vf64_t vf3, vf64_t vf4,
+		    vf64_t vf5)
+{
+  vf128[0] = test_vec_xscvdpqp (vf1);
+  vf1[VEC_DW_H] = vf1[VEC_DW_L];
+  vf128[1] = test_vec_xscvdpqp (vf1);
+
+  vf128[2] = test_vec_xscvdpqp (vf2);
+  vf2[VEC_DW_H] = vf2[VEC_DW_L];
+  vf128[3] = test_vec_xscvdpqp (vf2);
+
+  vf128[4] = test_vec_xscvdpqp (vf3);
+  vf3[VEC_DW_H] = vf3[VEC_DW_L];
+  vf128[5] = test_vec_xscvdpqp (vf3);
+
+  vf128[6] = test_vec_xscvdpqp (vf4);
+  vf4[VEC_DW_H] = vf4[VEC_DW_L];
+  vf128[7] = test_vec_xscvdpqp (vf4);
+
+  vf128[8] = test_vec_xscvdpqp (vf5);
+  vf5[VEC_DW_H] = vf5[VEC_DW_L];
+  vf128[8] = test_vec_xscvdpqp (vf5);
+}
+
+int timed_vec_dpqp_f128 (void)
+{
+#ifndef PVECLIB_DISABLE_F128MATH
+  __float128 tbl[10];
+  int i;
+
+  for (i=0; i<N; i++)
+    {
+      test_vec_dpqp_f128 (tbl, invfact1_2,
+			  invfact3_4, invfact5_6,
+			  invfact7_8, invfact9_10);
+    }
+#endif
+   return 0;
+}
+
+int timed_lib_dpqp_f128 (void)
+{
+#ifndef PVECLIB_DISABLE_F128MATH
+  __float128 tbl[10];
+  int i;
+
+  for (i=0; i<N; i++)
+    {
+      test_lib_dpqp_f128 (tbl, invfact1_2,
+			  invfact3_4, invfact5_6,
+			  invfact7_8, invfact9_10);
+    }
+#endif
+   return 0;
+}
+
+int timed_gcc_dpqp_f128 (void)
+{
+#ifndef PVECLIB_DISABLE_F128MATH
+  __float128 tbl[10];
+  int i;
+
+  for (i=0; i<N; i++)
+    {
+      test_gcc_dpqp_f128 (tbl, invfact1_2,
+			  invfact3_4, invfact5_6,
+			  invfact7_8, invfact9_10);
+    }
+#endif
+   return 0;
 }
 
 int timed_lib_max8_f128 (void)

--- a/src/testsuite/vec_perf_f128.h
+++ b/src/testsuite/vec_perf_f128.h
@@ -24,10 +24,14 @@
 
 extern int timed_expxsuba_v1_f128 (void);
 extern int timed_expxsuba_v2_f128 (void);
+
 extern int timed_gcc_max8_f128 (void);
 extern int timed_lib_max8_f128 (void);
 extern int timed_vec_max8_f128 (void);
+extern int timed_vec_max8_f128uz (void);
 
-//extern int test_time_f128 (void);
+extern int timed_gcc_dpqp_f128 (void);
+extern int timed_lib_dpqp_f128 (void);
+extern int timed_vec_dpqp_f128 (void);
 
 #endif /* SRC_TESTSUITE_VEC_PERF_F128_H_ */

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -40,10 +40,177 @@
 #include <pveclib/vec_f32_ppc.h>
 #include <pveclib/vec_bcd_ppc.h>
 
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 7)
+int
+test_gcc_cmpqpne_PWR9 (__float128 vfa, __float128 vfb)
+{
+  return (vfa != vfb);
+}
+
+int
+test_gcc_cmpqpeq_PWR9 (__float128 vfa, __float128 vfb)
+{
+  return (vfa == vfb);
+}
+
+int
+test_gcc_cmpqpneV2_PWR9 (__float128 vfa, __float128 vfb)
+{
+  return !(vfa == vfb);
+}
+
+void
+test_gcc_udqp_f128_PWR9 (__binary128 * vf128,
+		    vui64_t vf1, vui64_t vf2,
+		    vui64_t vf3, vui64_t vf4,
+		    vui64_t vf5)
+{
+  vf128[0] = vf1[VEC_DW_H];
+  vf128[1] = vf1[VEC_DW_L];
+  vf128[2] = vf2[VEC_DW_H];
+  vf128[3] = vf2[VEC_DW_L];
+  vf128[4] = vf3[VEC_DW_H];
+  vf128[5] = vf3[VEC_DW_L];
+  vf128[6] = vf4[VEC_DW_H];
+  vf128[7] = vf4[VEC_DW_L];
+  vf128[8] = vf5[VEC_DW_H];
+  vf128[9] = vf5[VEC_DW_L];
+}
+
+void
+test_gcc_dpqp_f128_PWR9 (__binary128 * vf128,
+		    vf64_t vf1, vf64_t vf2,
+		    vf64_t vf3, vf64_t vf4,
+		    vf64_t vf5)
+{
+  vf128[0] = vf1[VEC_DW_H];
+  vf128[1] = vf1[VEC_DW_L];
+  vf128[2] = vf2[VEC_DW_H];
+  vf128[3] = vf2[VEC_DW_L];
+  vf128[4] = vf3[VEC_DW_H];
+  vf128[5] = vf3[VEC_DW_L];
+  vf128[6] = vf4[VEC_DW_H];
+  vf128[7] = vf4[VEC_DW_L];
+  vf128[8] = vf5[VEC_DW_H];
+  vf128[9] = vf5[VEC_DW_L];
+}
+#endif
+
+int
+test_gcc_cmpdpne_PWR9 (double vfa, double vfb)
+{
+  return (vfa != vfb);
+}
+
+int
+test_vec_cmpqp_all_tone_PWR9 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpqp_all_tone (vfa, vfb);
+}
+
+int
+test_vec_cmpqp_all_uzne_PWR9 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpqp_all_uzne (vfa, vfb);
+}
+
+int
+test_vec_cmpqp_all_ne_PWR9 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpqp_all_ne (vfa, vfb);
+}
+
+int
+test_vec_cmpqp_all_toeq_PWR9 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpqp_all_toeq (vfa, vfb);
+}
+
+int
+test_vec_cmpqp_all_uzeq_PWR9 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpqp_all_uzeq (vfa, vfb);
+}
+
+int
+test_vec_cmpqp_all_eq_PWR9 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_cmpqp_all_eq (vfa, vfb);
+}
+
 int
 test_scalar_test_neg_PWR9 (__binary128 vfa)
 {
   return vec_signbitf128 (vfa);
+}
+
+// Convert Float DP to QP
+__binary128
+test_convert_dpqp_PWR9 (vf64_t f64)
+{
+  __binary128 result;
+#if defined (_ARCH_PWR9) && (__GNUC__ > 7)
+#if defined (__FLOAT128__) && (__GNUC__ > 9)
+  // earlier GCC versions generate extra data moves for this.
+  result = f64[VEC_DW_H];
+#else
+  // No extra data moves here.
+  __asm__(
+      "xscvdpqp %0,%1"
+      : "=v" (result)
+      : "v" (f64)
+      : );
+#endif
+#else // likely call to libgcc concert.
+  result = f64[VEC_DW_H];
+#endif
+  return result;
+}
+
+// Convert Float SD to QP
+__binary128
+test_convert_sdqp_PWR9 (vi64_t i64)
+{
+  __binary128 result;
+#if defined (_ARCH_PWR9) && (__GNUC__ > 7)
+#if defined (__FLOAT128__) && (__GNUC__ > 9)
+  // earlier GCC versions generate extra data moves for this.
+  result = i64[VEC_DW_H];
+#else
+  // No extra data moves here.
+  __asm__(
+      "xscvsdqp %0,%1"
+      : "=v" (result)
+      : "v" (i64)
+      : );
+#endif
+#else // likely call to libgcc concert.
+  result = i64[VEC_DW_H];
+#endif
+  return result;
+}
+
+// Convert Float UD to QP
+__binary128
+test_convert_udqp_PWR9 (vui64_t i64)
+{
+  __binary128 result;
+#if defined (_ARCH_PWR9) && (__GNUC__ > 7)
+#if defined (__FLOAT128__) && (__GNUC__ > 9)
+  // earlier GCC versions generate extra data moves for this.
+  result = i64[VEC_DW_H];
+#else
+  // No extra data moves here.
+  __asm__(
+      "xscvudqp %0,%1"
+      : "=v" (result)
+      : "v" (i64)
+      : );
+#endif
+#else // likely call to libgcc concert.
+  result = i64[VEC_DW_H];
+#endif
+  return result;
 }
 
 int
@@ -1528,7 +1695,7 @@ __test_scalar_insert_exp_f64 (double sig, unsigned long long int exp)
 #endif
 
 #ifdef scalar_cmp_exp_eq
-#if 0
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 8)
 /* there is an instruction for this, but is not supported in
    GCC (8.2) yet.  */
 int


### PR DESCRIPTION
Power9 and Power8 equivalent operations for double float, signed
and unsigned doubleword conversion to quad-precision float.
Include compile, unit, performance tests.

	* src/pveclib/vec_f128_ppc.h: Updates to doxygen.
	[f128_softfloat_0_0_2]: Quad-Precision converts for POWER8.
	(vec_xsiexpqp): Forward prototype.
	(vec_xscvdpqp, vec_xscvsdqp, vec_xscvudqp): New operations.

	* src/testsuite/arith128_test_f128.c (db_vec_xscvdpqp):
	New debug only function.
	(test_convert_dpqp, test_convert_udqp, test_convert_sdqp):
	New unit test fuinctions.
	(test_vec_f128): Add calls to new unit tests above.

	* src/testsuite/vec_perf_f128.c
	(f64_one, f64_fact2, f64_fact3, f64_fact4, f64_fact5,
	f64_fact6, f64_fact7, f64_fact8, f64_fact9, f64_fact10,
	invfact1_2, invfact3_4, invfact5_6, invfact7_8, invfact9_10):
	New constants used in timed tests.
	(test_gcc_dpqp_f128, test_vec_dpqp_f128, test_vec_cmpgtuqp,
	test_vec_xscvdpqp): New externs used as performance kernels.
	(test_lib_dpqp_f128): New performance kernel.
	(timed_vec_dpqp_f128, timed_lib_dpqp_f128,
	timed_gcc_dpqp_f128): New timed performance loops.

	* src/testsuite/vec_perf_f128.h (timed_vec_max8_f128uz,
	timed_gcc_dpqp_f128, timed_lib_dpqp_f128, timed_vec_dpqp):
	externs for timed performance loops.

	* src/testsuite/pveclib_perf.c: Align printf text.
	(timed_vec_max8_f128uz, timed_gcc_dpqp_f128,
	timed_gcc_dpqp_f128, timed_gcc_dpqp_f128):
	Timed runs for new perf functions.

	* src/testsuite/vec_f128_dummy.c (test_vec_xscvdpqp,
	test_convert_udqp, test_convert_sdqp, test_convert_dpqp_v3,
	test_convert_dpqp_v2): New compile tests.
	(test_convert_dpqp): Correct to match implementation.
	(test_vec_dpqp_f128, test_gcc_dpqp_f128): New compile tests
	also used in timed tests.

	* src/testsuite/vec_pwr9_dummy.c (test_gcc_cmpqpne_PWR9,
	test_gcc_cmpqpeq_PWR9, test_gcc_cmpqpneV2_PWR9): New
	POWER9 compile tests.
	(test_gcc_udqp_f128_PWR9, test_gcc_dpqp_f128_PWR9): New
	POWER9 compile tests.
	(test_gcc_cmpdpne_PWR9, test_vec_cmpqp_all_tone_PWR9,
	test_vec_cmpqp_all_uzne_PWR9, test_vec_cmpqp_all_ne_PWR9,
	test_vec_cmpqp_all_toeq_PWR9, test_vec_cmpqp_all_uzeq_PWR9,
	test_vec_cmpqp_all_eq_PWR9) Predicate function comnpile tests.
	(test_convert_dpqp_PWR9, test_convert_sdqp_PWR9,
	test_convert_udqp_PWR9): New POWER9 compile tests.
	[defined (scalar_cmp_exp_eq)  && (__GNUC__ > 8): Guard compiler
	version specific tests.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>