### PR TITLE
General cleanup for Wall warnings and typos.

### DIFF
--- a/src/pveclib/vec_common_ppc.h
+++ b/src/pveclib/vec_common_ppc.h
@@ -256,7 +256,7 @@ typedef __vector __bool int vb128_t;
 typedef union
 {
   /*! \brief Signed 128-bit integer from pair of 64-bit GPRs.  */
-  unsigned __int128 i128;
+  signed __int128 i128;
   /*! \brief Unsigned 128-bit integer from pair of 64-bit GPRs.  */
   unsigned __int128 ui128;
 #ifndef PVECLIB_DISABLE_DFP

--- a/src/pveclib/vec_f32_ppc.h
+++ b/src/pveclib/vec_f32_ppc.h
@@ -2109,7 +2109,6 @@ vec_xvxexpsp (vf32_t vrb)
   vui32_t tmp;
   const vui32_t expmask = CONST_VINT128_W(0x7f800000, 0x7f800000,
 					  0x7f800000, 0x7f800000);
-  const vui32_t zero = CONST_VINT128_W(0, 0, 0, 0);
 
   tmp = vec_and ((vui32_t) vrb, expmask);
   result = vec_srwi (tmp, 23);

--- a/src/pveclib/vec_f64_ppc.h
+++ b/src/pveclib/vec_f64_ppc.h
@@ -1654,7 +1654,7 @@ vec_xviexpdp (vui64_t sig, vui64_t exp)
       : );
 #endif
 #else
-  vui32_t tmp, t128;
+  vui32_t tmp;
   const vui32_t expmask = CONST_VINT128_W(0x7ff00000, 0, 0x7ff00000, 0);
 
   tmp = (vui32_t) vec_slqi ((vui128_t) exp, 52);
@@ -1704,7 +1704,6 @@ vec_xvxexpdp (vf64_t vrb)
 #else
   vui32_t tmp;
   const vui32_t expmask = CONST_VINT128_W(0x7ff00000, 0, 0x7ff00000, 0);
-  const vui32_t zero = CONST_VINT128_W(0, 0, 0, 0);
 
   tmp = vec_and ((vui32_t) vrb, expmask);
   result = (vui64_t) vec_srqi ((vui128_t) tmp, 52);

--- a/src/testsuite/arith128_test_f32.c
+++ b/src/testsuite/arith128_test_f32.c
@@ -2076,7 +2076,7 @@ int
 test_extract_insert_f32 ()
 {
   vf32_t x, xp, xpt;
-  vui32_t sig, sigt, sigs;
+  vui32_t sig, sigt;
   vui32_t exp, expt;
   vui32_t signmask;
   int rc = 0;

--- a/src/testsuite/arith128_test_f64.c
+++ b/src/testsuite/arith128_test_f64.c
@@ -2813,7 +2813,7 @@ int
 test_extract_insert_f64 ()
 {
   vf64_t x, xp, xpt;
-  vui64_t sig, sigt, sigs;
+  vui64_t sig, sigt;
   vui64_t exp, expt;
   vui64_t signmask;
   int rc = 0;

--- a/src/testsuite/vec_f64_dummy.c
+++ b/src/testsuite/vec_f64_dummy.c
@@ -561,6 +561,7 @@ __test_cmpledp (vf64_t a, vf64_t b)
 {
   return vec_cmple (a, b);
 }
+#endif
 
 /*
  * The following are both compile tests for Gather/Scatter operations
@@ -719,4 +720,3 @@ test_f64_matrix_gatherx4_transpose (double * tm, double * m)
 	}
     }
 }
-#endif

--- a/src/testsuite/vec_int128_dummy.c
+++ b/src/testsuite/vec_int128_dummy.c
@@ -1352,7 +1352,7 @@ example_print_vint128 (vi128_t value)
   t_mid = (vui64_t) vec_subuqm (val128, tmp);
 
   // Work-around for GCC PR 96139
-#ifdef __clang__
+#if defined (__clang__) || (__GNUC__ > 9)
   printf ("%c%07llu%016llu%016llu", sign, t_high[VEC_DW_L],
 	  t_mid[VEC_DW_L], t_low[VEC_DW_L]);
 #else


### PR DESCRIPTION
	* src/pveclib/vec_common_ppc.h (__VEC_U_128):
	Correct typedef for member i128.
	* src/pveclib/vec_f32_ppc.h (vec_xvxexpsp):
	Remove unused const var zero.
	* src/pveclib/vec_f64_ppc.h (vec_xviexpdp):
	Remove unused var t128.
	* src/testsuite/arith128_test_f32.c (test_extract_insert_f32):
	Remove unused var sigs.
	* src/testsuite/arith128_test_f64.c (test_extract_insert_f64):
	Remove unused var sigs.
	* src/testsuite/vec_f64_dummy.c:
	Move #endif matching #ifdef _ARCH_PWR8 up.  
Guard the vector double tests while leaving the gather/scatter matrix transpose test enabled for all targets.

	* src/testsuite/vec_int128_dummy.c
	(example_print_vint128 [__GNUC__ > 9]): long long format
	warn corrected after GCC 9.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>