### PR TITLE
Add P10 divide/modulo operations for doubleword.

### DIFF
--- a/src/testsuite/pveclib_perf.c
+++ b/src/testsuite/pveclib_perf.c
@@ -204,6 +204,48 @@ test_time_i128 (void)
   double delta_sec;
   int rc = 0;
 
+  printf ("\n%s vec_divmodud_lib start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_lib_divmodud ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s vec_divmodud_lib end", __FUNCTION__);
+  printf ("\n%s vec_divmodud_lib  tb delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
+	  delta_sec);
+
+  printf ("\n%s vec_divmodud start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_divmodud ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s vec_divmodud end", __FUNCTION__);
+  printf ("\n%s vec_divmodud  tb delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
+	  delta_sec);
+
+  printf ("\n%s vec_divqud start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_divqud ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s vec_divqud end", __FUNCTION__);
+  printf ("\n%s vec_divqud  tb delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
+	  delta_sec);
+
   printf ("\n%s mul10uq start, ...\n", __FUNCTION__);
   t_start = __builtin_ppc_get_timebase ();
   for (i = 0; i < TIMING_ITERATIONS; i++)

--- a/src/testsuite/vec_perf_i128.c
+++ b/src/testsuite/vec_perf_i128.c
@@ -50,6 +50,165 @@ static const vui32_t ten_64h =
 static const vui32_t ten_64l =
     CONST_VINT32_W(0x6e38ed64, 0xbf6a1f01, 0x00000000, 0x00000000);
 
+#if 0
+#else
+extern vui64_t test_divdud (vui64_t x, vui64_t y, vui64_t z);
+extern vui64_t test_moddud (vui64_t x, vui64_t y, vui64_t z);
+extern vui64_t test_divud (vui64_t y, vui64_t z);
+extern vui64_t test_modud (vui64_t y, vui64_t z);
+extern vui64_t test_divmodud (vui64_t *r, vui64_t y, vui64_t z);
+#endif
+
+vui64_t dummy_x2;
+
+int timed_divmodud (void)
+{
+  int ii;
+  int rc = 0;
+
+  vui64_t ix[4], hx, lx, dx, dy, dz, dq, dr;
+  vui64_t rq, qq, rr;
+
+  const vui64_t c32_9s =(vui64_t)CONST_VINT128_DW(0x000004ee2d6d415bUL,
+						  0x85acef80ffffffffUL);
+  const vui64_t ten16th = (vui64_t)CONST_VINT128_DW(10000000000000000UL,
+						    0UL);
+  const vui64_t ten2 = (vui64_t)CONST_VINT128_DW(100UL,
+						 0UL);
+  const vui64_t zero = vec_splat_u64(0);
+
+  dx = vec_mrgahd ((vui128_t) c32_9s, (vui128_t) c32_9s);
+  dy = vec_mrgald ((vui128_t) c32_9s, (vui128_t) c32_9s);
+  dz = vec_mrgahd ((vui128_t) ten16th, (vui128_t) ten16th);
+#if 0
+  dq = test_divdud (dx, dy, dz);
+  dr = test_moddud (dx, dy, dz);
+#else
+  dq = vec_divdud_inline (dx, dy, dz);
+  dr = vec_moddud_inline (dx, dy, dz);
+#endif
+  lx = vec_mrgahd ((vui128_t) dq, (vui128_t) dr);
+
+  ix[2] = zero;
+
+  // Convert low 16-digit binary values to 100s digits
+  for (ii = 1; ii < 9; ii++)
+    {
+#if 1
+#if 1
+      qq = test_divmodud (&rr, lx, ten2);
+#else
+      qq = test_divud (lx, ten2);
+      rr = test_modud (lx, ten2);
+#endif
+#else
+      qq = vec_vdivud_inline (lx, ten2);
+      rr = vec_vmodud_inline (lx, ten2);
+#endif
+      lx = vec_mrgald ((vui128_t) zero, (vui128_t) rq); // move Q to dividend
+      // Collect digits from remainder, rotate bytes into ix[2]
+      ix[2] = (vui64_t) vec_sld ((vui8_t) ix[2], (vui8_t) zero, 1);
+      ix[2] = (vui64_t) vec_or ((vui8_t) ix[2], (vui8_t) rr);
+      lx = qq;
+    }
+  dummy_x2 = ix[2];
+  return rc;
+}
+
+int timed_lib_divmodud (void)
+{
+  int ii;
+  int rc = 0;
+
+  vui64_t ix[4], hx, lx, dx, dy, dz, dq, dr;
+  vui64_t rq, qq, rr;
+
+  const vui64_t c32_9s =(vui64_t)CONST_VINT128_DW(0x000004ee2d6d415bUL,
+						  0x85acef80ffffffffUL);
+  const vui64_t ten16th = (vui64_t)CONST_VINT128_DW(10000000000000000UL,
+						    0UL);
+  const vui64_t ten2 = (vui64_t)CONST_VINT128_DW(100UL,
+						 0UL);
+  const vui64_t zero = vec_splat_u64(0);
+
+  dx = vec_mrgahd ((vui128_t) c32_9s, (vui128_t) c32_9s);
+  dy = vec_mrgald ((vui128_t) c32_9s, (vui128_t) c32_9s);
+  dz = vec_mrgahd ((vui128_t) ten16th, (vui128_t) ten16th);
+
+  dq = test_divdud (dx, dy, dz);
+  dr = test_moddud (dx, dy, dz);
+  lx = vec_mrgahd ((vui128_t) dq, (vui128_t) dr);
+
+  ix[2] = zero;
+
+  // Convert low 16-digit binary values to 100s digits
+  for (ii = 1; ii < 9; ii++)
+    {
+      qq = test_divud (lx, ten2);
+      rr = test_modud (lx, ten2);
+      lx = vec_mrgald ((vui128_t) zero, (vui128_t) rq); // move Q to dividend
+      // Collect digits from remainder, rotate bytes into ix[2]
+      ix[2] = (vui64_t) vec_sld ((vui8_t) ix[2], (vui8_t) zero, 1);
+      ix[2] = (vui64_t) vec_or ((vui8_t) ix[2], (vui8_t) rr);
+      lx = qq;
+    }
+  dummy_x2 = ix[2];
+  return rc;
+}
+
+#if 0
+extern vui64_t test_vec_divqud (vui128_t x_y, vui64_t z);
+#define test_divqud test_vec_divqud
+#else
+extern vui64_t test_divqud (vui128_t x_y, vui64_t z);
+#endif
+int timed_divqud (void)
+{
+  int ii;
+  int rc = 0;
+
+  vui64_t ix[4], hx, lx;
+  vui64_t rq;
+
+  const vui64_t c32_9s =(vui64_t)CONST_VINT128_DW(0x000004ee2d6d415bUL,
+						  0x85acef80ffffffffUL);
+  const vui64_t ten16th = (vui64_t)CONST_VINT128_DW(10000000000000000UL,
+						    0UL);
+  const vui64_t ten2 = (vui64_t)CONST_VINT128_DW(100UL,
+						 0UL);
+  const vui64_t zero = vec_splat_u64(0);
+
+  // Split QW into high/low 16 digits
+  rq = test_divqud ((vui128_t) c32_9s, ten16th);
+  // Extend Q as high digits
+  hx = vec_mrgald ((vui128_t) zero, (vui128_t) rq);
+  // Extend R as low digits
+  lx = vec_mrgahd ((vui128_t) zero, (vui128_t) rq);
+
+  ix[2] = zero;
+
+  // Convert high 16-digit binary values to 100s digits
+  for (ii = 1; ii < 9; ii++)
+    {
+      rq = test_divqud ((vui128_t) hx, ten2);
+      hx = vec_mrgald ((vui128_t) zero, (vui128_t) rq); // move Q to dividend
+      // Collect digits from remainder, rotate bytes into ix[2]
+      ix[3] = (vui64_t) vec_sld ((vui8_t) rq, (vui8_t) rq, 7);
+      ix[2] = (vui64_t) vec_sld ((vui8_t) ix[2], (vui8_t) ix[3], 1);
+    }
+
+  // Convert low 16-digit binary values to 100s digits
+  for (ii = 1; ii < 9; ii++)
+    {
+      rq = test_divqud ((vui128_t) lx, ten2);
+      lx = vec_mrgald ((vui128_t) zero, (vui128_t) rq); // move Q to dividend
+      // Collect digits from remainder, rotate bytes into ix[2]
+      ix[3] = (vui64_t) vec_sld ((vui8_t) rq, (vui8_t) rq, 7);
+      ix[2] = (vui64_t) vec_sld ((vui8_t) ix[2], (vui8_t) ix[3], 1);
+    }
+  dummy_x2 = ix[2];
+  return rc;
+}
 
 int timed_mul10uq (void)
 {

--- a/src/testsuite/vec_perf_i128.h
+++ b/src/testsuite/vec_perf_i128.h
@@ -23,6 +23,9 @@
 #ifndef TESTSUITE_VEC_PERF_I128_H_
 #define TESTSUITE_VEC_PERF_I128_H_
 
+extern int timed_divqud (void);
+extern int timed_divmodud (void);
+extern int timed_lib_divmodud (void);
 extern int timed_mul10uq (void);
 extern int timed_mul10uq2x (void);
 extern int timed_cmul10ecuq (void);

--- a/src/testsuite/vec_pwr10_dummy.c
+++ b/src/testsuite/vec_pwr10_dummy.c
@@ -660,4 +660,146 @@ test_vec_srqi_0_PWR10  (vui128_t a)
 {
   return (vec_srqi (a, 0));
 }
+
+vui64_t test_divmodud_PWR10 (vui64_t *r, vui64_t y, vui64_t z)
+{
+  *r = vec_vmodud_inline (y, z);
+  return vec_vdivud_inline (y, z);
+}
+
+vui64_t
+test_divqud_PWR10 (vui128_t x_y, vui64_t z)
+{
+  return vec_divqud_inline (x_y, z);
+}
+
+vui64_t test_vec_divud_PWR10 (vui64_t y, vui64_t z)
+{
+#if defined (_ARCH_PWR10)  && (__GNUC__ >= 10)
+  vui64_t res;
+#if (__GNUC__ >= 13)
+  res = vec_div (y, z);
+#else
+  __asm__(
+      "vdivud %0,%1,%2;\n"
+      : "=v" (res)
+      : "v" (y), "v" (z)
+      : );
+#endif
+  return res;
+#elif defined (_ARCH_PWR8)
+  __VEC_U_128 qu, yu, zu;
+#if 1
+  yu.ulong.lower = __builtin_unpack_vector_int128 ((vi128_t) y, 1);
+  yu.ulong.upper = __builtin_unpack_vector_int128 ((vi128_t) y, 0);
+  zu.ulong.lower = __builtin_unpack_vector_int128 ((vi128_t) z, 1);
+  zu.ulong.upper = __builtin_unpack_vector_int128 ((vi128_t) z, 0);
+#else
+  yu.vx2 = y;
+  zu.vx2 = z;
+#endif
+
+  qu.ulong.lower = yu.ulong.lower / zu.ulong.lower;
+  qu.ulong.upper = yu.ulong.upper / zu.ulong.upper;
+
+  return qu.vx2;
+#endif
+}
+
+vui64_t test_vec_divude_PWR10 (vui64_t x, vui64_t z)
+{
+#if defined (_ARCH_PWR10)  && (__GNUC__ >= 10)
+  vui64_t res;
+#if (__GNUC__ >= 13)
+  res = vec_dive (x, z);
+#else
+  __asm__(
+      "vdiveud %0,%1,%2;\n"
+      : "=v" (res)
+      : "v" (x), "v" (z)
+      : );
+#endif
+  return res;
+#elif defined (_ARCH_PWR8)
+  __VEC_U_128 qu, yu, zu;
+#if (__GNUC__ <= 10)
+  yu.ulong.lower = __builtin_unpack_vector_int128 ((vi128_t) x, 1);
+  yu.ulong.upper = __builtin_unpack_vector_int128 ((vi128_t) x, 0);
+  zu.ulong.lower = __builtin_unpack_vector_int128 ((vi128_t) z, 1);
+  zu.ulong.upper = __builtin_unpack_vector_int128 ((vi128_t) z, 0);
+#else
+  // Looks like AT16 handles this but what about 15/14 ...
+  // AT10 does not.
+  yu.vx2 = x;
+  zu.vx2 = z;
+#endif
+
+  qu.ulong.lower = __builtin_divdeu (yu.ulong.lower, zu.ulong.lower);
+  qu.ulong.upper = __builtin_divdeu (yu.ulong.upper, zu.ulong.upper);
+
+  return qu.vx2;
+#endif
+}
+
+vui64_t test_vec_modud_PWR10 (vui64_t y, vui64_t z)
+{
+#if defined (_ARCH_PWR10)  && (__GNUC__ >= 10)
+  vui64_t res;
+#if (__GNUC__ >= 13)
+  res = vec_mod (y, z);
+#else
+  __asm__(
+      "vmodud %0,%1,%2;\n"
+      : "=v" (res)
+      : "v" (y), "v" (z)
+      : );
+#endif
+  return res;
+#elif defined (_ARCH_PWR8)
+  __VEC_U_128 qu, yu, zu;
+#if (__GNUC__ <= 10)
+  yu.ulong.lower = __builtin_unpack_vector_int128 ((vi128_t) y, 1);
+  yu.ulong.upper = __builtin_unpack_vector_int128 ((vi128_t) y, 0);
+  zu.ulong.lower = __builtin_unpack_vector_int128 ((vi128_t) z, 1);
+  zu.ulong.upper = __builtin_unpack_vector_int128 ((vi128_t) z, 0);
+#else
+  yu.vx2 = y;
+  zu.vx2 = z;
+#endif
+
+  qu.ulong.lower = yu.ulong.lower % zu.ulong.lower;
+  qu.ulong.upper = yu.ulong.upper % zu.ulong.upper;
+
+  return qu.vx2;
+#endif
+}
+
+vui64_t test_vec_divdud_PWR10 (vui64_t x, vui64_t y, vui64_t z)
+{
+  vui64_t Q, R, Qt /*, Rt*/;
+  vui64_t r1, r2, q1, q2;
+  vb64_t CC, c1, c2;
+  const vui64_t ones = vec_splat_u64(1);
+
+  q1 = test_vec_divude_PWR10 (x, z);
+  r1 = vec_muludm (q1, z);
+  q2 = test_vec_divud_PWR10 (y, z);
+
+  r2 = vec_muludm (q2, z);
+  r2 = vec_subudm (y, r2);
+  Q  = vec_addudm (q1, q2);
+  R  = vec_subudm (r2, r1);
+
+  c1 = vec_cmpltud (R, r2);
+  c2 = vec_cmpgeud (R, z);
+  CC = vec_or (c1, c2);
+
+  Qt = vec_addudm (Q, ones);
+  Q = vec_selud (Q, Qt, CC);
+#if 0 // Corrected Remainder not returned
+  Rt = vec_subudm (R, z);
+  R = vec_selud (R, Rt, CC);
+#endif
+  return Q;
+}
 #endif


### PR DESCRIPTION
POWER10 added vector divde/divide-extended/modulo instrictions. This is the initial patch for the doubleword implementations. A later patch will add the platform specific implementations for static and IFUNC enabled dynamic libraries.

	* src/pveclib/vec_int64_ppc.h: General updates. [i64_missing_ops_0_0_PWR8]: New subsection "POWER8" header. [i64_missing_ops_0_0_PWR9]: New subsection "POWER9" header. [i64_missing_ops_0_0_PWR10: New subsection "POWER10" header. [i64_missing_ops_0_1]: New subsection test "Challenges and opportunities". [i64_missing_ops_0_2_1]: Update subsubsection "Doubleword integer multiplies". General updates. [i64_missing_ops_0_2_2]: New subsubsection text "Doubleword Integer Divide/Modulo". [i64_missing_ops_0_2_2_0]: New paragraph text "Vectorizable Divide implementations". [i64_missing_ops_0_2_2_1]: New paragraph text "Vectorized Shift-Subtract Divide". [i64_missing_ops_0_2_2_2]: New paragraph text "Transfer Vector elements for scalar divide". [i64_missing_ops_0_2_2_3]: New paragraph text "Special consideration for POWER7 and earlier". (vec_divqud_inline, vec_muludm, vec_pasted, vec_mrghd, vec_mrgld, vec_swapd, vec_rldi, vec_selud, vec_setb_sd, vec_sldi, vec_splat_u64, vec_splatd, vec_vdiveud_inline, vec_vdivud_inline [@cond INTERNAL]): Forward declares added. (vec_divdud_inline, vec_divqud_inline): New inline functions. (vec_maxsd, vec_maxud [(__GNUC__ >= 10)]): Use vec_max intrinsic. (vec_minsd, vec_minud [(__GNUC__ >= 10)]): Use vec_min intrinsic. (vec_moddud_inline): New inline function. (vec_msumudm, vec_muleud, vec_mulhud, vec_muloud, vec_muludm): Correct copybrief refs. (vec_setb_sd [(__GNUC__ >= 12)]): Use vec_expandm intrinsic. (vec_vdiveud_inline, vec_vdivud_inline): New inline functions. (vec_vmadd2eud, vec_vmaddeud, vec_vmadd2oud, vec_vmaddoud): Correct copybrief refs. (vec_vmodud_inline): New inline function. (vec_vmuleud, vec_vmuloud, vec_vmsumeud, vec_vmsumoud): Correct copybrief refs.

	* src/testsuite/arith128_test_i64.c (db_vec_modud, db_vec_divqud): New debug function. (test_vec_divide_dw, test_vec_modulo_dw, test_vec_divide_qud): New unit test functions. (test_vec_i64): Add new unit test to driver.

	* src/testsuite/pveclib_perf.c (test_time_i128): Add new timed tests to driver.
	* src/testsuite/vec_perf_i128.c (timed_divmodud, timed_lib_divmodud, timed_divqud): New timed test functions.
	* src/testsuite/vec_perf_i128.h (timed_divmodud, timed_lib_divmodud, timed_divqud): New timed test externs.

	* src/testsuite/vec_int64_dummy.c (test_divdud, test_moddud, test_divqud, test_divud, test_divude, test_modud, test_divmodud, test_divmoddud): New compile tests. (test_vec_divud, test_vec_divude, test_vec_modud, test_vec_divmodud_V1, test_vec_divmodud_V0, test_vec_divdud, test_vec_moddud, test_vec_divdud_V1, test_vec_divdud_V0, test_vec_divqud, test_vec_divmoddud, test_vec_divmoddud_V0): Experimental compile tests.

	* src/testsuite/vec_pwr10_dummy.c (test_divmodud_PWR10, test_divqud_PWR10, test_vec_divud_PWR10, test_vec_divude_PWR10, test_vec_modud_PWR10, test_vec_divdud_PWR10): New compile tests.

	* src/testsuite/vec_pwr9_dummy.c (test_divmodud_PWR9, test_divqud_PWR9, test_vec_divud_PWR9, test_vec_divude_PWR9, test_vec_modud_PWR9, test_vec_divqud_PWR9, test_vec_divdud_PWR9): New compile tests.