### PR TITLE
Update Float128 add/sub with round to odd for P8. V2.

### DIFF
--- a/src/testsuite/arith128_test_f128.c
+++ b/src/testsuite/arith128_test_f128.c
@@ -6159,6 +6159,66 @@ test_extract_insert_f128 ()
   xpt = vec_xfer_vui64t_2_bin128 ( vf128_nnan );
   rc += check_f128 ("check vec_xsiexpqp 12", x, xp, xpt);
 
+  x = vec_xfer_vui64t_2_bin128 ( vf128_one );
+  xp = vec_xfer_vui64t_2_bin128 ( vf128_nan );
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x =  ", x);
+  print_vfloat128x(" xp=  ", xp);
+#endif
+  exp = vec_xxxexpqpp (x, xp);
+  expt =  CONST_VINT128_DW(0x0000000000003fff, 0x0000000000007fff);
+  rc += check_vuint128x ("check vec_xsxexpqp 13", (vui128_t) exp, (vui128_t) expt);
+
+  return (rc);
+}
+int
+test_mask_f128 ()
+{
+  vui32_t exp, expt;
+  int rc = 0;
+
+  printf ("\ntest_mask_f128 ...\n");
+
+  exp = (vui32_t) vec_const64_f128_128();
+  expt =  CONST_VINT128_W (0, 128, 0, 128);
+  rc += check_vuint128x ("check vec_const64_f128_128 1", (vui128_t) exp, (vui128_t) expt);
+
+  exp = (vui32_t) vec_mask64_f128exp();
+  expt =  CONST_VINT128_W (0, 0x7fff, 0, 0x7fff);
+  rc += check_vuint128x ("check vec_mask64_f128exp 1", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_mask128_f128exp();
+  expt =  CONST_VINT128_W (0x7fff0000, 0, 0, 0);
+  rc += check_vuint128x ("check vec_mask128_f128exp 1", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_mask128_f128mag();
+  expt =  CONST_VINT128_W (0x7fffffff, -1, -1, -1);
+  rc += check_vuint128x ("check vec_mask128_f128mag 1", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_mask128_f128sig();
+  expt =  CONST_VINT128_W (0x0000ffff, -1, -1, -1);
+  rc += check_vuint128x ("check vec_mask128_f128sig 1", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_mask128_f128sign();
+  expt =  CONST_VINT128_W (0x80000000, 0, 0, 0);
+  rc += check_vuint128x ("check vec_mask128_f128sign 1", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_mask128_f128Cbit();
+  expt =  CONST_VINT128_W (0x00020000, 0, 0, 0);
+  rc += check_vuint128x ("check vec_mask128_f128Cbit 1", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_mask128_f128Lbit();
+  expt =  CONST_VINT128_W (0x00010000, 0, 0, 0);
+  rc += check_vuint128x ("check vec_mask128_f128Lbit 1", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_mask128_f128Qbit();
+  expt =  CONST_VINT128_W (0x00008000, 0, 0, 0);
+  rc += check_vuint128x ("check vec_mask128_f128Qbit 1", (vui128_t) exp, (vui128_t) expt);
+
+  exp = vec_const128_f128_128();
+  expt =  CONST_VINT128_W (0, 0, 0, 128);
+  rc += check_vuint128x ("check vec_const128_f128_128 1", (vui128_t) exp, (vui128_t) expt);
+
   return (rc);
 }
 
@@ -16459,6 +16519,7 @@ test_add_qpo_xtra (void)
   return (rc);
 }
 
+#undef __DEBUG_PRINT__
 //#define __DEBUG_PRINT__ 1
 #ifdef __DEBUG_PRINT__
 #define test_xssubqpo(_l,_k)	db_vec_xssubqpo(_l,_k)
@@ -17534,6 +17595,7 @@ test_vec_f128 (void)
 
   printf ("\n%s\n", __FUNCTION__);
 
+  rc += test_mask_f128 ();
   rc += test_const_f128 ();
   rc += test_all_is_f128 ();
   rc += test_vec_bool_f128 ();

--- a/src/testsuite/arith128_test_i128.c
+++ b/src/testsuite/arith128_test_i128.c
@@ -6831,7 +6831,6 @@ test_splat_128 (void)
 {
   vui128_t ek, k;
   vi128_t  el, l;
-  vui32_t e;
   int rc = 0;
 
   printf ("\ntest_splat_128 Vector Splat Immediate Signed/Unsigned Quadword\n");

--- a/src/testsuite/vec_pwr10_dummy.c
+++ b/src/testsuite/vec_pwr10_dummy.c
@@ -64,7 +64,7 @@ __test_splatudi_12_PWR10_v0 (void)
 }
 
 #if defined (_ARCH_PWR10) && (__GNUC__ > 11) \
-    || ((__GNUC__ == 11) && (__GNUC_MINOR__ > 2))
+    || ((__GNUC__ == 11) && (__GNUC_MINOR__ > 3))
 // New support defined in Power Vector Intrinsic Programming Reference.
 // Waiting for GCC 11.3?
 int

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -40,6 +40,19 @@
 #include <pveclib/vec_f32_ppc.h>
 #include <pveclib/vec_bcd_ppc.h>
 
+vui32_t
+test_mask128_f128sign_PWR9(void)
+{
+  return vec_mask128_f128sign ();
+}
+
+vui32_t
+test_mask128_f128sign_V0_PWR9(void)
+{
+  const vui32_t signmask = CONST_VINT128_W(0x80000000, 0, 0, 0);
+  return signmask;
+}
+
 // Attempts at better code to splat small DW constants.
 // Want to avoid addr calc and loads for what should be simple
 // splat immediate and unpack.
@@ -909,6 +922,18 @@ test_xfer_bin128_2_vui32t_V0_PWR9 (__binary128 f128)
   return vunion.vx4;
 }
 
+vui64_t
+test_mrgh_bin128_2_vui64t_PWR9 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_mrgh_bin128_2_vui64t (vfa, vfb) ;
+}
+
+vui64_t
+test_mrgl_bin128_2_vui64t_PWR9 (__binary128 vfa, __binary128 vfb)
+{
+  return vec_mrgl_bin128_2_vui64t (vfa, vfb) ;
+}
+
 vui32_t
 test_xfer_bin128_2_vui32t_PWR9 (__binary128 f128)
 {
@@ -925,6 +950,12 @@ __binary128
 test_xfer_vui32t_2_bin128_PWR9 (vui32_t f128)
 {
   return vec_xfer_vui32t_2_bin128 (f128);
+}
+
+vui64_t
+test_vec_xxxexpqpp_PWR9 (__binary128 f128a, __binary128 f128b)
+{
+  return vec_xxxexpqpp (f128a, f128b);
 }
 
 __binary128


### PR DESCRIPTION
Power9 provide round to odd versions for the QP arithmetic operations.
This patch provides an update P9/8 implementation for add/sub QP with
round to odd. This version includes optimization in constant loading
and logic simplification.

	* src/pveclib/vec_f128_ppc.h [doxygen]: General updates.
	[f128_softfloat_0_0_4]: New section
	"Constants and Masks for Quad-Precision Soft-float".
	[f128_softfloat_0_0_4_1]: New section
	"Special Constants for Quad-Precision Soft-float".
	[f128_softfloat_0_0_4_1_3]: New paragraph
	"Some constants are trickier"
	(union __VF_128): Add field ix1 scalar __int128.
	[@cond INTERNAL]: Add forward ref for vec_xxxexpqpp.
	(vec_const64_f128_128, vec_const128_f128_128,
	vec_mask64_f128exp, vec_mask128_f128exp,
	vec_mask128_f128mag, vec_mask128_f128sig,
	vec_mask128_f128sign, vec_mask128_f128Cbit,
	vec_mask128_f128Lbit, vec_mask128_f128Qbit):
	New inline functions for generating masks.
	(vec_or_bin128_2_vui32t, vec_xor_bin128_2_vui32t [\brief]):
	Correct brief description.
	(vec_andc_bin128_2_vui128t): New transfer function.
	(vec_mrgh_bin128_2_vui64t, vec_mrgl_bin128_2_vui64t):
	New transfer function.
	(vec_all_isinff128, vec_all_isnanf128):
	Replace mask generation.
	(vec_xsaddqpo, vec_xssubqpo): Replace implementation with
	latest optimizations from vec_f128_dummy.c
	(vec_xsiexpqp, vec_xsxexpqp, vec_xsxsigqp):
	Update latency for P8. Replace mask generation.
	(vec_xxxexpqpp): New inline function.

	* src/pveclib/vec_int128_ppc.h [doxygen]:
	Update description of sign mask.

	* src/testsuite/arith128_test_f128.c
	(test_extract_insert_f128):
	Add test case for vec_xxxexpqpp.
	(test_mask_f128): New unit test.
	(test_vec_f128): Add unit test to driver function.

	* src/testsuite/arith128_test_i128.c: (test_splat_128):
	Remove unused variables.

	* src/testsuite/vec_f128_dummy.c (__VEC_U_256): New struct.
	(test_const64_f128_128, test_const128_f128_128,
	test_mask64_f128exp, test_mask128_f128exp (void),
	test_mask128_f128exp_V2, test_mask128_f128exp_V1,
	test_mask128_f128exp_V0, test_mask128_f128mag,
	test_mask128_f128sig, test_mask128_f128sign,
	test_mask128_f128sign_V0, test_mask128_f128Cbit.
	test_mask128_f128Lbit, test_mask128_f128Qbit,
	test_mask128_CSE): New compile tests.
	(test_xsigqpmp, test_xsigqpo_v2, test_xsigqpo_v1,
	test_xsigqpo_v0, test_xexpqpp, test_xexpqpp_V2,
	test_xexpqpp_V1, test_xexpqpp_v0): New compile tests.
	(test_vec_addqpo): New version with optimizations.
	(test_vec_addqpo_V5): Rename of previous test_vec_addqpo.
	(test_vec_addqpo_V4, test_vec_addqpo_V3):
	Previous attempts at optimization.
	(test_vec_subqpo): New version with optimizations.
	(test_vec_subqpo_V2): Rename of previous test_vec_subqpo.
	(test_or_bin128_2_vui32t, test_xfer_bin128_2_ui128t_V0):
	New compile tests.
	(test_mrgh_bin128_2_vui64t, test_mrgl_bin128_2_vui64t,
	test_mrgh_bin128_2_vui64t_V0):
	New compile tests.
	(test_vec_xxxexpqpp): New compile tests.

	* src/testsuite/vec_pwr10_dummy.c
	[_ARCH_PWR10 && (__GNUC__ > 11) && (__GNUC_MINOR__ > 3)]:
	Compiler update did not include built-ins for quadword integer
	compare.

	* src/testsuite/vec_pwr9_dummy.c
	(test_mask128_f128sign_PWR9, test_mask128_f128sign_V0_PWR9):
	New compile tests.
	(test_mrgh_bin128_2_vui64t_PWR9,
	test_mrgl_bin128_2_vui64t_PWR9): New compile tests.
	(test_vec_xxxexpqpp_PWR9): New compile test.

Signed-off-by: Steven Munroe <munroesj52@gmail.com>