### PR TITLE
Fixes and work-arounds for int64.

### DIFF
--- a/src/pveclib/vec_f32_ppc.h
+++ b/src/pveclib/vec_f32_ppc.h
@@ -200,7 +200,7 @@ test_vec_cosf32 (vf32_t value)
  */
 
 #include <pveclib/vec_common_ppc.h>
-#include <pveclib/vec_int64_ppc.h>
+#include <pveclib/vec_int128_ppc.h>
 
 ///@cond INTERNAL
 static inline vf64_t

--- a/src/testsuite/arith128_print.c
+++ b/src/testsuite/arith128_print.c
@@ -1212,6 +1212,22 @@ check_v2b64x_priv (char *prefix, vb64_t val128, vb64_t shouldbe)
 }
 
 int
+check_v2ui64x_priv (char *prefix, vui64_t val128, vui64_t shouldbe)
+{
+  int rc = 0;
+
+  if (vec_any_ne ((vui32_t) val128, (vui32_t) shouldbe))
+    {
+      rc = 1;
+      printf ("%s\n", prefix);
+      print_v2xint64 ("\tshould be: ", shouldbe);
+      print_v2xint64 ("\t       is: ", val128);
+    }
+
+  return (rc);
+}
+
+int
 check_vb128c_priv (char *prefix, vb128_t val128, vb128_t shouldbe)
 {
   int rc = 0;

--- a/src/testsuite/arith128_print.h
+++ b/src/testsuite/arith128_print.h
@@ -319,6 +319,9 @@ extern int
 check_v2b64x_priv (char *prefix, vb64_t val128, vb64_t shouldbe);
 
 extern int
+check_v2ui64x_priv (char *prefix, vui64_t val128, vui64_t shouldbe);
+
+extern int
 check_v2f64_priv (char *prefix, vf64_t val128, vf64_t shouldbe);
 
 extern int
@@ -496,6 +499,19 @@ check_v2b64x (char *prefix, vb64_t val128, vb64_t shouldbe)
   if (vec_cmpud_any_ne((vui64_t )val128, (vui64_t )shouldbe))
     {
       rc = check_v2b64x_priv (prefix, val128, shouldbe);
+    }
+
+  return (rc);
+
+}
+
+static inline int
+check_v2ui64x (char *prefix, vui64_t val128, vui64_t shouldbe)
+{
+  int rc = 0;
+  if (vec_cmpud_any_ne((vui64_t )val128, (vui64_t )shouldbe))
+    {
+      rc = check_v2ui64x_priv (prefix, val128, shouldbe);
     }
 
   return (rc);

--- a/src/testsuite/arith128_test_i64.c
+++ b/src/testsuite/arith128_test_i64.c
@@ -12198,6 +12198,131 @@ test_setbd (void)
   return (rc);
 }
 
+//#define __DEBUG_PRINT__ 1
+int
+test_splatisd (void)
+{
+  vi64_t k;
+  vi64_t e;
+  int rc = 0;
+
+  printf ("\ntest_splatisd Vector Splat Immediate Signed Doubleword\n");
+
+  k = (vi64_t) vec_splat_s64 (0);
+
+#ifdef __DEBUG_PRINT__
+  printf         ("vec_splat_s64 ( 0 ) \n");
+  print_v2xint64 ("        =", (vui64_t) k);
+#endif
+  e = (vi64_t)CONST_VINT64_DW(0, 0);
+  rc += check_v2ui64x ("vec_splat_s64 :", (vui64_t) k, (vui64_t) e);
+
+  k = (vi64_t) vec_splat_s64 (-16);
+
+#ifdef __DEBUG_PRINT__
+  printf         ("vec_splat_s64 ( -16 ) \n");
+  print_v2xint64 ("        =", (vui64_t) k);
+#endif
+  e = (vi64_t)CONST_VINT64_DW(-16, -16);
+  rc += check_v2ui64x ("vec_splat_s64 :", (vui64_t) k, (vui64_t) e);
+
+  k = (vi64_t) vec_splat_s64 (-128);
+
+#ifdef __DEBUG_PRINT__
+  printf         ("vec_splat_s64 ( -128 ) \n");
+  print_v2xint64 ("        =", (vui64_t) k);
+#endif
+  e = (vi64_t)CONST_VINT64_DW(-128, -128);
+  rc += check_v2ui64x ("vec_splat_s64 :", (vui64_t) k, (vui64_t) e);
+
+  k = (vi64_t) vec_splat_s64 (-129);
+
+#ifdef __DEBUG_PRINT__
+  printf         ("vec_splat_s64 ( -129 ) \n");
+  print_v2xint64 ("        =", (vui64_t) k);
+#endif
+  e = (vi64_t)CONST_VINT64_DW(-129, -129);
+  rc += check_v2ui64x ("vec_splat_s64 :", (vui64_t) k, (vui64_t) e);
+
+  k = (vi64_t) vec_splat_s64 (15);
+
+#ifdef __DEBUG_PRINT__
+  printf         ("vec_splat_s64 ( 15 ) \n");
+  print_v2xint64 ("        =", (vui64_t) k);
+#endif
+  e = (vi64_t)CONST_VINT64_DW(15, 15);
+  rc += check_v2ui64x ("vec_splat_s64 :", (vui64_t) k, (vui64_t) e);
+
+  k = (vi64_t) vec_splat_s64 (127);
+
+#ifdef __DEBUG_PRINT__
+  printf         ("vec_splat_s64 ( 127 ) \n");
+  print_v2xint64 ("        =", (vui64_t) k);
+#endif
+  e = (vi64_t)CONST_VINT64_DW(127, 127);
+  rc += check_v2ui64x ("vec_splat_s64 :", (vui64_t) k, (vui64_t) e);
+
+  k = (vi64_t) vec_splat_s64 (128);
+
+#ifdef __DEBUG_PRINT__
+  printf         ("vec_splat_s64 ( 128 ) \n");
+  print_v2xint64 ("        =", (vui64_t) k);
+#endif
+  e = (vi64_t)CONST_VINT64_DW(128, 128);
+  rc += check_v2ui64x ("vec_splat_s64 :", (vui64_t) k, (vui64_t) e);
+
+  return (rc);
+}
+
+//#define __DEBUG_PRINT__ 1
+int
+test_splatiud (void)
+{
+  vui64_t k;
+  vui64_t e;
+  int rc = 0;
+
+  printf ("\ntest_splatiud Vector Splat Immediate Unsigned Doubleword\n");
+
+  k = (vui64_t) vec_splat_s64 (0);
+
+#ifdef __DEBUG_PRINT__
+  printf         ("vec_splat_u64 ( 0 ) \n");
+  print_v2xint64 ("        =", (vui64_t) k);
+#endif
+  e = (vui64_t)CONST_VINT64_DW(0, 0);
+  rc += check_v2ui64x ("vec_splat_u64 :", (vui64_t) k, (vui64_t) e);
+
+  k = (vui64_t) vec_splat_u64 (15);
+
+#ifdef __DEBUG_PRINT__
+  printf         ("vec_splat_u64 ( 15 ) \n");
+  print_v2xint64 ("        =", (vui64_t) k);
+#endif
+  e = (vui64_t)CONST_VINT64_DW(15, 15);
+  rc += check_v2ui64x ("vec_splat_u64 :", (vui64_t) k, (vui64_t) e);
+
+  k = (vui64_t) vec_splat_u64 (127);
+
+#ifdef __DEBUG_PRINT__
+  printf         ("vec_splat_u64 ( 127 ) \n");
+  print_v2xint64 ("        =", (vui64_t) k);
+#endif
+  e = (vui64_t)CONST_VINT64_DW(127, 127);
+  rc += check_v2ui64x ("vec_splat_u64 :", (vui64_t) k, (vui64_t) e);
+
+  k = (vui64_t) vec_splat_u64 (128);
+
+#ifdef __DEBUG_PRINT__
+  printf         ("vec_splat_u64 ( 128 ) \n");
+  print_v2xint64 ("        =", (vui64_t) k);
+#endif
+  e = (vui64_t)CONST_VINT64_DW(128, 128);
+  rc += check_v2ui64x ("vec_splat_u64 :", (vui64_t) k, (vui64_t) e);
+
+  return (rc);
+}
+
 int
 test_vec_i64 (void)
 {
@@ -12244,6 +12369,8 @@ test_vec_i64 (void)
   rc += test_lvgudx ();
   rc += test_stvgudx ();
   rc += test_setbd ();
+  rc += test_splatisd ();
+  rc += test_splatiud ();
 
   return (rc);
 }

--- a/src/testsuite/vec_pwr10_dummy.c
+++ b/src/testsuite/vec_pwr10_dummy.c
@@ -38,6 +38,31 @@
 #include <pveclib/vec_f32_ppc.h>
 #include <pveclib/vec_bcd_ppc.h>
 
+// Attempts at better code to splat small DW constants.
+// Want to avoid addr calc and loads for what should be simple
+// splat immediate and unpack/extend.
+vi64_t
+__test_splatisd_12_PWR10 (void)
+{
+  return vec_splat_s64 (12);
+}
+
+// vec_splati from word requires GCC 10 and PWR10
+#if ((__GNUC__ > 11) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
+vi64_t
+__test_splatudi_12_PWR10 (void)
+{
+  vi32_t vwi = vec_splati (12);
+  return vec_unpackl (vwi);
+}
+#endif
+
+vui64_t
+__test_splatudi_12_PWR10_v0 (void)
+{
+  return vec_splats ((unsigned long long) 12);
+}
+
 #if defined (_ARCH_PWR10) && (__GNUC__ > 11) \
     || ((__GNUC__ == 11) && (__GNUC_MINOR__ > 2))
 // New support defined in Power Vector Intrinsic Programming Reference.

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -40,6 +40,67 @@
 #include <pveclib/vec_f32_ppc.h>
 #include <pveclib/vec_bcd_ppc.h>
 
+// Attempts at better code to splat small DW constants.
+// Want to avoid addr calc and loads for what should be simple
+// splat immediate and unpack.
+vi64_t
+__test_splatisd_12_PWR9 (void)
+{
+  return vec_splat_s64 (12);
+}
+vi64_t
+__test_splatisd_16_PWR9 (void)
+{
+  return vec_splat_s64 (-16);
+}
+
+vi64_t
+__test_splatisd_127_PWR9 (void)
+{
+  return vec_splat_s64 (127);
+}
+
+vi64_t
+__test_splatiud_128_PWR9 (void)
+{
+  return vec_splat_s64 (128);
+}
+
+vui64_t
+__test_splatiud_127_PWR9 (void)
+{
+  return vec_splat_u64 (127);
+}
+vui64_t
+__test_splatisd_128_PWR9 (void)
+{
+  return vec_splat_u64 (128);
+}
+
+vui64_t
+__test_splatudi_12_PWR9 (void)
+{
+  return vec_splats ((unsigned long long) 12);
+}
+
+vui64_t
+test_sldi_1_PWR9 (vui64_t a)
+{
+  return vec_sldi (a, 1);
+}
+
+vui64_t
+test_sldi_15_PWR9 (vui64_t a)
+{
+  return vec_sldi (a, 15);
+}
+
+vui64_t
+test_sldi_16_PWR9 (vui64_t a)
+{
+  return vec_sldi (a, 16);
+}
+
 __binary128
 test_negqp_PWR9 (__binary128 vfa)
 {


### PR DESCRIPTION
During work on vec_f128_ppc.h, to implement P9 operations
for P8, found anomalies with compiler generation for small
vector integer DW constants. Exponents are handled as DWs
for arithmetic and compares.

See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104124

The compiles wants to convert vec_spats(<small-DW-int>) into a
vector load on P8, while it is a 2 instruction immediate
sequence on P9 and could be also on P8. This happens even
for splat immediate words that are cast to DW.

The associate loads require more cycles and cause register
pressure and vector spill reload and associated load-hit-store
rejects.

	* src/pveclib/vec_f32_ppc.h:
	Include <pveclib/vec_int128_ppc.h>, avoids citcular dependency
	between vec_int128_ppc.h and vec_int64_ppc.h.

	* src/pveclib/vec_int64_ppc.h (vec_splat_s64):
	Function prototype.
	(vec_selsd, vec_selud): New operations.
	(vec_splat_s64, vec_splat_u64): New immediate operations.

	* src/testsuite/arith128_print.c (check_v2ui64x_priv):
	New out-line check function.
	* src/testsuite/arith128_print.h (check_v2ui64x_priv):
	New extern.
	(check_v2ui64x): New inline check function.

	* src/testsuite/arith128_test_i64.c
	(test_splatisd, test_splatiud): New unit tests.
	(test_vec_i64): Add new unit tests to driver.

	* src/testsuite/vec_int64_dummy.c
	(__test_shift_cse): New compile test.
	(__test_splatisd_16, __test_splatisd_n1, __test_splatisd_0,
	__test_splatisd_15, __test_splatisd_127, __test_splatiud_0,
	__test_splatiud_15 ,__test_splatiud_127):
	Compile tests for new operations.
	(__test_splatudi_12_V3, __test_splatudi_12_V2,
	__test_splatudi_12_V1, __test_splatudi_8_V0,
	__test_splatudi_12_V0, __test_splatudi_0_V0,
	__test_splatudi_1_V0): New compile tests for DW immediates.
	* src/testsuite/vec_pwr10_dummy.c
	(__test_splatisd_12_PWR10):
	Compile tests for new operations.
	(__test_splatudi_12_PWR10, __test_splatudi_12_PWR10_v0):
	New compile tests for DW immediates.
	* src/testsuite/vec_pwr9_dummy.c
	(__test_splatisd_12_PWR9, __test_splatisd_16_PWR9,
	__test_splatisd_127_PWR9, __test_splatiud_128_PWR9,
	__test_splatiud_127_PWR9, __test_splatisd_128_PWR9):
	Compile tests for new operations.
	(__test_splatudi_12_PWR9):
	(test_sldi_1_PWR9, test_sldi_15_PWR9, test_sldi_16_PWR9):
	New compile tests for DW immediates.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>