### PR TITLE
Fix vec_copysign implementations per issue #158, Part 1B.

### DIFF
--- a/src/testsuite/arith128_test_f128.c
+++ b/src/testsuite/arith128_test_f128.c
@@ -4251,6 +4251,8 @@ test_copysignf128 (void)
 
   const __binary128 f128_snan = vec_xfer_vui64t_2_bin128 (
       CONST_VINT128_DW(0x7fff400000000000, 0));
+  const __binary128 f128_nsnan = vec_xfer_vui64t_2_bin128 (
+      CONST_VINT128_DW(0xffff400000000000, 0));
 
   __binary128 x, y, t, e;
   long tests_count = 0;
@@ -4277,185 +4279,34 @@ test_copysignf128 (void)
   print_vfloat128x(" x=  ", x);
 #endif
   t = vec_copysignf128 (x, y);
-  e = (__binary128) f128_zero;
+  e = (__binary128) f128_nzero;
   rc += check_f128 ("check vec_copysignf128", x, t, e);
 #endif
 #if 1
   tests_count++;
-  x = (__binary128) f128_one;
+  y = (__binary128) f128_one;
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
   t = vec_copysignf128 (x, y);
-  e = f128_one;
+  e = f128_none;
   rc += check_f128 ("check vec_copysignf128", x, t, e);
 #endif
-#if 1
-  tests_count++;
-  x = (__binary128) f128_none;
-#ifdef __DEBUG_PRINT__
-  print_vfloat128x(" x=  ", x);
-#endif
-  t = vec_copysignf128 (x, y);
-  e = f128_one;
-  rc += check_f128 ("check vec_copysignf128", x, t, e);
-#endif
-#if 1
-  tests_count++;
-  x = (__binary128) f128_max;
-#ifdef __DEBUG_PRINT__
-  print_vfloat128x(" x=  ", x);
-#endif
-  t = vec_copysignf128 (x, y);
-  e = f128_max;
-  rc += check_f128 ("check vec_copysignf128", x, t, e);
-#endif
-#if 1
-  tests_count++;
-  x = (__binary128) f128_nmax;
-#ifdef __DEBUG_PRINT__
-  print_vfloat128x(" x=  ", x);
-#endif
-  t = vec_copysignf128 (x, y);
-  e = f128_max;
-  rc += check_f128 ("check vec_copysignf128", x, t, e);
-#endif
-#if 1
-  tests_count++;
-  x = (__binary128) f128_min;
-#ifdef __DEBUG_PRINT__
-  print_vfloat128x(" x=  ", x);
-#endif
-  t = vec_copysignf128 (x, y);
-  e = f128_min;
-  rc += check_f128 ("check vec_copysignf128", x, t, e);
-#endif
-#if 1
-  tests_count++;
-  x = (__binary128) f128_nmin;
-#ifdef __DEBUG_PRINT__
-  print_vfloat128x(" x=  ", x);
-#endif
-  t = vec_copysignf128 (x, y);
-  e = f128_min;
-  rc += check_f128 ("check vec_copysignf128", x, t, e);
-#endif
-#if 1
-  tests_count++;
-  x = (__binary128) f128_sub;
-#ifdef __DEBUG_PRINT__
-  print_vfloat128x(" x=  ", x);
-#endif
-  t = vec_copysignf128 (x, y);
-  e = f128_sub;
-  rc += check_f128 ("check vec_copysignf128", x, t, e);
-#endif
-#if 1
-  tests_count++;
-  x = (__binary128) f128_nsub;
-#ifdef __DEBUG_PRINT__
-  print_vfloat128x(" x=  ", x);
-#endif
-  t = vec_copysignf128 (x, y);
-  e = f128_sub;
-  rc += check_f128 ("check vec_copysignf128", x, t, e);
-#endif
-#if 1
-  tests_count++;
-  x = (__binary128) f128_inf;
-#ifdef __DEBUG_PRINT__
-  print_vfloat128x(" x=  ", x);
-#endif
-  t = vec_copysignf128 (x, y);
-  e = f128_inf;
-  rc += check_f128 ("check vec_copysignf128", x, t, e);
-#endif
-#if 1
-  tests_count++;
-  x = (__binary128) f128_ninf;
-#ifdef __DEBUG_PRINT__
-  print_vfloat128x(" x=  ", x);
-#endif
-  t = vec_copysignf128 (x, y);
-  e = f128_inf;
-  rc += check_f128 ("check vec_copysignf128", x, t, e);
-#endif
-#if 1
-  tests_count++;
-  x = (__binary128) f128_nan;
-#ifdef __DEBUG_PRINT__
-  print_vfloat128x(" x=  ", x);
-#endif
-  t = vec_copysignf128 (x, y);
-  e = f128_nan;
-  rc += check_f128 ("check vec_copysignf128", x, t, e);
-#endif
-#if 1
-  tests_count++;
-  x = (__binary128) f128_nnan;
-#ifdef __DEBUG_PRINT__
-  print_vfloat128x(" x=  ", x);
-#endif
-  t = vec_copysignf128 (x, y);
-  e = f128_nan;
-  rc += check_f128 ("check vec_copysignf128", x, t, e);
-#endif
-#if 1
-  tests_count++;
-  x = (__binary128) f128_snan;
-#ifdef __DEBUG_PRINT__
-  print_vfloat128x(" x=  ", x);
-#endif
-  t = vec_copysignf128 (x, y);
-  e = f128_snan;
-  rc += check_f128 ("check vec_copysignf128", x, t, e);
-#endif
-
 #if 1
   tests_count++;
   x = (__binary128) f128_zero;
-  y = (__binary128) f128_nzero;
+  y = (__binary128) f128_none;
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
-  print_vfloat128x(" y=  ", y);
 #endif
   t = vec_copysignf128 (x, y);
-  e = (__binary128) f128_nzero;
+  e = f128_one;
   rc += check_f128 ("check vec_copysignf128", x, t, e);
 #endif
 #if 1
   tests_count++;
   x = (__binary128) f128_nzero;
-#ifdef __DEBUG_PRINT__
-  print_vfloat128x(" x=  ", x);
-#endif
-  t = vec_copysignf128 (x, y);
-  e = (__binary128) f128_nzero;
-  rc += check_f128 ("check vec_copysignf128", x, t, e);
-#endif
-#if 1
-  tests_count++;
-  x = (__binary128) f128_one;
-#ifdef __DEBUG_PRINT__
-  print_vfloat128x(" x=  ", x);
-#endif
-  t = vec_copysignf128 (x, y);
-  e = f128_none;
-  rc += check_f128 ("check vec_copysignf128", x, t, e);
-#endif
-#if 1
-  tests_count++;
-  x = (__binary128) f128_none;
-#ifdef __DEBUG_PRINT__
-  print_vfloat128x(" x=  ", x);
-#endif
-  t = vec_copysignf128 (x, y);
-  e = f128_none;
-  rc += check_f128 ("check vec_copysignf128", x, t, e);
-#endif
-#if 1
-  tests_count++;
-  x = (__binary128) f128_max;
+  y = (__binary128) f128_max;
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
@@ -4465,17 +4316,19 @@ test_copysignf128 (void)
 #endif
 #if 1
   tests_count++;
-  x = (__binary128) f128_nmax;
+  x = (__binary128) f128_zero;
+  y = (__binary128) f128_nmax;
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
   t = vec_copysignf128 (x, y);
-  e = f128_nmax;
+  e = f128_max;
   rc += check_f128 ("check vec_copysignf128", x, t, e);
 #endif
 #if 1
   tests_count++;
-  x = (__binary128) f128_min;
+  x = (__binary128) f128_nzero;
+  y = (__binary128) f128_min;
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
@@ -4485,17 +4338,19 @@ test_copysignf128 (void)
 #endif
 #if 1
   tests_count++;
-  x = (__binary128) f128_nmin;
+  x = (__binary128) f128_zero;
+  y = (__binary128) f128_nmin;
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
   t = vec_copysignf128 (x, y);
-  e = f128_nmin;
+  e = f128_min;
   rc += check_f128 ("check vec_copysignf128", x, t, e);
 #endif
 #if 1
   tests_count++;
-  x = (__binary128) f128_sub;
+  x = (__binary128) f128_nzero;
+  y = (__binary128) f128_sub;
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
@@ -4505,17 +4360,19 @@ test_copysignf128 (void)
 #endif
 #if 1
   tests_count++;
-  x = (__binary128) f128_nsub;
+  x = (__binary128) f128_zero;
+  y = (__binary128) f128_nsub;
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
   t = vec_copysignf128 (x, y);
-  e = f128_nsub;
+  e = f128_sub;
   rc += check_f128 ("check vec_copysignf128", x, t, e);
 #endif
 #if 1
   tests_count++;
-  x = (__binary128) f128_inf;
+  x = (__binary128) f128_nzero;
+  y = (__binary128) f128_inf;
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
@@ -4525,17 +4382,19 @@ test_copysignf128 (void)
 #endif
 #if 1
   tests_count++;
-  x = (__binary128) f128_ninf;
+  x = (__binary128) f128_zero;
+  y = (__binary128) f128_ninf;
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
   t = vec_copysignf128 (x, y);
-  e = f128_ninf;
+  e = f128_inf;
   rc += check_f128 ("check vec_copysignf128", x, t, e);
 #endif
 #if 1
   tests_count++;
-  x = (__binary128) f128_nan;
+  x = (__binary128) f128_nzero;
+  y = (__binary128) f128_nan;
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
@@ -4545,12 +4404,35 @@ test_copysignf128 (void)
 #endif
 #if 1
   tests_count++;
-  x = (__binary128) f128_nnan;
+  x = (__binary128) f128_zero;
+  y = (__binary128) f128_nnan;
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
   t = vec_copysignf128 (x, y);
-  e = f128_nnan;
+  e = f128_nan;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__binary128) f128_nzero;
+  y = (__binary128) f128_snan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = f128_nsnan;
+  rc += check_f128 ("check vec_copysignf128", x, t, e);
+#endif
+#if 1
+  tests_count++;
+  x = (__binary128) f128_zero;
+  y = (__binary128) f128_nsnan;
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = vec_copysignf128 (x, y);
+  e = f128_snan;
   rc += check_f128 ("check vec_copysignf128", x, t, e);
 #endif
   /* accumulate the number of values tested, in case we are doing

--- a/src/testsuite/arith128_test_f32.c
+++ b/src/testsuite/arith128_test_f32.c
@@ -1194,7 +1194,7 @@ test_float_cpsgn (void)
 
   i = (vf32_t) { 0.0, -0.0, 0.0, -0.0 };
   j = (vf32_t) {-0.0, 0.0, -0.0, 0.0 };
-  e = (vf32_t) {-0.0, 0.0, -0.0, 0.0 };
+  e = (vf32_t) { 0.0, -0.0, 0.0, -0.0 };
   k = vec_copysignf32 (i, j);
 
 #ifdef __DEBUG_PRINT__
@@ -1204,9 +1204,9 @@ test_float_cpsgn (void)
 #endif
   rc += check_v4f32x ("vec_copysignf32 1:", k, e);
 
-  i = (vf32_t) { __FLT_MAX__, __FLT_MIN__, __FLT_EPSILON__,
+  i = (vf32_t) {-0.0, 0.0, -0.0, 0.0 };
+  j = (vf32_t) { __FLT_MAX__, __FLT_MIN__, __FLT_EPSILON__,
 		  __FLT_DENORM_MIN__ };
-  j = (vf32_t) {-0.0, 0.0, -0.0, 0.0 };
   e = (vf32_t) { -(__FLT_MAX__), __FLT_MIN__, -(__FLT_EPSILON__),
 		  __FLT_DENORM_MIN__ };
   k = vec_copysignf32 (i, j);
@@ -1218,9 +1218,9 @@ test_float_cpsgn (void)
 #endif
   rc += check_v4f32x ("vec_copysignf32 2:", k, e);
 
-  i = (vf32_t) CONST_VINT128_W(__FLOAT_INF, __FLOAT_NINF, __FLOAT_INF,
+  i = (vf32_t) CONST_VINT32_W(0.0, -0.0, 0.0, -0.0);
+  j = (vf32_t) CONST_VINT128_W(__FLOAT_INF, __FLOAT_NINF, __FLOAT_INF,
 			       __FLOAT_NINF);
-  j = (vf32_t) CONST_VINT32_W(0.0, -0.0, 0.0, -0.0);
   e = (vf32_t) CONST_VINT128_W(__FLOAT_INF, __FLOAT_NINF, __FLOAT_INF,
 			       __FLOAT_NINF);
   k = vec_copysignf32 (i, j);
@@ -1232,9 +1232,9 @@ test_float_cpsgn (void)
 #endif
   rc += check_v4f32x ("vec_copysignf32 3:", k, e);
 
-  i = (vf32_t) CONST_VINT128_W(__FLOAT_NAN, __FLOAT_NNAN, __FLOAT_NSNAN,
+  i = (vf32_t) {-0.0, 0.0, 0.0, -0.0 };
+  j = (vf32_t) CONST_VINT128_W(__FLOAT_NAN, __FLOAT_NNAN, __FLOAT_NSNAN,
 			       __FLOAT_SNAN);
-  j = (vf32_t) {-0.0, 0.0, 0.0, -0.0 };
   e = (vf32_t) CONST_VINT128_W(__FLOAT_NNAN, __FLOAT_NAN, __FLOAT_SNAN,
 			       __FLOAT_NSNAN);
   k = vec_copysignf32 (i, j);

--- a/src/testsuite/arith128_test_f64.c
+++ b/src/testsuite/arith128_test_f64.c
@@ -1604,7 +1604,7 @@ test_double_cpsgn (void)
 
   i = (vf64_t) { 0.0, -0.0 };
   j = (vf64_t) { -0.0, 0.0 };
-  e = (vf64_t) { -0.0, 0.0 };
+  e = (vf64_t) { 0.0, -0.0 };
   k = vec_copysignf64 (i, j);
 
 #ifdef __DEBUG_PRINT__
@@ -1614,8 +1614,8 @@ test_double_cpsgn (void)
 #endif
   rc += check_v2f64x ("vec_copysignf64 1:", k, e);
 
-  i = (vf64_t) { __DBL_MAX__, __DBL_MIN__ };
-  j = (vf64_t) { -0.0, 0.0 };
+  i = (vf64_t) { -0.0, 0.0 };
+  j = (vf64_t) { __DBL_MAX__, __DBL_MIN__ };
   e = (vf64_t) { -(__DBL_MAX__), __DBL_MIN__ };
   k = vec_copysignf64 (i, j);
 
@@ -1626,8 +1626,8 @@ test_double_cpsgn (void)
 #endif
   rc += check_v2f64x ("vec_copysignf64 2:", k, e);
 
-  i = (vf64_t) { __DBL_EPSILON__, __DBL_DENORM_MIN__ };
-  j = (vf64_t) { -0.0, 0.0 };
+  i = (vf64_t) { -0.0, 0.0 };
+  j = (vf64_t) { __DBL_EPSILON__, __DBL_DENORM_MIN__ };
   e = (vf64_t) { -(__DBL_EPSILON__), __DBL_DENORM_MIN__ };
   k = vec_copysignf64 (i, j);
 
@@ -1638,8 +1638,8 @@ test_double_cpsgn (void)
 #endif
   rc += check_v2f64x ("vec_copysignf64 3:", k, e);
 
-  i = (vf64_t) CONST_VINT128_DW(__DOUBLE_INF, __DOUBLE_NINF);
-  j = (vf64_t) CONST_VINT64_DW(0.0, -0.0);
+  i = (vf64_t) CONST_VINT64_DW(0.0, -0.0);
+  j = (vf64_t) CONST_VINT128_DW(__DOUBLE_INF, __DOUBLE_NINF);
   e = (vf64_t) CONST_VINT128_DW(__DOUBLE_INF, __DOUBLE_NINF);
   k = vec_copysignf64 (i, j);
 
@@ -1650,8 +1650,8 @@ test_double_cpsgn (void)
 #endif
   rc += check_v2f64x ("vec_copysignf64 4:", k, e);
 
-  i = (vf64_t) CONST_VINT128_DW(__DOUBLE_INF, __DOUBLE_NINF);
-  j = (vf64_t) CONST_VINT64_DW(0.0, -0.0);
+  i = (vf64_t) CONST_VINT64_DW(0.0, -0.0);
+  j = (vf64_t) CONST_VINT128_DW(__DOUBLE_INF, __DOUBLE_NINF);
   e = (vf64_t) CONST_VINT128_DW(__DOUBLE_INF, __DOUBLE_NINF);
   k = vec_copysignf64 (i, j);
 
@@ -1662,8 +1662,8 @@ test_double_cpsgn (void)
 #endif
   rc += check_v2f64x ("vec_copysignf64 5:", k, e);
 
-  i = (vf64_t) CONST_VINT128_DW(__DOUBLE_NAN, __DOUBLE_NNAN);
-  j = (vf64_t) CONST_VINT64_DW( -0.0, 0.0 );
+  i = (vf64_t) CONST_VINT64_DW( -0.0, 0.0 );
+  j = (vf64_t) CONST_VINT128_DW(__DOUBLE_NAN, __DOUBLE_NNAN);
   e = (vf64_t) CONST_VINT128_DW(__DOUBLE_NNAN, __DOUBLE_NAN);
   k = vec_copysignf64 (i, j);
 
@@ -1674,8 +1674,8 @@ test_double_cpsgn (void)
 #endif
   rc += check_v2f64x ("vec_copysignf64 6:", k, e);
 
-  i = (vf64_t) CONST_VINT128_DW(__DOUBLE_NSNAN, __DOUBLE_SNAN);
-  j = (vf64_t) CONST_VINT64_DW ( 0.0, -0.0 );
+  i = (vf64_t) CONST_VINT64_DW ( 0.0, -0.0 );
+  j = (vf64_t) CONST_VINT128_DW(__DOUBLE_NSNAN, __DOUBLE_SNAN);
   e = (vf64_t) CONST_VINT128_DW(__DOUBLE_SNAN, __DOUBLE_NSNAN);
   k = vec_copysignf64 (i, j);
 

--- a/src/testsuite/vec_f32_dummy.c
+++ b/src/testsuite/vec_f32_dummy.c
@@ -35,6 +35,12 @@
 #include <testsuite/arith128_test_f32.h>
 
 vf32_t
+test_vec_copysignf32 (vf32_t x, vf32_t y)
+{
+  return vec_copysignf32 (x, y);
+}
+
+vf32_t
 test_vec_xviexpsp (vui32_t sig, vui32_t exp)
 {
   return vec_xviexpsp (sig, exp);

--- a/src/testsuite/vec_f64_dummy.c
+++ b/src/testsuite/vec_f64_dummy.c
@@ -36,6 +36,12 @@
 #include <testsuite/arith128_test_f64.h>
 
 vf64_t
+test_vec_copysignf64 (vf64_t x, vf64_t y)
+{
+  return vec_copysignf64 (x, y);
+}
+
+vf64_t
 test_vec_xviexpdp (vui64_t sig, vui64_t exp)
 {
   return vec_xviexpdp (sig, exp);


### PR DESCRIPTION
Rebased after the add/subqpo merge. Cliose #158 
Seems the GCC (and Clang followed) initially reversed the operands
for vec_cpsgn() (so the sign is copied from operand b into a).
This differs from the Intrinsic reference and ISA that say the sign
is copied from operand a into b.

Unfortunately PVECLIB implementations of vec_copysignf32(),
vec_copysignf64(), and vec_copysignf128() duplicated the results of
original GCC vec_cpsgn() for the implementation,

This has been reported as a bug and now GCC and Clang are in the
process of "fixing" this bug to match the Intrinsic reference guide.
The fix will be applied to currently supported versions but older
compiler version will remain unchanged.

This change set will correct the PVECLIB copysign implementation
to match the intrinsic reference manual. We will the macro
PVECLIB_CPSGN_FIXED to isolate the PVECLIB implementations from
the compiler changes.

	* src/pveclib/vec_f128_ppc.h (vec_copysignf128): Change to
	match operand order from Vector Intrinsic Reference.
	(vec_xscvsqqp [_ARCH_PWR9]): Use correct vec_copysignf128
	operand order.
	* src/pveclib/vec_f32_ppc.h (vec_copysignf32): Change to match
	operand order from Vector Intrinsic Reference.
	* src/pveclib/vec_f64_ppc.h (vec_copysignf64): Change to match
	operand order from Vector Intrinsic Reference.

	* src/testsuite/arith128_test_f128.c (test_copysignf128):
	Define new __float128 const f128_nsnan.
	Reverse test operands and results to match corrected
	vec_copysignf128() implementation. Remove duplicated tests.
	* src/testsuite/arith128_test_f32.c (test_float_cpsgn):
	Reverse test operands and results to match corrected
	vec_copysignf32() implementation.
	* src/testsuite/arith128_test_f64.c (test_double_cpsgn):
	Reverse test operands and results to match corrected
	vec_copysignf64() implementation.

	* src/testsuite/vec_f32_dummy.c (test_vec_copysignf32):
	new compile test.
	* src/testsuite/vec_f64_dummy.c (test_vec_copysignf64):
	new compile test.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>