### PR TITLE
Fix incompatible type assignment

### DIFF
--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -373,7 +373,7 @@ test_convert_qpuqz_PWR9 (__binary128 f128)
       else// is inf
 	{
 	  is_neg = vec_setb_qp (f128);
-	  result = (vb128_t) vec_nor ((vui32_t) is_neg, (vui32_t) is_neg);
+	  result = (vui128_t) vec_nor ((vui32_t) is_neg, (vui32_t) is_neg);
 	}
       //  else NaN or -Infinity returns zero
     }


### PR DESCRIPTION
One assignment to 'result' was using a cast to vb128_t, causing build errors
with GCC 12.

     * src/testsuite/vec_pwr9_dummy.c
     (test_convert_qpuqz_PWR9): Cast to vui128_t when assigning result

Signed-off-by: Matheus Castanho <msc@linux.ibm.com>
