### PR TITLE
P9/10 Float128 convert instructions plus P8 equivalants. P2

### DIFF
--- a/src/testsuite/pveclib_perf.c
+++ b/src/testsuite/pveclib_perf.c
@@ -682,6 +682,131 @@ test_time_f128 (void)
   printf ("\n%s cvt_dpqp_vec tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
 	  t_delta, delta_sec);
 
+  printf ("\n%s cvt_uqqp_gcc start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_gcc_uqqp_f128 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s cvt_uqqp_gcc end", __FUNCTION__);
+  printf ("\n%s cvt_uqqp_gcc tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+	  t_delta, delta_sec);
+
+  printf ("\n%s cvt_uqqp_lib start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_lib_uqqp_f128 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s cvt_uqqp_lib end", __FUNCTION__);
+  printf ("\n%s cvt_uqqp_lib tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+	  t_delta, delta_sec);
+
+  printf ("\n%s cvt_uqqp_vec start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_vec_uqqp_f128 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s cvt_uqqp_vec end", __FUNCTION__);
+  printf ("\n%s cvt_uqqp_vec tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+	  t_delta, delta_sec);
+
+  printf ("\n%s cvt_qpuq_gcc start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_gcc_qpuq_f128 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s cvt_qpuq_gcc end", __FUNCTION__);
+  printf ("\n%s cvt_qpuq_gcc tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+	  t_delta, delta_sec);
+
+  printf ("\n%s cvt_qpuq_lib start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_lib_qpuq_f128 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s cvt_qpuq_lib end", __FUNCTION__);
+  printf ("\n%s cvt_qpuq_lib tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+	  t_delta, delta_sec);
+
+  printf ("\n%s cvt_qpuq_vec start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_vec_qpuq_f128 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s cvt_qpuq_vec end", __FUNCTION__);
+  printf ("\n%s cvt_qpuq_vec tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+	  t_delta, delta_sec);
+  printf ("\n%s cvt_qpdpo_gcc start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_gcc_qpdpo_f128 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s cvt_qpdpo_gcc end", __FUNCTION__);
+  printf ("\n%s cvt_qpdpo_gcc tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+	  t_delta, delta_sec);
+
+  printf ("\n%s cvt_qpdpo_lib start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_lib_qpdpo_f128 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s cvt_qpdpo_lib end", __FUNCTION__);
+  printf ("\n%s cvt_qpdpo_lib tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+	  t_delta, delta_sec);
+
+  printf ("\n%s cvt_qpdpo_vec start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_vec_qpdpo_f128 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s cvt_qpdpo_vec end", __FUNCTION__);
+  printf ("\n%s cvt_qpdpo_vec tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+	  t_delta, delta_sec);
+
   return (rc);
 }
 #endif

--- a/src/testsuite/vec_perf_f128.c
+++ b/src/testsuite/vec_perf_f128.c
@@ -73,6 +73,24 @@ const vf64_t invfact5_6 = {120.0, 720.0};
 const vf64_t invfact7_8 = {5040.0, 40320.0};
 const vf64_t invfact9_10 = {362880.0, 3628800.0};
 
+const __float128 qpfact1 = 1.0Q;
+const __float128 qpfact2 = 2.0Q;
+const __float128 qpfact3 = 6.0Q;
+const __float128 qpfact4 = 24.0Q;
+const __float128 qpfact5 = 120.0Q;
+const __float128 qpfact6 = 720.0Q;
+const __float128 qpfact7 = 5040.0Q;
+const __float128 qpfact8 = 40320.0Q;
+
+const vui128_t i128fact1 = {1};
+const vui128_t i128fact2 = {2};
+const vui128_t i128fact3 = {6};
+const vui128_t i128fact4 = {24};
+const vui128_t i128fact5 = {120};
+const vui128_t i128fact6 = {720};
+const vui128_t i128fact7 = {5040};
+const vui128_t i128fact8 = {40320};
+
 __float128
 test_scalarLib_expxsuba_128 (__float128 x, __float128 a, __float128 expa)
 {
@@ -140,11 +158,56 @@ test_vec_dpqp_f128 (__binary128 * vf128,
 		    vf64_t vf3, vf64_t vf4,
 		    vf64_t vf5);
 
+extern void
+test_vec_uqqp_f128 (__binary128 * vf128,
+		    vui128_t vf1, vui128_t vf2,
+		    vui128_t vf3, vui128_t vf4,
+		    vui128_t vf5, vui128_t vf6,
+		    vui128_t vf7, vui128_t vf8);
+
+extern void
+test_gcc_uqqp_f128 (__binary128 * vf128,
+		    vui128_t vf1, vui128_t vf2,
+		    vui128_t vf3, vui128_t vf4,
+		    vui128_t vf5, vui128_t vf6,
+		    vui128_t vf7, vui128_t vf8);
+
+extern void
+test_vec_qpuq_f128 (vui128_t * vf128,
+		    __binary128 vf1, __binary128 vf2,
+		    __binary128 vf3, __binary128 vf4,
+		    __binary128 vf5, __binary128 vf6,
+		    __binary128 vf7, __binary128 vf8);
+
+extern void
+test_gcc_qpuq_f128 (vui128_t * vf128,
+		    __binary128 vf1, __binary128 vf2,
+		    __binary128 vf3, __binary128 vf4,
+		    __binary128 vf5, __binary128 vf6,
+		    __binary128 vf7, __binary128 vf8);
+
+extern void
+test_vec_qpdpo_f128 (vf64_t * vf128,
+		    __binary128 vf1, __binary128 vf2,
+		    __binary128 vf3, __binary128 vf4,
+		    __binary128 vf5, __binary128 vf6,
+		    __binary128 vf7, __binary128 vf8);
+
+extern void
+test_gcc_qpdpo_f128 (vf64_t * vf128,
+		    __binary128 vf1, __binary128 vf2,
+		    __binary128 vf3, __binary128 vf4,
+		    __binary128 vf5, __binary128 vf6,
+		    __binary128 vf7, __binary128 vf8);
+
 extern vb128_t
 test_vec_cmpgtuqp (__binary128 vfa, __binary128 vfb);
 
 extern __binary128
 test_vec_xscvdpqp (vf64_t f64);
+
+extern vf64_t
+test_vec_xscvqpdpo (__binary128 f128);
 
 __binary128
 test_lib_max8_f128 (__binary128 vf1, __binary128 vf2,
@@ -174,6 +237,38 @@ test_lib_max8_f128 (__binary128 vf1, __binary128 vf2,
 }
 
 void
+test_lib_qpdpo_f128 (vf64_t * vx64,
+		    __binary128 vf1, __binary128 vf2,
+		    __binary128 vf3, __binary128 vf4,
+		    __binary128 vf5, __binary128 vf6,
+		    __binary128 vf7, __binary128 vf8)
+{
+  vf64_t vxf1, vxf2, vxf3, vxf4;
+
+  vxf1 = test_vec_xscvqpdpo (vf1);
+  vxf2 = test_vec_xscvqpdpo (vf2);
+  vxf3 = test_vec_xscvqpdpo (vf3);
+  vxf4 = test_vec_xscvqpdpo (vf4);
+
+  vxf1[VEC_DW_L] = vxf2[VEC_DW_H];
+  vxf3[VEC_DW_L] = vxf4[VEC_DW_H];
+
+  vx64[0] = vxf1;
+  vx64[1] = vxf3;
+
+  vxf1 = test_vec_xscvqpdpo (vf5);
+  vxf2 = test_vec_xscvqpdpo (vf6);
+  vxf3 = test_vec_xscvqpdpo (vf7);
+  vxf4 = test_vec_xscvqpdpo (vf8);
+
+  vxf1[VEC_DW_L] = vxf2[VEC_DW_H];
+  vxf3[VEC_DW_L] = vxf4[VEC_DW_H];
+
+  vx64[2] = vxf1;
+  vx64[3] = vxf3;
+}
+
+void
 test_lib_dpqp_f128 (__binary128 * vf128,
 		    vf64_t vf1, vf64_t vf2,
 		    vf64_t vf3, vf64_t vf4,
@@ -198,6 +293,207 @@ test_lib_dpqp_f128 (__binary128 * vf128,
   vf128[8] = test_vec_xscvdpqp (vf5);
   vf5[VEC_DW_H] = vf5[VEC_DW_L];
   vf128[8] = test_vec_xscvdpqp (vf5);
+}
+
+extern vui128_t
+test_vec_xscvqpuqz (__binary128 f128);
+
+void
+test_lib_qpuq_f128 (vui128_t * vf128,
+		    __binary128 vf1, __binary128 vf2,
+		    __binary128 vf3, __binary128 vf4,
+		    __binary128 vf5, __binary128 vf6,
+		    __binary128 vf7, __binary128 vf8)
+{
+  vf128[0] = test_vec_xscvqpuqz (vf1);
+  vf128[1] = test_vec_xscvqpuqz (vf2);
+  vf128[2] = test_vec_xscvqpuqz (vf3);
+  vf128[3] = test_vec_xscvqpuqz (vf4);
+  vf128[4] = test_vec_xscvqpuqz (vf5);
+  vf128[5] = test_vec_xscvqpuqz (vf6);
+  vf128[6] = test_vec_xscvqpuqz (vf7);
+  vf128[7] = test_vec_xscvqpuqz (vf8);
+}
+
+extern __binary128
+test_vec_xscvuqqp (vui128_t int128);
+
+void
+test_lib_uqqp_f128 (__binary128 * vf128,
+		    vui128_t vf1, vui128_t vf2,
+		    vui128_t vf3, vui128_t vf4,
+		    vui128_t vf5, vui128_t vf6,
+		    vui128_t vf7, vui128_t vf8)
+{
+  vf128[0] = test_vec_xscvuqqp (vf1);
+  vf128[1] = test_vec_xscvuqqp (vf2);
+  vf128[2] = test_vec_xscvuqqp (vf3);
+  vf128[3] = test_vec_xscvuqqp (vf4);
+  vf128[4] = test_vec_xscvuqqp (vf5);
+  vf128[5] = test_vec_xscvuqqp (vf6);
+  vf128[6] = test_vec_xscvuqqp (vf7);
+  vf128[7] = test_vec_xscvuqqp (vf8);
+}
+int timed_lib_qpdpo_f128 (void)
+{
+#ifndef PVECLIB_DISABLE_F128MATH
+  vf64_t tbl[10];
+  int i;
+
+  for (i=0; i<N; i++)
+    {
+      test_lib_qpdpo_f128 (tbl,
+			  qpfact1, qpfact2,
+			  qpfact3, qpfact4,
+			  qpfact5, qpfact6,
+			  qpfact7, qpfact8);
+    }
+#endif
+   return 0;
+}
+
+int timed_gcc_qpdpo_f128 (void)
+{
+#ifndef PVECLIB_DISABLE_F128MATH
+  vf64_t tbl[10];
+  int i;
+
+  for (i=0; i<N; i++)
+    {
+      test_gcc_qpdpo_f128 (tbl,
+			  qpfact1, qpfact2,
+			  qpfact3, qpfact4,
+			  qpfact5, qpfact6,
+			  qpfact7, qpfact8);
+    }
+#endif
+   return 0;
+}
+
+int timed_vec_qpdpo_f128 (void)
+{
+#ifndef PVECLIB_DISABLE_F128MATH
+  vf64_t tbl[10];
+  int i;
+
+  for (i=0; i<N; i++)
+    {
+      test_vec_qpdpo_f128 (tbl,
+			  qpfact1, qpfact2,
+			  qpfact3, qpfact4,
+			  qpfact5, qpfact6,
+			  qpfact7, qpfact8);
+    }
+#endif
+   return 0;
+}
+
+int timed_vec_qpuq_f128 (void)
+{
+#ifndef PVECLIB_DISABLE_F128MATH
+  vui128_t tbl[10];
+  int i;
+
+  for (i=0; i<N; i++)
+    {
+      test_vec_qpuq_f128 (tbl,
+			  qpfact1, qpfact2,
+			  qpfact3, qpfact4,
+			  qpfact5, qpfact6,
+			  qpfact7, qpfact8);
+    }
+#endif
+   return 0;
+}
+
+int timed_lib_qpuq_f128 (void)
+{
+#ifndef PVECLIB_DISABLE_F128MATH
+  vui128_t tbl[10];
+  int i;
+
+  for (i=0; i<N; i++)
+    {
+      test_lib_qpuq_f128 (tbl,
+			  qpfact1, qpfact2,
+			  qpfact3, qpfact4,
+			  qpfact5, qpfact6,
+			  qpfact7, qpfact8);
+    }
+#endif
+   return 0;
+}
+
+int timed_gcc_qpuq_f128 (void)
+{
+#ifndef PVECLIB_DISABLE_F128MATH
+  vui128_t tbl[10];
+  int i;
+
+  for (i=0; i<N; i++)
+    {
+      test_gcc_qpuq_f128 (tbl,
+			  qpfact1, qpfact2,
+			  qpfact3, qpfact4,
+			  qpfact5, qpfact6,
+			  qpfact7, qpfact8);
+    }
+#endif
+   return 0;
+}
+
+int timed_vec_uqqp_f128 (void)
+{
+#ifndef PVECLIB_DISABLE_F128MATH
+  __float128 tbl[10];
+  int i;
+
+  for (i=0; i<N; i++)
+    {
+      test_vec_uqqp_f128 (tbl,
+			  i128fact1, i128fact2,
+			  i128fact3, i128fact4,
+			  i128fact5, i128fact6,
+			  i128fact7, i128fact8);
+    }
+#endif
+   return 0;
+}
+
+int timed_lib_uqqp_f128 (void)
+{
+#ifndef PVECLIB_DISABLE_F128MATH
+  __float128 tbl[10];
+  int i;
+
+  for (i=0; i<N; i++)
+    {
+      test_lib_uqqp_f128 (tbl,
+			  i128fact1, i128fact2,
+			  i128fact3, i128fact4,
+			  i128fact5, i128fact6,
+			  i128fact7, i128fact8);
+    }
+#endif
+   return 0;
+}
+
+int timed_gcc_uqqp_f128 (void)
+{
+#ifndef PVECLIB_DISABLE_F128MATH
+  __float128 tbl[10];
+  int i;
+
+  for (i=0; i<N; i++)
+    {
+      test_gcc_uqqp_f128 (tbl,
+			  i128fact1, i128fact2,
+			  i128fact3, i128fact4,
+			  i128fact5, i128fact6,
+			  i128fact7, i128fact8);
+    }
+#endif
+   return 0;
 }
 
 int timed_vec_dpqp_f128 (void)

--- a/src/testsuite/vec_perf_f128.h
+++ b/src/testsuite/vec_perf_f128.h
@@ -34,4 +34,16 @@ extern int timed_gcc_dpqp_f128 (void);
 extern int timed_lib_dpqp_f128 (void);
 extern int timed_vec_dpqp_f128 (void);
 
+extern int timed_gcc_uqqp_f128 (void);
+extern int timed_lib_uqqp_f128 (void);
+extern int timed_vec_uqqp_f128 (void);
+
+extern int timed_gcc_qpuq_f128 (void);
+extern int timed_lib_qpuq_f128 (void);
+extern int timed_vec_qpuq_f128 (void);
+
+extern int timed_gcc_qpdpo_f128 (void);
+extern int timed_lib_qpdpo_f128 (void);
+extern int timed_vec_qpdpo_f128 (void);
+
 #endif /* SRC_TESTSUITE_VEC_PERF_F128_H_ */

--- a/src/testsuite/vec_pwr10_dummy.c
+++ b/src/testsuite/vec_pwr10_dummy.c
@@ -55,6 +55,27 @@ test_gcc_cmpsq_gt_PWR10 (vi128_t a, vi128_t b)
 }
 #endif
 
+vi128_t
+__test_vec_abssq_PWR10 (vi128_t vra)
+{
+  return vec_abssq (vra);
+}
+
+
+// Convert QP to Unsigned Integer QW
+vui128_t
+test_vec_xscvqpuqz_PWR10 (__binary128 f128)
+{
+  return vec_xscvqpuqz (f128);
+}
+
+// Convert Integer QW to QP
+__binary128
+test_vec_xscvuqqp_PWR10 (vui128_t int128)
+{
+  return vec_xscvuqqp (int128);
+}
+
 vb128_t
 test_vec_cmpeqsq_PWR10 (vi128_t a, vi128_t b)
 {


### PR DESCRIPTION
Major doxygen update with the "story so far".
Some doxygen clean-up.
Addtional Power9 and Power8 equivalent quad-precision conversion
operations.
Includes compile, unit, performance tests.

	* src/pveclib/vec_f128_ppc.h: Update doxygen intro.
	Add subsections; f128_softfloat_IRRN_0_0, and
	f128_softfloat_0_0_2_2
	(vec_xsxexpqp, vec_xsxsigqp): Add forward static inline.
	(vec_xor_bin128_2_vui32t): New transfer operation.
	(vec_cmpneuzqp): Correct doxygen description.
	(vec_cmpqp_exp_eq, vec_cmpqp_exp_gt, vec_cmpqp_exp_lt,
	vec_cmpqp_exp_unordered): New compare exponent operations.
	(vec_nabsf128, vec_negf128, vec_xscvqpdpo, vec_xscvqpudz,
	vec_xscvqpuqz): New operations.
	(vec_xscvudqp): Correct POWER7 only implementation.
	(vec_xscvsqqp, vec_xscvuqqp):  New operations.

	* src/testsuite/arith128_test_f128.c (db_vec_xscvsqqp,
	db_vec_xscvqpuqz, db_vec_xscvqpdpo): New debug only
	implementations.
	(test_convert_uqqp, test_convert_sqqp, test_convert_qpuqz,
	test_convert_qpudz, test_convert_qpdpo): New unit tests.
	(test_vec_f128): Call new unit tests.

	*src/testsuite/pveclib_perf.c (test_time_f128): Add upqp, qpup,
	and qpdpo timed perf tests.

	* src/testsuite/vec_f128_dummy.c (test_vec_cmpqp_exp_eq,
	test_vec_cmpqp_exp_gt, test_vec_cmpqp_exp_lt,
	test_vec_cmpqp_exp_unordered) New compile tests.
	(test_vec_xscvqpdpo, test_vec_xscvqpudz, test_vec_xscvqpuqz):
	New compile tests.
	(test_vec_xscvsqqp, test_vec_xscvuqqp):
	New compile tests.
	(test_convert_uqqpn, test_convert_uqqpn_V0, test_convert_uqqpz,
	test_convert_uqqpo): New compile tests.
	(test_convert_qpuqz, test_convert_qpdpo_v2,
	test_convert_qpdpo): New compile tests.
	(test_xor_bin128_2_vui32t): New compile tests.
	(test_vec_qpdpo_f128, test_gcc_qpdpo_f128, test_vec_qpuq_f128,
	test_gcc_qpuq_f128, test_vec_uqqp_f128):
	New issolated perf/compile tests.

	* src/testsuite/vec_perf_f128.c (qpfact1, qpfact2, qpfact3,
	qpfact4, qpfact5, qpfact6, qpfact7, qpfact8): New constants.
	(i128fact1, i128fact2, i128fact3, i128fact4,
	i128fact5, i128fact6, i128fact7, i128fact8): New constants.
	(test_vec_uqqp_f128, test_gcc_uqqp_f128, test_vec_qpuq_f128,
	test_gcc_qpuq_f128 test_vec_qpdpo_f128 test_gcc_qpdpo_f128):
	New perf loop externs.
 	(test_vec_xscvqpdpo): New operation extern.
 	(test_lib_qpdpo_f128): New operation library driver.
 	(test_vec_xscvqpuqz): New operation extern.
 	test_lib_qpuq_f128): New operation library driver.
 	(test_vec_xscvuqqp): New operation extern.
 	test_lib_uqqp_f128): New operation library driver.
 	(timed_lib_qpdpo_f128, timed_gcc_qpdpo_f128,
 	timed_vec_qpdpo_f128, timed_vec_qpuq_f128, timed_lib_qpuq_f128,
 	timed_gcc_qpuq_f128, timed_vec_uqqp_f128, timed_lib_uqqp_f128,
 	timed_gcc_uqqp_f128): New timed loop drivers.

 	* src/testsuite/vec_perf_f128.h (timed_gcc_uqqp_f128,
 	timed_lib_uqqp_f128, timed_vec_uqqp_f128, timed_gcc_qpuq_f128,
 	timed_lib_qpuq_f128, timed_vec_qpuq_f128,
 	timed_gcc_qpdpo_f128, timed_lib_qpdpo_f128,
 	timed_vec_qpdpo_f128): timed loop driver externs.

 	* src/testsuite/vec_pwr9_dummy.c (test_vec_cmpqp_exp_eq,
	test_vec_cmpqp_exp_gt, test_vec_cmpqp_exp_lt,
	test_vec_cmpqp_exp_unordered): New compile tests.
	(test_vec_xscvqpdpo_PWR9, test_vec_xscvqpudz_PWR9,
	test_vec_xscvqpuqz_PWR9, test_vec_xscvdpqp_PWR9,
	test_vec_xscvsqqp_PWR9 test_vec_xscvuqqp_PWR9):
	New compile tests.
	(test_convert_qpdpo_PWR9, test_convert_qpuqz_PWR9,
	test_convert_uqqp_PWR9): New compile tests.
	(test_vec_absf128_PWR9, test_vec_nabsf128_PWR9,
	test_absdiff_PWR9, test_xor_bin128_2_vui32t_PWR9):
	New compile tests.

 	* src/testsuite/vec_pwr10_dummy.c (__test_vec_abssq_PWR10,
 	test_vec_xscvqpuqz_PWR10, test_vec_xscvuqqp_PWR10):
 	POWER10 compile test.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>