### PR TITLE
Fix problems for GCC V12 turning off -many

### DIFF
--- a/src/testsuite/pveclib_perf.c
+++ b/src/testsuite/pveclib_perf.c
@@ -555,7 +555,7 @@ test_time_f128 (void)
   double delta_sec;
   int rc = 0;
 
-#if 0
+#if 0 // turn off until Round-to-odd implementation is ready
   printf ("\n%s f128 CC start, ...\n", __FUNCTION__);
   t_start = __builtin_ppc_get_timebase ();
   for (i = 0; i < TIMING_ITERATIONS; i++)

--- a/src/testsuite/vec_f128_dummy.c
+++ b/src/testsuite/vec_f128_dummy.c
@@ -1066,21 +1066,11 @@ test_absdiff (__float128 vra, __float128 vrb)
 
 // TBD will sub-in pveclib softfloat for P8 when available
 
+#if 0 // turn off until Round-to-odd implementation is ready
 __float128
 test_scalar_add128 (__float128 vra, __float128 vrb)
 {
 #ifndef __clang__
-  if (__builtin_cpu_supports("ieee128"))
-    {
-      __float128 result;
-      __asm__(
-	      "xsaddqp %0,%1,%2"
-	      : "=v" (result)
-	      : "v" (vra), "v" (vrb)
-	      : );
-      return result;
-    }
-  else
     // Generate call to __addkf3
     return (vra + vrb);
 #else
@@ -1092,17 +1082,6 @@ __float128
 test_scalar_div128 (__float128 vra, __float128 vrb)
 {
 #ifndef __clang__
-  if (__builtin_cpu_supports("ieee128"))
-    {
-      __float128 result;
-      __asm__(
-	      "xsdivqp %0,%1,%2"
-	      : "=v" (result)
-	      : "v" (vra), "v" (vrb)
-	      : );
-      return result;
-    }
-  else
     // Generate call to __divkf3
     return (vra / vrb);
 #else
@@ -1114,17 +1093,6 @@ __float128
 test_scalar_mul128 (__float128 vra, __float128 vrb)
 {
 #ifndef __clang__
-  if (__builtin_cpu_supports("ieee128"))
-    {
-      __float128 result;
-      __asm__(
-	      "xsmulqp %0,%1,%2"
-	      : "=v" (result)
-	      : "v" (vra), "v" (vrb)
-	      : );
-      return result;
-    }
-  else
     // Generate call to __mulkf3
     return (vra * vrb);
 #else
@@ -1136,23 +1104,13 @@ __float128
 test_scalar_sub128 (__float128 vra, __float128 vrb)
 {
 #ifndef __clang__
-  if (__builtin_cpu_supports("ieee128"))
-    {
-      __float128 result;
-      __asm__(
-	      "xssubqp %0,%1,%2"
-	      : "=v" (result)
-	      : "v" (vra), "v" (vrb)
-	      : );
-      return result;
-    }
-  else
     // Generate call to __subkf3
     return (vra - vrb);
 #else
   return vra;
 #endif
 }
+#endif
 
 __float128
 test_scalarCC_expxsuba_128 (__float128 x, __float128 a, __float128 expa)

--- a/src/testsuite/vec_perf_f128.c
+++ b/src/testsuite/vec_perf_f128.c
@@ -31,6 +31,7 @@
 #ifdef __FLOAT128__
 #ifndef PVECLIB_DISABLE_F128ARITH
 
+#if 0 // turn off until Round-to-odd implementation is ready
 extern __float128
 test_scalar_add128 (__float128 vra, __float128 vrb);
 
@@ -42,6 +43,7 @@ test_scalar_mul128 (__float128 vra, __float128 vrb);
 
 extern __float128
 test_scalar_sub128 (__float128 vra, __float128 vrb);
+#endif
 
 extern __float128
 test_scalarCC_expxsuba_128 (__float128 x, __float128 a, __float128 expa);
@@ -73,6 +75,8 @@ const vf64_t invfact5_6 = {120.0, 720.0};
 const vf64_t invfact7_8 = {5040.0, 40320.0};
 const vf64_t invfact9_10 = {362880.0, 3628800.0};
 
+
+#if 0 // turn off until Round-to-odd implementation is ready
 __float128
 test_scalarLib_expxsuba_128 (__float128 x, __float128 a, __float128 expa)
 {
@@ -106,6 +110,7 @@ test_scalarLib_expxsuba_128 (__float128 x, __float128 a, __float128 expa)
   term = test_scalar_add128 (term, xmaf8);
   return test_scalar_mul128(expa, term);;
 }
+#endif
 
 #define N 10
 #define TIMING_ITERATIONS 10
@@ -330,6 +335,7 @@ int timed_expxsuba_v1_f128 (void)
    return 0;
 }
 
+#if 0 // turn off until Round-to-odd implementation is ready
 int timed_expxsuba_v2_f128 (void)
 {
 #ifndef PVECLIB_DISABLE_F128MATH
@@ -343,6 +349,7 @@ int timed_expxsuba_v2_f128 (void)
 #endif
    return 0;
 }
+#endif
 
 #endif
 #endif

--- a/src/testsuite/vec_perf_f128.h
+++ b/src/testsuite/vec_perf_f128.h
@@ -22,8 +22,10 @@
 #ifndef SRC_TESTSUITE_VEC_PERF_F128_H_
 #define SRC_TESTSUITE_VEC_PERF_F128_H_
 
+#if 0 // turn off until Round-to-odd implementation is ready
 extern int timed_expxsuba_v1_f128 (void);
 extern int timed_expxsuba_v2_f128 (void);
+#endif
 
 extern int timed_gcc_max8_f128 (void);
 extern int timed_lib_max8_f128 (void);


### PR DESCRIPTION
PVECLIB compile fails for GCC12 as reported:
https://github.com/advancetoolchain/advance-toolchain/pull/2275

Seems GCC V12 wants to disable explicitly enabling -many for
assembly. vec_f128_dummy.c had some perf code trying to compare
hard/soft-float performance using in-line __builtin_cpu_supports.
This trick requires -many to work. So disable them for now, but
will need something similar for perf testing the round-to-odd
implementations.

	* src/testsuite/pveclib_perf.c: Add commment about disabling
	some tests until the F128 round-to-odd implementations are
	ready.

	* src/testsuite/vec_f128_dummy.c (test_scalar_add128,
	test_scalar_div128, test_scalar_mul128, test_scalar_sub128):
	Remove __builtin_cpu_supports code. Conditionally Disable the
	lot.

	* src/testsuite/vec_perf_f128.c (test_scalar_add128,
	test_scalar_div128, test_scalar_mul128, test_scalar_sub128):
	Conditionally Disable these externs.
	(test_scalarLib_expxsuba_128):
	Conditionally Disable this perf-test.
	(timed_expxsuba_v2_f128):
	Conditionally Disable this perf-test.

	* src/testsuite/vec_perf_f128.h (timed_expxsuba_v1_f128.
	timed_expxsuba_v2_f128): Conditionally Disable these externs.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>