### PR TITLE
Performance tuning for mulqpo. Part2

### DIFF
--- a/src/testsuite/pveclib_perf.c
+++ b/src/testsuite/pveclib_perf.c
@@ -808,18 +808,18 @@ test_time_f128 (void)
   printf ("\n%s cvt_qpdpo_vec tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
 	  t_delta, delta_sec);
 
-  printf ("\n%s mulqpo_gcc start, ...\n", __FUNCTION__);
+  printf ("\n%s mulqpn_gcc start, ...\n", __FUNCTION__);
   t_start = __builtin_ppc_get_timebase ();
   for (i = 0; i < TIMING_ITERATIONS; i++)
     {
-      rc += timed_gcc_mulqpo_f128 ();
+      rc += timed_gcc_mulqpn_f128 ();
     }
   t_end = __builtin_ppc_get_timebase ();
   t_delta = t_end - t_start;
   delta_sec = TimeDeltaSec (t_delta);
 
-  printf ("\n%s mulqpo_gcc end", __FUNCTION__);
-  printf ("\n%s mulqpo_gcc tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+  printf ("\n%s mulqpn_gcc end", __FUNCTION__);
+  printf ("\n%s mulqpn_gcc tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
 	  t_delta, delta_sec);
 
   printf ("\n%s mulqpo_lib start, ...\n", __FUNCTION__);

--- a/src/testsuite/vec_perf_f128.c
+++ b/src/testsuite/vec_perf_f128.c
@@ -205,7 +205,7 @@ test_gcc_qpdpo_f128 (vf64_t * vf128,
 		    __binary128 vf7, __binary128 vf8);
 
 extern void
-test_gcc_mulqpo_f128 (__binary128 * vf128,
+test_gcc_mulqpn_f128 (__binary128 * vf128,
 		    __binary128 vf1, __binary128 vf2,
 		    __binary128 vf3, __binary128 vf4,
 		    __binary128 vf5, __binary128 vf6,
@@ -556,7 +556,7 @@ int timed_gcc_subqpn_f128 (void)
    return 0;
 }
 
-int timed_gcc_mulqpo_f128 (void)
+int timed_gcc_mulqpn_f128 (void)
 {
 #ifndef PVECLIB_DISABLE_F128MATH
   __binary128 tbl[10];
@@ -564,7 +564,7 @@ int timed_gcc_mulqpo_f128 (void)
 
   for (i=0; i<N; i++)
     {
-      test_gcc_mulqpo_f128 (tbl,
+      test_gcc_mulqpn_f128 (tbl,
 			  qpfact1, qpfact2,
 			  qpfact3, qpfact4,
 			  qpfact5, qpfact6,

--- a/src/testsuite/vec_perf_f128.h
+++ b/src/testsuite/vec_perf_f128.h
@@ -48,7 +48,7 @@ extern int timed_gcc_qpdpo_f128 (void);
 extern int timed_lib_qpdpo_f128 (void);
 extern int timed_vec_qpdpo_f128 (void);
 
-extern int timed_gcc_mulqpo_f128 (void);
+extern int timed_gcc_mulqpn_f128 (void);
 extern int timed_lib_mulqpo_f128 (void);
 extern int timed_lib_mulqpn_f128 (void);
 

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -826,6 +826,15 @@ test_xor_bin128_2_vui32t_PWR9 (__binary128 f128, vui32_t mask)
 }
 
 vui32_t
+test_xfer_bin128_2_vui32t_V0_PWR9 (__binary128 f128)
+{
+  __VF_128 vunion;
+
+  vunion.vf1 = f128;
+  return vunion.vx4;
+}
+
+vui32_t
 test_xfer_bin128_2_vui32t_PWR9 (__binary128 f128)
 {
   return vec_xfer_bin128_2_vui32t (f128);


### PR DESCRIPTION
Still working around the compiler (GCC) that will generate extraneous
store/reloads. This seems to be related to loading vector constants
that have multiple uses and long live-ranges. Work-arounds include:
1) Using vec_splat_s64/vec_splat_u64 to avoid loads from .rodata.
2) Eliminate/consolidate constants that exceed the (-16 <-> 15)
immediate constant range,
3) Move constants to appropriate local scope.
4) Replace if/then/else blocks with boolean select logic.
5) Use __builtin_expect to optimize the common path (finite not
zero/denormal) to fall through code.

Still not clear what is going on (cause/effect) here. It should not
be registers pressure as analysis show that the code does not all
the volatile VRs (4 remain unused) and only 2 of the available
volatile VSRs.  I suspect the compiler has conflicting constraints
left over from the old (BE) ABI definition.

This delivers a stable 0.9% improvement over the previous version
and still slightly faster than __mulkf3 () with the
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100085
fix applied.

	* src/pveclib/vec_f128_ppc.h [f128_softfloat_0_0_3_1]: Update
	doxygen docs to reflect recent mulqpo optimizations.
	(vec_xsmulqpo): Update doxygen latency estimates.
	(vec_xsmulqpo [_ARCH_PWR8]): Additional optimizations.
	Change variable naming for consistency.

	* src/testsuite/pveclib_perf.c {test_time_f128):
	Rename timed_gcc_mulqpo_f128 to timed_gcc_mulqpn_f128,
	libgcc does not support round to odd.
	* src/testsuite/vec_perf_f128.c (test_gcc_mulqpn_f128,
	timed_gcc_mulqpn_f128): Renamed for for consistency.
	* src/testsuite/vec_perf_f128.h (timed_gcc_mulqpn_f128):
	New extern.

	* src/testsuite/vec_f128_dummy.c:
	(test_vec_addqpo): New compile test variant of addqpo.
	(test_vec_addqpo_V2): Rename previous variant to V2.
	(test_vec_addqpo_V1 [_ARCH_PWR7]): Enable compile for P7.
	(test_vec_addqpo_V0 [_ARCH_PWR7]): Enable compile for P7.
	(test_vec_subqpo): New compile test variant of subqpo.
	(test_vec_subqpo_V1): Rename previous variant to V1.
	(test_vec_mulqpn): New compile test variant of mulqp.
	(test_vec_mulqpn_V1): Rename previous variant to V1.
	(test_vec_xsmulqpo): New compile test from vec_xsmulqpo().
	(test_check_sig_ovf, test_check_sig_ovf_V0): New compile tests.
	(test_vec_mulqpo): New compile test variant of mulqpo.
	(test_vec_mulqpo_V5): Rename previous variant to V5.
	(test_vec_qpdpo_f128 [_ARCH_PWR8]): Guard compiler support
	for P7/BE.
	* src/testsuite/vec_pwr9_dummy.c
	(test_xfer_bin128_2_vui32t_V0_PWR9): New compile test variant.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>