### PR TITLE
Add QP round-to-odd operations to runtime library. Close #178.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -47,7 +47,7 @@ PVECCOMPILE = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 	$(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) \
 	$(AM_CFLAGS)
 
-vec_dynrt_PWR10.lo: vec_runtime_PWR10.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
+vec_dynrt_PWR10.lo: vec_runtime_PWR10.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 if am__fastdepCC
 	$(PVECCOMPILE) -fpic $(PVECLIB_POWER10_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR10.c
 	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
@@ -59,7 +59,7 @@ endif
 	$(PVECCOMPILE) -fpic $(PVECLIB_POWER10_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR10.c
 endif
 
-vec_staticrt_PWR10.lo: vec_runtime_PWR10.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
+vec_staticrt_PWR10.lo: vec_runtime_PWR10.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 if am__fastdepCC
 	$(PVECCOMPILE) -fpie $(PVECLIB_POWER10_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR10.c
 	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
@@ -71,7 +71,7 @@ endif
 	$(PVECCOMPILE) -fpie $(PVECLIB_POWER10_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR10.c
 endif
 
-vec_dynrt_PWR9.lo: vec_runtime_PWR9.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
+vec_dynrt_PWR9.lo: vec_runtime_PWR9.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 if am__fastdepCC
 	$(PVECCOMPILE) -fpic $(PVECLIB_POWER9_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR9.c
 	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
@@ -83,7 +83,7 @@ endif
 	$(PVECCOMPILE) -fpic $(PVECLIB_POWER9_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR9.c
 endif
 
-vec_staticrt_PWR9.lo: vec_runtime_PWR9.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
+vec_staticrt_PWR9.lo: vec_runtime_PWR9.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 if am__fastdepCC
 	$(PVECCOMPILE) -fpie $(PVECLIB_POWER9_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR9.c
 	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
@@ -95,7 +95,7 @@ endif
 	$(PVECCOMPILE) -fpie $(PVECLIB_POWER9_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR9.c
 endif
 
-vec_dynrt_PWR8.lo: vec_runtime_PWR8.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
+vec_dynrt_PWR8.lo: vec_runtime_PWR8.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 if am__fastdepCC
 	$(PVECCOMPILE) -fpic $(PVECLIB_POWER8_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR8.c
 	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
@@ -107,7 +107,7 @@ endif
 	$(PVECCOMPILE) -fpic $(PVECLIB_POWER8_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR8.c
 endif
 
-vec_staticrt_PWR8.lo: vec_runtime_PWR8.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
+vec_staticrt_PWR8.lo: vec_runtime_PWR8.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 if am__fastdepCC
 	$(PVECCOMPILE) -fpie $(PVECLIB_POWER8_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR8.c
 	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
@@ -119,7 +119,7 @@ endif
 	$(PVECCOMPILE) -fpie $(PVECLIB_POWER8_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR8.c
 endif
 
-vec_dynrt_PWR7.lo: vec_runtime_PWR7.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
+vec_dynrt_PWR7.lo: vec_runtime_PWR7.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 if am__fastdepCC
 	$(PVECCOMPILE) -fpic $(PVECLIB_POWER7_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR7.c
 	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
@@ -131,7 +131,7 @@ endif
 	$(PVECCOMPILE) -fpic $(PVECLIB_POWER7_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR7.c
 endif
 
-vec_staticrt_PWR7.lo: vec_runtime_PWR7.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
+vec_staticrt_PWR7.lo: vec_runtime_PWR7.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 if am__fastdepCC
 	$(PVECCOMPILE) -fpie $(PVECLIB_POWER7_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR7.c
 	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -1974,56 +1974,56 @@ uninstall-am: uninstall-libLTLIBRARIES uninstall-pveclibincludeHEADERS
 .PRECIOUS: Makefile
 
 
-vec_dynrt_PWR10.lo: vec_runtime_PWR10.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
+vec_dynrt_PWR10.lo: vec_runtime_PWR10.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 @am__fastdepCC_TRUE@	$(PVECCOMPILE) -fpic $(PVECLIB_POWER10_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR10.c
 @am__fastdepCC_TRUE@	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	source='vec_runtime_PWR10.c' object='$@' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(PVECCOMPILE) -fpic $(PVECLIB_POWER10_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR10.c
 
-vec_staticrt_PWR10.lo: vec_runtime_PWR10.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
+vec_staticrt_PWR10.lo: vec_runtime_PWR10.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 @am__fastdepCC_TRUE@	$(PVECCOMPILE) -fpie $(PVECLIB_POWER10_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR10.c
 @am__fastdepCC_TRUE@	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	source='vec_runtime_PWR10.c' object='$@' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(PVECCOMPILE) -fpie $(PVECLIB_POWER10_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR10.c
 
-vec_dynrt_PWR9.lo: vec_runtime_PWR9.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
+vec_dynrt_PWR9.lo: vec_runtime_PWR9.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 @am__fastdepCC_TRUE@	$(PVECCOMPILE) -fpic $(PVECLIB_POWER9_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR9.c
 @am__fastdepCC_TRUE@	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	source='vec_runtime_PWR9.c' object='$@' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(PVECCOMPILE) -fpic $(PVECLIB_POWER9_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR9.c
 
-vec_staticrt_PWR9.lo: vec_runtime_PWR9.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
+vec_staticrt_PWR9.lo: vec_runtime_PWR9.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 @am__fastdepCC_TRUE@	$(PVECCOMPILE) -fpie $(PVECLIB_POWER9_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR9.c
 @am__fastdepCC_TRUE@	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	source='vec_runtime_PWR9.c' object='$@' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(PVECCOMPILE) -fpie $(PVECLIB_POWER9_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR9.c
 
-vec_dynrt_PWR8.lo: vec_runtime_PWR8.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
+vec_dynrt_PWR8.lo: vec_runtime_PWR8.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 @am__fastdepCC_TRUE@	$(PVECCOMPILE) -fpic $(PVECLIB_POWER8_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR8.c
 @am__fastdepCC_TRUE@	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	source='vec_runtime_PWR8.c' object='$@' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(PVECCOMPILE) -fpic $(PVECLIB_POWER8_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR8.c
 
-vec_staticrt_PWR8.lo: vec_runtime_PWR8.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
+vec_staticrt_PWR8.lo: vec_runtime_PWR8.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 @am__fastdepCC_TRUE@	$(PVECCOMPILE) -fpie $(PVECLIB_POWER8_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR8.c
 @am__fastdepCC_TRUE@	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	source='vec_runtime_PWR8.c' object='$@' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(PVECCOMPILE) -fpie $(PVECLIB_POWER8_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR8.c
 
-vec_dynrt_PWR7.lo: vec_runtime_PWR7.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
+vec_dynrt_PWR7.lo: vec_runtime_PWR7.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 @am__fastdepCC_TRUE@	$(PVECCOMPILE) -fpic $(PVECLIB_POWER7_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR7.c
 @am__fastdepCC_TRUE@	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	source='vec_runtime_PWR7.c' object='$@' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(PVECCOMPILE) -fpic $(PVECLIB_POWER7_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR7.c
 
-vec_staticrt_PWR7.lo: vec_runtime_PWR7.c vec_int512_runtime.c $(pveclibinclude_HEADERS)
+vec_staticrt_PWR7.lo: vec_runtime_PWR7.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 @am__fastdepCC_TRUE@	$(PVECCOMPILE) -fpie $(PVECLIB_POWER7_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR7.c
 @am__fastdepCC_TRUE@	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	source='vec_runtime_PWR7.c' object='$@' libtool=yes @AMDEPBACKSLASH@

--- a/src/pveclib/vec_common_ppc.h
+++ b/src/pveclib/vec_common_ppc.h
@@ -198,6 +198,23 @@
  * \sa \ref mainpage_endian_issues_1_1
  */
 
+/*! \brief Macro to add platform suffix for static calls.
+ * \sa \ref main_libary_issues_0_0_0_2
+ * \sa \ref main_libary_issues_0_0 */
+#ifdef _ARCH_PWR10
+#define __VEC_PWR_IMP(FNAME) FNAME ## _PWR10
+#else
+#ifdef _ARCH_PWR9
+#define __VEC_PWR_IMP(FNAME) FNAME ## _PWR9
+#else
+#ifdef _ARCH_PWR8
+#define __VEC_PWR_IMP(FNAME) FNAME ## _PWR8
+#else
+#define __VEC_PWR_IMP(FNAME) FNAME ## _PWR7
+#endif
+#endif
+#endif
+
 /*! \brief vector of 8-bit unsigned char elements. */
 typedef __vector unsigned char vui8_t;
 /*! \brief vector of 16-bit unsigned short elements. */

--- a/src/pveclib/vec_f128_ppc.h
+++ b/src/pveclib/vec_f128_ppc.h
@@ -4699,6 +4699,17 @@ static inline __binary128 vec_xsiexpqp (vui128_t sig, vui64_t exp);
 static inline vui64_t vec_xsxexpqp (__binary128 f128);
 static inline vui128_t vec_xsxsigqp (__binary128 f128);
 static inline vui64_t vec_xxxexpqpp (__binary128 vfa, __binary128 vfb);
+
+extern __binary128
+__VEC_PWR_IMP (vec_xsaddqpo) (__binary128 vfa, __binary128 vfb);
+extern __binary128
+__VEC_PWR_IMP (vec_xsmaddqpo) (__binary128 vfa, __binary128 vfb, __binary128 vfc);
+extern __binary128
+__VEC_PWR_IMP (vec_xsmsubqpo) (__binary128 vfa, __binary128 vfb, __binary128 vfc);
+extern __binary128
+__VEC_PWR_IMP (vec_xsmulqpo) (__binary128 vfa, __binary128 vfb);
+extern __binary128
+__VEC_PWR_IMP (vec_xssubqpo) (__binary128 vfa, __binary128 vfb);
 ///@endcond
 
 /** \brief Generate doubleword splat constant 112.
@@ -6055,6 +6066,7 @@ vec_const_nansf128 ()
  *  |--------:|:-----:|:---------|
  *  |power8   | 6     | 2/cycle  |
  *  |power9   | 3     | 2/cycle  |
+ *  |power10  | 4-5   | 2/cycle  |
  *
  *  @param vfa 128-bit vector treated as a scalar __binary128.
  *  @param vfb 128-bit vector treated as a scalar __binary128.
@@ -6110,6 +6122,7 @@ vec_cmpeqtoqp (__binary128 vfa, __binary128 vfb)
  *  |--------:|:-----:|:---------|
  *  |power8   | 10    | 1/cycle  |
  *  |power9   | 3     | 2/cycle  |
+ *  |power10  | 4-5   | 2/cycle  |
  *
  *  @param vfa 128-bit vector treated as a scalar __binary128.
  *  @param vfb 128-bit vector treated as a scalar __binary128.
@@ -6173,6 +6186,7 @@ vec_cmpequzqp (__binary128 vfa, __binary128 vfb)
  *  |--------:|:-----:|:---------|
  *  |power8   | 18-30 | 1/cycle  |
  *  |power9   | 3     | 2/cycle  |
+ *  |power10  | 4-5   | 2/cycle  |
  *
  *  @param vfa 128-bit vector treated as a scalar __binary128.
  *  @param vfb 128-bit vector treated as a scalar __binary128.
@@ -6239,6 +6253,8 @@ vec_cmpequqp (__binary128 vfa, __binary128 vfb)
  *  |--------:|:-----:|:---------|
  *  |power8   | 26-35 | 2/cycle  |
  *  |power9   | 3     | 2/cycle  |
+ *  |power10  | 4-5   | 2/cycle  |
+ *
  *
  *  @param vfa 128-bit vector treated as a scalar __binary128.
  *  @param vfb 128-bit vector treated as a scalar __binary128.
@@ -6308,6 +6324,7 @@ vec_cmpgetoqp (__binary128 vfa, __binary128 vfb)
  *  |--------:|:-----:|:---------|
  *  |power8   | 28-37 | 2/cycle  |
  *  |power9   | 3     | 2/cycle  |
+ *  |power10  | 4-5   | 2/cycle  |
  *
  *  @param vfa 128-bit vector treated as a scalar __binary128.
  *  @param vfb 128-bit vector treated as a scalar __binary128.
@@ -6382,6 +6399,7 @@ vec_cmpgeuzqp (__binary128 vfa, __binary128 vfb)
  *  |--------:|:-----:|:---------|
  *  |power8   | 28-37 | 2/cycle  |
  *  |power9   | 3     | 2/cycle  |
+ *  |power10  | 4-5   | 2/cycle  |
  *
  *  @param vfa 128-bit vector treated as a scalar __binary128.
  *  @param vfb 128-bit vector treated as a scalar __binary128.
@@ -6459,6 +6477,7 @@ vec_cmpgeuqp (__binary128 vfa, __binary128 vfb)
  *  |--------:|:-----:|:---------|
  *  |power8   | 26-35 | 2/cycle  |
  *  |power9   | 3     | 2/cycle  |
+ *  |power10  | 4-5   | 2/cycle  |
  *
  *  @param vfa 128-bit vector treated as a scalar __binary128.
  *  @param vfb 128-bit vector treated as a scalar __binary128.
@@ -6528,6 +6547,7 @@ vec_cmpgttoqp (__binary128 vfa, __binary128 vfb)
  *  |--------:|:-----:|:---------|
  *  |power8   | 28-37 | 2/cycle  |
  *  |power9   | 3     | 2/cycle  |
+ *  |power10  | 4-5   | 2/cycle  |
  *
  *  @param vfa 128-bit vector treated as a scalar __binary128.
  *  @param vfb 128-bit vector treated as a scalar __binary128.
@@ -6602,6 +6622,7 @@ vec_cmpgtuzqp (__binary128 vfa, __binary128 vfb)
  *  |--------:|:-----:|:---------|
  *  |power8   | 28-37 | 2/cycle  |
  *  |power9   | 3     | 2/cycle  |
+ *  |power10  | 4-5   | 2/cycle  |
  *
  *  @param vfa 128-bit vector treated as a scalar __binary128.
  *  @param vfb 128-bit vector treated as a scalar __binary128.
@@ -6679,6 +6700,7 @@ vec_cmpgtuqp (__binary128 vfa, __binary128 vfb)
  *  |--------:|:-----:|:---------|
  *  |power8   | 26-35 | 2/cycle  |
  *  |power9   | 3     | 2/cycle  |
+ *  |power10  | 4-5   | 2/cycle  |
  *
  *  @param vfa 128-bit vector treated as a scalar __binary128.
  *  @param vfb 128-bit vector treated as a scalar __binary128.
@@ -6748,6 +6770,7 @@ vec_cmpletoqp (__binary128 vfa, __binary128 vfb)
  *  |--------:|:-----:|:---------|
  *  |power8   | 28-37 | 2/cycle  |
  *  |power9   | 3     | 2/cycle  |
+ *  |power10  | 4-5   | 2/cycle  |
  *
  *  @param vfa 128-bit vector treated as a scalar __binary128.
  *  @param vfb 128-bit vector treated as a scalar __binary128.
@@ -6822,6 +6845,7 @@ vec_cmpleuzqp (__binary128 vfa, __binary128 vfb)
  *  |--------:|:-----:|:---------|
  *  |power8   | 28-37 | 2/cycle  |
  *  |power9   | 3     | 2/cycle  |
+ *  |power10  | 4-5   | 2/cycle  |
  *
  *  @param vfa 128-bit vector treated as a scalar __binary128.
  *  @param vfb 128-bit vector treated as a scalar __binary128.
@@ -6899,6 +6923,7 @@ vec_cmpleuqp (__binary128 vfa, __binary128 vfb)
  *  |--------:|:-----:|:---------|
  *  |power8   | 26-35 | 2/cycle  |
  *  |power9   | 3     | 2/cycle  |
+ *  |power10  | 4-5   | 2/cycle  |
  *
  *  @param vfa 128-bit vector treated as a scalar __binary128.
  *  @param vfb 128-bit vector treated as a scalar __binary128.
@@ -6968,6 +6993,7 @@ vec_cmplttoqp (__binary128 vfa, __binary128 vfb)
  *  |--------:|:-----:|:---------|
  *  |power8   | 28-37 | 2/cycle  |
  *  |power9   | 3     | 2/cycle  |
+ *  |power10  | 4-5   | 2/cycle  |
  *
  *  @param vfa 128-bit vector treated as a scalar __binary128.
  *  @param vfb 128-bit vector treated as a scalar __binary128.
@@ -7042,6 +7068,7 @@ vec_cmpltuzqp (__binary128 vfa, __binary128 vfb)
  *  |--------:|:-----:|:---------|
  *  |power8   | 28-37 | 2/cycle  |
  *  |power9   | 3     | 2/cycle  |
+ *  |power10  | 4-5   | 2/cycle  |
  *
  *  @param vfa 128-bit vector treated as a scalar __binary128.
  *  @param vfb 128-bit vector treated as a scalar __binary128.
@@ -7117,6 +7144,7 @@ vec_cmpltuqp (__binary128 vfa, __binary128 vfb)
  *  |--------:|:-----:|:---------|
  *  |power8   | 6     | 2/cycle  |
  *  |power9   | 3     | 2/cycle  |
+ *  |power10  | 5-8   | 2/cycle  |
  *
  *  @param vfa 128-bit vector treated as a scalar __binary128.
  *  @param vfb 128-bit vector treated as a scalar __binary128.
@@ -7173,6 +7201,7 @@ vec_cmpnetoqp (__binary128 vfa, __binary128 vfb)
  *  |--------:|:-----:|:---------|
  *  |power8   | 10    | 1/cycle  |
  *  |power9   | 3     | 2/cycle  |
+ *  |power10  | 5-8   | 2/cycle  |
  *
  *  @param vfa 128-bit vector treated as a scalar __binary128.
  *  @param vfb 128-bit vector treated as a scalar __binary128.
@@ -7237,6 +7266,7 @@ vec_cmpneuzqp (__binary128 vfa, __binary128 vfb)
  *  |--------:|:-----:|:---------|
  *  |power8   | 18-30 | 1/cycle  |
  *  |power9   | 3     | 2/cycle  |
+ *  |power10  | 5-8   | 2/cycle  |
  *
  *  @param vfa 128-bit vector treated as a scalar __binary128.
  *  @param vfb 128-bit vector treated as a scalar __binary128.
@@ -8958,6 +8988,7 @@ vec_self128 (__binary128 vfa, __binary128 vfb, vb128_t mask)
  *  |--------:|:-----:|:---------|
  *  |power8   | 4 - 6 | 2/cycle  |
  *  |power9   |   6   | 2/cycle  |
+ *  |power10  | 3 - 4 | 4/cycle  |
  *
  *  @param f128 a 128-bit vector treated a signed __int128.
  *  @return a 128-bit vector bool of all '1's if the sign bit is '1'.
@@ -9026,6 +9057,54 @@ vec_signbitf128 (__binary128 f128)
  *  to produce the quad-precision result.
  *  The rounding mode is round to odd.
  *
+ *  This is the dynamic call ABI for IFUNC selection when dynamically
+ *  linked to the <I>libpvec.so</I> runtime library. The IFUNC resolver
+ *  will dynamically select the best implementation for processor the
+ *  application is running on. This will be one of the <B>-mcpu</B>
+ *  specific builds from the <I>libpvecstatic</I> archive. This binding occurs
+ *  on first call to the function each time the application runs.
+ *
+ *  \note For POWER9/10 use the xsaddqpo instruction.
+ *  For POWER8 use the soft-float implementation from
+ *  vec_xsaddqpo_inline().
+ *
+ *  The application may choose to statically bind to a <B>-mcpu</B>
+ *  specific build when the application is linked to <I>libpvecstatic.a</I>.
+ *  The static implementations are vec_xsaddqpo_PWR7 (BE only),
+ *  vec_xsaddqpo_PWR8, vec_xsaddqpo_PWR9 and vec_xsaddqpo_PWR10.
+ *  For applications calling a static implementation based on the
+ *  compilers <B>-mcpu=</B> option use the __VEC_PWR_IMP() macro.
+ *  For example:
+ * \code
+  result = __VEC_PWR_IMP(vec_xsaddqpo) (qpfact1, vf1);
+ * \endcode
+ *  __VEC_PWR_IMP() will add the appropriate suffix for the
+ *  compile target.
+ *
+ *  \note This operation <I>may not</I> follow the PowerISA
+ *  relative to setting the FPSCR.
+ *  However if the hardware target includes the xsaddqpo instruction,
+ *  the implementation may use that.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 54-71 | 1/cycle  |
+ *  |power9   |   12  |1/12 cycle|
+ *  |power10  | 12-13 | 2/cycle  |
+ *
+ *  @param vfa 128-bit vector treated as a scalar __binary128.
+ *  @param vfb 128-bit vector treated as a scalar __binary128.
+ *  @return a scalar __binary128 value.
+ */
+extern __binary128
+vec_xsaddqpo (__binary128 vfa, __binary128 vfb);
+
+/** \brief VSX Scalar Add Quad-Precision using round to Odd.
+ *
+ *  The quad-precision element of vectors vfa and vfb are added
+ *  to produce the quad-precision result.
+ *  The rounding mode is round to odd.
+ *
  *  For POWER9 use the xsaddqpo instruction.
  *  For POWER8 use this soft-float implementation using
  *  vector instruction generated by PVECLIB operations.
@@ -9040,13 +9119,14 @@ vec_signbitf128 (__binary128 f128)
  *  |--------:|:-----:|:---------|
  *  |power8   | 54-71 | 1/cycle  |
  *  |power9   |   12  |1/12 cycle|
+ *  |power10  | 12-13 | 2/cycle  |
  *
  *  @param vfa 128-bit vector treated as a scalar __binary128.
  *  @param vfb 128-bit vector treated as a scalar __binary128.
- *  @return a vector unsigned __int128 value.
+ *  @return a scalar __binary128 value.
  */
 static inline __binary128
-vec_xsaddqpo (__binary128 vfa, __binary128 vfb)
+vec_xsaddqpo_inline (__binary128 vfa, __binary128 vfb)
 {
   __binary128 result;
 #if defined (_ARCH_PWR9) && (__GNUC__ > 7)
@@ -9294,6 +9374,54 @@ vec_xsaddqpo (__binary128 vfa, __binary128 vfb)
  *  to produce the quad-precision result.
  *  The rounding mode is round to odd.
  *
+ *  This is the dynamic call ABI for IFUNC selection when dynamically
+ *  linked to the <I>libpvec.so</I> runtime library. The IFUNC resolver
+ *  will dynamically select the best implementation for processor the
+ *  application is running on. This will be one of the <B>-mcpu</B>
+ *  specific builds from the <I>libpvecstatic</I> archive. This binding occurs
+ *  on first call to the function each time the application runs.
+ *
+ *  \note For POWER9/10 use the xssubqpo instruction.
+ *  For POWER8 use the soft-float implementation from
+ *  vec_xssubqpo_inline().
+ *
+ *  The application may choose to statically bind to a <B>-mcpu</B>
+ *  specific build when the application is linked to <I>libpvecstatic.a</I>.
+ *  The static implementations are vec_xssubqpo_PWR7 (BE only),
+ *  vec_xssubqpo_PWR8, vec_xssubqpo_PWR9 and vec_xssubqpo_PWR10.
+ *  For applications calling a static implementation based on the
+ *  compilers <B>-mcpu=</B> option use the __VEC_PWR_IMP() macro.
+ *  For example:
+ * \code
+  result = __VEC_PWR_IMP(vec_xsaddqpo) (qpfact1, vf1);
+ * \endcode
+ *  __VEC_PWR_IMP() will add the appropriate suffix for the
+ *  compile target.
+ *
+ *  \note This operation <I>may not</I> follow the PowerISA
+ *  relative to setting the FPSCR.
+ *  However if the hardware target includes the xssubqpo instruction,
+ *  the implementation may use that.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 54-71 | 1/cycle  |
+ *  |power9   |   12  |1/12 cycle|
+ *  |power10  | 12-13 | 2/cycle  |
+ *
+ *  @param vfa 128-bit vector treated as a scalar __binary128.
+ *  @param vfb 128-bit vector treated as a scalar __binary128.
+ *  @return a scalar __binary128 value.
+ */
+extern __binary128
+vec_xssubqpo (__binary128 vfa, __binary128 vfb);
+
+/** \brief VSX Scalar Subtract Quad-Precision using round to Odd.
+ *
+ *  The quad-precision element of vector vfb is subtracted from vfa
+ *  to produce the quad-precision result.
+ *  The rounding mode is round to odd.
+ *
  *  For POWER9 use the xssubqpo instruction.
  *  For POWER8 use this soft-float implementation using
  *  vector instruction generated by PVECLIB operations.
@@ -9308,13 +9436,14 @@ vec_xsaddqpo (__binary128 vfa, __binary128 vfb)
  *  |--------:|:-----:|:---------|
  *  |power8   | 51-70 | 1/cycle  |
  *  |power9   |   12  |1/12 cycle|
+ *  |power10  | 12-13 | 2/cycle  |
  *
  *  @param vfa 128-bit vector treated as a scalar __binary128.
  *  @param vfb 128-bit vector treated as a scalar __binary128.
- *  @return a vector unsigned __int128 value.
+ *  @return a scalar __binary128 value.
  */
 static inline __binary128
-vec_xssubqpo (__binary128 vfa, __binary128 vfb)
+vec_xssubqpo_inline (__binary128 vfa, __binary128 vfb)
 {
   __binary128 result;
 #if defined (_ARCH_PWR9) && (__GNUC__ > 7)
@@ -9897,6 +10026,7 @@ vec_xscvqpudz (__binary128 f128)
  *  |--------:|:-----:|:---------|
  *  |power8   |   ?   | 2/cycle  |
  *  |power9   |   ?   | 2/cycle  |
+ *  |power10  | 12-13 | 2/cycles |
  *
  *  @param f128 128-bit vector treated as a scalar __binary128.
  *  @return a vector unsigned __int128 value.
@@ -9979,7 +10109,8 @@ vec_xscvqpuqz (__binary128 f128)
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
  *  |power8   |   ?   | 2/cycle  |
- *  |power9   |   3   | 2/cycle  |
+ *  |power9   |   12  | 1/cycle  |
+ *  |power10  | 12-13 | 2/cycles |
  *
  *  @param int64 a vector signed long long. The left most element is converted.
  *  @return a __binary128 value.
@@ -10059,7 +10190,8 @@ static inline vec_xscvsdqp (vi64_t int64)
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
  *  |power8   |   ?   | 2/cycle  |
- *  |power9   |   3   | 2/cycle  |
+ *  |power9   |   12  | 1/cycle  |
+ *  |power10  | 12-13 | 2/cycles |
  *
  *  @param int64 a vector unsigned long long. The left most element is converted.
  *  @return a __binary128 value.
@@ -10134,8 +10266,9 @@ static inline vec_xscvudqp (vui64_t int64)
  *
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
- *  |power8   |   ?   | 2/cycle  |
- *  |power9   | 44-53 |1/13cycles|
+ *  |power8   |   ?   |  NA      |
+ *  |power9   | 38-47 |1/13cycles|
+ *  |power10  | 12-13 | 2/cycles |
  *
  *  @param int128 a vector signed __int128 which is converted to QP format.
  *  @return a __binary128 value.
@@ -10275,8 +10408,9 @@ static inline vec_xscvsqqp (vi128_t int128)
  *
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
- *  |power8   |   ?   | 2/cycle  |
+ *  |power8   |   ?   |  NA      |
  *  |power9   | 38-47 |1/13cycles|
+ *  |power10  | 12-13 | 2/cycles |
  *
  *  @param int128 a vector unsigned __int128 which is converted to QP format.
  *  @return a __binary128 value.
@@ -10371,6 +10505,55 @@ static inline vec_xscvuqqp (vui128_t int128)
  *  produce the quad-precision result.
  *  The rounding mode is round to odd.
  *
+ *  This is the dynamic call ABI for IFUNC selection when dynamically
+ *  linked to the <I>libpvec.so</I> runtime library. The IFUNC resolver
+ *  will dynamically select the best implementation for processor the
+ *  application is running on. This will be one of the <B>-mcpu</B>
+ *  specific builds from the <I>libpvecstatic</I> archive. This binding occurs
+ *  on first call to the function each time the application runs.
+ *
+ *  \note For POWER9/10 use the xsmaddqpo instruction.
+ *  For POWER8 use the soft-float implementation from
+ *  vec_xsmaddqpo_inline().
+ *
+ *  The application may choose to statically bind to a <B>-mcpu</B>
+ *  specific build when the application is linked to <I>libpvecstatic.a</I>.
+ *  The static implementations are vec_xsmaddqpo_PWR7 (BE only),
+ *  vec_xsmaddqpo_PWR8, vec_xsmaddqpo_PWR9 and vec_xsmaddqpo_PWR10.
+ *  For applications calling a static implementation based on the
+ *  compilers <B>-mcpu=</B> option use the __VEC_PWR_IMP() macro.
+ *  For example:
+ * \code
+  result = __VEC_PWR_IMP(vec_xsmaddqpo) (qpfact1, vf1);
+ * \endcode
+ *  __VEC_PWR_IMP() will add the appropriate suffix for the
+ *  compile target.
+ *
+ *  \note This operation <I>may not</I> follow the PowerISA
+ *  relative to setting the FPSCR.
+ *  However if the hardware target includes the xsmaddqpo instruction,
+ *  the implementation may use that.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   |   ??  | 1/cycle  |
+ *  |power9   |   12  |1/12 cycle|
+ *  |power10  |   25  |1/18 cycle|
+ *
+ *  @param vfa 128-bit vector treated as a scalar __binary128.
+ *  @param vfb 128-bit vector treated as a scalar __binary128.
+ *  @param vfc 128-bit vector treated as a scalar __binary128.
+ *  @return The __binary128 result of  vfa * vfb + vfc
+ */
+extern __binary128
+vec_xsmaddqpo (__binary128 vfa, __binary128 vfb, __binary128 vfc);
+
+/** \brief VSX Scalar Multiply-Add Quad-Precision using round to Odd.
+ *
+ *  The quad-precision element of vectors vfa * vfb + vfc
+ *  produce the quad-precision result.
+ *  The rounding mode is round to odd.
+ *
  *  For POWER9 use the xsmaddqpo instruction.
  *  For POWER8 use this soft-float implementation using
  *  vector instruction generated by PVECLIB operations.
@@ -10385,6 +10568,7 @@ static inline vec_xscvuqqp (vui128_t int128)
  *  |--------:|:-----:|:---------|
  *  |power8   |   ??  | 1/cycle  |
  *  |power9   |   24  |1/12 cycle|
+ *  |power10  |   25  |1/18 cycle|
  *
  *  @param vfa 128-bit vector treated as a scalar __binary128.
  *  @param vfb 128-bit vector treated as a scalar __binary128.
@@ -10392,7 +10576,7 @@ static inline vec_xscvuqqp (vui128_t int128)
  *  @return The __binary128 result of  vfa * vfb + vfc
  */
 static inline __binary128
-vec_xsmaddqpo (__binary128 vfa, __binary128 vfb, __binary128 vfc)
+vec_xsmaddqpo_inline (__binary128 vfa, __binary128 vfb, __binary128 vfc)
 {
   __binary128 result;
 #if defined (_ARCH_PWR9) && (__GNUC__ > 7)
@@ -11055,13 +11239,62 @@ vec_xsmaddqpo (__binary128 vfa, __binary128 vfb, __binary128 vfc)
  *  produce the quad-precision result.
  *  The rounding mode is round to odd.
  *
+ *  This is the dynamic call ABI for IFUNC selection when dynamically
+ *  linked to the <I>libpvec.so</I> runtime library. The IFUNC resolver
+ *  will dynamically select the best implementation for processor the
+ *  application is running on. This will be one of the <B>-mcpu</B>
+ *  specific builds from the <I>libpvecstatic</I> archive. This binding occurs
+ *  on first call to the function each time the application runs.
+ *
+ *  \note For POWER9/10 use the xsmsubqpo instruction.
+ *  For POWER8 use the soft-float implementation from
+ *  vec_xsmsubqpo_inline().
+ *
+ *  The application may choose to statically bind to a <B>-mcpu</B>
+ *  specific build when the application is linked to <I>libpvecstatic.a</I>.
+ *  The static implementations are vec_xsmsubqpo_PWR7 (BE only),
+ *  vec_xsmsubqpo_PWR8, vec_xsmsubqpo_PWR9 and vec_xsmsubqpo_PWR10.
+ *  For applications calling a static implementation based on the
+ *  compilers <B>-mcpu=</B> option use the __VEC_PWR_IMP() macro.
+ *  For example:
+ * \code
+  result = __VEC_PWR_IMP(vec_xsmsubqpo) (qpfact1, vf1);
+ * \endcode
+ *  __VEC_PWR_IMP() will add the appropriate suffix for the
+ *  compile target.
+ *
+ *  \note This operation <I>may not</I> follow the PowerISA
+ *  relative to setting the FPSCR.
+ *  However if the hardware target includes the xsmsubqpo instruction,
+ *  the implementation may use that.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   |   ??  | 1/cycle  |
+ *  |power9   |   12  |1/12 cycle|
+ *  |power10  |   25  |1/18 cycle|
+ *
+ *  @param vfa 128-bit vector treated as a scalar __binary128.
+ *  @param vfb 128-bit vector treated as a scalar __binary128.
+ *  @param vfc 128-bit vector treated as a scalar __binary128.
+ *  @return The __binary128 result of  vfa * vfb + vfc
+ */
+extern __binary128
+vec_xsmsubqpo (__binary128 vfa, __binary128 vfb, __binary128 vfc);
+
+/** \brief VSX Scalar Multiply-Sub Quad-Precision using round to Odd.
+ *
+ *  The quad-precision element of vectors vfa * vfb - vfc
+ *  produce the quad-precision result.
+ *  The rounding mode is round to odd.
+ *
  *  For POWER9 use the xsmsubqpo instruction.
  *  For POWER8 use this soft-float implementation using
  *  vector instruction generated by PVECLIB operations.
  *
  *  \note This operation <I>may not</I> follow the PowerISA
  *  relative to setting the FPSCR.
- *  However if the hardware target includes the xsmaddqpo instruction,
+ *  However if the hardware target includes the xsmsubqpo instruction,
  *  the implementation may use that.
  *
  *  |processor|Latency|Throughput|
@@ -11076,7 +11309,7 @@ vec_xsmaddqpo (__binary128 vfa, __binary128 vfb, __binary128 vfc)
  */
 
 static inline __binary128
-vec_xsmsubqpo (__binary128 vfa, __binary128 vfb, __binary128 vfc)
+vec_xsmsubqpo_inline (__binary128 vfa, __binary128 vfb, __binary128 vfc)
 {
 #if defined (_ARCH_PWR9) && (__GNUC__ > 7)
   __binary128 result;
@@ -11097,9 +11330,57 @@ vec_xsmsubqpo (__binary128 vfa, __binary128 vfb, __binary128 vfc)
   __binary128 nsrc3;
 
   nsrc3 = vec_self128 (vec_negf128 (vfc), vfc, vec_isnanf128(vfc));
-  return vec_xsmaddqpo (vfa, vfb, nsrc3);
+  return vec_xsmaddqpo_inline (vfa, vfb, nsrc3);
 #endif
 }
+
+/** \brief VSX Scalar Multiply Quad-Precision using round to Odd.
+ *
+ *  The quad-precision element of vectors vfa and vfb are multiplied
+ *  to produce the quad-precision result.
+ *  The rounding mode is round to odd.
+ *
+ *  This is the dynamic call ABI for IFUNC selection when dynamically
+ *  linked to the <I>libpvec.so</I> runtime library. The IFUNC resolver
+ *  will dynamically select the best implementation for processor the
+ *  application is running on. This will be one of the <B>-mcpu</B>
+ *  specific builds from the <I>libpvecstatic</I> archive. This binding occurs
+ *  on first call to the function each time the application runs.
+ *
+ *  \note For POWER9/10 use the xsmulqpo instruction.
+ *  For POWER8 use the soft-float implementation from
+ *  vec_xsmulqpo_inline().
+ *
+ *  The application may choose to statically bind to a <B>-mcpu</B>
+ *  specific build when the application is linked to <I>libpvecstatic.a</I>.
+ *  The static implementations are vec_xsmulqpo_PWR7 (BE only),
+ *  vec_xsmulqpo_PWR8, vec_xsmulqpo_PWR9 and vec_xsmulqpo_PWR10.
+ *  For applications calling a static implementation based on the
+ *  compilers <B>-mcpu=</B> option use the __VEC_PWR_IMP() macro.
+ *  For example:
+ * \code
+  result = __VEC_PWR_IMP(vec_xsmulqpo) (qpfact1, vf1);
+ * \endcode
+ *  __VEC_PWR_IMP() will add the appropriate suffix for the
+ *  compile target.
+ *
+ *  \note This operation <I>may not</I> follow the PowerISA
+ *  relative to setting the FPSCR.
+ *  However if the hardware target includes the xsmulqpo instruction,
+ *  the implementation may use that.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 54-71 | 1/cycle  |
+ *  |power9   |   12  |1/12 cycle|
+ *  |power10  |   25  |1/18 cycle|
+ *
+ *  @param vfa 128-bit vector treated as a scalar __binary128.
+ *  @param vfb 128-bit vector treated as a scalar __binary128.
+ *  @return a scalar __binary128 value.
+ */
+extern __binary128
+vec_xsmulqpo (__binary128 vfa, __binary128 vfb);
 
 /** \brief VSX Scalar Multiply Quad-Precision using round to Odd.
  *
@@ -11121,13 +11402,14 @@ vec_xsmsubqpo (__binary128 vfa, __binary128 vfb, __binary128 vfc)
  *  |--------:|:-----:|:---------|
  *  |power8   | 78-84 | 1/cycle  |
  *  |power9   |   24  |1/12 cycle|
+ *  |power10  |   25  |1/18 cycle|
  *
  *  @param vfa 128-bit vector treated as a scalar __binary128.
  *  @param vfb 128-bit vector treated as a scalar __binary128.
- *  @return a vector unsigned __int128 value.
+ *  @return a scalar __binary128 value.
  */
 static inline __binary128
-vec_xsmulqpo (__binary128 vfa, __binary128 vfb)
+vec_xsmulqpo_inline (__binary128 vfa, __binary128 vfb)
 {
   __binary128 result;
 #if defined (_ARCH_PWR9) && (__GNUC__ > 7)

--- a/src/pveclib/vec_int128_ppc.h
+++ b/src/pveclib/vec_int128_ppc.h
@@ -3615,7 +3615,7 @@ vec_cmpsq_all_gt (vi128_t vra, vi128_t vrb)
 {
 #if defined (_ARCH_PWR10) && defined (__VSX__)  && (__GNUC__ >= 10)
 #if (__GNUC__ > 11) || ((__GNUC__ == 11) && (__GNUC_MINOR__ >= 2))
-  return vec_all_ge (vra, vrb);
+  return vec_all_gt (vra, vrb);
 #else
   vb128_t vrt;
   int u, r;
@@ -3893,7 +3893,7 @@ vec_cmpuq_all_gt (vui128_t vra, vui128_t vrb)
 {
 #if defined (_ARCH_PWR10) && defined (__VSX__)  && (__GNUC__ >= 10)
 #if (__GNUC__ > 11) || ((__GNUC__ == 11) && (__GNUC_MINOR__ >= 2))
-  return vec_all_ge (vra, vrb);
+  return vec_all_gt (vra, vrb);
 #else
   vb128_t vrt;
   int u, r;

--- a/src/pveclib/vec_int512_ppc.h
+++ b/src/pveclib/vec_int512_ppc.h
@@ -1344,21 +1344,6 @@ typedef union
 #define COMPILE_FENCE __asm (";":::)
 #endif
 
-/*! \brief Macro to add platform suffix for static calls. */
-#ifdef _ARCH_PWR10
-#define __VEC_PWR_IMP(FNAME) FNAME ## _PWR10
-#else
-#ifdef _ARCH_PWR9
-#define __VEC_PWR_IMP(FNAME) FNAME ## _PWR9
-#else
-#ifdef _ARCH_PWR8
-#define __VEC_PWR_IMP(FNAME) FNAME ## _PWR8
-#else
-#define __VEC_PWR_IMP(FNAME) FNAME ## _PWR7
-#endif
-#endif
-#endif
-
 /** \brief Vector Add 512-bit Unsigned Integer & Write Carry.
  *
  *  Compute the 512 bit sum of two 512 bit values a, b and

--- a/src/testsuite/arith128_test_qpo.c
+++ b/src/testsuite/arith128_test_qpo.c
@@ -1847,9 +1847,15 @@ extern __binary128 test_vec_addqpo (__binary128 vfa, __binary128 vfb);
 #define test_xsaddqpo(_l,_k)	test_vec_addqpo(_l,_k)
 #endif
 #else
+#if 1
+// Test implementation from libpvecstatic
+extern __binary128 __VEC_PWR_IMP (vec_xsaddqpo) (__binary128 vfa, __binary128 vfb);
+#define test_xsaddqpo(_l,_k)	__VEC_PWR_IMP (vec_xsaddqpo)(_l,_k)
+#else
 // Test implementation expanded from vec_f128_ppc.h
 extern __binary128 test_vec_xsaddqpo (__binary128 vfa, __binary128 vfb);
 #define test_xsaddqpo(_l,_k)	test_vec_xsaddqpo(_l,_k)
+#endif
 #endif
 
 int
@@ -3048,9 +3054,15 @@ extern __binary128 test_vec_mulqpo (__binary128 vfa, __binary128 vfb);
 #define test_xsmulqpo(_l,_k)	test_vec_mulqpo(_l,_k)
 #endif
 #else
+#if 1
+// Test implementation from libpvecstatic
+extern __binary128 __VEC_PWR_IMP (vec_xsmulqpo) (__binary128 vfa, __binary128 vfb);
+#define test_xsmulqpo(_l,_k)	__VEC_PWR_IMP (vec_xsmulqpo)(_l,_k)
+#else
 // Test implementation expanded from vec_f128_ppc.h
 extern __binary128 test_vec_xsmulqpo (__binary128 vfa, __binary128 vfb);
 #define test_xsmulqpo(_l,_k)	test_vec_xsmulqpo(_l,_k)
+#endif
 #endif
 
 int
@@ -4047,9 +4059,15 @@ extern __binary128 test_vec_subqpo (__binary128 vfa, __binary128 vfb);
 #define test_xssubqpo(_l,_k)	test_vec_subqpo(_l,_k)
 #endif
 #else
+#if 1
+// Test implementation from libpvecstatic
+extern __binary128 __VEC_PWR_IMP (vec_xssubqpo) (__binary128 vfa, __binary128 vfb);
+#define test_xssubqpo(_l,_k)	__VEC_PWR_IMP (vec_xssubqpo)(_l,_k)
+#else
 // Test implementation expanded from vec_f128_ppc.h
 extern __binary128 test_vec_xssubqpo (__binary128 vfa, __binary128 vfb);
 #define test_xssubqpo(_l,_k)	test_vec_xssubqpo(_l,_k)
+#endif
 #endif
 
 int
@@ -5121,9 +5139,15 @@ extern __binary128 test_vec_maddqpo (__binary128 vfa, __binary128 vfb, __binary1
 #define test_xsmaddqpo(_l,_k,_j)	test_vec_maddqpo(_l,_k,_j)
 #endif
 #else
+#if 1
+// Test implementation from libpvecstatic
+extern __binary128 __VEC_PWR_IMP (vec_xsmaddqpo) (__binary128 vfa, __binary128 vfb, __binary128 vfc);
+#define test_xsmaddqpo(_l,_k,_j)	__VEC_PWR_IMP (vec_xsmaddqpo)(_l,_k,_j)
+#else
 // Test implementation expanded from vec_f128_ppc.h
 extern __binary128 test_vec_xsmaddqpo (__binary128 vfa, __binary128 vfb, __binary128 vfc);
 #define test_xsmaddqpo(_l,_k,_j)	test_vec_xsmaddqpo(_l,_k,_j)
+#endif
 #endif
 
 int
@@ -11701,9 +11725,15 @@ extern __binary128 test_vec_msubqpo (__binary128 vfa, __binary128 vfb, __binary1
 #define test_xsmsubqpo(_l,_k,_m)	test_vec_msubqpo(_l,_k,_m)
 #endif
 #else
+#if 1
+// Test implementation from libpvecstatic
+extern __binary128 __VEC_PWR_IMP (vec_xsmsubqpo) (__binary128 vfa, __binary128 vfb, __binary128 vfc);
+#define test_xsmsubqpo(_l,_k,_j)	__VEC_PWR_IMP (vec_xsmsubqpo)(_l,_k,_j)
+#else
 // Test implementation expanded from vec_f128_ppc.h
 extern __binary128 test_vec_xsmsubqpo (__binary128 vfa, __binary128 vfb, __binary128 vfc);
 #define test_xsmsubqpo(_l,_k,_m)	test_vec_xsmsubqpo(_l,_k,_m)
+#endif
 #endif
 
 int

--- a/src/testsuite/vec_f128_dummy.c
+++ b/src/testsuite/vec_f128_dummy.c
@@ -159,13 +159,13 @@ force_eMin_V0 (vui64_t x_exp)
 __binary128
 test_vec_xsaddqpo (__binary128 vfa, __binary128 vfb)
 {
-  return vec_xsaddqpo (vfa, vfb);
+  return vec_xsaddqpo_inline (vfa, vfb);
 }
 
 __binary128
 test_vec_xssubqpo (__binary128 vfa, __binary128 vfb)
 {
-  return vec_xssubqpo (vfa, vfb);
+  return vec_xssubqpo_inline (vfa, vfb);
 }
 
 vui64_t
@@ -3975,19 +3975,19 @@ test_vec_mulqpn_V1 (__binary128 vfa, __binary128 vfb)
 __binary128
 test_vec_xsmulqpo (__binary128 vfa, __binary128 vfb)
 {
-  return vec_xsmulqpo (vfa, vfb);
+  return vec_xsmulqpo_inline (vfa, vfb);
 }
 
 __binary128
 test_vec_xsmaddqpo (__binary128 vfa, __binary128 vfb, __binary128 vfc)
 {
-  return vec_xsmaddqpo (vfa, vfb, vfc);
+  return vec_xsmaddqpo_inline (vfa, vfb, vfc);
 }
 
 __binary128
 test_vec_xsmsubqpo (__binary128 vfa, __binary128 vfb, __binary128 vfc)
 {
-  return vec_xsmsubqpo (vfa, vfb, vfc);
+  return vec_xsmsubqpo_inline (vfa, vfb, vfc);
 }
 
 int
@@ -4032,7 +4032,7 @@ test_vec_msubqpo (__binary128 vfa, __binary128 vfb, __binary128 vfc)
   __binary128 nsrc3;
 
   nsrc3 = vec_self128 (vec_negf128 (vfc), vfc, vec_isnanf128(vfc));
-  return vec_xsmaddqpo (vfa, vfb, nsrc3);
+  return vec_xsmaddqpo_inline (vfa, vfb, nsrc3);
 #endif
 }
 

--- a/src/testsuite/vec_perf_f128.c
+++ b/src/testsuite/vec_perf_f128.c
@@ -401,8 +401,14 @@ test_lib_uqqp_f128 (__binary128 * vf128,
   vf128[7] = test_vec_xscvuqqp (vf8);
 }
 
+#if 1
+// Test implementation from libpvecstatic
+extern __binary128 __VEC_PWR_IMP (vec_xsaddqpo) (__binary128 vfa, __binary128 vfb);
+#define test_vec_addqpo(_l,_k)	__VEC_PWR_IMP (vec_xsaddqpo)(_l,_k)
+#else
+// Test implementation from vec_f128_dummy.c
 extern __binary128 test_vec_addqpo (__binary128 vfa, __binary128 vfb);
-
+#endif
 
 void
 test_lib_addqpo_f128 (__binary128 * vf128,
@@ -423,7 +429,15 @@ test_lib_addqpo_f128 (__binary128 * vf128,
   *vf128 = result;
 }
 
+
+#if 1
+// Test implementation from libpvecstatic
+extern __binary128 __VEC_PWR_IMP (vec_xsaddqpo) (__binary128 vfa, __binary128 vfb);
+#define test_vec_subqpo(_l,_k)	__VEC_PWR_IMP (vec_xsaddqpo)(_l,_k)
+#else
+// Test implementation from vec_f128_dummy.c
 extern __binary128 test_vec_subqpo (__binary128 vfa, __binary128 vfb);
+#endif
 
 
 void
@@ -445,8 +459,14 @@ test_lib_subqpo_f128 (__binary128 * vf128,
   *vf128 = result;
 }
 
+#if 1
+// Test implementation from libpvecstatic
+extern __binary128 __VEC_PWR_IMP (vec_xsmulqpo) (__binary128 vfa, __binary128 vfb);
+#define test_vec_mulqpo(_l,_k)	__VEC_PWR_IMP (vec_xsmulqpo)(_l,_k)
+#else
+// Test implementation from vec_f128_dummy.c
 extern __binary128 test_vec_mulqpo (__binary128 vfa, __binary128 vfb);
-
+#endif
 
 void
 test_lib_mulqpo_f128 (__binary128 * vf128,
@@ -489,8 +509,6 @@ test_lib_mulqpn_f128 (__binary128 * vf128,
   *vf128 = result;
 }
 
-extern __binary128
-test_vec_maddqpo (__binary128, __binary128, __binary128);
 
 // term1st == const __float128 f128_one = 1.0Q;
 // f128_fact[] ==
@@ -503,6 +521,16 @@ test_vec_maddqpo (__binary128, __binary128, __binary128);
   const __float128 f128_fact5 = (1.0Q / 720.0Q);
   const __float128 f128_fact6 = (1.0Q / 5040.0Q);
   const __float128 f128_fact7 = (1.0Q / 40320.0Q);
+#endif
+
+#if 1
+  // Test implementation from libpvecstatic
+  extern __binary128 __VEC_PWR_IMP (vec_xsmaddqpo) (__binary128 vfa, __binary128 vfb, __binary128 vfc);
+  #define test_vec_maddqpo(_l,_k,_j)	__VEC_PWR_IMP (vec_xsmaddqpo)(_l,_k,_j)
+#else
+  // Test implementation from vec_f128_dummy.c
+  extern __binary128
+  test_vec_maddqpo (__binary128, __binary128, __binary128);
 #endif
 
 __float128

--- a/src/vec_f128_runtime.c
+++ b/src/vec_f128_runtime.c
@@ -1,0 +1,55 @@
+/*
+ Copyright (c) [2023] Steven Munroe.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ vec_int512_runtime.c
+
+ Contributors:
+      Steven Munroe
+      Created on: Aug 1, 2023
+ */
+
+#include <pveclib/vec_f128_ppc.h>
+
+__binary128
+__VEC_PWR_IMP (vec_xsaddqpo) (__binary128 vfa, __binary128 vfb)
+{
+  return vec_xsaddqpo_inline (vfa, vfb);
+}
+
+__binary128
+__VEC_PWR_IMP (vec_xssubqpo) (__binary128 vfa, __binary128 vfb)
+{
+  return vec_xssubqpo_inline (vfa, vfb);
+}
+
+__binary128
+__VEC_PWR_IMP (vec_xsmulqpo) (__binary128 vfa, __binary128 vfb)
+{
+  return vec_xsmulqpo_inline (vfa, vfb);
+}
+
+__binary128
+__VEC_PWR_IMP (vec_xsmaddqpo) (__binary128 vfa, __binary128 vfb, __binary128 vfc)
+{
+  return vec_xsmaddqpo_inline (vfa, vfb, vfc);
+}
+
+__binary128
+__VEC_PWR_IMP (vec_xsmsubqpo) (__binary128 vfa, __binary128 vfb, __binary128 vfc)
+{
+  return vec_xsmsubqpo_inline (vfa, vfb, vfc);
+}
+
+

--- a/src/vec_runtime_PWR10.c
+++ b/src/vec_runtime_PWR10.c
@@ -25,6 +25,7 @@
    PWR10.  */
 
 #include "vec_int512_runtime.c"
+#include "vec_f128_runtime.c"
 #endif
 
 

--- a/src/vec_runtime_PWR7.c
+++ b/src/vec_runtime_PWR7.c
@@ -24,4 +24,5 @@
 // POWER7 supports only BIG Endian. So build PWR7 runtime for BE only.
 
 #include "vec_int512_runtime.c"
+#include "vec_f128_runtime.c"
 #endif

--- a/src/vec_runtime_PWR8.c
+++ b/src/vec_runtime_PWR8.c
@@ -21,3 +21,4 @@
  */
 
 #include "vec_int512_runtime.c"
+#include "vec_f128_runtime.c"

--- a/src/vec_runtime_PWR9.c
+++ b/src/vec_runtime_PWR9.c
@@ -25,6 +25,7 @@
    PWR9.  */
 
 #include "vec_int512_runtime.c"
+#include "vec_f128_runtime.c"
 #endif
 
 


### PR DESCRIPTION
The Float128 arithmetic operations xs[add|sub|mul|madd|msub|...] are generally too large for in-lining. So rename the static inline operations with the "_inline" suffix. Then create
src/vec_f128_runtime.c to provide static implementations using the static inline operations from vec_f128_ppc.h for each operation. The vec_f128_runtime.c file is #included in
src/vec_runtime_PWR[7|8|9|10].c files to build the build the libpvecstatic archive. Finally update src/vec_runtime_DYN.c to define the resolvers and IFUNC aliases for each operation. With library rebuilt we can update the unit/performance tests to call the library implementations.

	* src/Makefile.am (vec_dynrt_PWR10.lo, vec_dynrt_PWR9.lo vec_dynrt_PWR8.lo, vec_dynrt_PWR7.lo): Add depenency on vec_f128_runtime.c. (vec_staticrt_PWR10.lo, vec_staticrt_PWR9.lo vec_staticrt_PWR8.lo, vec_staticrt_PWR7.lo): Add depenency on vec_f128_runtime.c.
	* src/Makefile.in: automake generated.

	* src/pveclib/vec_common_ppc.h: Conditionally define __VEC_PWR_IMP().

	* src/pveclib/vec_f128_ppc.h [///@cond]: Declare externs for Quad-precision round-to-odd _ARCH_PWR# qualifiied operations. (vec_cmpeqtoqp, vec_cmpequzqp, vec_cmpequqp, vec_cmpgetoqp, vec_cmpgeuzqp, vec_cmpgeuqp, vec_cmpgttoqp, vec_cmpgtuzqp, vec_cmpgtuqp, vec_cmpletoqp, vec_cmpleuzqp, vec_cmpleuqp, vec_cmplttoqp, vec_cmpltuzqp, vec_cmpltuqp, vec_cmpnetoqp, vec_cmpneuzqp, vec_cmpneuqp): Doxygen update Power10 latency values. (vec_xsaddqpo, vec_xsaddqpo_inline) Rename for static inline. Add extern for IFUNC enabled dynamic library. (vec_xssubqpo, vec_xssubqpo_inline) Rename for static inline. Add extern for IFUNC enabled dynamic library. (vec_xsaddqpo, vec_xsaddqpo_inline) Rename for static inline. Add extern for IFUNC enabled dynamic library. (vec_xscvsdqp, vec_xscvudqp, vec_xscvsqqp, vec_xscvuqqp): Doxygen update Power10 latency values. (vec_xsmaddqpo, vec_xsmaddqpo_inline) Rename for static inline. Add extern for IFUNC enabled dynamic library. (vec_xsmsubqpo, vec_xsmsubqpo_inline) Rename for static inline. Add extern for IFUNC enabled dynamic library. (vec_xsmulqpo, vec_xsmulqpo_inline) Rename for static inline. Add extern for IFUNC enabled dynamic library.

	* src/pveclib/vec_int128_ppc.h (vec_cmpsq_all_gt, vec_cmpuq_all_gt): Correct pasto, use vec_all_gt to match the operation.

	* src/pveclib/vec_int512_ppc.h [__VEC_PWR_IMP()]: Move define to vec_common_ppc.h

	* src/testsuite/arith128_test_qpo.c [test_xsaddqpo]: Conditionally define to use vec_xsaddqpo_PWR[7|8|9|10]. [test_xsmulqpo]: Conditionally define to use vec_xsmulqpo_PWR[7|8|9|10]. [test_xssubqpo]: Conditionally define to use vec_xssubqpo_PWR[7|8|9|10]. [test_xsmaddqpo]: Conditionally define to use vec_xsmaddqpo_PWR[7|8|9|10]. [test_xsmsubqpo]: Conditionally define to use vec_xsmsubqpo_PWR[7|8|9|10].

	* src/testsuite/vec_f128_dummy.c (test_vec_xsaddqpo, test_vec_xssubqpo): Use the static inline implementation. (test_vec_xsmulqpo, test_vec_xsmaddqpo, test_vec_xsmsubqpo): Use the static inline implementation. (test_vec_msubqpo): Use the static inline implementation of vec_xsmaddqpo_inline

	* src/testsuite/vec_perf_f128.c[test_vec_addqpo]: Define to use the libpvecstatic implementation. [test_vec_subqpo]: Define to use the libpvecstatic implementation. [test_vec_mulqpo]: Define to use the libpvecstatic implementation. [test_vec_maddqpo]: Define to use the libpvecstatic implementation.

	* src/vec_f128_runtime.c: New file.

	* src/vec_runtime_DYN.c [RESPASTE, VEC_RESOLVER_2, VEC_RESOLVER_3]: Define macros to generate the resolvers and IFUNC aliases. [VEC_F128_LIB_LIST]: Define macro to generate the extern list of F128 runtime operations with target suffix. Generate extern lists using parameterized targets. [VEC_INT512_LIB_LIST]: Define macro to generate the extern list of int512 runtime operations with target suffix. Replace manual extern lists using parameterized target. Replace manually generated resolvers with VEC_RESOLVER_2, VEC_RESOLVER_3 where applicable. Add resolvers for F128 operations.

	* src/vec_runtime_PWR10.c: #include "vec_f128_runtime.c"
	* src/vec_runtime_PWR9.c: #include "vec_f128_runtime.c"
	* src/vec_runtime_PWR8.c: #include "vec_f128_runtime.c"
	* src/vec_runtime_PWR7.c: #include "vec_f128_runtime.c"