### PR TITLE
P9 Float128 add/sub with round to odd, plus P8 equivalent.

### DIFF
--- a/src/testsuite/pveclib_perf.c
+++ b/src/testsuite/pveclib_perf.c
@@ -850,6 +850,62 @@ test_time_f128 (void)
   printf ("\n%s mulqpn_lib tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
 	  t_delta, delta_sec);
 
+  printf ("\n%s addqpn_gcc start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_gcc_addqpn_f128 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s addqpn_gcc end", __FUNCTION__);
+  printf ("\n%s addqpn_gcc tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+	  t_delta, delta_sec);
+
+  printf ("\n%s addqpo_lib start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_lib_addqpo_f128 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s addqpo_lib end", __FUNCTION__);
+  printf ("\n%s addqpo_lib tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+	  t_delta, delta_sec);
+
+  printf ("\n%s subqpn_gcc start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_gcc_subqpn_f128 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s subqpn_gcc end", __FUNCTION__);
+  printf ("\n%s subqpn_gcc tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+	  t_delta, delta_sec);
+
+  printf ("\n%s subqpo_lib start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_lib_subqpo_f128 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s subqpo_lib end", __FUNCTION__);
+  printf ("\n%s subqpo_lib tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+	  t_delta, delta_sec);
+
   return (rc);
 }
 #endif

--- a/src/testsuite/vec_perf_f128.c
+++ b/src/testsuite/vec_perf_f128.c
@@ -211,6 +211,20 @@ test_gcc_mulqpo_f128 (__binary128 * vf128,
 		    __binary128 vf5, __binary128 vf6,
 		    __binary128 vf7, __binary128 vf8);
 
+extern void
+test_gcc_addqpn_f128 (__binary128 * vf128,
+		    __binary128 vf1, __binary128 vf2,
+		    __binary128 vf3, __binary128 vf4,
+		    __binary128 vf5, __binary128 vf6,
+		    __binary128 vf7, __binary128 vf8);
+
+extern void
+test_gcc_subqpn_f128 (__binary128 * vf128,
+		    __binary128 vf1, __binary128 vf2,
+		    __binary128 vf3, __binary128 vf4,
+		    __binary128 vf5, __binary128 vf6,
+		    __binary128 vf7, __binary128 vf8);
+
 extern vb128_t
 test_vec_cmpgtuqp (__binary128 vfa, __binary128 vfb);
 
@@ -346,6 +360,50 @@ test_lib_uqqp_f128 (__binary128 * vf128,
   vf128[7] = test_vec_xscvuqqp (vf8);
 }
 
+extern __binary128 test_vec_addqpo (__binary128 vfa, __binary128 vfb);
+
+
+void
+test_lib_addqpo_f128 (__binary128 * vf128,
+		      __binary128 vf1, __binary128 vf2,
+		      __binary128 vf3, __binary128 vf4,
+		      __binary128 vf5, __binary128 vf6,
+		      __binary128 vf7, __binary128 vf8)
+{
+  __binary128 result;
+  result = test_vec_addqpo (qpfact1, vf1);
+  result = test_vec_addqpo (result, vf2);
+  result = test_vec_addqpo (result, vf3);
+  result = test_vec_addqpo (result, vf4);
+  result = test_vec_addqpo (result, vf5);
+  result = test_vec_addqpo (result, vf6);
+  result = test_vec_addqpo (result, vf7);
+  result = test_vec_addqpo (result, vf8);
+  *vf128 = result;
+}
+
+extern __binary128 test_vec_subqpo (__binary128 vfa, __binary128 vfb);
+
+
+void
+test_lib_subqpo_f128 (__binary128 * vf128,
+		      __binary128 vf1, __binary128 vf2,
+		      __binary128 vf3, __binary128 vf4,
+		      __binary128 vf5, __binary128 vf6,
+		      __binary128 vf7, __binary128 vf8)
+{
+  __binary128 result;
+  result = test_vec_subqpo (qpfact1, vf1);
+  result = test_vec_subqpo (result, vf2);
+  result = test_vec_subqpo (result, vf3);
+  result = test_vec_subqpo (result, vf4);
+  result = test_vec_subqpo (result, vf5);
+  result = test_vec_subqpo (result, vf6);
+  result = test_vec_subqpo (result, vf7);
+  result = test_vec_subqpo (result, vf8);
+  *vf128 = result;
+}
+
 extern __binary128 test_vec_mulqpo (__binary128 vfa, __binary128 vfb);
 
 
@@ -390,6 +448,42 @@ test_lib_mulqpn_f128 (__binary128 * vf128,
   *vf128 = result;
 }
 
+int timed_lib_addqpo_f128 (void)
+{
+#ifndef PVECLIB_DISABLE_F128MATH
+  __binary128 tbl[10];
+  int i;
+
+  for (i=0; i<N; i++)
+    {
+      test_lib_addqpo_f128 (tbl,
+			  qpfact1, qpfact2,
+			  qpfact3, qpfact4,
+			  qpfact5, qpfact6,
+			  qpfact7, qpfact8);
+    }
+#endif
+   return 0;
+}
+
+int timed_lib_subqpo_f128 (void)
+{
+#ifndef PVECLIB_DISABLE_F128MATH
+  __binary128 tbl[10];
+  int i;
+
+  for (i=0; i<N; i++)
+    {
+      test_lib_subqpo_f128 (tbl,
+			  qpfact1, qpfact2,
+			  qpfact3, qpfact4,
+			  qpfact5, qpfact6,
+			  qpfact7, qpfact8);
+    }
+#endif
+   return 0;
+}
+
 int timed_lib_mulqpo_f128 (void)
 {
 #ifndef PVECLIB_DISABLE_F128MATH
@@ -417,6 +511,42 @@ int timed_lib_mulqpn_f128 (void)
   for (i=0; i<N; i++)
     {
       test_lib_mulqpn_f128 (tbl,
+			  qpfact1, qpfact2,
+			  qpfact3, qpfact4,
+			  qpfact5, qpfact6,
+			  qpfact7, qpfact8);
+    }
+#endif
+   return 0;
+}
+
+int timed_gcc_addqpn_f128 (void)
+{
+#ifndef PVECLIB_DISABLE_F128MATH
+  __binary128 tbl[10];
+  int i;
+
+  for (i=0; i<N; i++)
+    {
+      test_gcc_addqpn_f128 (tbl,
+			  qpfact1, qpfact2,
+			  qpfact3, qpfact4,
+			  qpfact5, qpfact6,
+			  qpfact7, qpfact8);
+    }
+#endif
+   return 0;
+}
+
+int timed_gcc_subqpn_f128 (void)
+{
+#ifndef PVECLIB_DISABLE_F128MATH
+  __binary128 tbl[10];
+  int i;
+
+  for (i=0; i<N; i++)
+    {
+      test_gcc_subqpn_f128 (tbl,
 			  qpfact1, qpfact2,
 			  qpfact3, qpfact4,
 			  qpfact5, qpfact6,

--- a/src/testsuite/vec_perf_f128.h
+++ b/src/testsuite/vec_perf_f128.h
@@ -52,4 +52,10 @@ extern int timed_gcc_mulqpo_f128 (void);
 extern int timed_lib_mulqpo_f128 (void);
 extern int timed_lib_mulqpn_f128 (void);
 
+extern int timed_gcc_addqpn_f128 (void);
+extern int timed_lib_addqpo_f128 (void);
+
+extern int timed_gcc_subqpn_f128 (void);
+extern int timed_lib_subqpo_f128 (void);
+
 #endif /* SRC_TESTSUITE_VEC_PERF_F128_H_ */

--- a/src/testsuite/vec_pwr10_dummy.c
+++ b/src/testsuite/vec_pwr10_dummy.c
@@ -39,9 +39,9 @@
 #include <pveclib/vec_bcd_ppc.h>
 
 #if defined (_ARCH_PWR10) && (__GNUC__ > 11) \
-    || ((__GNUC__ == 11) && (__GNUC_MINOR__ >= 2))
+    || ((__GNUC__ == 11) && (__GNUC_MINOR__ > 2))
 // New support defined in Power Vector Intrinsic Programming Reference.
-// Waiting for GCC 11.2?
+// Waiting for GCC 11.3?
 int
 test_gcc_cmpsq_all_gt_PWR10 (vi128_t a, vi128_t b)
 {


### PR DESCRIPTION
Power9 provide round to odd versions for the QP arithmetic operations.
This patch provides P9/8 implementation for add/sub QP with round
to odd. Includes compile, unit, and performance tests.

	* src/pveclib/vec_f128_ppc.h [doxygen brief]:
	Added micro-benchmark data. Other clean up.
	[doxygen f128_softfloat_0_0]: Clarifications.
	[doxygen f128_softfloat_0_0_0]: Clarifications.
	[doxygen f128_softfloat_IRRN_0_0]: Clarifying Note.
	[doxygen f128_softfloat_IRRN_0_1]:
	Improve internal representation (IR) overview.
	[doxygen f128_softfloat_IRRN_0_2]:
	Expond on how the IR impacts rounding.
	[doxygen f128_softfloat_0_0_3_2]:
	Add overview of Add Quad-Precision with Round-to-Odd.
	[doxygen f128_softfloat_0_0_3_3]:
	Add overview of Subract Quad-Precision with Round-to-Odd.
	[__clang__]: Clang keeps changing, tried to fix it.
	(vec_negf128 [__FLOAT128__) && (__GNUC__ > 7]:
	Use C arithmetic syntax for negate.
	(vec_xsaddqpo, vec_xssubqpo): New inline operations.
	(vec_xsmulqpo): Update latency numbers.

	* src/testsuite/arith128_test_f128.c
	(db_vec_xsaddqpo, db_vec_xssubqpo): New debug implementations.
	(test_add_qpo, test_sub_qpo): New unit test functions.
	(test_sub_qpo): Add test_add_qpo and test_sub_qpo to test
	driver.

	* src/testsuite/pveclib_perf.c (test_time_f128):
	Add timed tests timed_gcc_addqpn_f128, timed_lib_addqpo_f128,
	timed_gcc_subqpn_f128, and timed_lib_subqpo_f128.

	* src/testsuite/vec_f128_dummy.c (force_eMin, force_eMin_V0,
	test_vec_xsaddqpo, test_vec_xssubqpo, test_genqpo_v0,
	test_vec_addqpo, test_vec_addqpo_V1, test_vec_addqpo_V0,
	test_negqp_nan_v0, test_vec_subqpo, test_vec_subqpo_V0):
	New compile tests. Some are used in unit and perf tests.
	(test_gcc_addqpn_f128, test_gcc_subqpn_f128):
	New combined compile and perf operation tests.
	(test_gcc_mulqpn_f128, test_gcc_mulqpo_f128): Fix
	combined compile and perf operation tests.

	* src/testsuite/vec_perf_f128.c (test_gcc_addqpn_f128,
	test_gcc_subqpn_f128, test_vec_addqpo, test_vec_subqpo):
	New externs.
 	(test_lib_addqpo_f128, test_lib_subqpo_f128):
 	New inner perf test.
 	(timed_lib_addqpo_f128, timed_lib_subqpo_f128,
 	timed_gcc_addqpn_f128, timed_gcc_subqpn_f128):
 	New timed perf tests.

 	* src/testsuite/vec_perf_f128.h (timed_gcc_addqpn_f128.
 	timed_lib_addqpo_f128, timed_gcc_subqpn_f128,
 	timed_lib_subqpo_f128): New externs.

 	*src/testsuite/vec_pwr10_dummy.c
 	[(__GNUC__ == 11) && (__GNUC_MINOR__ > 2)]:
 	Waiting for fixes in GCC 11.3?

 	* src/testsuite/vec_pwr9_dummy.c (test_negqp_PWR9):
 	New compile test.
 	Various -Wall clean-ups.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>