### PR TITLE
Fix type conversions between vector types

### DIFF
--- a/src/pveclib/vec_int128_ppc.h
+++ b/src/pveclib/vec_int128_ppc.h
@@ -6065,7 +6065,7 @@ vec_setb_ncq (vui128_t vcy)
 static inline vb128_t
 vec_setb_sq (vi128_t vra)
 {
-  vui128_t result;
+  vb128_t result;
 
 #if defined (_ARCH_PWR10)  && (__GNUC__ >= 10)
   __asm__(
@@ -6325,7 +6325,7 @@ vec_sraq (vi128_t vra, vui128_t vrb)
   /* For some reason the vsr instruction only works
    * correctly if the bit shift value is splatted to each byte
    * of the vector.  */
-  vsgn = vec_setb_sq (vra);
+  vsgn = (vui128_t) vec_setb_sq (vra);
   vsht = vec_sub (zero, (vui8_t) vrb);
   result = (vui8_t) vec_sldq (vsgn, (vui128_t) vra, (vui128_t) vsht);
 #endif
@@ -6375,7 +6375,7 @@ vec_sraqi (vi128_t vra, const unsigned int shb)
 	{
 	  if (shb > 0)
 	    {
-	      vsgn = vec_setb_sq (vra);
+	      vsgn = (vui128_t) vec_setb_sq (vra);
 	      result = vec_sld ((vui8_t) vsgn, (vui8_t) vra, 16 - (shb / 8));
 	    }
 	  else
@@ -6401,7 +6401,7 @@ vec_sraqi (vi128_t vra, const unsigned int shb)
 	      else
 		lshift = vec_splats ((unsigned char) lshb);
 
-	      vsgn = vec_setb_sq (vra);
+	      vsgn = (vui128_t) vec_setb_sq (vra);
 	      result = (vui8_t) vec_sldq (vsgn, (vui128_t) vra,
 					  (vui128_t) lshift);
 #ifdef _ARCH_PWR8

--- a/src/testsuite/vec_int128_dummy.c
+++ b/src/testsuite/vec_int128_dummy.c
@@ -433,19 +433,19 @@ test_cmpuq_all_ne (vui128_t a, vui128_t b)
   return vec_cmpuq_all_ne (a, b);
 }
 
-vui128_t
+vb128_t
 test_setb_cyq (vui128_t vcy)
 {
   return vec_setb_cyq (vcy);
 }
 
-vui128_t
+vb128_t
 test_setb_ncq (vui128_t vcy)
 {
   return vec_setb_ncq (vcy);
 }
 
-vui128_t
+vb128_t
 test_setb_sq (vi128_t vcy)
 {
   return vec_setb_sq (vcy);

--- a/src/testsuite/vec_pwr10_dummy.c
+++ b/src/testsuite/vec_pwr10_dummy.c
@@ -276,7 +276,7 @@ test_setb_sd_PWR10 (vi64_t vra)
   return vec_setb_sd (vra);
 }
 
-vui128_t
+vb128_t
 test_setb_sq_PWR10 (vi128_t vcy)
 {
   return vec_setb_sq (vcy);


### PR DESCRIPTION
Build with GCC 11.1 was broken because of some implicit type conversions,
causing the compilation to fail with many errors like this:

```
$ pveclib/src/pveclib/vec_int128_ppc.h:4610:22: error: incompatible types when
assigning to type ‘vui128_t’ {aka ‘__vector(1) __int128 unsigned’} from type
‘vb128_t’ {aka ‘__vector(1) __int128’}
 4610 |               vsgn = vec_setb_sq (vra);
      |                      ^~~~~~~~~~~
```

Some of these were caused by testsuite wrappers with different signatures from
their inner functions and also some missing casts on the definitions of
vec_sraq, vec_sraqi, and vec_setb_ncq.
