### PR TITLE
P9 Float128 Multiply-Sub with round to odd, plus P8 equivalent.

### DIFF
--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -270,6 +270,31 @@ test_vec_maddqpo_PWR9 (__binary128 vfa, __binary128 vfb, __binary128 vfc)
 #endif
   return result;
 }
+__binary128
+test_vec_msubqpo (__binary128 vfa, __binary128 vfb, __binary128 vfc)
+{
+  __binary128 result;
+#if defined (_ARCH_PWR9) && (__GNUC__ > 7)
+#if defined (__FLOAT128__) && (__GNUC__ > 8)
+  /* There is no __builtin for msubqpo, but the compiler should convert
+   * this fmaf128 to xsmsubqpo */
+  result = __builtin_fmaf128_round_to_odd (vfa, vfb, vec_negf128 (vfc));
+#else
+  __asm__(
+      "xsmsubqpo %0,%1,%2"
+      : "+v" (vfc)
+      : "v" (vfa), "v" (vfb)
+      : );
+  result = vfc;
+#endif
+  return result;
+#else
+  __binary128 nsrc3;
+
+  nsrc3 = vec_self128 (vec_negf128 (vfc), vfc, vec_isnanf128(vfc));
+  return vec_xsmaddqpo (vfa, vfb, nsrc3);
+#endif
+}
 
 __binary128
 test_mulqpo_PWR9 (__binary128 vfa, __binary128 vfb)


### PR DESCRIPTION
Power9 provides round to odd versions for the QP arithmetic operations. This patch provides P9/8 implementation for multiply-sub QP with round to odd. Includes compile, unit, and performance tests. Also a small bug (issue #175) common to madd/msub was found and is included in this update.

	* src/pveclib/vec_f128_ppc.h [f128_softfloat_0_0_3_4_0]: 
	Update doxygen code to match code changes. 
        [f128_softfloat_0_0_3_5]: Add doxygen text for Multiply-Sub
       Quad-Precision with Round-to-Odd. 
        [__clang_major__]: Try to fix Clang 15/16.
        (vec_xsmaddqpo): Small update to doxygen description. 
        Update code to fix issue #175. (vec_xsmsubqpo): New PVECLIB operation.

	* src/testsuite/arith128_test_f128.c (db_vec_maddqpo): 
	Update code to fix issue #175. [test_xsmaddqpo]: 
        Define operation for unit-test. [test_madd_qpo_zero_c]: 
        Add unit-test case for -0.0 addend. 
        [test_xsmsubqpo]: New unit-test operation. 
       (test_msub_qpo_xtra_c1, test_msub_qpo_xtra_c2, test_msub_qpo_xtra_c3, test_msub_qpo_xtra_c4, test_msub_qpo_xtra_c5, test_msub_qpo_xtra_c8, test_msub_qpo_xtra_c7, test_msub_qpo_xtra_c8, test_msub_qpo_xtra);
        New unit-test for PowerISA 3.0 Table 80 Actions. 
        (test_msub_qpo_zero_c): New unit-test for msubqpo with 0.0 addends. 
        (test_msub_qpo): New unit-test for msubqpo general cases. 
        (test_vec_f128): Update unit-test driver to call new unit-tests.

	* src/testsuite/vec_f128_dummy.c (test_scalargcc_exp_f128 [_ARCH_PWR9]): 
	Declare f128_one. 
        (test_vec_xsmsubqpo): New compile test for vec_f128_ppc.h. 
        (test_vec_msubqpo): New compile test. 
        (test_vec_maddqpo): Update code to fix issue #175.

	* src/testsuite/vec_pwr9_dummy.c (test_vec_msubqpo): New compile test.