### PR TITLE
Add P10 divide/modulo operations for quadword.

### DIFF
--- a/doc/pveclib-doxygen-pveclib.doxy
+++ b/doc/pveclib-doxygen-pveclib.doxy
@@ -1395,17 +1395,6 @@ EXT_LINKS_IN_WINDOW    = NO
 
 FORMULA_FONTSIZE       = 10
 
-# Use the FORMULA_TRANPARENT tag to determine whether or not the images
-# generated for formulas are transparent PNGs. Transparent PNGs are not
-# supported properly for IE 6.0, but are supported on all modern browsers.
-#
-# Note that when changing this option you need to delete any form_*.png files in
-# the HTML output directory before the changes have effect.
-# The default value is: YES.
-# This tag requires that the tag GENERATE_HTML is set to YES.
-
-FORMULA_TRANSPARENT    = YES
-
 # Enable the USE_MATHJAX option to render LaTeX formulas using MathJax (see
 # http://www.mathjax.org) which uses client side Javascript for the rendering
 # instead of using pre-rendered bitmaps. Use this if you do not have LaTeX
@@ -1672,16 +1661,6 @@ LATEX_BATCHMODE        = NO
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
 LATEX_HIDE_INDICES     = NO
-
-# If the LATEX_SOURCE_CODE tag is set to YES then doxygen will include source
-# code with syntax highlighting in the LaTeX output.
-#
-# Note that which sources are shown also depends on other settings such as
-# SOURCE_BROWSER.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_LATEX is set to YES.
-
-LATEX_SOURCE_CODE      = NO
 
 # The LATEX_BIB_STYLE tag can be used to specify the style to use for the
 # bibliography, e.g. plainnat, or ieeetr. See
@@ -2007,15 +1986,6 @@ EXTERNAL_PAGES         = YES
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
 
-# If the CLASS_DIAGRAMS tag is set to YES, doxygen will generate a class diagram
-# (in HTML and LaTeX) for classes with base or super classes. Setting the tag to
-# NO turns the diagrams off. Note that this option also works with HAVE_DOT
-# disabled, but it is recommended to install and use dot, since it yields more
-# powerful graphs.
-# The default value is: YES.
-
-CLASS_DIAGRAMS         = YES
-
 # If set to YES the inheritance and collaboration graphs will hide inheritance
 # and usage relations if the target is undocumented or is not a class.
 # The default value is: YES.
@@ -2040,23 +2010,6 @@ HAVE_DOT               = NO
 # This tag requires that the tag HAVE_DOT is set to YES.
 
 DOT_NUM_THREADS        = 0
-
-# When you want a differently looking font in the dot files that doxygen
-# generates you can specify the font name using DOT_FONTNAME. You need to make
-# sure dot is able to find the font, which can be done by putting it in a
-# standard location or by setting the DOTFONTPATH environment variable or by
-# setting DOT_FONTPATH to the directory containing the font.
-# The default value is: Helvetica.
-# This tag requires that the tag HAVE_DOT is set to YES.
-
-DOT_FONTNAME           = Helvetica
-
-# The DOT_FONTSIZE tag can be used to set the size (in points) of the font of
-# dot graphs.
-# Minimum value: 4, maximum value: 24, default value: 10.
-# This tag requires that the tag HAVE_DOT is set to YES.
-
-DOT_FONTSIZE           = 10
 
 # By default doxygen will tell dot to use the default font as specified with
 # DOT_FONTNAME. If you specify a different font using DOT_FONTNAME you can set
@@ -2245,18 +2198,6 @@ DOT_GRAPH_MAX_NODES    = 50
 # This tag requires that the tag HAVE_DOT is set to YES.
 
 MAX_DOT_GRAPH_DEPTH    = 0
-
-# Set the DOT_TRANSPARENT tag to YES to generate images with a transparent
-# background. This is disabled by default, because dot on Windows does not seem
-# to support this out of the box.
-#
-# Warning: Depending on the platform used, enabling this option may lead to
-# badly anti-aliased labels on the edges of a graph (i.e. they become hard to
-# read).
-# The default value is: NO.
-# This tag requires that the tag HAVE_DOT is set to YES.
-
-DOT_TRANSPARENT        = NO
 
 # Set the DOT_MULTI_TARGETS tag to YES to allow dot to generate multiple output
 # files in one run (i.e. multiple -o and -T options on the command line). This

--- a/doc/pveclibmaindox.h
+++ b/doc/pveclibmaindox.h
@@ -1918,7 +1918,7 @@ __VEC_PWR_IMP (vec_mul512x512) (__VEC_U_512 m1, __VEC_U_512 m2)
 * Other multiple precision functions supporting BCD and BCD <-> binary
 * conversions are likely candidates.
 *
-* \note Current Clang compilers silently ignore "#pragme GCC target".
+* \note Current Clang compilers silently ignore "\#pragme GCC target".
 * This causes all such targeted runtimes to revert to the compiler
 * default target or configure CFLAGS "-mcpu=". In this case the
 * __VEC_PWR_IMP()

--- a/src/testsuite/arith128_test_i512.c
+++ b/src/testsuite/arith128_test_i512.c
@@ -428,6 +428,150 @@ test_mul512x128 (void)
   rc += check_vuint128x ("vec_mul512x128 5a:", kp.x2.v1x128, ep.x2.v1x128);
   rc += check_vint512   ("vec_mul512x128 5b:", kp.x2.v0x512, ep.x2.v0x512);
 
+  i.vx0 = (vui128_t) CONST_VINT128_W (0x000004ee, 0x2d6d415b, 0x85acef81, 0x00000000); /* 10**32 */
+  i.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j     = (vui128_t) CONST_VINT128_W (0x000004ee, 0x2d6d415b, 0x85acef81, 0x00000000);
+  k = __VEC_PWR_IMP (vec_mul512x128)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x ("  10**32  ", i);
+  print_vint128x ("* 10**32  ", j);
+  print_vint640x ("        = ", k);
+#endif
+  kp.x640 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x6e38ed64, 0xbf6a1f01, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00184f03, 0xe93ff9f4, 0xdaa797ed);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x128 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vuint128x ("vec_mul512x128 6a:", kp.x2.v1x128, ep.x2.v1x128);
+  rc += check_vint512   ("vec_mul512x128 6b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  i = kp.x2.v0x512;
+  k = __VEC_PWR_IMP (vec_mul512x128)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x ("  10**64  ", i);
+  print_vint128x ("* 10**32  ", j);
+  print_vint640x ("        = ", k);
+#endif
+  kp.x640 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0xe1178e81, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x62e7f4a7, 0x79f5080f, 0x1c46d01a, 0xe478b23b);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x77d9d58b, 0x62cd8a51);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x128 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vuint128x ("vec_mul512x128 7a:", kp.x2.v1x128, ep.x2.v1x128);
+  rc += check_vint512   ("vec_mul512x128 7b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  i = kp.x2.v0x512;
+  k = __VEC_PWR_IMP (vec_mul512x128)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x ("  10**96  ", i);
+  print_vint128x ("* 10**32  ", j);
+  print_vint640x ("        = ", k);
+#endif
+  kp.x640 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x2374e42f, 0x0f1538fd, 0x03df9909, 0x2e953e01);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0xa6337f19, 0xbccdb0da, 0xc404dc08, 0xd3cff5ec);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x0000024e, 0xe91f2603);
+  ep.x2.v1x128 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vuint128x ("vec_mul512x128 8a:", kp.x2.v1x128, ep.x2.v1x128);
+  rc += check_vint512   ("vec_mul512x128 8b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  i = kp.x2.v0x512;
+  k = __VEC_PWR_IMP (vec_mul512x128)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x ("  10**128 ", i);
+  print_vint128x ("* 10**32  ", j);
+  print_vint640x (" =10**160 ", k);
+#endif
+  kp.x640 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0xb70f2850, 0x5222d0f4, 0xfbc32d81, 0x00000000);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0xf8591999, 0xd6395d7d, 0xdc421413, 0x5713f2f3);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x12b7fe61, 0x7aa577b9, 0x86b314d6, 0x0092381c);
+  ep.x2.v1x128 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x000b616a);
+  rc += check_vuint128x ("vec_mul512x128 9a:", kp.x2.v1x128, ep.x2.v1x128);
+  rc += check_vint512   ("vec_mul512x128 9b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  i.vx0 = (vui128_t) CONST_VINT128_W (0x000004ee, 0x2d6d415b, 0x85acef81, 0x00000000); /* 10**32 */
+  i.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  i.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  j     = (vui128_t) CONST_VINT128_W (0x0000000c, 0x9f2c9cd0, 0x4674edea, 0x40000000); /* 10**30 */
+  k = __VEC_PWR_IMP (vec_mul512x128)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x ("  10**32  ", i);
+  print_vint128x ("* 10**30  ", j);
+  print_vint640x ("        = ", k);
+#endif
+  kp.x640 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x2261d969, 0xf7ac94ca, 0x40000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00003e3a, 0xeb4ae138, 0x3562f4b8);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x128 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vuint128x ("vec_mul512x128 6a:", kp.x2.v1x128, ep.x2.v1x128);
+  rc += check_vint512   ("vec_mul512x128 6b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  i = kp.x2.v0x512;
+  k = __VEC_PWR_IMP (vec_mul512x128)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x ("  10**62 ", i);
+  print_vint128x ("* 10**30  ", j);
+  print_vint640x (" =10**92  ", k);
+#endif
+  kp.x640 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x608f6351, 0x10000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x7668ee97, 0x42f4c93e, 0x0e502fb0, 0x2174d9b8);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00031174, 0x77e509c4);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v1x128 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vuint128x ("vec_mul512x128 7a:", kp.x2.v1x128, ep.x2.v1x128);
+  rc += check_vint512   ("vec_mul512x128 7b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  i = kp.x2.v0x512;
+  k = __VEC_PWR_IMP (vec_mul512x128)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x ("  10**92  ", i);
+  print_vint128x ("* 10**30  ", j);
+  print_vint640x (" =10**122 ", k);
+#endif
+  kp.x640 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0xe4000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x71919d1a, 0x73fa5e25, 0xdc93b819, 0x4541ecbc);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0xd65a5181, 0xd7ccdd5e, 0x237a6c1a, 0x561573a4);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0026b9d5);
+  ep.x2.v1x128 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vuint128x ("vec_mul512x128 8a:", kp.x2.v1x128, ep.x2.v1x128);
+  rc += check_vint512   ("vec_mul512x128 8b:", kp.x2.v0x512, ep.x2.v0x512);
+
+  i = kp.x2.v0x512;
+  k = __VEC_PWR_IMP (vec_mul512x128)(i, j);
+
+#ifdef __DEBUG_PRINT__
+  print_vint512x ("  10**122 ", i);
+  print_vint128x ("* 10**30  ", j);
+  print_vint640x (" =10**152 ", k);
+#endif
+  kp.x640 = k;
+  ep.x2.v0x512.vx0 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  ep.x2.v0x512.vx1 = (vui128_t) CONST_VINT128_W (0x3e21f795, 0x4fe4a741, 0xd3ad0eeb, 0xa1000000);
+  ep.x2.v0x512.vx2 = (vui128_t) CONST_VINT128_W (0xd2d8af57, 0xd5d929cb, 0x5f1e32bf, 0xfbdc5d1c);
+  ep.x2.v0x512.vx3 = (vui128_t) CONST_VINT128_W (0x01e8ca31, 0x85deb719, 0xa2fd64b0, 0xccbf84ba);
+  ep.x2.v1x128 = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+  rc += check_vuint128x ("vec_mul512x128 9a:", kp.x2.v1x128, ep.x2.v1x128);
+  rc += check_vint512   ("vec_mul512x128 9b:", kp.x2.v0x512, ep.x2.v0x512);
+
   return (rc);
 }
 

--- a/src/testsuite/pveclib_perf.c
+++ b/src/testsuite/pveclib_perf.c
@@ -204,6 +204,90 @@ test_time_i128 (void)
   double delta_sec;
   int rc = 0;
 
+  printf ("\n%s vec_divuq_gcc start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_gcc_divuq ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s vec_divuq_gcc end", __FUNCTION__);
+  printf ("\n%s vec_divuq_gcc  tb delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
+	  delta_sec);
+
+  printf ("\n%s vec_divuq2_gcc start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_gcc_divuq2 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s vec_divuq2_gcc end", __FUNCTION__);
+  printf ("\n%s vec_divuq2_qcc  tb delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
+	  delta_sec);
+
+  printf ("\n%s vec_divuq_lib start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_vec_divuq ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s vec_divuq_lib end", __FUNCTION__);
+  printf ("\n%s vec_divuq_lib  tb delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
+	  delta_sec);
+
+  printf ("\n%s vec_divuq2_lib start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_vec_divuq2 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s vec_divuq2_lib end", __FUNCTION__);
+  printf ("\n%s vec_divuq2_lib  tb delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
+	  delta_sec);
+
+  printf ("\n%s vec_divuqe_lib start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_vec_divuqe ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s vec_divuqe_lib end", __FUNCTION__);
+  printf ("\n%s vec_divuqe_lib  tb delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
+	  delta_sec);
+
+  printf ("\n%s vec_divdqu_lib start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_vec_divdqu ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s vec_divdqu_lib end", __FUNCTION__);
+  printf ("\n%s vec_divdqu_lib  tb delta = %lu, sec = %10.6g\n", __FUNCTION__, t_delta,
+	  delta_sec);
+
   printf ("\n%s vec_divmodud_lib start, ...\n", __FUNCTION__);
   t_start = __builtin_ppc_get_timebase ();
   for (i = 0; i < TIMING_ITERATIONS; i++)

--- a/src/testsuite/vec_f128_dummy.c
+++ b/src/testsuite/vec_f128_dummy.c
@@ -4013,8 +4013,8 @@ test_check_sig_ovf_V0 (vui128_t q_sig)
 __binary128
 test_vec_msubqpo (__binary128 vfa, __binary128 vfb, __binary128 vfc)
 {
-  __binary128 result;
 #if defined (_ARCH_PWR9) && (__GNUC__ > 7)
+  __binary128 result;
 #if defined (__FLOAT128__) && (__GNUC__ > 8)
   /* There is no __builtin for msubqpo, but the compiler should convert
    * this fmaf128 to xsmsubqpo */

--- a/src/testsuite/vec_int64_dummy.c
+++ b/src/testsuite/vec_int64_dummy.c
@@ -1560,7 +1560,9 @@ vui64_t test_vec_divude (vui64_t x, vui64_t z)
   vb64_t ge;
   vui64_t t, xt;
   const vui64_t ones = vec_splat_u64(1);
+#if defined (_ARCH_PWR8)
   const vui64_t zeros = vec_splat_u64(0);
+#endif
   vui64_t y = vec_splat_u64(0);
 
   for (i = 1; i <= 64; i++)
@@ -2050,7 +2052,9 @@ vui64_t test_vec_divdud_V1 (vui64_t x, vui64_t y, vui64_t z)
   vb64_t ge;
   vui64_t t, c, xt;
   const vui64_t ones = vec_splat_u64(1);
+#if defined (_ARCH_PWR8)
   const vui64_t zeros = vec_splat_u64(0);
+#endif
 
   for (i = 1; i <= 64; i++)
     {

--- a/src/testsuite/vec_perf_i128.c
+++ b/src/testsuite/vec_perf_i128.c
@@ -50,6 +50,644 @@ static const vui32_t ten_64h =
 static const vui32_t ten_64l =
     CONST_VINT32_W(0x6e38ed64, 0xbf6a1f01, 0x00000000, 0x00000000);
 
+// 10**152-1
+static const vui128_t c152[] = {
+    CONST_VUINT128_QxW (0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff),
+    CONST_VUINT128_QxW (0x3e21f795, 0x4fe4a741, 0xd3ad0eeb, 0xa0ffffff),
+    CONST_VUINT128_QxW (0xd2d8af57, 0xd5d929cb, 0x5f1e32bf, 0xfbdc5d1c),
+    CONST_VUINT128_QxW (0x01e8ca31, 0x85deb719, 0xa2fd64b0, 0xccbf84ba)};
+
+#if 0
+extern vui128_t test_vec_moduq (vui128_t y, vui128_t z);
+extern vui128_t test_vec_modduq (vui128_t x, vui128_t y, vui128_t z);
+extern __VEC_U_128P test_vec_moddivduq (vui128_t x, vui128_t y, vui128_t z);
+#define test_divdqu	test_vec_moddivduq
+#define test_moduq	test_vec_moduq
+#define test_modduq	test_vec_modduq
+#else
+extern vui128_t test_moduq (vui128_t y, vui128_t z);
+extern vui128_t test_modduq (vui128_t x, vui128_t y, vui128_t z);
+extern __VEC_U_128P test_divdqu (vui128_t x, vui128_t y, vui128_t z);
+#endif
+// Reduce a 150+ digit (4xQW) value into 5x 30-digit values that can be printed
+int
+timed_vec_divdqu ()
+{
+__VEC_U_128P mq;
+vui128_t ix[4], qx[4];
+#ifdef __DEBUG_PRINT__
+vui128_t rx[5];
+#endif
+const vui128_t *dx = c152;
+// 10**30
+vui128_t c30 = (vui128_t) CONST_VINT128_W (0x0000000c, 0x9f2c9cd0, 0x4674edea, 0x40000000);
+
+vui128_t zero = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+vui128_t er, eq;
+int rc = 0;
+
+ix[0] = zero;
+ix[1] = dx[3];
+ix[2] = c30;
+
+mq = test_divdqu (ix[0], ix[1], ix[2]);
+
+// record 1st (QW) quotient digit
+qx[3] = mq.vx0;
+// Remainder and next (QW) digit
+ix[0] = mq.vx1;
+ix[1] = dx[2];
+
+mq = test_divdqu (ix[0], ix[1], ix[2]);
+// record 2st (QW) quotient digit
+qx[2] = mq.vx0;
+// Remainder and next (QW) digit
+ix[0] = mq.vx1;
+ix[1] = dx[1];
+
+mq = test_divdqu (ix[0], ix[1], ix[2]);
+// record 3rd (QW) quotient digit
+qx[1] = mq.vx0;
+// Remainder and next (QW) digit
+ix[0] = mq.vx1;
+ix[1] = dx[0];
+
+mq = test_divdqu (ix[0], ix[1], ix[2]);
+
+// record 4th (QW) quotient digit
+qx[0] = mq.vx0;
+#ifdef __DEBUG_PRINT__
+// record 1th (QW) remainder digit
+rx[0] = mq.vx1;
+#endif
+// Remainder and next (QW) digit
+ix[0] = qx[3];
+ix[1] = qx[2];
+
+mq = test_divdqu (ix[0], ix[1], ix[2]);
+
+// record 1st (QW) quotient digit
+qx[3] =(vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+qx[2] = mq.vx0;
+// Remainder and next (QW) digit
+ix[0] = mq.vx1;
+ix[1] = qx[1];
+
+mq = test_divdqu (ix[0], ix[1], ix[2]);
+
+qx[1] = mq.vx0;
+// Remainder and next (QW) digit
+ix[0] = mq.vx1;
+ix[1] = qx[0];
+
+mq = test_divdqu (ix[0], ix[1], ix[2]);
+
+// record 4th (QW) quotient digit
+qx[0] = mq.vx0;
+#ifdef __DEBUG_PRINT__
+// record 2th (QW) remainder digit
+rx[1] = mq.vx1;
+#endif
+// Remainder and next (QW) digit
+ix[0] = qx[2];
+ix[1] = qx[1];
+
+mq = test_divdqu (ix[0], ix[1], ix[2]);
+
+// record 2st (QW) quotient digit
+qx[2] =(vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+qx[1] = mq.vx0;
+// Remainder and next (QW) digit
+ix[0] = mq.vx1;
+ix[1] = qx[0];
+
+mq = test_divdqu (ix[0], ix[1], ix[2]);
+
+// record 4th (QW) quotient digit
+qx[0] = mq.vx0;
+
+#ifdef __DEBUG_PRINT__
+// record 3th (QW) remainder digit
+rx[2] = mq.vx1;
+#endif
+// Remainder and next (QW) digit
+ix[0] = qx[1];
+ix[1] = qx[0];
+
+mq = test_divdqu (ix[0], ix[1], ix[2]);
+
+// record 3rd (QW) quotient digit
+qx[1] =(vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
+// record 4th (QW) quotient digit
+qx[0] = mq.vx0;
+#ifdef __DEBUG_PRINT__
+// record 4th (QW) remainder digit
+rx[3] = mq.vx1;
+#endif
+
+// Remainder and next (QW) digit
+ix[0] = qx[1];
+ix[1] = qx[0];
+
+mq = test_divdqu (ix[0], ix[1], ix[2]);
+
+// record 5th (QW) quotient digit
+qx[0] = mq.vx0;
+#ifdef __DEBUG_PRINT__
+// record 5th (QW) remainder digit
+rx[4] = mq.vx1;
+#endif
+// 10**30-1
+er = (vui128_t) CONST_VINT128_W (0x0000000c, 0x9f2c9cd0, 0x4674edea, 0x3fffffff);
+eq = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000063);
+
+rc += check_vuint128x ("moddiv k er:", (vui128_t)mq.vx1, (vui128_t) er);
+rc += check_vuint128x ("moddiv k eq:", (vui128_t)mq.vx0, (vui128_t) eq);
+
+#ifdef __DEBUG_PRINT__
+print_vint128x ("      Q ", (vui128_t) qx[3]);
+print_vint128x ("        ", (vui128_t) qx[2]);
+print_vint128x ("        ", (vui128_t) qx[1]);
+print_vint128x ("        ", (vui128_t) qx[0]);
+print_vint128x ("      R ", (vui128_t) rx[4]);
+print_vint128x ("        ", (vui128_t) rx[3]);
+print_vint128x ("        ", (vui128_t) rx[2]);
+print_vint128x ("        ", (vui128_t) rx[1]);
+print_vint128x ("        ", (vui128_t) rx[0]);
+#endif
+
+return (rc);
+}
+
+
+#if 0
+// extern vui128_t test_vec_divduq (vui128_t x, vui128_t y, vui128_t z);
+// #define test_divduq	test_vec_divduq
+extern vui128_t test_vec_divuqe (vui128_t x, vui128_t z);
+#define test_divuqe	test_vec_divuqe
+extern vui128_t test_vec_divuq (vui128_t y, vui128_t z);
+#define test_divuq	test_vec_divuq
+#else
+// extern vui128_t test_divduq (vui128_t x, vui128_t y, vui128_t z);
+extern vui128_t test_divuqe (vui128_t x, vui128_t z);
+extern vui128_t test_divuq (vui128_t y, vui128_t z);
+#endif
+int
+timed_vec_divuqe (void)
+{
+
+  vui128_t ix[4];
+  vui128_t rnd = (vui128_t)CONST_VINT128_DW128(0UL, 0x80UL);
+  vui128_t es;
+  vui128_t rq;
+  int rc = 0;
+
+  //Taylor series to compute e as a scaled fix-point value
+  // This use case requires a 256-bit / 128-bit divide.
+  ix[0] = (vui128_t)CONST_VINT128_DW128(0x0001000000000000UL, 0UL);
+  ix[1] = (vui128_t)CONST_VINT128_DW128(0x0100000000000000UL, 0UL);
+  ix[2] = (vui128_t)CONST_VINT128_DW128(0x0100000000000000UL, 0UL);
+  ix[3] = (vui128_t)CONST_VINT128_DW128(0x0100000000000000UL, 0x0UL);
+
+  rq = test_divuqe (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[3], rq); // next term
+  // round and normalize
+  rq    = vec_adduqm (rq, rnd);
+  ix[0] = vec_srqi (rq, 8);
+  ix[2] = vec_adduqm (ix[2], ix[1]);
+
+  rq = test_divuqe (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[3], rq); // next term
+  // round and normalize
+  rq    = vec_adduqm (rq, rnd);
+  ix[0] = vec_srqi (rq, 8);
+  ix[2] = vec_adduqm (ix[2], ix[1]);
+
+  rq = test_divuqe (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[3], rq); // next term
+  // round and normalize
+  //Taylor series to compute e
+  rq    = vec_adduqm (rq, rnd);
+  ix[0] = vec_srqi (rq, 8);
+  ix[2] = vec_adduqm (ix[2], ix[1]);
+
+  rq = test_divuqe (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[3], rq); // next term
+  // round and normalize
+  rq    = vec_adduqm (rq, rnd);
+  ix[0] = vec_srqi (rq, 8);
+  ix[2] = vec_adduqm (ix[2], ix[1]);
+
+  rq = test_divuqe (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[3], rq); // next term
+  // round and normalize
+  rq    = vec_adduqm (rq, rnd);
+  ix[0] = vec_srqi (rq, 8);
+  ix[2] = vec_adduqm (ix[2], ix[1]);
+
+  rq = test_divuqe (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[3], rq); // next term
+  // round and normalize
+  rq    = vec_adduqm (rq, rnd);
+  ix[0] = vec_srqi (rq, 8);
+  ix[2] = vec_adduqm (ix[2], ix[1]);
+
+  rq = test_divuqe (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[3], rq); // next term
+  // round and normalize
+  rq    = vec_adduqm (rq, rnd);
+  ix[0] = vec_srqi (rq, 8);
+  ix[2] = vec_adduqm (ix[2], ix[1]);
+
+  rq = test_divuqe (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[3], rq); // next term
+  // round and normalize
+  rq    = vec_adduqm (rq, rnd);
+  ix[0] = vec_srqi (rq, 8);
+  ix[2] = vec_adduqm (ix[2], ix[1]);
+
+  rq = test_divuqe (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[3], rq); // next term
+  // round and normalize
+  rq    = vec_adduqm (rq, rnd);
+  ix[0] = vec_srqi (rq, 8);
+  ix[2] = vec_adduqm (ix[2], ix[1]);
+
+  rq = test_divuqe (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[3], rq); // last term
+  es = (vui128_t)CONST_VINT128_DW128(0x02b7e150ed3c569dUL, 0x975c4df261fe4d9aUL);
+  rc += check_vuint128x ("divuqe-sum :", (vui128_t)ix[3], (vui128_t) es);
+
+  return (rc);
+}
+
+int
+timed_vec_divuq (void)
+{
+  //Taylor series to compute e
+  // This use case requires a 128-bit / 64-bit divide
+
+  vui128_t ix[4];
+  vui128_t es;
+  vui128_t rq;
+  int rc = 0;
+
+  ix[0] = (vui128_t)CONST_VINT128_DW128(0x0100000000000000UL, 0UL);
+  ix[1] = (vui128_t)CONST_VINT128_DW128(0UL, 1UL);
+  ix[2] = (vui128_t)CONST_VINT128_DW128(0UL, 1UL);
+  ix[3] = (vui128_t)CONST_VINT128_DW128(0x0100000000000000UL, 0x0UL);
+
+  rq = test_divuq (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[3], rq); // next term
+  ix[0] = rq;
+  ix[2] = vec_adduqm (ix[2], ix[1]);
+
+  rq = test_divuq (ix[0], ix[2]);
+  ix[3] = vec_adduqm (ix[3], rq); // next term
+  ix[0] = rq;
+  ix[2] = vec_adduqm (ix[2], ix[1]);
+
+  rq = test_divuq (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[3], rq); // next term
+  ix[0] = rq;
+  ix[2] = vec_adduqm (ix[2], ix[1]);
+
+  rq = test_divuq (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[3], rq); // next term
+  ix[0] = rq;
+  ix[2] = vec_adduqm (ix[2], ix[1]);
+
+  rq = test_divuq (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[3], rq); // next term
+  ix[0] = rq;
+  ix[2] = vec_adduqm (ix[2], ix[1]);
+
+  rq = test_divuq (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[3], rq); // next term
+  ix[0] = rq;
+  ix[2] = vec_adduqm (ix[2], ix[1]);
+
+  rq = test_divuq (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[3], rq); // next term
+  ix[0] = rq;
+  ix[2] = vec_adduqm (ix[2], ix[1]);
+
+  rq = test_divuq (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[3], rq); // next term
+  ix[0] = rq;
+  ix[2] = vec_adduqm (ix[2], ix[1]);
+
+  rq = test_divuq (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[3], rq); // next term
+  ix[0] = rq;
+  ix[2] = vec_adduqm (ix[2], ix[1]);
+
+  rq = test_divuq (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[3], rq); // last term
+  es = (vui128_t)CONST_VINT128_DW128(0x02b7e150ed3c569dUL, 0x975c4df261fe4d64UL);
+  rc += check_vuint128x ("divuq-sum :", (vui128_t)ix[3], (vui128_t) es);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128x ("   'sum ", (vui128_t) ix[3]);
+#endif
+
+  return (rc);
+}
+
+int
+timed_vec_divuq2 (void)
+{
+  // Newton's method sqr
+  // This use case requires a full 128-bit / 128-bit divide.
+  vui128_t ix[4];
+  vui128_t es;
+  vui128_t rq;
+  int rc = 0;
+
+  ix[0] = (vui128_t)CONST_VINT128_DW128(__UINT64_MAX__, __UINT64_MAX__);
+  ix[1] = (vui128_t)CONST_VINT128_DW128(__UINT64_MAX__, __UINT64_MAX__);
+
+  // initial estimate of g0
+  ix[2] = vec_srqi (ix[1], 56);
+  // a / g0
+  rq = test_divuq (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[2], rq);
+  ix[2] = vec_srqi (ix[3], 1);
+
+  // a / gn
+  rq = test_divuq (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[2], rq);
+  ix[2] = vec_srqi (ix[3], 1);
+
+  // a / gn
+  rq = test_divuq (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[2], rq);
+  ix[2] = vec_srqi (ix[3], 1);
+
+  // a / gn
+  rq = test_divuq (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[2], rq);
+  ix[2] = vec_srqi (ix[3], 1);
+
+  // a / gn
+  rq = test_divuq (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[2], rq);
+  ix[2] = vec_srqi (ix[3], 1);
+
+  // a / gn
+  rq = test_divuq (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[2], rq);
+  ix[2] = vec_srqi (ix[3], 1);
+
+  // a / gn
+  rq = test_divuq (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[2], rq);
+  ix[2] = vec_srqi (ix[3], 1);
+
+  // a / gn
+  rq = test_divuq (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[2], rq);
+  ix[2] = vec_srqi (ix[3], 1);
+
+  // a / gn
+  rq = test_divuq (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[2], rq);
+  ix[2] = vec_srqi (ix[3], 1);
+
+  // a / gn
+  rq = test_divuq (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[2], rq);
+  ix[2] = vec_srqi (ix[3], 1);
+
+  // a / gn
+  rq = test_divuq (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[2], rq);
+  ix[2] = vec_srqi (ix[3], 1);
+
+  // a / gn
+  rq = test_divuq (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[2], rq);
+  ix[2] = vec_srqi (ix[3], 1);
+
+  // a / gn
+  rq = test_divuq (ix[0], ix[2]);
+
+  ix[3] = vec_adduqm (ix[2], rq);
+  ix[2] = vec_srqi (ix[3], 1);
+
+  es = (vui128_t)CONST_VINT128_DW128(1UL, 0UL);
+  rc += check_vuint128x ("divuq-sum :", (vui128_t)ix[2], (vui128_t) es);
+
+  return (rc);
+}
+
+#define CONST_UINT128_QxD(__q0, __q1) ( \
+    (((unsigned __int128) __q0) << 64) \
+    + ((unsigned __int128) __q1))
+
+unsigned __int128 dummy_i2;
+unsigned __int128 dummy_i3;
+unsigned __int128 divuq_parm0 = CONST_UINT128_QxD(0x0100000000000000UL, 0UL);
+unsigned __int128 divuq_parm1 = CONST_UINT128_QxD(0UL, 1UL);
+unsigned __int128 divuq2_parm = CONST_UINT128_QxD(__UINT64_MAX__, __UINT64_MAX__);
+
+extern unsigned __int128 __udivti3 (unsigned __int128, unsigned __int128);
+
+int
+timed_gcc_divuq (void)
+{
+  //Taylor series to compute e**x where x = 1.0
+  // This use case requires a 128-bit / 64-bit divide
+
+  unsigned __int128 ix[4];
+  unsigned __int128 es;
+  unsigned __int128 rq;
+  int rc = 0;
+
+  // Making sure this code actually calls __udivti3 !
+  ix[0] = divuq_parm0;
+  ix[1] = divuq_parm1;
+  ix[2] = CONST_UINT128_QxD(0UL, 1UL);
+  // Scaled Fixed-point 128.120 == 1.0
+  ix[3] = CONST_UINT128_QxD(0x0100000000000000UL, 0x0UL);
+
+  rq = (ix[0] / ix[2]);
+  ix[3] = (ix[3] + rq); // next term
+  ix[0] = rq;
+  ix[2] = (ix[2] + ix[1]);
+
+  rq = (ix[0] / ix[2]);
+  ix[3] = (ix[3] + rq); // next term
+  ix[0] = rq;
+  ix[2] = (ix[2] + ix[1]);
+
+  rq = (ix[0] / ix[2]);
+  ix[3] = (ix[3] + rq); // next term
+  ix[0] = rq;
+  ix[2] = (ix[2] + ix[1]);
+
+  rq = (ix[0] / ix[2]);
+  ix[3] = (ix[3] + rq); // next term
+  ix[0] = rq;
+  ix[2] = (ix[2] + ix[1]);
+
+  rq = (ix[0] / ix[2]);
+  ix[3] = (ix[3] + rq); // next term
+  ix[0] = rq;
+  ix[2] = (ix[2] + ix[1]);
+
+  rq = (ix[0] / ix[2]);
+  ix[3] = (ix[3] + rq); // next term
+  ix[0] = rq;
+  ix[2] = (ix[2] + ix[1]);
+
+  rq = (ix[0] / ix[2]);
+  ix[3] = (ix[3] + rq); // next term
+  ix[0] = rq;
+  ix[2] = (ix[2] + ix[1]);
+
+  rq = (ix[0] / ix[2]);
+  ix[3] = (ix[3] + rq); // next term
+  ix[0] = rq;
+  ix[2] = (ix[2] + ix[1]);
+
+  rq = (ix[0] / ix[2]);
+  ix[3] = (ix[3] + rq); // next term
+  ix[0] = rq;
+  ix[2] = (ix[2] + ix[1]);
+
+  rq = (ix[0] / ix[2]);
+
+  ix[3] = (ix[3] + rq); // last term
+
+  dummy_i3 = ix[3];
+  es = CONST_UINT128_QxD(0x02b7e150ed3c569dUL, 0x975c4df261fe4d64UL);
+  rc += check_int128 ("div_int128-sum :", ix[3], es);
+
+  return (rc);
+}
+
+int
+timed_gcc_divuq2 (void)
+{
+  // Newton's method square root
+  // This use case requires a full 128-bit / 128-bit divide.
+  unsigned __int128 ix[4];
+  unsigned __int128  es;
+  unsigned __int128  rq;
+  int rc = 0;
+
+  // Making sure this code actually calls __udivti3 !
+  ix[0] = divuq2_parm; // parm a from extern
+  ix[1] = divuq2_parm;
+
+  // improve initial estimate of g0
+  ix[2] = (ix[1] >> 56);
+
+  // a / g0
+  rq = (ix[0] / ix[2]);
+  ix[3] = (ix[2] + rq);
+  ix[2] = (ix[3] >> 1);
+
+  // a / gn
+  rq = (ix[0] / ix[2]);
+  ix[3] = (ix[2] + rq);
+  ix[2] = (ix[3] >> 1);
+
+  // a / gn
+  rq = (ix[0] / ix[2]);
+  ix[3] = (ix[2] + rq);
+  ix[2] = (ix[3] >> 1);
+
+  // a / gn
+  rq = (ix[0] / ix[2]);
+  ix[3] = (ix[2] + rq);
+  ix[2] = (ix[3] >> 1);
+
+  // a / gn
+  rq = (ix[0] / ix[2]);
+  ix[3] = (ix[2] + rq);
+  ix[2] = (ix[3] >> 1);
+
+  // a / gn
+  rq = (ix[0] / ix[2]);
+  ix[3] = (ix[2] + rq);
+  ix[2] = (ix[3] >> 1);
+
+  // a / gn
+  rq = (ix[0] / ix[2]);
+  ix[3] = (ix[2] + rq);
+  ix[2] = (ix[3] >> 1);
+
+  // a / gn
+  rq = (ix[0] / ix[2]);
+  ix[3] = (ix[2] + rq);
+  ix[2] = (ix[3] >> 1);
+
+  // a / gn
+  rq = (ix[0] / ix[2]);
+  ix[3] = (ix[2] + rq);
+  ix[2] = (ix[3] >> 1);
+
+  // a / gn
+  rq = (ix[0] / ix[2]);
+  ix[3] = (ix[2] + rq);
+  ix[2] = (ix[3] >> 1);
+
+  // a / gn
+  rq = (ix[0] / ix[2]);
+  ix[3] = (ix[2] + rq);
+  ix[2] = (ix[3] >> 1);
+
+  // a / gn
+  rq = (ix[0] / ix[2]);
+  ix[3] = (ix[2] + rq);
+  ix[2] = (ix[3] >> 1);
+
+  // a / gn
+  rq = (ix[0] / ix[2]);
+  ix[3] = (ix[2] + rq);
+  ix[2] = (ix[3] >> 1);
+
+  dummy_i2 = ix[2];
+
+  es = CONST_UINT128_QxD(1UL, 0UL);
+  rc += check_int128 ("div2_int128-sum :", ix[2], es);
+
+  return (rc);
+}
+
 #if 0
 #else
 extern vui64_t test_divdud (vui64_t x, vui64_t y, vui64_t z);
@@ -57,6 +695,8 @@ extern vui64_t test_moddud (vui64_t x, vui64_t y, vui64_t z);
 extern vui64_t test_divud (vui64_t y, vui64_t z);
 extern vui64_t test_modud (vui64_t y, vui64_t z);
 extern vui64_t test_divmodud (vui64_t *r, vui64_t y, vui64_t z);
+extern __VEC_U_128P test_divdqu (vui128_t x, vui128_t y, vui128_t z);
+//#define test_moddivduq	test_divdqu
 #endif
 
 vui64_t dummy_x2;
@@ -66,7 +706,7 @@ int timed_divmodud (void)
   int ii;
   int rc = 0;
 
-  vui64_t ix[4], hx, lx, dx, dy, dz, dq, dr;
+  vui64_t ix[4], lx, dx, dy, dz, dq, dr;
   vui64_t rq, qq, rr;
 
   const vui64_t c32_9s =(vui64_t)CONST_VINT128_DW(0x000004ee2d6d415bUL,
@@ -120,7 +760,7 @@ int timed_lib_divmodud (void)
   int ii;
   int rc = 0;
 
-  vui64_t ix[4], hx, lx, dx, dy, dz, dq, dr;
+  vui64_t ix[4], lx, dx, dy, dz, dq, dr;
   vui64_t rq, qq, rr;
 
   const vui64_t c32_9s =(vui64_t)CONST_VINT128_DW(0x000004ee2d6d415bUL,

--- a/src/testsuite/vec_perf_i128.h
+++ b/src/testsuite/vec_perf_i128.h
@@ -32,6 +32,12 @@ extern int timed_cmul10ecuq (void);
 extern int timed_mulluq (void);
 extern int timed_muludq (void);
 extern int timed_muludqx (void);
+extern int timed_vec_divdqu (void);
+extern int timed_vec_divuqe (void);
+extern int timed_vec_divuq (void);
+extern int timed_vec_divuq2 (void);
+extern int timed_gcc_divuq (void);
+extern int timed_gcc_divuq2 (void);
 extern int timed_longdiv_e32 (void);
 #ifndef PVECLIB_DISABLE_DFP
 extern int timed_longbcdcf_10e32 (void);

--- a/src/testsuite/vec_pwr10_dummy.c
+++ b/src/testsuite/vec_pwr10_dummy.c
@@ -38,6 +38,49 @@
 #include <pveclib/vec_f32_ppc.h>
 #include <pveclib/vec_bcd_ppc.h>
 
+vui128_t test_divuqe_PWR10 (vui128_t x, vui128_t z)
+{
+  return vec_vdivuqe_inline (x, z);
+}
+
+vui128_t test_divuq_PWR10 (vui128_t y, vui128_t z)
+{
+  return vec_vdivuq_inline (y, z);
+}
+
+vui128_t test_moduq_PWR10 (vui128_t y, vui128_t z)
+{
+  return vec_vmoduq_inline (y, z);
+}
+
+vui128_t test_divduq_PWR10 (vui128_t x, vui128_t y, vui128_t z)
+{
+  return vec_divduq (x, y, z);
+}
+
+vui128_t test_modduq_PWR10 (vui128_t x, vui128_t y, vui128_t z)
+{
+  return vec_modduq (x, y, z);
+}
+
+__VEC_U_128P test_divdqu_PWR10 (vui128_t x, vui128_t y, vui128_t z)
+{
+  return vec_divdqu_inline (x, y, z);
+}
+
+vui128_t
+test_vec_mulqud_PWR10 (vui128_t *mulu, vui128_t a, vui128_t b)
+{
+  vui128_t l128, h128;
+  vui64_t b_eud = vec_mrgahd ((vui128_t) b, (vui128_t)b);
+  l128 = vec_vmuloud ((vui64_t ) a, b_eud);
+  h128 = vec_vmaddeud ((vui64_t ) a, b_eud, (vui64_t ) l128);
+  l128 = vec_slqi (l128, 64);
+
+  *mulu = (vui128_t) h128;
+  return ((vui128_t) l128);
+}
+
 // Attempts at better code to splat small DW constants.
 // Want to avoid addr calc and loads for what should be simple
 // splat immediate and unpack/extend.
@@ -47,7 +90,7 @@ __test_splatisd_12_PWR10 (void)
   return vec_splat_s64 (12);
 }
 
-// vec_splati from word requires GCC 10 and PWR10
+// vec_splati from word requires GCC 12 and PWR10
 #if defined (_ARCH_PWR10) && ((__GNUC__ > 11) \
     && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
 vi64_t
@@ -64,10 +107,8 @@ __test_splatudi_12_PWR10_v0 (void)
   return vec_splats ((unsigned long long) 12);
 }
 
-#if defined (_ARCH_PWR10) && (__GNUC__ > 11) \
-    || ((__GNUC__ == 11) && (__GNUC_MINOR__ > 3))
+#if defined (_ARCH_PWR10) && (__GNUC__ > 11)
 // New support defined in Power Vector Intrinsic Programming Reference.
-// Waiting for GCC 11.3?
 int
 test_gcc_cmpsq_all_gt_PWR10 (vi128_t a, vi128_t b)
 {
@@ -368,6 +409,13 @@ __test_cmsumudm_PWR10 (vui128_t * carry, vui64_t a, vui64_t b, vui128_t c)
 }
 
 vui128_t
+__test_cmsumudm_V2_PWR10 (vui128_t * carry, vui64_t a, vui64_t b, vui128_t c)
+{
+  *carry = vec_msumcud ( a, b, c);
+  return vec_msumudm ( a, b, c);
+}
+
+vui128_t
 test_vec_srdbi_PWR10  (vui128_t a, vui128_t b, const unsigned int  sh)
 {
   return (vec_vsrdbi (a, b, sh));
@@ -437,6 +485,12 @@ vui128_t
 test_vec_slqi_7_PWR10  (vui128_t a)
 {
   return (vec_slqi (a, 7));
+}
+
+vui128_t
+test_vec_slqi_8_PWR10  (vui128_t a)
+{
+  return (vec_slqi (a, 8));
 }
 
 vi128_t
@@ -566,9 +620,111 @@ __test_mulluq_PWR10 (vui128_t a, vui128_t b)
 }
 
 vui128_t
+__test_mulluq_V1_PWR10 (vui128_t a, vui128_t b)
+{
+  vui64_t t, tmq;
+  /* compute the 256 bit product of two 128 bit values a, b.
+   * The high 128 bits are accumulated in t and the low 128-bits
+   * in tmq.  Only the low order 128 bits of the product are
+   * returned.
+   */
+#ifdef _ARCH_PWR9
+  const vui64_t zero = { 0, 0 };
+  vui64_t b_swap = vec_swapd ((vui64_t) b);
+  /* multiply the low 64-bits of a and b.  For PWR9 this is just
+   * vmsumudm with conditioned inputs.  */
+  tmq = (vui64_t) vec_vmuloud ((vui64_t) a, (vui64_t) b);
+  /* we can use multiply sum here because we only need the low 64-bits
+   * and don't care if we lose the carry / overflow.  */
+  /* sum = (a[h] * b[l]) + (a[l] * b[h])) + zero).  */
+  t   = (vui64_t) vec_msumudm ((vui64_t) a, b_swap, (vui128_t) zero);
+  /* result = sum ({tmq[h] + t[l]} , {tmq[l] + zero}).  */
+  /* Shift t left 64-bits and use doubleword add. */
+  t   = (vui64_t) vec_mrgald ((vui128_t) t, (vui128_t) zero);
+  tmq = (vui64_t) vec_addudm ((vui64_t) t, (vui64_t) tmq);
+#else
+#endif
+  return ((vui128_t) tmq);
+}
+
+vui128_t
 __test_muludq_PWR10 (vui128_t *mulh, vui128_t a, vui128_t b)
 {
   return vec_muludq (mulh, a, b);
+}
+
+vui128_t
+__test_muludq_V1_PWR10 (vui128_t *mulu, vui128_t a, vui128_t b)
+{
+  vui32_t t, tmq;
+  /* compute the 256 bit product of two 128 bit values a, b.
+   * The high 128 bits are accumulated in t and the low 128-bits
+   * in tmq. The high 128-bits of the product are returned to the
+   * address of the 1st parm. The low 128-bits are the return
+   * value.
+   */
+#ifdef _ARCH_PWR10
+  const vui64_t zero = { 0, 0 };
+  vui64_t a_swap = vec_swapd ((vui64_t) a);
+  vui128_t thq, tlq, tx;
+  vui128_t txl, txh, tc1;
+  vui128_t thh, tll;
+  /* multiply the high and low 64-bits of a and b.  */
+  tll = vec_vmuloud ((vui64_t)a, (vui64_t)b);
+  thh = vec_vmuleud ((vui64_t)a, (vui64_t)b);
+  /* multiply and sum the middle products with carry-out */
+  tx  = vec_vmsumudm_inline  ((vui64_t)a_swap, (vui64_t)b, (vui128_t)zero);
+  tc1 = vec_vmsumcud_inline  ((vui64_t)a_swap, (vui64_t)b, (vui128_t)zero);
+  /* Align the middle product and carry-out for double quadword sum */
+#if 0
+  txl = (vui128_t) vec_mrgald ( tx,  (vui128_t) zero);
+#else
+  txl = vec_sldqi ( tx,  tc1, 64);
+#endif
+  txh = vec_sldqi ( tc1, tx,  64);
+  /* Double quadword sum for 256-bit product */
+  tc1 = vec_addcuq (tll, txl);
+  tlq  = vec_adduqm (tll, txl);
+  thq  = vec_addeuqm (thh, txh, tc1);
+
+  t = (vui32_t) thq;
+  tmq = (vui32_t) tlq;
+#else
+  const vui64_t zero = { 0, 0 };
+  vui64_t a_swap = vec_swapd ((vui64_t) a);
+  vui128_t thq, tlq, tx;
+  vui128_t t0l, tc1;
+  vui128_t thh, thl, tlh, tll;
+  /* multiply the low 64-bits of a and b.  For PWR9 this is just
+   * vmsumudm with conditioned inputs.  */
+  tll = vec_vmuloud ((vui64_t)a, (vui64_t)b);
+  thh = vec_vmuleud ((vui64_t)a, (vui64_t)b);
+  thl = vec_vmuloud (a_swap, (vui64_t)b);
+#if 0
+  tlh = vec_vmuleud (a_swap, (vui64_t)b);
+  /* sum the two middle products (plus the high 64-bits of the low
+   * product.  This will generate a carry that we need to capture.  */
+  t0l   = (vui128_t) vec_mrgahd ( (vui128_t) zero, tll);
+#else
+  tlh = vec_vmaddeud (a_swap, (vui64_t)b, (vui64_t)tll);
+#endif
+  tc1 = vec_addcuq (thl, tlh);
+  tx   = vec_adduqm (thl, tlh);
+#if 0
+  tx   = vec_adduqm (tx, t0l);
+#endif
+  /* result = t[l] || tll[l].  */
+  tlq = (vui128_t) vec_mrgald ((vui128_t) tx, (vui128_t) tll);
+  /* Sum the high product plus the high sum (with carry) of middle
+   * partial products.  This can't overflow.  */
+  thq = (vui128_t) vec_permdi ((vui64_t) tc1, (vui64_t) tx, 2);
+  thq = vec_adduqm ( thh, thq);
+
+  t = (vui32_t) thq;
+  tmq = (vui32_t) tlq;
+#endif
+  *mulu = (vui128_t) t;
+  return ((vui128_t) tmq);
 }
 
 vui128_t
@@ -801,5 +957,87 @@ vui64_t test_vec_divdud_PWR10 (vui64_t x, vui64_t y, vui64_t z)
   R = vec_selud (R, Rt, CC);
 #endif
   return Q;
+}
+
+__VEC_U_128P test_vec_moddivduq_PWR10 (vui128_t x, vui128_t y, vui128_t z)
+{
+  __VEC_U_128P result;
+#if defined (_ARCH_PWR8)
+  vui128_t Q, R;
+  vui128_t r1, r2, q1, q2;
+  vb128_t CC, c1, c2;
+  const vui128_t ones = {(__int128) 1};
+
+  // Based on the PowerISA, Programming Note for
+  // Divide Word Extended [Unsigned] but vectorized
+  // for vector __int128
+  q1 = vec_vdivuqe_inline (x, z);
+  q2 = vec_vdivuq_inline  (y, z);
+  r1 = vec_mulluq (q1, z);
+
+  r2 = vec_mulluq (q2, z);
+  r2 = vec_subuqm (y, r2);
+  Q  = vec_adduqm (q1, q2);
+  R  = vec_subuqm (r2, r1);
+
+  c1 = vec_cmpltuq (R, r2);
+#if defined (_ARCH_PWR8) // vorc requires P8
+  c2 = vec_cmpgtuq (z, R);
+  CC = (vb128_t) vec_orc ((vb32_t)c1, (vb32_t)c2);
+#else
+  c2 = vec_cmpgeuq (R, z);
+  CC = (vb128_t) vec_or ((vb32_t)c1, (vb32_t)c2);
+#endif
+// Corrected Quotient returned for divduq.
+  vui128_t Qt;
+  Qt = vec_adduqm (Q, ones);
+  Q = vec_seluq (Q, Qt, CC);
+  result.vx0 = Q;
+// Corrected Remainder not returned for divduq.
+  vui128_t Rt;
+  Rt = vec_subuqm (R, z);
+  R = vec_seluq (R, Rt, CC);
+  result.vx1 = R;
+#else
+  /* Based on Hacker's Delight (2nd Edition) Figure 9-2.
+   * "Divide long unsigned shift-and-subtract algorithm."
+   * Converted to use vector unsigned __int128 and PVEClIB
+   * operations.
+   * As cmpgeuq is based on detecting the carry-out of (x -z) and
+   * setting the bool via setb_cyq, we can use this carry (variable t)
+   * to generate quotient bits.
+   * Multi-precision shift-left is simpler then general addition,
+   * so we can simplify carry generation. This allows delaying the
+   * the y left-shift / quotient accumulation to a later.
+   * */
+  int i;
+  vb128_t ge;
+  vui128_t t, cc, c, xt;
+  //t = (vui128_t) CONST_VINT128_W (0, 0, 0, 0);
+
+  for (i = 1; i <= 128; i++)
+    {
+      // Left shift (x || y) requires 257-bits, is (t || x || y)
+      // t from previous iteration generates to 0/1 for low order y-bits.
+      c = vec_addcuq (y, y);
+      t = vec_addcuq (x, x);
+      x = vec_addeuqm (x, x, c);
+
+      // deconstruct ((t || x) >= z)
+      // Carry from subcuq == 1 for x >= z
+      cc = vec_subcuq (x, z);
+      // Combine t with (x >= z) for 129-bit compare
+      t  = (vui128_t) vec_or ((vui32_t)cc, (vui32_t)t);
+      // Convert to a bool for select
+      ge = vec_setb_cyq (t);
+
+      xt = vec_subuqm (x, z);
+      y = vec_addeuqm (y, y, t);
+      x = vec_seluq (x, xt, ge);
+    }
+  result.vx0 = y; // Q
+  result.vx1 = x; // R
+#endif
+  return result;
 }
 #endif


### PR DESCRIPTION
POWER10 added vector divde/divide-extended/modulo instructions. This is the initial patch for the quadword implementations. Also some general Wall fixups and latent compile error fixes. A later patch will add the platform specific implementations for static and IFUNC enabled dynamic libraries.

	* doc/pveclib-doxygen-pveclib.doxy [FORMULA_TRANSPARENT, LATEX_SOURCE_CODE, CLASS_DIAGRAMS, DOT_FONTNAME, DOT_FONTSIZE, DOT_TRANSPARENT]: Remove tags that are no longer support is recent doxygen versions.
	* doc/pveclibmaindox.h: Escape \# for pragma to fix formating.

	* src/pveclib/vec_int128_ppc.h: Update copyright year. General doxygen text updates, mostly POWER10 related. [int128_multiply_0_1]: New Subsection Implementing Quadword Multiply. [int128_multiply_0_1_0_0]: New subsubsection POWER7/8 Implementation of Quadword Multiply. [int128_multiply_0_1_0_1]: New subsubsection POWER9/10 Implementation of Quadword Multiply. [int128_multiply_0_1_1]: New subsubsection Implementing Quadword Multiply High. [int128_multiply_0_1_2]: New subsubsection Implementing Quadword Multiply Low. [int128_multiply_0_1_3]: New subsubsection Implementing Quadword Multiply with double Quadword result. [int128_Divide_0_1]: New subsection Implementing Quadword Divide/Modulo. [int128_Divide_0_1_1]: New subsubsection Vectorizable Divide implementations. [int128_Divide_0_1_1_1]: New paragraph Vectorized Shift-Subtract Quadword Divide. [int128_Divide_0_1_1_2]: New paragraph Vectorized Quadword Long division. [int128_Divide_0_1_1_3]: New paragraph Divide Quadword implementation. [int128_Divide_0_1_1_4]: New paragraph Divide Extended Quadword implementation. [int128_Divide_0_1_1_5]: New paragraph Quadword Modulo implementation. [int128_Divide_0_1_1_6]: New paragraph Double Quadword Divide implementation. (__VEC_U_128P): New type quadword integer pair. (vec_vdivuqe_inline, vec_vdivuq_inline, vec_vmoduq_inline, vec_divdqu_inline, vec_seluq, vec_vmsumcud_inline, vec_vmsumudm_inline): New Forward function prototypes. (vec_divduq, vec_divuqe, vec_divuq): New functions. (vec_divdqu_inline, vec_modduq, vec_moduq): New functions. (vec_msumudm): Update brief description. (vec_mulhuq): Update brief description. (vec_mulhuq [_ARCH_PWR10]): Add POWER10 specific implementation. (vec_mulluq): Update brief description. (vec_mulhuq [_ARCH_PWR9]): Update POWER9 specific implementation. (vec_muludq): Update brief description. (vec_muludq [_ARCH_PWR10]): Add POWER10 specific implementation. (vec_muludq [_ARCH_PWR9]): Update POWER9 specific implementation. (vec_slqi [_ARCH_PWR10]): Fix for POWER10 specific implementation. (vec_vdivuqe_inline, vec_vdivuq_inline, vec_vmoduq_inline): New functions. (vec_vmuleud): Update brief description. (vec_vmulhud_inline): New functions. (vec_vmulld_inline): Add POWER10 specific implementation. (vec_vmuloud): Update brief description. (vec_vmsumcud_inline, vec_vmsumudm_inline): New functions.

	* src/pveclib/vec_int64_ppc.h[i64_missing_ops_0_2_2_1]: Add ref to doxygen description. (vec_divqud_inline [_ARCH_PWR9]):Fix for POWER9 specific compiler issue. (vec_moddud_inline): Fix Wall warning.

	* src/testsuite/arith128_test_i128.c (db_vec_divuqe, db_vec_divuq, db_vec_divdqu, db_vec_moduq): New dubug functions. (test_vec_divide_QW, test_vec_modulo_QW, test_vec_moddiv_QW, test_vec_divext_QW, est_vec_div1_QW, test_vec_div_QW): New unit test functions. (test_vec_i128): Call new unit tests from driver.

	* src/testsuite/arith128_test_i512.c (test_mul512x128): Additional cases for unit test.

	* src/testsuite/vec_f128_dummy.c (test_vec_msubqpo); Fix Wall warning.
	* src/testsuite/vec_int128_dummy.c (test_divuqe, test_divuq, test_moduq, test_divduq, test_modduq, test_divdqu): Inline expantion compile test. (test_vec_mulqud, test_vec_xxx; test_vec_xxx_V2, test_vec_xxx_V1, test_vec_xxx_V0): compile tests. (test_vec_divuqe, test_vec_divuq, test_vec_divduq, test_vec_divdqu): Implementation compile tests. (test_vec_udivqi3): compile tests. (test_vec_moduq, test_vec_modduq): Implementation compile tests. (__test_cmsumudm_V2): compile tests.
	* src/testsuite/vec_int64_dummy.c (test_vec_divude, test_vec_divdud_V1[_ARCH_PWR8]): Fix Wall warnings.
	* src/testsuite/vec_pwr10_dummy.c (test_divuqe_PWR10, vec_vdivuqe_inline, test_divuq_PWR10, test_moduq_PWR10, test_divduq_PWR10, test_modduq_PWR10, test_vec_mulqud_PWR10): Implementation compile tests. (__test_splatudi_12_PWR10 [_ARCH_PWR10 && (__GNUC__ > 11)]): Guard using intrinsic vec_splati for compiler support. (test_gcc_cmpsq_all_gt_PWR10, test_gcc_cmpsq_gt_PWR10 [_ARCH_PWR10 && (__GNUC__ > 11)]): Guard using intrinsic ec_cmpgt for signed __int128 for compiler support. (__test_cmsumudm_V2_PWR10, test_vec_slqi_8_PWR10): Implementation compile tests. (__test_mulluq_V1_PWR10, __test_muludq_V1_PWR10, test_vec_moddivduq_PWR10): Compile test for code generation.
	* src/testsuite/vec_pwr9_dummy.c (test_vec_msubqpo_PWR9): Fix Wall warning. (__test_cmsumudm_V2_PWR10, __test_mulhuq_x_PWR9, __test_mulluq_V1_PWR9, __test_muludq_w_PWR9): Compile test for code generation. (test_divuqe_PWR9, test_divuq_PWR9, test_moduq_PWR9, test_divduq_PWR9, test_modduq_PWR9, test_divdqu_PWR9): Implementation compile tests. (test_vec_moddivduq_PWR9): Compile test for code generation.

	* src/testsuite/pveclib_perf.c ()test_time_i128): Add timed tests for quadword divide.
	* src/testsuite/vec_perf_i128.c (c152): Constant 10**152-1. (timed_vec_divdqu, timed_vec_divuqe, timed_vec_divuq, timed_vec_divuq2): Timed test for new PVEVLIB functions. (timed_gcc_divuq, timed_gcc_divuq2): Timed libgcc functions for comparison. (test_divdqu): Timed test for new PVEVLIB functions. (timed_divmodud): Fix Wall warnings.
	* src/testsuite/vec_perf_i128.h (timed_vec_divdqu, timed_vec_divuqe, timed_vec_divuq, timed_vec_divuq2, timed_gcc_divuq, timed_gcc_divuq2): New externs for timed tests.