### PR TITLE
P9 Float128 Multiply-Add with round to odd, plus P8 equivalent.

### DIFF
--- a/src/testsuite/pveclib_perf.c
+++ b/src/testsuite/pveclib_perf.c
@@ -906,6 +906,34 @@ test_time_f128 (void)
   printf ("\n%s subqpo_lib tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
 	  t_delta, delta_sec);
 
+  printf ("\n%s maddqpn_gcc start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_gcc_maddqpn_f128 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s maddqpn_gcc end", __FUNCTION__);
+  printf ("\n%s maddqpn_gcc tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+	  t_delta, delta_sec);
+
+  printf ("\n%s maddqpo_lib start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_lib_maddqpo_f128 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s maddqpo_lib end", __FUNCTION__);
+  printf ("\n%s maddqpo_lib tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+	  t_delta, delta_sec);
+
   return (rc);
 }
 #endif

--- a/src/testsuite/vec_f128_dummy.c
+++ b/src/testsuite/vec_f128_dummy.c
@@ -58,6 +58,79 @@ typedef struct
   ///@endcond
 } __VEC_U_256;
 
+#ifdef __FLOAT128__
+__binary128
+test_vec_maddqpo (__binary128, __binary128, __binary128);
+
+#if 0
+  const __float128 f128_fact0 = (1.0Q / 1.0Q);
+  const __float128 f128_fact1 = (1.0Q / 2.0Q);
+  const __float128 f128_fact2 = (1.0Q / 6.0Q);
+  const __float128 f128_fact3 = (1.0Q / 24.0Q);
+  const __float128 f128_fact4 = (1.0Q / 120.0Q);
+  const __float128 f128_fact5 = (1.0Q / 720.0Q);
+  const __float128 f128_fact6 = (1.0Q / 5040.0Q);
+  const __float128 f128_fact7 = (1.0Q / 40320.0Q);
+#endif
+
+__float128
+test_scalarlib_exp_f128 (__float128 term1st, __float128 f128_fact[])
+{
+  const __float128 f128_one = 1.0Q;
+  __float128 term;
+
+  // 1st 8 terms of e = 1 + 1/1! + 1/2!+ 1/3! ...
+  term = test_vec_maddqpo (term1st, f128_fact[0], term1st);
+  term = test_vec_maddqpo (term1st, f128_fact[1], term);
+  term = test_vec_maddqpo (term1st, f128_fact[2], term);
+  term = test_vec_maddqpo (term1st, f128_fact[3], term);
+  term = test_vec_maddqpo (term1st, f128_fact[4], term);
+  term = test_vec_maddqpo (term1st, f128_fact[5], term);
+  term = test_vec_maddqpo (term1st, f128_fact[6], term);
+
+  return test_vec_maddqpo (f128_one, f128_fact[7], term);
+}
+
+__float128
+test_scalargcc_exp_f128 (__float128 term1st, __float128 f128_fact[])
+{
+  __float128 term;
+
+#if defined (_ARCH_PWR9)
+  // 1st 8 terms of e = 1 + 1/1! + 1/2!+ 1/3! ...
+  term = __builtin_fmaf128 (f128_one, f128_fact[0], term1st);
+  term = __builtin_fmaf128 (f128_one, f128_fact[1], term);
+  term = __builtin_fmaf128 (f128_one, f128_fact[2], term);
+  term = __builtin_fmaf128 (f128_one, f128_fact[3], term);
+  term = __builtin_fmaf128 (f128_one, f128_fact[4], term);
+  term = __builtin_fmaf128 (f128_one, f128_fact[5], term);
+  term = __builtin_fmaf128 (f128_one, f128_fact[6], term);
+
+  return __builtin_fmaf128 (f128_one, f128_fact[7], term);
+#else
+  __float128 infrac;
+
+  // 1st 8 terms of e = 1 + 1/1! + 1/2!+ 1/3! ...
+  infrac = term1st * f128_fact[0];
+  term =   term1st + infrac;
+  infrac = term1st * f128_fact[1];
+  term =   term + infrac;
+  infrac = term1st * f128_fact[2];
+  term =   term + infrac;
+  infrac = term1st * f128_fact[3];
+  term =   term + infrac;
+  infrac = term1st * f128_fact[4];
+  term =   term + infrac;
+  infrac = term1st * f128_fact[5];
+  term =   term + infrac;
+  infrac = term1st * f128_fact[6];
+  term =   term + infrac;
+  infrac = term1st * f128_fact[7];
+  return term + infrac;
+#endif
+}
+#endif
+
 vui64_t
 force_eMin (vui64_t x_exp)
 {
@@ -95,9 +168,121 @@ test_vec_xssubqpo (__binary128 vfa, __binary128 vfb)
 }
 
 vui64_t
+test_const64_f128_16_V2(void)
+{
+  vui32_t mask32;
+
+  mask32 = vec_splat_u32 (8);
+  // Generate {16, 16, 16, 16, 16, 16, 16, 16} from count leading zeros of {0,..}
+  mask32 = vec_add(mask32, mask32);
+#if defined (_ARCH_PWR8)
+  mask32 = (vui32_t) vec_unpackl ( (vi32_t) mask32 );
+#else
+  const vui32_t q_zero = CONST_VINT128_W (0, 0, 0, 0);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  mask32= vec_mergeh (mask32, q_zero);
+#else
+  mask32 = vec_mergel (q_zero, mask32);
+#endif
+#endif
+  return (vui64_t) mask32;
+}
+
+vui64_t
+test_const64_f128_16_V1(void)
+{
+  vui32_t shift32, mask32;
+
+  shift32 = vec_splat_u32 (4);
+  mask32 = vec_splat_u32 (1);
+  // Generate {16, 16, 16, 16, 16, 16, 16, 16} from count leading zeros of {0,..}
+  mask32 = vec_sl(mask32, shift32);
+#if defined (_ARCH_PWR8)
+  mask32 = (vui32_t) vec_unpackl ( (vi32_t) mask32 );
+#else
+  const vui32_t q_zero = CONST_VINT128_W (0, 0, 0, 0);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  mask32= vec_mergeh (mask32, q_zero);
+#else
+  mask32 = vec_mergel (q_zero, mask32);
+#endif
+#endif
+  return (vui64_t) mask32;
+}
+
+vui64_t
+test_const64_f128_16_V0(void)
+{
+  const vui32_t q_zero = CONST_VINT128_W (0, 0, 0, 0);
+  vui32_t mask32;
+  vui16_t mask16;
+  // Generate {16, 16, 16, 16, 16, 16, 16, 16} from count leading zeros of {0,..}
+  mask16 = vec_clzh((vui16_t) q_zero);
+  mask32 = (vui32_t) vec_unpackl ((vi16_t) mask16);
+#if defined (_ARCH_PWR8)
+  mask32 = (vui32_t) vec_unpackl ( (vi32_t) mask32 );
+#else
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  mask32= vec_mergeh (mask32, q_zero);
+#else
+  mask32 = vec_mergel (q_zero, mask32);
+#endif
+#endif
+  return (vui64_t) mask32;
+}
+
+vui64_t
+test_const64_f128_112 (void)
+{
+  return vec_const64_f128_112 ();
+}
+
+vui64_t
+test_const64_f128_112_V0(void)
+{
+  //  const vui32_t dw_128 = CONST_VINT128_W(0, 112, 0, 112};
+  vui32_t shift32, mask32;
+
+  shift32 = vec_splat_u32 (4);
+  mask32 = vec_splat_u32 (7);
+  // result (0x7 << 4) = 0x70
+  mask32 = vec_sl(mask32, shift32);
+#if defined (_ARCH_PWR8)
+  mask32 = (vui32_t) vec_unpackl ( (vi32_t) mask32 );
+#else
+  const vui32_t q_zero = CONST_VINT128_W (0, 0, 0, 0);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  mask32= vec_mergeh (mask32, q_zero);
+#else
+  mask32 = vec_mergel (q_zero, mask32);
+#endif
+#endif
+  return (vui64_t) mask32;
+}
+
+vui64_t
 test_const64_f128_128 (void)
 {
   return vec_const64_f128_128 ();
+}
+
+vui64_t
+test_const64_f128_128_V0(void)
+{
+  //  const vui32_t dw_128 = CONST_VINT128_W(0, 16, 0, 128);
+  const vui32_t q_zero = CONST_VINT128_W (0, 0, 0, 0);
+#if defined (_ARCH_PWR8)
+  // Generate {64, 64} from count leading zeros of {0, 0}
+  vui64_t dw64 = vec_clzd((vui64_t) q_zero);
+  // Generate {128, 128}
+  return vec_addudm (dw64, dw64);
+#else
+  const vui32_t q_ones = CONST_VINT128_W (-1, -1, -1, -1);
+  vui32_t signmask;
+  signmask = vec_sl (q_ones, q_ones);
+  signmask = vec_sld (q_zero, signmask, 1);
+  return vec_mrgald ((vui128_t) signmask, (vui128_t) signmask);
+#endif
 }
 
 vui32_t
@@ -3792,6 +3977,12 @@ test_vec_xsmulqpo (__binary128 vfa, __binary128 vfb)
   return vec_xsmulqpo (vfa, vfb);
 }
 
+__binary128
+test_vec_xsmaddqpo (__binary128 vfa, __binary128 vfb, __binary128 vfc)
+{
+  return vec_xsmaddqpo (vfa, vfb, vfc);
+}
+
 int
 test_check_sig_ovf (vui128_t q_sig)
 {
@@ -3809,6 +4000,762 @@ test_check_sig_ovf_V0 (vui128_t q_sig)
   vui16_t t_sig = vec_splat ((vui16_t) q_sig, VEC_HW_H);
   t_sig = vec_and (t_sig, sig_cl_mask);
   return vec_all_gt (t_sig, sig_l_mask);
+}
+
+
+__binary128
+test_vec_maddqpo (__binary128 vfa, __binary128 vfb, __binary128 vfc)
+{
+  __binary128 result;
+#if defined (_ARCH_PWR9) && (__GNUC__ > 7)
+#if defined (__FLOAT128__) && (__GNUC__ > 8)
+  // earlier GCC versions generate extra data moves for this.
+  result = __builtin_fmaf128_round_to_odd (vfa, vfb, vfc);
+#else
+  // No extra data moves here.
+  __asm__(
+      "xsmaddqpo %0,%1,%2"
+      : "+v" (vfc)
+      : "v" (vfa), "v" (vfb)
+      : );
+  result = vfc;
+#endif
+  return result;
+#elif  defined (_ARCH_PWR7)
+  vui64_t q_exp, /*a_exp, b_exp,*/ c_exp, x_exp;
+  vui128_t q_sig, a_sig, b_sig, c_sig, c_sig_l, p_sig_h, p_sig_l, p_odd;
+  vui32_t q_sign, a_sign, b_sign, c_sign;
+  vui128_t a_mag, b_mag, c_mag;
+  const vui32_t q_zero = CONST_VINT128_W (0, 0, 0, 0);
+  const vui32_t q_ones = CONST_VINT128_W (-1, -1, -1, -1);
+  //const vui64_t exp_naninf = (vui64_t) { 0x7fff, 0x7fff };
+  const vui64_t exp_naninf = vec_mask64_f128exp();
+  const vui32_t magmask = vec_mask128_f128mag();
+
+  //a_exp = vec_xsxexpqp (vfa);
+  //b_exp = vec_xsxexpqp (vfb);
+
+  // Vector extract the exponents from vfa, vfb
+  x_exp = vec_xxxexpqpp (vfa, vfb);
+#if 1
+  // Vector extract the exponents from vfc
+  c_exp = vec_xxxexpqpp (vfc, vfc);
+#else
+  c_exp = vec_xsxexpqp (vfc);
+  c_exp = vec_mrgahd ((vui128_t) c_exp, (vui128_t) c_exp);
+#endif
+  // Mask off sign bits so can use integers for magnitude compare.
+  a_mag = (vui128_t) vec_and_bin128_2_vui32t (vfa, magmask);
+  b_mag = (vui128_t) vec_and_bin128_2_vui32t (vfb, magmask);
+  a_sign = vec_andc_bin128_2_vui32t (vfa, magmask);
+  b_sign = vec_andc_bin128_2_vui32t (vfb, magmask);
+#if 0
+  c_mag = (vui128_t) vec_and_bin128_2_vui32t (vfc, magmask);
+  c_sign = vec_andc_bin128_2_vui32t (vfc, magmask);
+#endif
+  q_sign = vec_xor (a_sign, b_sign);
+
+//  if (vec_all_isfinitef128 (vfa) && vec_all_isfinitef128 (vfb))
+  if (__builtin_expect ((vec_cmpud_all_lt (x_exp, exp_naninf)
+      && vec_cmpud_all_lt (c_exp, exp_naninf)), 1))
+    {
+      const vui64_t exp_dnrm = (vui64_t) q_zero;
+      vui64_t exp_min, exp_one, exp_bias;
+      vui32_t diff_sign;
+      vui128_t p_tmp;
+      //vb128_t a_lt_b;
+#if 0
+#if 1
+      c_mag = (vui128_t) vec_and_bin128_2_vui32t (vfc, magmask);
+      c_sign = vec_andc_bin128_2_vui32t (vfc, magmask);
+#endif
+      // check for zero significands in multiply
+      if (__builtin_expect (
+	    (vec_all_eq((vui32_t ) a_mag, (vui32_t ) q_zero)
+	  || vec_all_eq((vui32_t ) b_mag, (vui32_t ) q_zero)),
+	  0))
+	{ // Multiply by zero + zero, return QP signed zero
+	  if (vec_all_eq((vui32_t ) c_mag, (vui32_t ) q_zero))
+		{ // Special case of both zero with different sign
+		  vui32_t diff_sign = vec_xor (q_sign, c_sign);
+		  diff_sign = (vui32_t) vec_setb_sq ((vi128_t) diff_sign);
+		  q_sign = vec_sel (q_sign, (vui32_t) q_zero, diff_sign);
+		  result = vec_xfer_vui32t_2_bin128 (q_sign);
+		}
+	  else
+	    result = vfc;
+
+	  return result;
+	}
+#endif
+      // const vui64_t exp_min, exp_one = { 1, 1 };
+      // exp_min = exp_one = vec_splat_u64 (1);
+      { // Extract the significands and insert the Hidden bit
+	//const vui32_t q_zero = CONST_VINT128_W(0, 0, 0, 0);
+	const vui32_t sigmask = vec_mask128_f128sig ();
+	vui32_t a_s32, b_s32/*, c_s32*/;
+	vui16_t a_e16, b_e16/*, c_e16*/, x_hidden;
+	vb16_t a_norm, b_norm/*, c_norm*/;
+
+	//const vui32_t hidden = vec_mask128_f128Lbit();
+	x_hidden = vec_splat_u16(1);
+	// Assume that the operands are finite magnitudes
+	// Mask off the significands
+	// Applying sigmask to orignal inputs can save 2 cycles here
+	a_s32 = vec_and_bin128_2_vui32t (vfa, sigmask);
+	b_s32 = vec_and_bin128_2_vui32t (vfb, sigmask);
+	// But still need a/b_mag for exp extract to clear sign-bit
+	// Mask off the exponents in high halfword
+	a_e16 = (vui16_t) vec_andc ((vui32_t) a_mag, sigmask);
+	b_e16 = (vui16_t) vec_andc ((vui32_t) b_mag, sigmask);
+	// Compare exponents for finite i.e. > denomal (q_zero)
+	a_norm = vec_cmpgt (a_e16, (vui16_t) q_zero);
+	b_norm = vec_cmpgt (b_e16, (vui16_t) q_zero);
+	// For Normal QP insert (hidden) L-bit into significand
+	a_sig = (vui128_t) vec_sel ((vui16_t) a_s32, x_hidden, a_norm);
+	b_sig = (vui128_t) vec_sel ((vui16_t) b_s32, x_hidden, b_norm);
+      }
+#if 1
+#if 1
+      c_mag = (vui128_t) vec_and_bin128_2_vui32t (vfc, magmask);
+      c_sign = vec_andc_bin128_2_vui32t (vfc, magmask);
+#endif
+      { // Extract the significands and insert the Hidden bit
+	//const vui32_t q_zero = CONST_VINT128_W(0, 0, 0, 0);
+	const vui32_t sigmask = vec_mask128_f128sig ();
+	vui32_t /*a_s32, b_s32,*/ c_s32;
+	vui16_t /*a_e16, b_e16,*/ c_e16, x_hidden;
+	vb16_t /*a_norm, b_norm,*/ c_norm;
+
+	//const vui32_t hidden = vec_mask128_f128Lbit();
+	x_hidden = vec_splat_u16(1);
+	// Assume that the operands are finite magnitudes
+	// Mask off the significands
+	// Applying sigmask to orignal inputs can save 2 cycles here
+	c_s32 = vec_and_bin128_2_vui32t (vfc, sigmask);
+	// But still need a/b_mag for exp extract to clear sign-bit
+	// Mask off the exponents in high halfword
+	c_e16 = (vui16_t) vec_andc ((vui32_t) c_mag, sigmask);
+	// Compare exponents for finite i.e. > denomal (q_zero)
+	c_norm = vec_cmpgt (c_e16, (vui16_t) q_zero);
+	// For Normal QP insert (hidden) L-bit into significand
+	c_sig = (vui128_t) vec_sel ((vui16_t) c_s32, x_hidden, c_norm);
+      }
+#endif
+#if 0
+      // check for zero significands in multiply
+      if (__builtin_expect (
+	    (vec_all_eq((vui32_t ) a_mag, (vui32_t ) q_zero)
+	  || vec_all_eq((vui32_t ) b_mag, (vui32_t ) q_zero)),
+	  0))
+	{ // Multiply by zero + zero, return QP signed zero
+	  if (vec_all_eq((vui32_t ) c_mag, (vui32_t ) q_zero))
+		{ // Special case of both zero with different sign
+		  vui32_t diff_sign = vec_xor (q_sign, c_sign);
+		  diff_sign = (vui32_t) vec_setb_sq ((vi128_t) diff_sign);
+		  q_sign = vec_sel (q_sign, (vui32_t) q_zero, diff_sign);
+		  result = vec_xfer_vui32t_2_bin128 (q_sign);
+		}
+	  else
+	    result = vfc;
+
+	  return result;
+	}
+#endif
+
+      // Precondition the significands before multiply so that the
+      // high-order 114-bits (C,L,FRACTION) of the product are right
+      // adjusted in p_sig_h. And the Low-order 112-bits are left
+      // justified in p_sig_l.
+      // Logically this (multiply) step could be moved after the zero
+      // test. But this uses a lot of registers and the compiler may
+      // see this as register pressure and decide to spill and reload
+      // unrelated data around this block.
+      // The zero multiply is rare so on average performance is better
+      // if we get this started now.
+      a_sig = vec_slqi (a_sig, 8);
+      b_sig = vec_slqi (b_sig, 8);
+      p_sig_l = vec_muludq (&p_sig_h, a_sig, b_sig);
+#if 0
+#if 1
+      c_mag = (vui128_t) vec_and_bin128_2_vui32t (vfc, magmask);
+      c_sign = vec_andc_bin128_2_vui32t (vfc, magmask);
+#endif
+      { // Extract the significands and insert the Hidden bit
+	//const vui32_t q_zero = CONST_VINT128_W(0, 0, 0, 0);
+	const vui32_t sigmask = vec_mask128_f128sig ();
+	vui32_t a_s32, b_s32, c_s32;
+	vui16_t a_e16, b_e16, c_e16, x_hidden;
+	vb16_t a_norm, b_norm, c_norm;
+
+	//const vui32_t hidden = vec_mask128_f128Lbit();
+	x_hidden = vec_splat_u16(1);
+	// Assume that the operands are finite magnitudes
+	// Mask off the significands
+	// Applying sigmask to orignal inputs can save 2 cycles here
+	c_s32 = vec_and_bin128_2_vui32t (vfc, sigmask);
+	// But still need a/b_mag for exp extract to clear sign-bit
+	// Mask off the exponents in high halfword
+	c_e16 = (vui16_t) vec_andc ((vui32_t) c_mag, sigmask);
+	// Compare exponents for finite i.e. > denomal (q_zero)
+	c_norm = vec_cmpgt (c_e16, (vui16_t) q_zero);
+	// For Normal QP insert (hidden) L-bit into significand
+	c_sig = (vui128_t) vec_sel ((vui16_t) c_s32, x_hidden, c_norm);
+      }
+#endif
+#if 1
+      // check for zero significands in multiply
+      if (__builtin_expect (
+	    (vec_all_eq((vui32_t ) a_sig, (vui32_t ) q_zero)
+	  || vec_all_eq((vui32_t ) b_sig, (vui32_t ) q_zero)),
+	  0))
+	{ // Multiply by zero + zero, return QP signed zero
+	  if (vec_all_eq((vui32_t ) c_sig, (vui32_t ) q_zero))
+		{ // Special case of both zero with different sign
+		  vui32_t diff_sign = vec_xor (q_sign, c_sign);
+		  diff_sign = (vui32_t) vec_setb_sq ((vi128_t) diff_sign);
+		  q_sign = vec_sel (q_sign, (vui32_t) q_zero, diff_sign);
+		  result = vec_xfer_vui32t_2_bin128 (q_sign);
+		}
+	  else
+	    result = vfc;
+
+	  return result;
+	}
+#endif
+      // const vui64_t exp_min, exp_one = { 1, 1 };
+      exp_min = exp_one = vec_splat_u64 (1);
+      //const vui64_t exp_bias = (vui64_t) { 0x3fff, 0x3fff };
+      exp_bias = (vui64_t) vec_srhi ((vui16_t) exp_naninf, 1);
+	{ // Compute product exponent q_exp
+	  // Operand exponents should >= Emin for computation
+	  vb64_t exp_mask;
+	  exp_mask = vec_cmpequd (x_exp, exp_dnrm);
+	  x_exp = vec_selud (x_exp, exp_min, (vb64_t) exp_mask);
+	  // sum exponents across x_exp
+	  q_exp = vec_addudm (x_exp, vec_swapd (x_exp));
+	  // Sum includes 2 x exp_bias, So subtract 1 x exp_bias
+	  q_exp = vec_subudm (q_exp, exp_bias);
+	  exp_mask = vec_cmpequd (c_exp, exp_dnrm);
+	  c_exp = vec_selud (c_exp, exp_min, (vb64_t) exp_mask);
+	}
+#if 1
+      // Check for carry; shift right 1 and adjust exp +1
+	{
+	  vb128_t carry_mask;
+	  vui128_t sig_h, sig_l;
+	  // Test Carry-bit (greater than L-bit)
+	  vui16_t sig_l_mask = vec_splat_u16(1);
+	  vui16_t t_sig = vec_splat ((vui16_t) p_sig_h, VEC_HW_H);
+	  carry_mask = (vb128_t) vec_cmpgt (t_sig, sig_l_mask);
+	  // Shift double quadword right 1 bit
+	  p_tmp = vec_sldqi (p_sig_h, p_sig_l, 120);
+	  sig_h = vec_srqi (p_sig_h, 1);
+	  sig_l = vec_slqi (p_tmp, 7);
+	  // Increment the exponent
+	  x_exp = vec_addudm (q_exp, exp_one);
+	  // Select original or normalized exp/sig
+	  p_sig_h = vec_seluq (p_sig_h, sig_h, carry_mask);
+	  p_sig_l = vec_seluq (p_sig_l, sig_l, carry_mask);
+	  q_exp = vec_selud (q_exp, x_exp, (vb64_t) carry_mask);
+	}
+#endif
+      // We have the product in q_sign, q_exp, p_sig_h/p_sig_l
+      // And the addend (vfc) in c_sign, c_exp,  c_sig/c_sig_l
+      c_sig_l = (vui128_t) q_zero;
+      q_sig = p_sig_h;
+      // Generation sign difference for signed 0.0
+
+      // If sign(vfa) != sign(vfb) will need to:
+      // 1) Subtract instead of add significands
+      // 2) Generate signed zeros
+
+      // If magnitude(prod) >  magnitude(c) will need to swap prod/c, later
+      // a_lt_b = vec_cmpltuq (q_sig, c_sig);
+      diff_sign = (vui32_t) vec_cmpneuq ((vui128_t) q_sign, (vui128_t) c_sign);
+      if (vec_cmpud_all_eq (q_exp, c_exp))
+	{
+	  vui128_t /*add_sig, sub_sig, s_sig,*/ carry;
+
+	  if (vec_all_eq (q_sign, c_sign))
+	    { // Same sign, simple add
+	      q_sig = vec_adduqm (p_sig_h, c_sig);
+	      p_sig_h = q_sig;
+	      // q_sign = q_sign;
+	    }
+	  else
+	    { // different sign, subtract smallest from largest magnitude
+	      const vui64_t exp_112 = vec_const64_f128_112();
+
+	      if (vec_cmpuq_all_lt (q_sig, c_sig))
+		{
+		  carry = vec_subcuq (c_sig_l, p_sig_l);
+		  p_sig_l = vec_subuqm (c_sig_l, p_sig_l);
+		  q_sig = vec_subeuqm (c_sig, p_sig_h, carry);
+		  p_sig_h = q_sig;
+		  q_sign = c_sign;
+		}
+	      else
+		{
+		  q_sig = vec_subuqm (q_sig, c_sig);
+		  p_sig_h = q_sig;
+		  // q_sign = q_sign;
+		}
+
+	      if (__builtin_expect (vec_cmpuq_all_eq (q_sig, (vui128_t) q_zero),
+				    0))
+		{
+		  if (vec_cmpuq_all_eq (p_sig_l, (vui128_t) q_zero))
+		    { // Special case of both zero with different sign
+		      q_sign = vec_sel (q_sign, (vui32_t) q_zero, diff_sign);
+		      //q_sign = vec_xor (q_sign, c_sign);
+		      return vec_xfer_vui32t_2_bin128 (q_sign);
+		    }
+
+		  // If p_sig_h == 0 after subtract and p_sig_l != 0
+		  // Need to pre-normalize if we can, because the code that
+		  // follows is not expecting delta exp > 112
+		  // But must maintain q_exp >= E_min
+		  if (vec_cmpud_all_gt ((vui64_t) q_exp, exp_112))
+		    {
+		      vui128_t t_sig;
+		      t_sig = (vui128_t) vec_sld ((vui32_t) p_sig_h,
+						  (vui32_t) p_sig_l, 14);
+		      p_sig_l = vec_slqi (p_sig_l, 112);
+		      p_sig_h = t_sig;
+		      q_exp = vec_subudm (q_exp, exp_112);
+		      q_sig = p_sig_h;
+		    }
+		}
+	    }
+	}
+      else
+	{
+	  // 2a) If p_exp > c_exp then
+	  //if (vec_cmpuq_all_ne (c_sig, (vui128_t) q_zero))
+	    { // and c_sig != zero
+	      //     any bits shifted out of b_sig are ORed into the X-bit
+	      if (vec_cmpud_all_lt (c_exp, q_exp))
+		{ //     shift (c_sig) right by (q_exp - c_exp)
+		  vui64_t d_exp, l_exp;
+		  vui128_t t_sig, carry;
+		  vb128_t exp_mask;
+		  const vui64_t exp_128 = vec_const64_f128_128 ();
+		  const vui64_t exp_256 = vec_addudm (exp_128, exp_128);
+
+		  d_exp = vec_subudm (q_exp, c_exp);
+		  exp_mask = (vb128_t) vec_cmpltud (d_exp, exp_128);
+		  if (vec_cmpud_all_lt (d_exp, exp_128))
+		    {
+		      l_exp = vec_subudm (exp_128, d_exp);
+		      t_sig = vec_srq (c_sig, (vui128_t) d_exp);
+		      c_sig_l = vec_slq (c_sig, (vui128_t) l_exp);
+		      t_sig = vec_seluq ((vui128_t) q_zero, t_sig, exp_mask);
+		      //c_sig_l = vec_seluq (c_sig, c_sig_l, exp_mask);
+		    }
+		  else
+		    {
+		      if (vec_cmpud_all_lt (d_exp, exp_256))
+			{
+			  d_exp = vec_subudm (d_exp, exp_128);
+			  if (vec_cmpud_all_eq (d_exp, (vui64_t) q_zero))
+			    {
+			      // if (d_exp == 128) then shift 128 not 0 bits
+			      c_sig_l = c_sig;
+			      c_sig = (vui128_t) q_zero;
+			      p_odd = (vui128_t) q_zero;
+			    }
+			  else
+			    {
+			      l_exp = vec_subudm (exp_128, d_exp);
+			      t_sig = vec_srq (c_sig, (vui128_t) d_exp);
+			      c_sig_l = vec_slq (c_sig, (vui128_t) l_exp);
+			      p_odd = vec_addcuq (c_sig_l, (vui128_t) q_ones);
+			      c_sig_l = (vui128_t) vec_or ((vui32_t) t_sig,
+							   (vui32_t) p_odd);
+			      c_sig = (vui128_t) q_zero;
+			    }
+			}
+		      else
+			{
+			  p_odd = vec_addcuq (c_sig, (vui128_t) q_ones);
+			  c_sig = (vui128_t) q_zero;
+			  c_sig_l = p_odd;
+			}
+		      t_sig = c_sig;
+		    }
+
+		  if (vec_all_eq(q_sign, c_sign))
+		    { // Same sign, simple add
+		      carry = vec_addcuq (c_sig_l, p_sig_l);
+		      p_sig_l = vec_adduqm (c_sig_l, p_sig_l);
+		      q_sig = vec_addeuqm (t_sig, p_sig_h, carry);
+		      p_sig_h = q_sig;
+		      // q_sign = q_sign;
+		    }
+		  else
+		    {
+		      carry = vec_subcuq (p_sig_l, c_sig_l);
+		      p_sig_l = vec_subuqm (p_sig_l, c_sig_l);
+		      q_sig = vec_subeuqm (p_sig_h, t_sig, carry);
+		      p_sig_h = q_sig;
+		      // q_sign = q_sign;
+		    }
+
+		}
+	      else
+		{
+		  // 2b) If q_exp < c_exp
+		  // Shift p_sig_h | p_sig_l right by (c_exp - q_exp)
+		  vui64_t d_exp, l_exp;
+		  vui128_t t_sig, carry;
+		  //vb128_t exp_mask;
+		  const vui64_t exp_128 = vec_const64_f128_128 ();
+		  const vui64_t exp_256 = vec_addudm (exp_128, exp_128);
+
+		  d_exp = vec_subudm (c_exp, q_exp);
+		  //exp_mask = (vb128_t) vec_cmpltud (d_exp, exp_128);
+		  if (vec_cmpud_all_lt (d_exp, exp_128))
+		    {
+		      // if (d_exp < 128) then shift right 1-127 bits
+		      vui128_t p_sig_x;
+		      l_exp = vec_subudm (exp_128, d_exp);
+		      // Isolate bits shifted out of P_sig_l for x-bit
+		      p_sig_x = vec_slq (p_sig_l, (vui128_t) l_exp);
+		      t_sig = vec_srq (p_sig_h, (vui128_t) d_exp);
+		      p_sig_l = vec_sldq (p_sig_h, p_sig_l, (vui128_t) l_exp);
+		      p_odd = vec_addcuq (p_sig_x, (vui128_t) q_ones);
+		      p_sig_l = (vui128_t) vec_or ((vui32_t) p_sig_l,
+						   (vui32_t) p_odd);
+		      p_sig_h = t_sig;
+		    }
+		  else
+		    {
+		      if (vec_cmpud_all_lt (d_exp, exp_256))
+			{
+			  d_exp = vec_subudm (d_exp, exp_128);
+			  if (vec_cmpud_all_eq (d_exp, (vui64_t) q_zero))
+			    {
+			      // if (d_exp == 128) then shift 128 (not 0 bits)
+			      p_odd = vec_addcuq (p_sig_l, (vui128_t) q_ones);
+			      p_sig_l = (vui128_t) vec_or ((vui32_t) p_sig_h,
+							   (vui32_t) p_odd);
+			      p_sig_h = (vui128_t) q_zero;
+			    }
+			  else
+			    {
+			      // if (d_exp > 128) then shift right 128+ bits
+			      vui128_t p_sig_x;
+			      l_exp = vec_subudm (exp_128, d_exp);
+			      t_sig = vec_srq (p_sig_h, (vui128_t) d_exp);
+			      p_sig_x = vec_slq (p_sig_h, (vui128_t) l_exp);
+			      p_sig_x = (vui128_t) vec_or ((vui32_t) p_sig_x,
+							   (vui32_t) p_sig_l);
+			      p_odd = vec_addcuq (p_sig_x, (vui128_t) q_ones);
+			      p_sig_l = (vui128_t) vec_or ((vui32_t) t_sig,
+							   (vui32_t) p_odd);
+			      p_sig_h = (vui128_t) q_zero;
+			    }
+			}
+		      else
+			{ // Shift >= 256, Accumulate all bits from p_sig_h | p_sig_l into x-bit
+			  t_sig = (vui128_t) vec_or ((vui32_t) p_sig_h,
+						     (vui32_t) p_sig_l);
+			  p_odd = vec_addcuq (t_sig, (vui128_t) q_ones);
+			  // Zero all product bits (includeing GR) while preserving X-bit
+			  p_sig_h = (vui128_t) q_zero;
+			  p_sig_l = p_odd;
+			}
+		    }
+
+		  c_sig_l = (vui128_t) q_zero;
+		  if (vec_all_eq(q_sign, c_sign))
+		    { // Same sign, simple add
+		      carry = vec_addcuq (c_sig_l, p_sig_l);
+		      p_sig_l = vec_adduqm (c_sig_l, p_sig_l);
+		      p_sig_h = vec_addeuqm (c_sig, p_sig_h, carry);
+		      q_sig = p_sig_h;
+		      q_sign = c_sign;
+		    }
+		  else
+		    {
+		      carry = vec_subcuq (c_sig_l, p_sig_l);
+		      p_sig_l = vec_subuqm (c_sig_l, p_sig_l);
+		      p_sig_h = vec_subeuqm (c_sig, p_sig_h, carry);
+		      q_sig = p_sig_h;
+		      q_sign = c_sign;
+		    }
+		  q_exp = c_exp;
+		}
+	    }
+
+	}
+
+      // check for significand overfloaw again
+	{
+	  vb128_t carry_mask;
+	  vui128_t sig_h, sig_l;
+	  // Test Carry-bit (greater than L-bit)
+	  vui16_t sig_l_mask = vec_splat_u16(1);
+	  vui16_t t_sig = vec_splat ((vui16_t) p_sig_h, VEC_HW_H);
+	  carry_mask = (vb128_t) vec_cmpgt (t_sig, sig_l_mask);
+	  // Shift double quadword right 1 bit
+	  p_tmp = vec_sldqi (p_sig_h, p_sig_l, 120);
+	  sig_h = vec_srqi (p_sig_h, 1);
+	  sig_l = vec_slqi (p_tmp, 7);
+	  // Increment the exponent
+	  x_exp = vec_addudm (q_exp, exp_one);
+	  // Select original or normalized exp/sig
+	  p_sig_h = vec_seluq (p_sig_h, sig_h, carry_mask);
+	  p_sig_l = vec_seluq (p_sig_l, sig_l, carry_mask);
+	  q_exp = vec_selud (q_exp, x_exp, (vb64_t) carry_mask);
+	}
+      // There are two cases for denormal
+      // 1) The sum of unbiased exponents is less the E_min (tiny).
+      // 2) The significand is less then 1.0 (C and L-bits are zero).
+      //  2a) The exponent is > E_min
+      //  2b) The exponent is == E_min
+      //
+      // Check for Tiny exponent
+      if (__builtin_expect (
+	  (vec_cmpsd_all_lt ((vi64_t) q_exp, (vi64_t) exp_min)), 0))
+	{
+	  //const vui64_t exp_128 = (vui64_t) { 128, 128 };
+	  const vui64_t exp_128 = vec_const64_f128_128();
+	  const vui64_t too_tiny = (vui64_t) { 116, 116 };
+	  // const vui32_t xmask = CONST_VINT128_W(0x1fffffff, -1, -1, -1);
+	  vui32_t xmask = (vui32_t) vec_srqi ((vui128_t) q_ones, 3);
+	  vui32_t tmp;
+
+	  // Intermediate result is tiny, unbiased exponent < -16382
+	  //x_exp = vec_subudm ((vui64_t) exp_tiny, q_exp);
+	  x_exp = vec_subudm (exp_min, q_exp);
+
+	  if (vec_cmpud_all_gt ((vui64_t) x_exp, too_tiny))
+	    {
+	      // Intermediate result is too tiny, the shift will
+	      // zero the fraction and the GR-bit leaving only the
+	      // Sticky bit. The X-bit needs to include all bits
+	      // from p_sig_h and p_sig_l
+	      p_sig_l = vec_srqi (p_sig_l, 8);
+	      p_sig_l = (vui128_t) vec_or ((vui32_t) p_sig_l,
+					   (vui32_t) p_sig_h);
+	      // generate a carry into bit-2 for any nonzero bits 3-127
+	      p_sig_l = vec_adduqm (p_sig_l, (vui128_t) xmask);
+	      q_sig = (vui128_t) q_zero;
+	      p_sig_l = (vui128_t) vec_andc ((vui32_t) p_sig_l, xmask);
+	    }
+	  else
+	    { // Normal tiny, right shift may loose low order bits
+	      // from p_sig_l. So collect any 1-bits below GRX and
+	      // OR them into the X-bit, before the right shift.
+	      vui64_t l_exp;
+
+	      // Propagate low order bits into the sticky bit
+	      // GRX left adjusted in p_sig_l
+	      // Issolate bits below GDX (bits 3-128).
+	      tmp = vec_and ((vui32_t) p_sig_l, xmask);
+	      // generate a carry into bit-2 for any nonzero bits 3-127
+	      tmp = (vui32_t) vec_adduqm ((vui128_t) tmp, (vui128_t) xmask);
+	      // Or this with the X-bit to propagate any sticky bits into X
+	      p_sig_l = (vui128_t) vec_or ((vui32_t) p_sig_l, tmp);
+	      p_sig_l = (vui128_t) vec_andc ((vui32_t) p_sig_l, xmask);
+
+	      l_exp = vec_subudm (exp_128, x_exp);
+	      p_sig_l = vec_sldq (p_sig_h, p_sig_l, (vui128_t) l_exp);
+	      p_sig_h = vec_srq (p_sig_h, (vui128_t) x_exp);
+	      q_sig = p_sig_h;
+	    }
+	  // Set the exponent for denormal
+	  q_exp = exp_dnrm;
+	}
+      // Exponent is not tiny but significand may be denormal
+      // Isolate sig CL bits and compare
+      vui16_t t_sig = vec_splat ((vui16_t) p_sig_h, VEC_HW_H);
+      if (__builtin_expect ((vec_all_eq(t_sig, (vui16_t ) q_zero)), 0))
+	{
+	  // Is below normal range. This can happen when
+	  // multiplying a denormal by a normal.
+	  // So try to normalize the significand.
+	  //const vui64_t exp_15 = { 15, 15 };
+	  const vui64_t exp_15 = vec_splat_u64 (15);
+	  vui64_t c_exp, d_exp;
+	  vui128_t c_sig;
+	  vb64_t exp_mask;
+
+#if 0
+	  const vui64_t exp_112 = vec_const64_f128_112();
+	  // Not sure this test is needed here
+	  if (vec_cmpuq_all_eq (p_sig_h, (vui128_t) q_zero)
+	      && vec_cmpud_all_gt ((vui64_t) q_exp, exp_112))
+	    {
+	      vui128_t t_sig;
+	      t_sig = (vui128_t) vec_sld ((vui32_t) p_sig_h, (vui32_t) p_sig_l, 14);
+	      p_sig_l = vec_slqi (p_sig_l, 112);
+	      p_sig_h = t_sig;
+	      q_exp = vec_subudm (q_exp, exp_112);
+	      print_vint128x (" exp (adj?):", (vui128_t) q_exp);
+	      print_vint128x (" sig (lsht):", (vui128_t) p_sig_h);
+	      print_vint128x ("     (lsht):", (vui128_t) p_sig_l);
+	      q_sig = p_sig_h;
+	    }
+#endif
+	  c_sig = vec_clzq (p_sig_h);
+	  c_exp = vec_splatd ((vui64_t) c_sig, VEC_DW_L);
+	  c_exp = vec_subudm (c_exp, exp_15);
+	  d_exp = vec_subudm (q_exp, exp_min);
+	  d_exp = vec_minud (c_exp, d_exp);
+	  exp_mask = vec_cmpgtud (q_exp, c_exp);
+
+	  // Intermediate result <= tiny, unbiased exponent <= -16382
+	  if (vec_cmpsd_all_gt ((vi64_t) q_exp, (vi64_t) exp_min))
+	    {
+	      // Try to normalize the significand.
+	      p_sig_h = vec_sldq (p_sig_h, p_sig_l, (vui128_t) d_exp);
+	      p_sig_l = vec_slq (p_sig_l, (vui128_t) d_exp);
+	      q_sig = p_sig_h;
+	      // Compare computed exp to shift count to normalize.
+	      //exp_mask = vec_cmpgtud (q_exp, c_exp);
+	      q_exp = vec_subudm (q_exp, d_exp);
+	      q_exp = vec_selud (exp_dnrm, q_exp, exp_mask);
+	    }
+	  else
+	    { // sig is denormal range (L-bit is 0). Set exp to zero.
+	      q_exp = exp_dnrm;
+	    }
+	}
+
+      // Round to odd from lower product bits
+      p_odd = vec_addcuq (p_sig_l, (vui128_t) q_ones);
+      q_sig = (vui128_t) vec_or ((vui32_t) q_sig, (vui32_t) p_odd);
+
+      // Check for exponent overflow -> __FLT128_MAX__ (round to odd)
+      if (__builtin_expect ((vec_cmpud_all_ge ( q_exp, exp_naninf)), 0))
+	{
+	  // Intermediate result is huge, unbiased exponent > 16383
+	  // so return __FLT128_MAX__ with the appropriate sign.
+	  const vui32_t f128_max = CONST_VINT128_W(0x7ffeffff, -1, -1, -1);
+	  vui32_t f128_smax = vec_or ((vui32_t) f128_max, q_sign);
+	  return vec_xfer_vui32t_2_bin128 (f128_smax);
+	}
+      else // combine sign, exp, and significand for return
+	{
+	  // Merge sign, significand, and exponent into final result
+	  q_sig = (vui128_t) vec_or ((vui32_t) q_sig, q_sign);
+	  vui32_t tmp, t128;
+	  // convert DW exp_naninf to QW expmask
+	  vui32_t expmask = vec_sld ((vui32_t) exp_naninf, q_zero, 14);
+	  // convert q_exp from DW to QW for QP format
+	  tmp = vec_sld ((vui32_t) q_exp, q_zero, 14);
+	  t128 = vec_sel ((vui32_t) q_sig, tmp, expmask);
+	  result = vec_xfer_vui32t_2_bin128 (t128);
+	  return result;
+	}
+    }
+  else
+    { // One, two, or three operands are NaN or Infinity
+      //const vui32_t q_nan = CONST_VINT128_W(0x00008000, 0, 0, 0);
+      vui32_t q_nan = vec_mask128_f128Qbit ();
+      vui32_t q_inf = vec_mask128_f128exp ();
+#if 1
+      c_mag = (vui128_t) vec_and_bin128_2_vui32t (vfc, magmask);
+      c_sign = vec_andc_bin128_2_vui32t (vfc, magmask);
+#endif
+      // the product operands are NaN or Infinity
+      if (vec_cmpud_any_eq (x_exp, exp_naninf))
+	{
+	  // One or more operands are NaN
+	  if (vec_all_isnanf128 (vfa))
+	    {
+	      // vfa is NaN, Convert vfa to QNaN and return
+	      vui32_t vf128 = vec_or_bin128_2_vui32t (vfa, q_nan);
+	      return vec_xfer_vui32t_2_bin128 (vf128);
+	    }
+	  else if (vec_all_isnanf128 (vfb))
+	    {
+	      if (vec_all_isnanf128 (vfc))
+		{
+		  // vfb is NaN, Convert vfc to QNaN and return
+		  vui32_t vf128 = vec_or_bin128_2_vui32t (vfc, q_nan);
+		  return vec_xfer_vui32t_2_bin128 (vf128);
+		}
+	      else
+		{
+		  // vfb is NaN, Convert vfb to QNaN and return
+		  vui32_t vf128 = vec_or_bin128_2_vui32t (vfb, q_nan);
+		  return vec_xfer_vui32t_2_bin128 (vf128);
+		}
+	    }
+	  else  // Or one or both operands are Infinity
+	    {
+	      if (vec_cmpud_all_eq (x_exp, (vui64_t) exp_naninf))
+		{
+		  // Infinity x Infinity == signed Infinity
+		  q_sig = (vui128_t) q_inf;
+		}
+	      else
+		{
+		  // One each Infinity/Finite value, check for 0.0
+		  if (vec_cmpuq_all_eq (a_mag, (vui128_t) q_zero)
+		      || vec_cmpuq_all_eq (b_mag, (vui128_t) q_zero))
+		    {
+		      if (vec_all_isnanf128 (vfc))
+			{
+			      // vfb is NaN, Convert vfb to QNaN and return
+			      vui32_t vf128 = vec_or_bin128_2_vui32t (vfc, q_nan);
+			      return vec_xfer_vui32t_2_bin128 (vf128);
+			}
+		      else
+		      // Inifinty x Zero is Default Quiet NaN
+		        return vec_const_nanf128 ();
+		    }
+		  else // an Infinity and a Nonzero finite number
+		    {
+		      // Return Infinity with product sign.
+		      q_sig = (vui128_t) q_inf;
+		    }
+		}
+	      // At this point we have a signed infinity product
+	      // Need to check addend for nan/infinity
+	      if (vec_all_isnanf128 (vfc))
+		{
+		  // vfc is NaN, Convert vfc to QNaN and return
+		  vui32_t vf128 = vec_or_bin128_2_vui32t (vfc, q_nan);
+		  return vec_xfer_vui32t_2_bin128 (vf128);
+		}
+	      else  // Or addend is also Infinity
+		{
+		  if (vec_cmpud_all_eq (c_exp, exp_naninf)
+		      && vec_cmpud_any_ne ((vui64_t) q_sign, (vui64_t) c_sign))
+		    { // Both operands infinity and opposite sign
+		      // Inifinty + Infinity (opposite sign) is Default Quiet NaN
+		      return vec_const_nanf128 ();
+		    }
+		    }
+	      // Merge sign, exp/sig into final result
+	      q_sig = (vui128_t) vec_or ((vui32_t) q_sig, q_sign);
+	      return vec_xfer_vui128t_2_bin128 (q_sig);
+	    }
+	}
+      else // The product is finite but the addend is not
+	{
+	      if (vec_all_isnanf128 (vfc))
+		{
+		  // vfa is NaN, Convert vfa to QNaN and return
+		  vui32_t vf128 = vec_or_bin128_2_vui32t (vfc, q_nan);
+		  return vec_xfer_vui32t_2_bin128 (vf128);
+		}
+	      else  // Or addend is Infinity
+		{
+		  // return infinity
+		  return vfc;
+		}
+	}
+    }
+#else
+  result = vfa * vfb;
+#endif
+  return result;
 }
 
 __binary128
@@ -3829,7 +4776,7 @@ test_vec_mulqpo (__binary128 vfa, __binary128 vfb)
 #endif
   return result;
 #elif  defined (_ARCH_PWR7)
-  vui64_t q_exp, a_exp, b_exp, x_exp;
+  vui64_t q_exp, x_exp;
   vui128_t q_sig, a_sig, b_sig, p_sig_h, p_sig_l, p_odd;
   vui32_t q_sign, a_sign, b_sign;
   vui128_t a_mag, b_mag;
@@ -4038,8 +4985,7 @@ test_vec_mulqpo (__binary128 vfa, __binary128 vfb)
 	      q_exp = exp_dnrm;
 	    }
 	}
-      // Merge sign early will not effect rounding for this mode
-      // q_ssig = vec_or ((vui32_t) q_sig, q_sign);
+
       // Round to odd from lower product bits
       p_odd = vec_addcuq (p_sig_l, (vui128_t) q_ones);
       q_sig = (vui128_t) vec_or ((vui32_t) q_sig, (vui32_t) p_odd);
@@ -4135,7 +5081,7 @@ test_vec_mulqpo_V7 (__binary128 vfa, __binary128 vfb)
       : );
 #endif
 #elif  defined (_ARCH_PWR7)
-  vui64_t q_exp, a_exp, b_exp, x_exp;
+  vui64_t q_exp, x_exp;
   vui128_t q_sig, a_sig, b_sig, p_sig_h, p_sig_l, p_odd;
   vui32_t q_sign, a_sign, b_sign;
   // const vui64_t q_zero = { 0, 0 };
@@ -4425,8 +5371,7 @@ test_vec_mulqpo_V7 (__binary128 vfa, __binary128 vfb)
 	      q_exp = exp_dnrm;
 	    }
 	}
-      // Merge sign early will not effect rounding for this mode
-      // q_ssig = vec_or ((vui32_t) q_sig, q_sign);
+
       // Round to odd from lower product bits
       p_odd = vec_addcuq (p_sig_l, (vui128_t) q_ones);
       q_sig = (vui128_t) vec_or ((vui32_t) q_sig, (vui32_t) p_odd);
@@ -4487,8 +5432,6 @@ test_vec_mulqpo_V7 (__binary128 vfa, __binary128 vfb)
 	  const vui32_t magmask = vec_mask128_f128mag();
 	  a_mag = (vui128_t) vec_and_bin128_2_vui32t (vfa, magmask);
 	  b_mag = (vui128_t) vec_and_bin128_2_vui32t (vfb, magmask);
-	  a_exp = vec_splatd (x_exp, VEC_DW_H);
-	  // b_exp = vec_splatd (x_exp, VEC_DW_L);
 	  if (vec_cmpud_all_eq (x_exp, (vui64_t) exp_naninf))
 	    {
 	      // Infinity x Infinity == signed Infinity
@@ -8222,7 +9165,7 @@ test_vec_xxxsigqpp_V2 (vui128_t a_mag, vui128_t b_mag)
         const vui32_t q_zero = CONST_VINT128_W (0, 0, 0, 0);
 	const vui32_t hidden = vec_mask128_f128Lbit();
 	const  vui32_t sigmask = vec_mask128_f128sig();
-	vui32_t a_norm, b_norm, x_norm;
+	vui32_t a_norm, b_norm;
 	vui32_t a_s32, b_s32;
 	vui32_t a_e32, b_e32;
 	// Assume that the operands are finite
@@ -8502,37 +9445,37 @@ test_cosf128 (__binary128 value)
 #endif
 
 vb128_t
-_test_f128_isinff128 (__Float128 value)
+_test_f128_isinff128 (__binary128 value)
 {
   return (vec_isinff128 (value));
 }
 
 int
-_test_f128_isinf_sign (__Float128 value)
+_test_f128_isinf_sign (__binary128 value)
 {
   return (vec_isinf_signf128 (value));
 }
 
 vb128_t
-_test_f128_isnan (__Float128 value)
+_test_f128_isnan (__binary128 value)
 {
   return (vec_isnanf128 (value));
 }
 
 vb128_t
-_test_pred_f128_finite (__Float128 value)
+_test_pred_f128_finite (__binary128 value)
 {
   return (vec_isfinitef128 (value));
 }
 
 vb128_t
-_test_pred_f128_normal (__Float128 value)
+_test_pred_f128_normal (__binary128 value)
 {
   return (vec_isnormalf128 (value));
 }
 
 vb128_t
-_test_pred_f128_subnormal (__Float128 value)
+_test_pred_f128_subnormal (__binary128 value)
 {
   return (vec_issubnormalf128 (value));
 }
@@ -8552,31 +9495,31 @@ _test_xfer_bin128_2_vui16t (__binary128 f128)
 // __clang__ has a bug whenever -mfloat128 is enabled, maybe clang 10.0.1
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 int
-test_gcc_f128_signbit (__Float128 value)
+test_gcc_f128_signbit (__binary128 value)
   {
     return (signbit(value));
   }
 
 int
-test_gcc_f128_isinf (__Float128 value)
+test_gcc_f128_isinf (__binary128 value)
   {
     return (isinf(value));
   }
 
 int
-test_gcc_float128_isnan (__Float128 value)
+test_gcc_float128_isnan (__binary128 value)
   {
     return (isnan(value));
   }
 
-__Float128
-test_gcc_f128_copysign (__Float128 valx, __Float128 valy)
+__binary128
+test_gcc_f128_copysign (__binary128 valx, __binary128 valy)
   {
     return (__builtin_copysignf128(valx, valy));
   }
 
 int
-test_glibc_f128_classify (__Float128 value)
+test_glibc_f128_classify (__binary128 value)
   {
     if (isfinite(value))
     return 1;

--- a/src/testsuite/vec_perf_f128.c
+++ b/src/testsuite/vec_perf_f128.c
@@ -84,6 +84,26 @@ const __float128 qpfact6 = 720.0Q;
 const __float128 qpfact7 = 5040.0Q;
 const __float128 qpfact8 = 40320.0Q;
 
+const __float128 f128_fact1 = (1.0Q / 1.0Q);
+const __float128 f128_fact2 = (1.0Q / 2.0Q);
+const __float128 f128_fact3 = (1.0Q / 6.0Q);
+const __float128 f128_fact4 = (1.0Q / 24.0Q);
+const __float128 f128_fact5 = (1.0Q / 120.0Q);
+const __float128 f128_fact6 = (1.0Q / 720.0Q);
+const __float128 f128_fact7 = (1.0Q / 5040.0Q);
+const __float128 f128_fact8 = (1.0Q / 40320.0Q);
+
+__float128 f128_invfact[] = {
+    (1.0Q / 1.0Q),
+    (1.0Q / 2.0Q),
+    (1.0Q / 6.0Q),
+    (1.0Q / 24.0Q),
+    (1.0Q / 120.0Q),
+    (1.0Q / 720.0Q),
+    (1.0Q / 5040.0Q),
+    (1.0Q / 40320.0Q)
+};
+
 const vui128_t i128fact1 = {1};
 const vui128_t i128fact2 = {2};
 const vui128_t i128fact3 = {6};
@@ -92,6 +112,27 @@ const vui128_t i128fact5 = {120};
 const vui128_t i128fact6 = {720};
 const vui128_t i128fact7 = {5040};
 const vui128_t i128fact8 = {40320};
+
+#if 1 // turn off until Round-to-odd implementation is ready
+extern __binary128 test_vec_maddqpo (__binary128 vfa, __binary128 vfb, __binary128 vfc);
+
+__float128
+test_scalarLib_exp_128 (__float128 x, __float128 a, __float128 expa)
+{
+  __float128 term;
+
+  // 1st 8 terms of e = 1 + 1/1! + 1/2!+ 1/3! ...
+  term = test_vec_maddqpo (f128_one, f128_fact1, f128_one);
+  term = test_vec_maddqpo (f128_one, f128_fact2, term);
+  term = test_vec_maddqpo (f128_one, f128_fact3, term);
+  term = test_vec_maddqpo (f128_one, f128_fact4, term);
+  term = test_vec_maddqpo (f128_one, f128_fact5, term);
+  term = test_vec_maddqpo (f128_one, f128_fact6, term);
+  term = test_vec_maddqpo (f128_one, f128_fact7, term);
+
+  return test_vec_maddqpo (f128_one, f128_fact8, term);
+}
+#endif
 
 #if 0 // turn off until Round-to-odd implementation is ready
 __float128
@@ -102,30 +143,30 @@ test_scalarLib_expxsuba_128 (__float128 x, __float128 a, __float128 expa)
   __float128 xma6, xmaf6, xma7, xmaf7, xma8, xmaf8;
 
   // 1st 8 terms of e**x = e**a * taylor( x-a )
-  xma = test_scalar_sub128 (x, a);
-  term = test_scalar_add128 (f128_one, xma);
-  xma2 = test_scalar_mul128 (xma, xma);
-  xmaf2 = test_scalar_mul128 (xma2, inv_fact2);
-  term = test_scalar_add128 (term, xmaf2);
-  xma3 = test_scalar_mul128 (xma2, xma);
-  xmaf3 = test_scalar_mul128 (xma3, inv_fact3);
-  term = test_scalar_add128 (term, xmaf3);
-  xma4 = test_scalar_mul128 (xma3, xma);
-  xmaf4 = test_scalar_mul128 (xma4, inv_fact4);
-  term = test_scalar_add128 (term, xmaf4);
-  xma5 = test_scalar_mul128 (xma4, xma);
-  xmaf5 = test_scalar_mul128 (xma5, inv_fact5);
-  term = test_scalar_add128 (term, xmaf5);
-  xma6 = test_scalar_mul128 (xma5, xma);
-  xmaf6 = test_scalar_mul128 (xma6, inv_fact6);
-  term = test_scalar_add128 (term, xmaf6);
-  xma7 = test_scalar_mul128 (xma6, xma);
-  xmaf7 = test_scalar_mul128 (xma7, inv_fact7);
-  term = test_scalar_add128 (term, xmaf7);
-  xma8 = test_scalar_mul128 (xma7, xma);
-  xmaf8 = test_scalar_mul128 (xma8, inv_fact8);
-  term = test_scalar_add128 (term, xmaf8);
-  return test_scalar_mul128(expa, term);;
+  xma = test_gcc_subqpn_f128 (x, a);
+  term = test_gcc_addqpn_f128 (f128_one, xma);
+  xma2 = test_gcc_mulqpn_f128 (xma, xma);
+  xmaf2 = test_gcc_mulqpn_f128 (xma2, inv_fact2);
+  term = test_gcc_addqpn_f128 (term, xmaf2);
+  xma3 = test_gcc_mulqpn_f128 (xma2, xma);
+  xmaf3 = test_gcc_mulqpn_f128 (xma3, inv_fact3);
+  term = test_gcc_addqpn_f128 (term, xmaf3);
+  xma4 = test_gcc_mulqpn_f128 (xma3, xma);
+  xmaf4 = test_gcc_mulqpn_f128 (xma4, inv_fact4);
+  term = test_gcc_addqpn_f128 (term, xmaf4);
+  xma5 = test_gcc_mulqpn_f128 (xma4, xma);
+  xmaf5 = test_gcc_mulqpn_f128 (xma5, inv_fact5);
+  term = test_gcc_addqpn_f128 (term, xmaf5);
+  xma6 = test_gcc_mulqpn_f128 (xma5, xma);
+  xmaf6 = test_gcc_mulqpn_f128 (xma6, inv_fact6);
+  term = test_gcc_addqpn_f128 (term, xmaf6);
+  xma7 = test_gcc_mulqpn_f128 (xma6, xma);
+  xmaf7 = test_gcc_mulqpn_f128 (xma7, inv_fact7);
+  term = test_gcc_addqpn_f128 (term, xmaf7);
+  xma8 = test_gcc_mulqpn_f128 (xma7, xma);
+  xmaf8 = test_gcc_mulqpn_f128 (xma8, inv_fact8);
+  term = test_gcc_addqpn_f128 (term, xmaf8);
+  return test_gcc_mulqpn_f128(expa, term);;
 }
 #endif
 
@@ -448,6 +489,82 @@ test_lib_mulqpn_f128 (__binary128 * vf128,
   *vf128 = result;
 }
 
+extern __binary128
+test_vec_maddqpo (__binary128, __binary128, __binary128);
+
+// term1st == const __float128 f128_one = 1.0Q;
+// f128_fact[] ==
+#if 0
+  const __float128 f128_fact0 = (1.0Q / 1.0Q);
+  const __float128 f128_fact1 = (1.0Q / 2.0Q);
+  const __float128 f128_fact2 = (1.0Q / 6.0Q);
+  const __float128 f128_fact3 = (1.0Q / 24.0Q);
+  const __float128 f128_fact4 = (1.0Q / 120.0Q);
+  const __float128 f128_fact5 = (1.0Q / 720.0Q);
+  const __float128 f128_fact6 = (1.0Q / 5040.0Q);
+  const __float128 f128_fact7 = (1.0Q / 40320.0Q);
+#endif
+
+__float128
+test_lib_maddqpo_f128 (__float128 term1st, __float128 f128_fact[])
+{
+  const __float128 f128_one = 1.0Q;
+  //const __float128 f128_e = 2.71828182845904523536028747135266249775724709369996Q;
+  __float128 term;
+
+  // 1st 8 terms of e = 1 + 1/1! + 1/2!+ 1/3! ...
+  term = test_vec_maddqpo (term1st, f128_fact[0], term1st);
+  term = test_vec_maddqpo (term1st, f128_fact[1], term);
+  term = test_vec_maddqpo (term1st, f128_fact[2], term);
+  term = test_vec_maddqpo (term1st, f128_fact[3], term);
+  term = test_vec_maddqpo (term1st, f128_fact[4], term);
+  term = test_vec_maddqpo (term1st, f128_fact[5], term);
+  term = test_vec_maddqpo (term1st, f128_fact[6], term);
+
+  return test_vec_maddqpo (f128_one, f128_fact[7], term);
+}
+
+__float128
+test_gcc_maddqpn_f128 (__float128 term1st, __float128 f128_fact[])
+{
+  //const __float128 f128_one = 1.0Q;
+  //const __float128 f128_e = 2.71828182845904523536028747135266249775724709369996Q;
+  __float128 term;
+
+#if defined (_ARCH_PWR9)
+  // 1st 8 terms of e = 1 + 1/1! + 1/2!+ 1/3! ...
+  term = __builtin_fmaf128 (f128_one, f128_fact[0], term1st);
+  term = __builtin_fmaf128 (f128_one, f128_fact[1], term);
+  term = __builtin_fmaf128 (f128_one, f128_fact[2], term);
+  term = __builtin_fmaf128 (f128_one, f128_fact[3], term);
+  term = __builtin_fmaf128 (f128_one, f128_fact[4], term);
+  term = __builtin_fmaf128 (f128_one, f128_fact[5], term);
+  term = __builtin_fmaf128 (f128_one, f128_fact[6], term);
+
+  return __builtin_fmaf128 (f128_one, f128_fact[7], term);
+#else
+  __float128 infrac;
+
+  // 1st 8 terms of e = 1 + 1/1! + 1/2!+ 1/3! ...
+  infrac = term1st * f128_fact[0];
+  term =   term1st + infrac;
+  infrac = term1st * f128_fact[1];
+  term =   term + infrac;
+  infrac = term1st * f128_fact[2];
+  term =   term + infrac;
+  infrac = term1st * f128_fact[3];
+  term =   term + infrac;
+  infrac = term1st * f128_fact[4];
+  term =   term + infrac;
+  infrac = term1st * f128_fact[5];
+  term =   term + infrac;
+  infrac = term1st * f128_fact[6];
+  term =   term + infrac;
+  infrac = term1st * f128_fact[7];
+  return term + infrac;
+#endif
+}
+
 int timed_lib_addqpo_f128 (void)
 {
 #ifndef PVECLIB_DISABLE_F128MATH
@@ -520,6 +637,23 @@ int timed_lib_mulqpn_f128 (void)
    return 0;
 }
 
+// Use static extern to avoid "set but not used" warning
+__binary128 stbl[10];
+
+int timed_lib_maddqpo_f128 (void)
+{
+#ifndef PVECLIB_DISABLE_F128MATH
+  int i;
+
+  for (i=0; i<N; i++)
+    {
+      stbl[i] = test_lib_maddqpo_f128 (f128_one,
+			     f128_invfact);
+    }
+#endif
+   return 0;
+}
+
 int timed_gcc_addqpn_f128 (void)
 {
 #ifndef PVECLIB_DISABLE_F128MATH
@@ -569,6 +703,28 @@ int timed_gcc_mulqpn_f128 (void)
 			  qpfact3, qpfact4,
 			  qpfact5, qpfact6,
 			  qpfact7, qpfact8);
+    }
+#endif
+   return 0;
+}
+
+extern __float128
+test_scalargcc_exp_f128 (__float128 term1st, __float128 f128_fact[]);
+
+int timed_gcc_maddqpn_f128 (void)
+{
+#ifndef PVECLIB_DISABLE_F128MATH
+  int i;
+
+  for (i=0; i<N; i++)
+    {
+#if 0
+      stbl[i] = test_gcc_maddqpn_f128 (f128_one,
+			     f128_invfact);
+#else
+      stbl[i] = test_scalargcc_exp_f128 (f128_one,
+			     f128_invfact);
+#endif
     }
 #endif
    return 0;

--- a/src/testsuite/vec_perf_f128.h
+++ b/src/testsuite/vec_perf_f128.h
@@ -27,6 +27,8 @@ extern int timed_expxsuba_v1_f128 (void);
 extern int timed_expxsuba_v2_f128 (void);
 #endif
 
+extern __binary128 f128_invfact[];
+
 extern int timed_gcc_max8_f128 (void);
 extern int timed_lib_max8_f128 (void);
 extern int timed_vec_max8_f128 (void);
@@ -57,5 +59,8 @@ extern int timed_lib_addqpo_f128 (void);
 
 extern int timed_gcc_subqpn_f128 (void);
 extern int timed_lib_subqpo_f128 (void);
+
+extern int timed_gcc_maddqpn_f128 (void);
+extern int timed_lib_maddqpo_f128 (void);
 
 #endif /* SRC_TESTSUITE_VEC_PERF_F128_H_ */

--- a/src/vec_runtime_DYN.c
+++ b/src/vec_runtime_DYN.c
@@ -36,7 +36,7 @@
  *
  * The base platform for Little Endian is POWER8 as the first
  * officially supported LE platform for POWER. The highest supported
- * platform is is currently POWER9.  All the latest Distros are
+ * platform is is currently POWER10.  All the latest Distros are
  * Little Endian.
  *
  * We depend on the compiler and runtime (GLIBC 2.23) to support


### PR DESCRIPTION
Power9 provide round to odd versions for the QP arithmetic operations. This patch provides P9/8 implementation for multiply-add QP with round to odd. Includes compile, unit, and performance tests.

	* src/pveclib/vec_f128_ppc.h [f128_softfloat_IRRN_0_1_3]: Update doxygen "IR for multiply" with diagrams. [f128_softfloat_IRRN_0_1_4]: New "IR for multiply add". [f128_softfloat_0_0_3_4]: New subsection "Multiply-Add Quad-Precision with Round-to-Odd". General doxygen improvements. (vec_xsmaddqpo): New inline operation. (vec_xsmulqpo): Clean up -Wall warnings for unused vars.

	* src/testsuite/arith128_test_f128.c (db_vec_maddqpo): New debug function. (test_mask_f128): Add test for vec_const64_f128_112. (test_madd_qpo_xtra_c1, test_madd_qpo_xtra_c2, test_madd_qpo_xtra_c3, test_madd_qpo_xtra_c4, test_madd_qpo_xtra_c5, test_madd_qpo_xtra_c6, test_madd_qpo_xtra_c7, test_madd_qpo_xtra_c8): New unit tests. Extra tests for non-finite operands per PowerISA 3.0C Table 71. (test_madd_qpo_xtra): New unit test combining xtra_c1-c8. Complete coverage for per PowerISA 3.0C Table 71. (test_madd_qpo_zero_c): New unit test. Test for madd with finite multiplicands and zero addend. (test_madd_qpo): New unit test. More general madd  with finite operands. (test_vec_f128): Update f128 unit test driver. Add calls to test_madd_qpo, test_madd_qpo_zero_c, test_madd_qpo_xtra.

	*src/testsuite/pveclib_perf.c (test_time_f128):
	Add timed tests timed_gcc_maddqpo_f128, timed_lib_mulqpo_f128.

	* src/testsuite/vec_f128_dummy.c (test_vec_maddqpo, test_scalarlib_exp_f128, test_scalargcc_exp_f128): New timing cores for madd operations. (test_vec_xsmaddqpo, test_vec_maddqpo): New compiler tests.

	* src/testsuite/vec_perf_f128.c (test_lib_maddqpo_f128): Use test_vec_maddqpo to compute 8 terms of e. (test_gcc_maddqpn_f128): Use __builtin_fmaf128 for P9, otherwise softfloat multiple and add to compute 8 terms of e.
	* src/testsuite/vec_perf_f128.h (timed_gcc_maddqpn_f128, timed_lib_maddqpo_f128) New externs.

	* src/testsuite/vec_pwr9_dummy.c (test_scalarLib_exp_128_PWR9): Compile test for __builtin_fmaf128.

	* src/vec_runtime_DYN.c: Update comment to include POWER10.