### PR TITLE
Operations for generating small quadword integer const values.

### DIFF
--- a/src/testsuite/arith128_test_i128.c
+++ b/src/testsuite/arith128_test_i128.c
@@ -6826,6 +6826,102 @@ test_setbq (void)
 
   return (rc);
 }
+int
+test_splat_128 (void)
+{
+  vui128_t ek, k;
+  vi128_t  el, l;
+  vui32_t e;
+  int rc = 0;
+
+  printf ("\ntest_splat_128 Vector Splat Immediate Signed/Unsigned Quadword\n");
+
+  l =  vec_splat_s128 (0);
+  el = (vi128_t) CONST_VINT128_DW128(0, 0);
+  rc += check_vuint128x ("vec_splat_s128(0):", (vui128_t) l, (vui128_t) el);
+
+  k =  vec_splat_u128 (0);
+  ek = CONST_VINT128_DW128(0, 0);
+  rc += check_vuint128x ("vec_splat_u128(0):", k, ek);
+
+  l =  vec_splat_s128 (-1);
+  el = (vi128_t) CONST_VINT128_DW128(-1, -1);
+  rc += check_vuint128x ("vec_splat_s128(-1):", (vui128_t) l, (vui128_t) el);
+
+  l =  vec_splat_s128 (-16);
+  el = (vi128_t) CONST_VINT128_DW128(-1, -16);
+  rc += check_vuint128x ("vec_splat_s128(-16):", (vui128_t) l, (vui128_t) el);
+
+  l =  vec_splat_s128 (-128);
+  el = (vi128_t) CONST_VINT128_DW128(-1, -128);
+  rc += check_vuint128x ("vec_splat_s128(-128):", (vui128_t) l, (vui128_t) el);
+
+  l =  vec_splat_s128 (-255);
+  el = (vi128_t) CONST_VINT128_DW128(-1, -255);
+  rc += check_vuint128x ("vec_splat_s128(-255):", (vui128_t) l, (vui128_t) el);
+
+  l =  vec_splat_s128 (-256);
+  el = (vi128_t) CONST_VINT128_DW128(-1, -256);
+  rc += check_vuint128x ("vec_splat_s128(-256):", (vui128_t) l, (vui128_t) el);
+
+  l =  vec_splat_s128 (1);
+  el = (vi128_t) CONST_VINT128_DW128(0, 1);
+  rc += check_vuint128x ("vec_splat_s128(1):", (vui128_t) l, (vui128_t) el);
+
+  k =  vec_splat_u128 (1);
+  ek = CONST_VINT128_DW128(0, 1);
+  rc += check_vuint128x ("vec_splat_u128(1):", k, ek);
+
+  l =  vec_splat_s128 (15);
+  el = (vi128_t) CONST_VINT128_DW128(0, 15);
+  rc += check_vuint128x ("vec_splat_s128(15):", (vui128_t) l, (vui128_t) el);
+
+  k =  vec_splat_u128 (15);
+  ek = CONST_VINT128_DW128(0, 15);
+  rc += check_vuint128x ("vec_splat_u128(15):", k, ek);
+
+  l =  vec_splat_s128 (16);
+  el = (vi128_t) CONST_VINT128_DW128(0, 16);
+  rc += check_vuint128x ("vec_splat_s128(16):", (vui128_t) l, (vui128_t) el);
+
+  k =  vec_splat_u128 (16);
+  ek = CONST_VINT128_DW128(0, 16);
+  rc += check_vuint128x ("vec_splat_u128(16):", k, ek);
+
+  l =  vec_splat_s128 (127);
+  el = (vi128_t) CONST_VINT128_DW128(0, 127);
+  rc += check_vuint128x ("vec_splat_s128(127):", (vui128_t) l, (vui128_t) el);
+
+  k =  vec_splat_u128 (127);
+  ek = CONST_VINT128_DW128(0, 127);
+  rc += check_vuint128x ("vec_splat_u128(127):", k, ek);
+
+  l =  vec_splat_s128 (128);
+  el = (vi128_t) CONST_VINT128_DW128(0, 128);
+  rc += check_vuint128x ("vec_splat_s128(128):", (vui128_t) l, (vui128_t) el);
+
+  k =  vec_splat_u128 (128);
+  ek = CONST_VINT128_DW128(0, 128);
+  rc += check_vuint128x ("vec_splat_u128(128):", k, ek);
+
+  l =  vec_splat_s128 (255);
+  el = (vi128_t) CONST_VINT128_DW128(0, 255);
+  rc += check_vuint128x ("vec_splat_s128(255):", (vui128_t) l, (vui128_t) el);
+
+  k =  vec_splat_u128 (255);
+  ek = CONST_VINT128_DW128(0, 255);
+  rc += check_vuint128x ("vec_splat_u128(255):", k, ek);
+
+  l =  vec_splat_s128 (256);
+  el = (vi128_t) CONST_VINT128_DW128(0, 256);
+  rc += check_vuint128x ("vec_splat_s128(256):", (vui128_t) l, (vui128_t) el);
+
+  k =  vec_splat_u128 (256);
+  ek = CONST_VINT128_DW128(0, 256);
+  rc += check_vuint128x ("vec_splat_u128(256):", k, ek);
+
+  return (rc);
+}
 
 //#define __DEBUG_PRINT__ 1
 int
@@ -10166,6 +10262,7 @@ test_vec_i128 (void)
   printf ("\n%s\n", __FUNCTION__);
 #if 1
   rc += test_xfer_int128 ();
+  rc += test_splat_128 ();
   rc += test_revbq ();
   rc += test_clzq ();
   rc += test_ctzq ();

--- a/src/testsuite/vec_int128_dummy.c
+++ b/src/testsuite/vec_int128_dummy.c
@@ -26,6 +26,123 @@
 #include "arith128.h"
 #include <testsuite/arith128_print.h>
 
+// Attempts at better code to splat small QW constants.
+// Want to avoid addr calc and loads for what should be simple
+// splat immediate and sld.
+vi128_t
+__test_splatisq_16 (void)
+{
+  return vec_splat_s128 (-16);
+}
+
+vi128_t
+__test_splatisq_n1 (void)
+{
+  return vec_splat_s128 (-1);
+}
+
+vi128_t
+__test_splatisq_0 (void)
+{
+  return vec_splat_s128 (0);
+}
+
+vi128_t
+__test_splatisq_n1_V1 (void)
+{
+  const vui64_t q_ones = {-1, -1};
+  return (vi128_t) q_ones;
+}
+
+vi128_t
+__test_splatisq_n1_V0 (void)
+{
+  const vui32_t q_ones = {-1, -1, -1, -1};
+  return (vi128_t) q_ones;
+}
+
+vi128_t
+__test_splatisq_0_V0 (void)
+{
+  const vui32_t q_zero = {0, 0, 0, 0};
+  return (vi128_t) q_zero;
+}
+
+vui32_t
+__test_splatisq_signmask_V0 (void)
+{
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
+  return signmask;
+}
+
+vi128_t
+__test_splatisq_15_V2 (void)
+{
+  //  const vui32_t qw_15 = CONST_VINT128_W(0, 0, 0, 15);
+  const vui32_t q_zero = CONST_VINT128_W (0, 0, 0, 0);
+  vui32_t qw_15 = (vui32_t) vec_splat_s32(15);
+  return (vi128_t) vec_sld (q_zero, qw_15, 4);
+}
+
+vi128_t
+__test_splatisq_15_V1 (void)
+{
+  const vui128_t qw_15 = {15};
+  return (vi128_t) qw_15;
+}
+
+vi128_t
+__test_splatisq_15_V0 (void)
+{
+  const vui32_t qw_15 = CONST_VINT128_W(0, 0, 0, 15);
+  return (vi128_t) qw_15;
+}
+
+vi128_t
+__test_splatisq_15 (void)
+{
+  return vec_splat_s128 (15);
+}
+
+vi128_t
+__test_splatisq_127 (void)
+{
+  return vec_splat_s128 (127);
+}
+
+vui128_t
+__test_splatiuq_0 (void)
+{
+  return vec_splat_u128 (0);
+}
+
+vui128_t
+__test_splatiuq_15 (void)
+{
+  return vec_splat_u128 (15);
+}
+
+vui128_t
+__test_splatiuq_127 (void)
+{
+  return vec_splat_u128 (127);
+}
+
+vui128_t
+__test_splatiuq_128 (void)
+{
+  return vec_splat_u128 (128);
+}
+
+vui128_t
+__test_splatiuq_128_V0 (void)
+{
+  // Expect the compiler to generate vspltisw/vslb here.
+  vui8_t vbi = vec_splats ((unsigned char) 128);
+  const vui32_t q_zero = {0, 0, 0, 0};
+  return (vui128_t) vec_sld ((vui8_t) q_zero, vbi, 1);;
+}
+
 vi128_t
 __test_vec_abssq (vi128_t vra)
 {

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -83,6 +83,81 @@ __test_splatudi_12_PWR9 (void)
   return vec_splats ((unsigned long long) 12);
 }
 
+// Attempts at better code to splat small QW constants.
+// Want to avoid addr calc and loads for what should be simple
+// splat immediate and sld.
+vi128_t
+__test_splatisq_16_PWR9 (void)
+{
+  return vec_splat_s128 (-16);
+}
+
+vi128_t
+__test_splatisq_n1_PWR9 (void)
+{
+  return vec_splat_s128 (-1);
+}
+
+vi128_t
+__test_splatisq_0_PWR9 (void)
+{
+  return vec_splat_s128 (0);
+}
+
+vi128_t
+__test_splatisq_15_PWR9 (void)
+{
+  return vec_splat_s128 (15);
+}
+
+vi128_t
+__test_splatisq_127_PWR9 (void)
+{
+  return vec_splat_s128 (127);
+}
+
+vi128_t
+__test_splatisq_128_PWR9 (void)
+{
+  return vec_splat_s128 (128);
+}
+
+vui128_t
+__test_splatiuq_0_PWR9 (void)
+{
+  return vec_splat_u128 (0);
+}
+
+vui128_t
+__test_splatiuq_15_PWR9 (void)
+{
+  return vec_splat_u128 (15);
+}
+
+vui128_t
+__test_splatiuq_127_PWR9 (void)
+{
+  return vec_splat_u128 (127);
+}
+
+vui128_t
+__test_splatiuq_128_PWR9 (void)
+{
+  return vec_splat_u128 (128);
+}
+
+vui128_t
+__test_splatiuq_255_PWR9 (void)
+{
+  return vec_splat_u128 (255);
+}
+
+vui128_t
+__test_splatiuq_256_PWR9 (void)
+{
+  return vec_splat_u128 (256);
+}
+
 vui64_t
 test_sldi_1_PWR9 (vui64_t a)
 {


### PR DESCRIPTION
New operations to avoid stoirage load and cache misses while using
small quadword integer constants. This became evident during the
implementation of float128 implementation.

	* src/pveclib/vec_int128_ppc.h [int128_const_0_0_3]:
	Doxygen subsection for Loading small Quadword constants.
	(vec_splat_s128, vec_splat_u128): New int128 operations.

	* src/testsuite/arith128_test_i128.c (test_splat_128):
	New unit test.
	(test_vec_i128): Add unit test to driver.

	* src/testsuite/vec_int128_dummy.c (__test_splatisq_16,
	__test_splatisq_n1, __test_splatisq_0, __test_splatisq_n1_V1,
	__test_splatisq_n1_V0, __test_splatisq_0_V0,
	__test_splatisq_signmask_V0, __test_splatisq_15_V2,
	__test_splatisq_15_V1, __test_splatisq_15_V0,
	__test_splatisq_15, __test_splatisq_127, __test_splatiuq_0,
	__test_splatiuq_15, __test_splatiuq_127, __test_splatiuq_128,
	__test_splatiuq_128_V0): New compile tests.
	* src/testsuite/vec_pwr9_dummy.c (__test_splatisq_16_PWR9,
	__test_splatisq_n1_PWR9, __test_splatisq_0_PWR9,
	__test_splatisq_15_PWR9, __test_splatisq_127_PWR9,
	__test_splatisq_128_PWR9, __test_splatiuq_0_PWR9,
	__test_splatiuq_15_PWR9, __test_splatiuq_127_PWR9,
	__test_splatiuq_128_PWR9, __test_splatiuq_255_PWR9,
	__test_splatiuq_256_PWR9): New compile tests.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>