### PR TITLE
Add P7/8/9/10 divide/modulo quadword operations to libraries.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -47,7 +47,7 @@ PVECCOMPILE = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 	$(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) \
 	$(AM_CFLAGS)
 
-vec_dynrt_PWR10.lo: vec_runtime_PWR10.c vec_int64_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
+vec_dynrt_PWR10.lo: vec_runtime_PWR10.c vec_int64_runtime.c vec_int128_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 if am__fastdepCC
 	$(PVECCOMPILE) -fpic $(PVECLIB_POWER10_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR10.c
 	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
@@ -59,7 +59,7 @@ endif
 	$(PVECCOMPILE) -fpic $(PVECLIB_POWER10_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR10.c
 endif
 
-vec_staticrt_PWR10.lo: vec_runtime_PWR10.c vec_int64_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
+vec_staticrt_PWR10.lo: vec_runtime_PWR10.c vec_int64_runtime.c vec_int128_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 if am__fastdepCC
 	$(PVECCOMPILE) -fpie $(PVECLIB_POWER10_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR10.c
 	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
@@ -71,7 +71,7 @@ endif
 	$(PVECCOMPILE) -fpie $(PVECLIB_POWER10_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR10.c
 endif
 
-vec_dynrt_PWR9.lo: vec_runtime_PWR9.c vec_int64_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
+vec_dynrt_PWR9.lo: vec_runtime_PWR9.c vec_int64_runtime.c vec_int128_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 if am__fastdepCC
 	$(PVECCOMPILE) -fpic $(PVECLIB_POWER9_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR9.c
 	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
@@ -83,7 +83,7 @@ endif
 	$(PVECCOMPILE) -fpic $(PVECLIB_POWER9_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR9.c
 endif
 
-vec_staticrt_PWR9.lo: vec_runtime_PWR9.c vec_int64_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
+vec_staticrt_PWR9.lo: vec_runtime_PWR9.c vec_int64_runtime.c vec_int128_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 if am__fastdepCC
 	$(PVECCOMPILE) -fpie $(PVECLIB_POWER9_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR9.c
 	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
@@ -95,7 +95,7 @@ endif
 	$(PVECCOMPILE) -fpie $(PVECLIB_POWER9_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR9.c
 endif
 
-vec_dynrt_PWR8.lo: vec_runtime_PWR8.c vec_int64_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
+vec_dynrt_PWR8.lo: vec_runtime_PWR8.c vec_int64_runtime.c vec_int128_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 if am__fastdepCC
 	$(PVECCOMPILE) -fpic $(PVECLIB_POWER8_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR8.c
 	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
@@ -107,7 +107,7 @@ endif
 	$(PVECCOMPILE) -fpic $(PVECLIB_POWER8_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR8.c
 endif
 
-vec_staticrt_PWR8.lo: vec_runtime_PWR8.c vec_int64_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
+vec_staticrt_PWR8.lo: vec_runtime_PWR8.c vec_int64_runtime.c vec_int128_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 if am__fastdepCC
 	$(PVECCOMPILE) -fpie $(PVECLIB_POWER8_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR8.c
 	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
@@ -119,7 +119,7 @@ endif
 	$(PVECCOMPILE) -fpie $(PVECLIB_POWER8_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR8.c
 endif
 
-vec_dynrt_PWR7.lo: vec_runtime_PWR7.c vec_int64_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
+vec_dynrt_PWR7.lo: vec_runtime_PWR7.c vec_int64_runtime.c vec_int128_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 if am__fastdepCC
 	$(PVECCOMPILE) -fpic $(PVECLIB_POWER7_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR7.c
 	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
@@ -131,7 +131,7 @@ endif
 	$(PVECCOMPILE) -fpic $(PVECLIB_POWER7_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR7.c
 endif
 
-vec_staticrt_PWR7.lo: vec_runtime_PWR7.c vec_int64_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
+vec_staticrt_PWR7.lo: vec_runtime_PWR7.c vec_int64_runtime.c vec_int128_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 if am__fastdepCC
 	$(PVECCOMPILE) -fpie $(PVECLIB_POWER7_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR7.c
 	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
@@ -162,8 +162,9 @@ EXTRA_DIST = \
   vec_runtime_PWR10.c \
   vec_runtime_common.c \
   vec_int64_runtime.c \
+  vec_int128_runtime.c \
   vec_int512_runtime.c \
-  vec_f126_runtime.c
+  vec_f128_runtime.c
 
 distclean-local:
 	rm $(DEPDIR)/*.Plo

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -723,7 +723,8 @@ PVECCOMPILE = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 
 EXTRA_DIST = vec_runtime_PWR7.c vec_runtime_PWR8.c vec_runtime_PWR9.c \
 	vec_runtime_PWR10.c vec_runtime_common.c vec_int64_runtime.c \
-	vec_int512_runtime.c vec_f126_runtime.c $(pveclib_la_INCLUDES)
+	vec_int128_runtime.c vec_int512_runtime.c vec_f128_runtime.c \
+	$(pveclib_la_INCLUDES)
 
 # libpvec definitions.
 # libpvec_la already includes vec_runtime_DYN.c compiled compiled -fpic
@@ -1976,56 +1977,56 @@ uninstall-am: uninstall-libLTLIBRARIES uninstall-pveclibincludeHEADERS
 .PRECIOUS: Makefile
 
 
-vec_dynrt_PWR10.lo: vec_runtime_PWR10.c vec_int64_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
+vec_dynrt_PWR10.lo: vec_runtime_PWR10.c vec_int64_runtime.c vec_int128_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 @am__fastdepCC_TRUE@	$(PVECCOMPILE) -fpic $(PVECLIB_POWER10_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR10.c
 @am__fastdepCC_TRUE@	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	source='vec_runtime_PWR10.c' object='$@' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(PVECCOMPILE) -fpic $(PVECLIB_POWER10_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR10.c
 
-vec_staticrt_PWR10.lo: vec_runtime_PWR10.c vec_int64_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
+vec_staticrt_PWR10.lo: vec_runtime_PWR10.c vec_int64_runtime.c vec_int128_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 @am__fastdepCC_TRUE@	$(PVECCOMPILE) -fpie $(PVECLIB_POWER10_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR10.c
 @am__fastdepCC_TRUE@	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	source='vec_runtime_PWR10.c' object='$@' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(PVECCOMPILE) -fpie $(PVECLIB_POWER10_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR10.c
 
-vec_dynrt_PWR9.lo: vec_runtime_PWR9.c vec_int64_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
+vec_dynrt_PWR9.lo: vec_runtime_PWR9.c vec_int64_runtime.c vec_int128_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 @am__fastdepCC_TRUE@	$(PVECCOMPILE) -fpic $(PVECLIB_POWER9_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR9.c
 @am__fastdepCC_TRUE@	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	source='vec_runtime_PWR9.c' object='$@' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(PVECCOMPILE) -fpic $(PVECLIB_POWER9_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR9.c
 
-vec_staticrt_PWR9.lo: vec_runtime_PWR9.c vec_int64_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
+vec_staticrt_PWR9.lo: vec_runtime_PWR9.c vec_int64_runtime.c vec_int128_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 @am__fastdepCC_TRUE@	$(PVECCOMPILE) -fpie $(PVECLIB_POWER9_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR9.c
 @am__fastdepCC_TRUE@	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	source='vec_runtime_PWR9.c' object='$@' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(PVECCOMPILE) -fpie $(PVECLIB_POWER9_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR9.c
 
-vec_dynrt_PWR8.lo: vec_runtime_PWR8.c vec_int64_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
+vec_dynrt_PWR8.lo: vec_runtime_PWR8.c vec_int64_runtime.c vec_int128_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 @am__fastdepCC_TRUE@	$(PVECCOMPILE) -fpic $(PVECLIB_POWER8_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR8.c
 @am__fastdepCC_TRUE@	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	source='vec_runtime_PWR8.c' object='$@' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(PVECCOMPILE) -fpic $(PVECLIB_POWER8_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR8.c
 
-vec_staticrt_PWR8.lo: vec_runtime_PWR8.c vec_int64_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
+vec_staticrt_PWR8.lo: vec_runtime_PWR8.c vec_int64_runtime.c vec_int128_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 @am__fastdepCC_TRUE@	$(PVECCOMPILE) -fpie $(PVECLIB_POWER8_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR8.c
 @am__fastdepCC_TRUE@	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	source='vec_runtime_PWR8.c' object='$@' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(PVECCOMPILE) -fpie $(PVECLIB_POWER8_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR8.c
 
-vec_dynrt_PWR7.lo: vec_runtime_PWR7.c vec_int64_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
+vec_dynrt_PWR7.lo: vec_runtime_PWR7.c vec_int64_runtime.c vec_int128_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 @am__fastdepCC_TRUE@	$(PVECCOMPILE) -fpic $(PVECLIB_POWER7_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR7.c
 @am__fastdepCC_TRUE@	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	source='vec_runtime_PWR7.c' object='$@' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(PVECCOMPILE) -fpic $(PVECLIB_POWER7_CFLAGS) -c -o $@ $(srcdir)/vec_runtime_PWR7.c
 
-vec_staticrt_PWR7.lo: vec_runtime_PWR7.c vec_int64_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
+vec_staticrt_PWR7.lo: vec_runtime_PWR7.c vec_int64_runtime.c vec_int128_runtime.c vec_int512_runtime.c vec_f128_runtime.c $(pveclibinclude_HEADERS)
 @am__fastdepCC_TRUE@	$(PVECCOMPILE) -fpie $(PVECLIB_POWER7_CFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $(srcdir)/vec_runtime_PWR7.c
 @am__fastdepCC_TRUE@	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	source='vec_runtime_PWR7.c' object='$@' libtool=yes @AMDEPBACKSLASH@

--- a/src/testsuite/arith128_test_i128.c
+++ b/src/testsuite/arith128_test_i128.c
@@ -907,7 +907,7 @@ db_example_longdiv_10e31 (vui128_t *q, vui128_t *d, long int _N)
 
 
 //#define __DEBUG_PRINT__ 1
-vui128_t db_vec_divuqe (vui128_t x, vui128_t z)
+vui128_t db_vec_diveuq (vui128_t x, vui128_t z)
 {
 #if defined (_ARCH_PWR10)  && (__GNUC__ >= 10)
   vui128_t res;
@@ -11112,10 +11112,10 @@ test_xfer_int128 (void)
 extern vui128_t test_vec_divduq (vui128_t x, vui128_t y, vui128_t z);
 #define test_divduq	test_vec_divduq
 #if 0
-#define test_divuqe	db_vec_divuqe
+#define test_diveuq	db_vec_diveuq
 #else
-extern vui128_t test_vec_divuqe (vui128_t x, vui128_t z);
-#define test_divuqe	test_vec_divuqe
+extern vui128_t test_vec_diveuq (vui128_t x, vui128_t z);
+#define test_diveuq	test_vec_diveuq
 #endif
 #if 0
 #define test_divuq	db_vec_divuq
@@ -11124,9 +11124,20 @@ extern vui128_t test_vec_divuq (vui128_t y, vui128_t z);
 #define test_divuq	test_vec_divuq
 #endif
 #else
+#if 1
+// Use static lib implementations.
+extern vui128_t  __VEC_PWR_IMP(vec_divduq) (vui128_t x, vui128_t y, vui128_t z);
+#define test_divduq __VEC_PWR_IMP(vec_divduq)
+extern vui128_t  __VEC_PWR_IMP(vec_diveuq) (vui128_t x, vui128_t z);
+#define test_diveuq __VEC_PWR_IMP(vec_diveuq)
+extern vui128_t  __VEC_PWR_IMP(vec_divuq) (vui128_t y, vui128_t z);
+#define test_divuq __VEC_PWR_IMP(vec_divuq)
+#else
+// use implementations from vec_int128_dummy compile tests.
 extern vui128_t test_divduq (vui128_t x, vui128_t y, vui128_t z);
-extern vui128_t test_divuqe (vui128_t x, vui128_t z);
+extern vui128_t test_diveuq (vui128_t x, vui128_t z);
 extern vui128_t test_divuq (vui128_t y, vui128_t z);
+#endif
 #endif
 //#define __DEBUG_PRINT__
 int
@@ -11156,7 +11167,7 @@ test_vec_divide_QW (void)
 
   rc += check_vuint128x ("divduq:", (vui128_t)rq, (vui128_t) er);
 #if 1
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[0]);
@@ -11183,7 +11194,7 @@ test_vec_divide_QW (void)
 
   rc += check_vuint128x ("divduq:", (vui128_t)rq, (vui128_t) er);
 #if 1
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[0]);
@@ -11211,7 +11222,7 @@ test_vec_divide_QW (void)
   rc += check_vuint128x ("divduq:", (vui128_t)rq, (vui128_t) er);
 #if 1
   er = (vui128_t)CONST_VINT128_DW128(__UINT64_MAX__-1, __UINT64_MAX__-1);
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[0]);
@@ -11238,7 +11249,7 @@ test_vec_divide_QW (void)
   rc += check_vuint128x ("divuq:", (vui128_t)rq, (vui128_t) er);
 
 #if 0
-  rq = test_divuqe (ix[1], ix[2]);
+  rq = test_diveuq (ix[1], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[1]);
@@ -11419,7 +11430,7 @@ test_vec_divide_QW (void)
   rc += check_vuint128x ("divduq!!:", (vui128_t)rq, (vui128_t) er);
 
   er = (vui128_t)CONST_VINT128_DW128(0x0UL, 0x0UL);
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[0]);
@@ -11513,7 +11524,7 @@ test_vec_divide_QW (void)
   rc += check_vuint128x ("divduq:", (vui128_t)rq, (vui128_t) er);
 
   er = (vui128_t)CONST_VINT128_DW128(__UINT64_MAX__, (__UINT64_MAX__-1));
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[0]);
@@ -11551,7 +11562,7 @@ test_vec_divide_QW (void)
 
   rc += check_vuint128x ("divduq:", (vui128_t)rq, (vui128_t) er);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[0]);
@@ -11583,7 +11594,7 @@ test_vec_divide_QW (void)
 
   er =  (vui128_t)CONST_VINT128_DW128(0x4b3b4ca85a86c47all,
                                       0x098a223ffffffffell);
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[0]);
@@ -11598,7 +11609,7 @@ test_vec_divide_QW (void)
   ix[2] = (vui128_t)CONST_VINT128_DW128(0x0001000000000000UL, 0UL);
   er = (vui128_t)CONST_VINT128_DW128(0x0001000000000000UL, 0UL);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[0]);
@@ -11614,7 +11625,7 @@ test_vec_divide_QW (void)
   ix[2] = (vui128_t)CONST_VINT128_DW128(0x0100000000000000UL, 0UL);
   er = (vui128_t)CONST_VINT128_DW128(0x0100000000000000UL, 0UL);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[0]);
@@ -11640,7 +11651,7 @@ test_vec_divide_QW (void)
 
   rc += check_vuint128x ("divduq:", (vui128_t)rq, (vui128_t) er);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[0]);
@@ -11666,7 +11677,7 @@ test_vec_divide_QW (void)
 
   rc += check_vuint128x ("divduq:", (vui128_t)rq, (vui128_t) er);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[0]);
@@ -11692,7 +11703,7 @@ test_vec_divide_QW (void)
 
   rc += check_vuint128x ("divduq:", (vui128_t)rq, (vui128_t) er);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[0]);
@@ -11718,7 +11729,7 @@ test_vec_divide_QW (void)
 
   rc += check_vuint128x ("divduq:", (vui128_t)rq, (vui128_t) er);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[0]);
@@ -11744,7 +11755,7 @@ test_vec_divide_QW (void)
 
   rc += check_vuint128x ("divduq:", (vui128_t)rq, (vui128_t) er);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[0]);
@@ -11770,7 +11781,7 @@ test_vec_divide_QW (void)
 
   rc += check_vuint128x ("divduq:", (vui128_t)rq, (vui128_t) er);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[0]);
@@ -11796,7 +11807,7 @@ test_vec_divide_QW (void)
 
   rc += check_vuint128x ("divduq:", (vui128_t)rq, (vui128_t) er);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[0]);
@@ -11822,7 +11833,7 @@ test_vec_divide_QW (void)
 
   rc += check_vuint128x ("divduq:", (vui128_t)rq, (vui128_t) er);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[0]);
@@ -11848,7 +11859,7 @@ test_vec_divide_QW (void)
 
   rc += check_vuint128x ("divduq:", (vui128_t)rq, (vui128_t) er);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[0]);
@@ -11874,7 +11885,7 @@ test_vec_divide_QW (void)
 
   rc += check_vuint128x ("divduq:", (vui128_t)rq, (vui128_t) er);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[0]);
@@ -11889,7 +11900,7 @@ test_vec_divide_QW (void)
   ix[2] = (vui128_t)CONST_VINT128_DW128(0x0000000c9f2c9cd0UL, 0x4674edea40000000UL);
   er =    (vui128_t)CONST_VINT128_DW128(0x71919d1a73fa5e25UL, 0xdc93b8194055b965UL);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[0]);
@@ -11927,19 +11938,29 @@ extern vui128_t test_vec_moduq (vui128_t y, vui128_t z);
 #endif
 #define test_modduq	test_vec_modduq
 #else
+#if 1
+extern vui128_t  __VEC_PWR_IMP(vec_moduq) (vui128_t y, vui128_t z);
+#define test_moduq __VEC_PWR_IMP(vec_moduq)
+extern vui128_t  __VEC_PWR_IMP(vec_modduq) (vui128_t x, vui128_t y, vui128_t z);
+#define test_modduq __VEC_PWR_IMP(vec_modduq)
+extern __VEC_U_128RQ  __VEC_PWR_IMP(vec_divdqu) (vui128_t x, vui128_t y, vui128_t z);
+#define test_divdqu __VEC_PWR_IMP(vec_divdqu)
+#define test_moddivduq __VEC_PWR_IMP(vec_divdqu)
+#else
 extern vui128_t test_moduq (vui128_t y, vui128_t z);
 extern vui128_t test_modduq (vui128_t x, vui128_t y, vui128_t z);
-extern __VEC_U_128P test_divdqu (vui128_t x, vui128_t y, vui128_t z);
+extern __VEC_U_128RQ test_divdqu (vui128_t x, vui128_t y, vui128_t z);
 // Correct for the renaming to Divide Double Quadword Unsigned
 // Which returns the quotient and remainder.
 #define test_moddivduq	test_divdqu
+#endif
 #endif
 //#define __DEBUG_PRINT__
 
 int
 test_vec_modulo_QW (void)
 {
-  __VEC_U_128P mq;
+  __VEC_U_128RQ mq;
   vui128_t ix[4];
   vui128_t er;
   vui128_t rq;
@@ -12039,12 +12060,12 @@ test_vec_modulo_QW (void)
   print_vint128x (" moddiv ", (vui128_t) ix[0]);
   print_vint128x ("        ", (vui128_t) ix[1]);
   print_vint128x ("        ", (vui128_t) ix[2]);
-  print_vint128x ("    rmq=", (vui128_t) mq.vx1);
-  print_vint128x ("       =", (vui128_t) mq.vx0);
+  print_vint128x ("    rmq=", (vui128_t) mq.R);
+  print_vint128x ("       =", (vui128_t) mq.Q);
 #endif
 
-  rc += check_vuint128x ("moddiv01:", (vui128_t)mq.vx1, (vui128_t) er);
-  rc += check_vuint128x ("moddiv00:", (vui128_t)mq.vx0, (vui128_t) ix[2]);
+  rc += check_vuint128x ("moddiv01:", (vui128_t)mq.R, (vui128_t) er);
+  rc += check_vuint128x ("moddiv00:", (vui128_t)mq.Q, (vui128_t) ix[2]);
 
   rq = test_moduq (ix[1], ix[2]);
 
@@ -12079,12 +12100,12 @@ test_vec_modulo_QW (void)
   print_vint128x (" moddiv ", (vui128_t) ix[0]);
   print_vint128x ("        ", (vui128_t) ix[1]);
   print_vint128x ("        ", (vui128_t) ix[2]);
-  print_vint128x ("    rmq=", (vui128_t) mq.vx1);
-  print_vint128x ("       =", (vui128_t) mq.vx0);
+  print_vint128x ("    rmq=", (vui128_t) mq.R);
+  print_vint128x ("       =", (vui128_t) mq.Q);
 #endif
 
-  rc += check_vuint128x ("moddiv11:", (vui128_t)mq.vx1, (vui128_t) er);
-  rc += check_vuint128x ("moddiv10:", (vui128_t)mq.vx0, (vui128_t) er);
+  rc += check_vuint128x ("moddiv11:", (vui128_t)mq.R, (vui128_t) er);
+  rc += check_vuint128x ("moddiv10:", (vui128_t)mq.Q, (vui128_t) er);
 #endif
 
   ix[2] = (vui128_t)CONST_VINT128_DW128(0x4b3b4ca85a86c47all,
@@ -12113,12 +12134,12 @@ test_vec_modulo_QW (void)
   print_vint128x (" moddiv ", (vui128_t) ix[0]);
   print_vint128x ("        ", (vui128_t) ix[1]);
   print_vint128x ("        ", (vui128_t) ix[2]);
-  print_vint128x ("    rmq=", (vui128_t) mq.vx1);
-  print_vint128x ("       =", (vui128_t) mq.vx0);
+  print_vint128x ("    rmq=", (vui128_t) mq.R);
+  print_vint128x ("       =", (vui128_t) mq.Q);
 #endif
 
-  rc += check_vuint128x ("moddiv21:", (vui128_t)mq.vx1, (vui128_t) er);
-  rc += check_vuint128x ("moddiv20:", (vui128_t)mq.vx0, (vui128_t) ix[2]);
+  rc += check_vuint128x ("moddiv21:", (vui128_t)mq.R, (vui128_t) er);
+  rc += check_vuint128x ("moddiv20:", (vui128_t)mq.Q, (vui128_t) ix[2]);
 
   ix[0] = (vui128_t)CONST_VINT128_DW128(0UL, 0UL);
   ix[1] = (vui128_t)CONST_VINT128_DW128(0x4b3b4ca85a86c47all,
@@ -12186,12 +12207,12 @@ test_vec_modulo_QW (void)
   print_vint128x (" moddiv ", (vui128_t) ix[0]);
   print_vint128x ("        ", (vui128_t) ix[1]);
   print_vint128x ("        ", (vui128_t) ix[2]);
-  print_vint128x ("    rmq=", (vui128_t) mq.vx1);
-  print_vint128x ("       =", (vui128_t) mq.vx0);
+  print_vint128x ("    rmq=", (vui128_t) mq.R);
+  print_vint128x ("       =", (vui128_t) mq.Q);
 #endif
 
-  rc += check_vuint128x ("moddiv31:", (vui128_t)mq.vx1, (vui128_t) er);
-  rc += check_vuint128x ("moddiv30:", (vui128_t)mq.vx0, (vui128_t) ix[3]);
+  rc += check_vuint128x ("moddiv31:", (vui128_t)mq.R, (vui128_t) er);
+  rc += check_vuint128x ("moddiv30:", (vui128_t)mq.Q, (vui128_t) ix[3]);
 
 #ifndef __DEBUG_PRINT__
   if (rc == 1)
@@ -12209,7 +12230,7 @@ test_vec_modulo_QW (void)
 int
 test_vec_moddiv_QW (void)
 {
-  __VEC_U_128P mq;
+  __VEC_U_128RQ mq;
   vui128_t ix[4], qx[4];
 #ifdef __DEBUG_PRINT__
   vui128_t rx[6];
@@ -12240,19 +12261,19 @@ test_vec_moddiv_QW (void)
   print_vint128x (" moddiv ", (vui128_t) ix[0]);
   print_vint128x ("        ", (vui128_t) ix[1]);
   print_vint128x ("        ", (vui128_t) ix[2]);
-  print_vint128x ("    rmq=", (vui128_t) mq.vx1);
-  print_vint128x ("       =", (vui128_t) mq.vx0);
+  print_vint128x ("    rmq=", (vui128_t) mq.R);
+  print_vint128x ("       =", (vui128_t) mq.Q);
 #endif
   eq = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x0026b9d5);
   er = (vui128_t) CONST_VINT128_W (0x0000000a, 0x91834589, 0x32ffa889, 0x8cbf84ba);
 
-  rc += check_vuint128x ("moddiv a er:", (vui128_t)mq.vx1, (vui128_t) er);
-  rc += check_vuint128x ("moddiv a eq:", (vui128_t)mq.vx0, (vui128_t) eq);
+  rc += check_vuint128x ("moddiv a er:", (vui128_t)mq.R, (vui128_t) er);
+  rc += check_vuint128x ("moddiv a eq:", (vui128_t)mq.Q, (vui128_t) eq);
 
   // record 1st (QW) quotient digit
-  qx[3] = mq.vx0;
+  qx[3] = mq.Q;
   // Remainder and next (QW) digit
-  ix[0] = mq.vx1;
+  ix[0] = mq.R;
   ix[1] = c152[2];
 
   mq = test_moddivduq (ix[0], ix[1], ix[2]);
@@ -12261,18 +12282,18 @@ test_vec_moddiv_QW (void)
   print_vint128x (" moddiv ", (vui128_t) ix[0]);
   print_vint128x ("        ", (vui128_t) ix[1]);
   print_vint128x ("        ", (vui128_t) ix[2]);
-  print_vint128x ("    rmq=", (vui128_t) mq.vx1);
-  print_vint128x ("       =", (vui128_t) mq.vx0);
+  print_vint128x ("    rmq=", (vui128_t) mq.R);
+  print_vint128x ("       =", (vui128_t) mq.Q);
 #endif
   er = (vui128_t) CONST_VINT128_W (0x00000005, 0x99709868, 0xff9e4dee, 0xfbdc5d1c);
   eq = (vui128_t) CONST_VINT128_W (0xd65a5181, 0xd7ccdd5e, 0x237a6c1a, 0x561573a4);
 
-  rc += check_vuint128x ("moddiv b er:", (vui128_t)mq.vx1, (vui128_t) er);
-  rc += check_vuint128x ("moddiv b eq:", (vui128_t)mq.vx0, (vui128_t) eq);
+  rc += check_vuint128x ("moddiv b er:", (vui128_t)mq.R, (vui128_t) er);
+  rc += check_vuint128x ("moddiv b eq:", (vui128_t)mq.Q, (vui128_t) eq);
   // record 2st (QW) quotient digit
-  qx[2] = mq.vx0;
+  qx[2] = mq.Q;
   // Remainder and next (QW) digit
-  ix[0] = mq.vx1;
+  ix[0] = mq.R;
   ix[1] = c152[1];
 
   mq = test_moddivduq (ix[0], ix[1], ix[2]);
@@ -12281,18 +12302,18 @@ test_vec_moddiv_QW (void)
   print_vint128x (" moddiv ", (vui128_t) ix[0]);
   print_vint128x ("        ", (vui128_t) ix[1]);
   print_vint128x ("        ", (vui128_t) ix[2]);
-  print_vint128x ("    rmq=", (vui128_t) mq.vx1);
-  print_vint128x ("       =", (vui128_t) mq.vx0);
+  print_vint128x ("    rmq=", (vui128_t) mq.R);
+  print_vint128x ("       =", (vui128_t) mq.Q);
 #endif
   er = (vui128_t) CONST_VINT128_W (0x0000000b, 0x3dc3bba9, 0x7ec023e4, 0xa0ffffff);
   eq = (vui128_t) CONST_VINT128_W (0x71919d1a, 0x73fa5e25, 0xdc93b819, 0x4541ecbc);
 
-  rc += check_vuint128x ("moddiv c er:", (vui128_t)mq.vx1, (vui128_t) er);
-  rc += check_vuint128x ("moddiv c eq:", (vui128_t)mq.vx0, (vui128_t) eq);
+  rc += check_vuint128x ("moddiv c er:", (vui128_t)mq.R, (vui128_t) er);
+  rc += check_vuint128x ("moddiv c eq:", (vui128_t)mq.Q, (vui128_t) eq);
   // record 3rd (QW) quotient digit
-  qx[1] = mq.vx0;
+  qx[1] = mq.Q;
   // Remainder and next (QW) digit
-  ix[0] = mq.vx1;
+  ix[0] = mq.R;
   ix[1] = c152[0];
 
   mq = test_moddivduq (ix[0], ix[1], ix[2]);
@@ -12301,22 +12322,22 @@ test_vec_moddiv_QW (void)
   print_vint128x (" moddiv ", (vui128_t) ix[0]);
   print_vint128x ("        ", (vui128_t) ix[1]);
   print_vint128x ("        ", (vui128_t) ix[2]);
-  print_vint128x ("    rmq=", (vui128_t) mq.vx1);
-  print_vint128x ("       =", (vui128_t) mq.vx0);
+  print_vint128x ("    rmq=", (vui128_t) mq.R);
+  print_vint128x ("       =", (vui128_t) mq.Q);
 #endif
   // 10**30-1
   er = (vui128_t) CONST_VINT128_W (0x0000000c, 0x9f2c9cd0, 0x4674edea, 0x3fffffff);
   eq = (vui128_t) CONST_VINT128_W (0xe3ffffff, 0xffffffff, 0xffffffff, 0xffffffff);
 
-  rc += check_vuint128x ("moddiv d er:", (vui128_t)mq.vx1, (vui128_t) er);
-  rc += check_vuint128x ("moddiv d eq:", (vui128_t)mq.vx0, (vui128_t) eq);
+  rc += check_vuint128x ("moddiv d er:", (vui128_t)mq.R, (vui128_t) er);
+  rc += check_vuint128x ("moddiv d eq:", (vui128_t)mq.Q, (vui128_t) eq);
 
   // record 4th (QW) quotient digit
-  qx[0] = mq.vx0;
+  qx[0] = mq.Q;
 
 #ifdef __DEBUG_PRINT__
   // record 1th (QW) remainder digit
-  rx[0] = mq.vx1;
+  rx[0] = mq.R;
 
   print_vint128x ("      Q ", (vui128_t) qx[3]);
   print_vint128x ("        ", (vui128_t) qx[2]);
@@ -12334,19 +12355,19 @@ test_vec_moddiv_QW (void)
   print_vint128x (" moddiv ", (vui128_t) ix[0]);
   print_vint128x ("        ", (vui128_t) ix[1]);
   print_vint128x ("        ", (vui128_t) ix[2]);
-  print_vint128x ("    rmq=", (vui128_t) mq.vx1);
-  print_vint128x ("       =", (vui128_t) mq.vx0);
+  print_vint128x ("    rmq=", (vui128_t) mq.R);
+  print_vint128x ("       =", (vui128_t) mq.Q);
 #endif
   er = (vui128_t) CONST_VINT128_W (0x00000005, 0xd68afdd8, 0x5f4bc881, 0x561573a4);
   eq = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00031174, 0x77e509c4);
 
-  rc += check_vuint128x ("moddiv e er:", (vui128_t)mq.vx1, (vui128_t) er);
-  rc += check_vuint128x ("moddiv e eq:", (vui128_t)mq.vx0, (vui128_t) eq);
+  rc += check_vuint128x ("moddiv e er:", (vui128_t)mq.R, (vui128_t) er);
+  rc += check_vuint128x ("moddiv e eq:", (vui128_t)mq.Q, (vui128_t) eq);
   // record 1st (QW) quotient digit
   qx[3] =(vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
-  qx[2] = mq.vx0;
+  qx[2] = mq.Q;
   // Remainder and next (QW) digit
-  ix[0] = mq.vx1;
+  ix[0] = mq.R;
   ix[1] = qx[1];
 
   mq = test_moddivduq (ix[0], ix[1], ix[2]);
@@ -12355,18 +12376,18 @@ test_vec_moddiv_QW (void)
   print_vint128x (" moddiv ", (vui128_t) ix[0]);
   print_vint128x ("        ", (vui128_t) ix[1]);
   print_vint128x ("        ", (vui128_t) ix[2]);
-  print_vint128x ("    rmq=", (vui128_t) mq.vx1);
-  print_vint128x ("       =", (vui128_t) mq.vx0);
+  print_vint128x ("    rmq=", (vui128_t) mq.R);
+  print_vint128x ("       =", (vui128_t) mq.Q);
 #endif
   er = (vui128_t) CONST_VINT128_W (0x00000004, 0xc2c28a47, 0x1a78277b, 0x4541ecbc);
   eq = (vui128_t) CONST_VINT128_W (0x7668ee97, 0x42f4c93e, 0x0e502fb0, 0x2174d9b8);
 
-  rc += check_vuint128x ("moddiv f er:", (vui128_t)mq.vx1, (vui128_t) er);
-  rc += check_vuint128x ("moddiv f eq:", (vui128_t)mq.vx0, (vui128_t) eq);
+  rc += check_vuint128x ("moddiv f er:", (vui128_t)mq.R, (vui128_t) er);
+  rc += check_vuint128x ("moddiv f eq:", (vui128_t)mq.Q, (vui128_t) eq);
 
-  qx[1] = mq.vx0;
+  qx[1] = mq.Q;
   // Remainder and next (QW) digit
-  ix[0] = mq.vx1;
+  ix[0] = mq.R;
   ix[1] = qx[0];
 
   mq = test_moddivduq (ix[0], ix[1], ix[2]);
@@ -12375,21 +12396,21 @@ test_vec_moddiv_QW (void)
   print_vint128x (" moddiv ", (vui128_t) ix[0]);
   print_vint128x ("        ", (vui128_t) ix[1]);
   print_vint128x ("        ", (vui128_t) ix[2]);
-  print_vint128x ("    rmq=", (vui128_t) mq.vx1);
-  print_vint128x ("       =", (vui128_t) mq.vx0);
+  print_vint128x ("    rmq=", (vui128_t) mq.R);
+  print_vint128x ("       =", (vui128_t) mq.Q);
 #endif
   // 10**30-1
   er = (vui128_t) CONST_VINT128_W (0x0000000c, 0x9f2c9cd0, 0x4674edea, 0x3fffffff);
   eq = (vui128_t) CONST_VINT128_W (0x608f6351, 0x0fffffff, 0xffffffff, 0xffffffff);
 
-  rc += check_vuint128x ("moddiv g er:", (vui128_t)mq.vx1, (vui128_t) er);
-  rc += check_vuint128x ("moddiv g eq:", (vui128_t)mq.vx0, (vui128_t) eq);
+  rc += check_vuint128x ("moddiv g er:", (vui128_t)mq.R, (vui128_t) er);
+  rc += check_vuint128x ("moddiv g eq:", (vui128_t)mq.Q, (vui128_t) eq);
   // record 4th (QW) quotient digit
-  qx[0] = mq.vx0;
+  qx[0] = mq.Q;
 
 #ifdef __DEBUG_PRINT__
   // record 2th (QW) remainder digit
-  rx[1] = mq.vx1;
+  rx[1] = mq.R;
 
   print_vint128x ("      Q ", (vui128_t) qx[3]);
   print_vint128x ("        ", (vui128_t) qx[2]);
@@ -12408,19 +12429,19 @@ test_vec_moddiv_QW (void)
   print_vint128x (" moddiv ", (vui128_t) ix[0]);
   print_vint128x ("        ", (vui128_t) ix[1]);
   print_vint128x ("        ", (vui128_t) ix[2]);
-  print_vint128x ("    rmq=", (vui128_t) mq.vx1);
-  print_vint128x ("       =", (vui128_t) mq.vx0);
+  print_vint128x ("    rmq=", (vui128_t) mq.R);
+  print_vint128x ("       =", (vui128_t) mq.Q);
 #endif
   er = (vui128_t) CONST_VINT128_W (0x00000001, 0xb1f6f4e1, 0x64956a52, 0x2174d9b8);
   eq = (vui128_t) CONST_VINT128_W (0x00000000, 0x00003e3a, 0xeb4ae138, 0x3562f4b8);
 
-  rc += check_vuint128x ("moddiv h er:", (vui128_t)mq.vx1, (vui128_t) er);
-  rc += check_vuint128x ("moddiv h eq:", (vui128_t)mq.vx0, (vui128_t) eq);
+  rc += check_vuint128x ("moddiv h er:", (vui128_t)mq.R, (vui128_t) er);
+  rc += check_vuint128x ("moddiv h eq:", (vui128_t)mq.Q, (vui128_t) eq);
   // record 2st (QW) quotient digit
   qx[2] =(vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
-  qx[1] = mq.vx0;
+  qx[1] = mq.Q;
   // Remainder and next (QW) digit
-  ix[0] = mq.vx1;
+  ix[0] = mq.R;
   ix[1] = qx[0];
 
   mq = test_moddivduq (ix[0], ix[1], ix[2]);
@@ -12429,21 +12450,21 @@ test_vec_moddiv_QW (void)
   print_vint128x (" moddiv ", (vui128_t) ix[0]);
   print_vint128x ("        ", (vui128_t) ix[1]);
   print_vint128x ("        ", (vui128_t) ix[2]);
-  print_vint128x ("    rmq=", (vui128_t) mq.vx1);
-  print_vint128x ("       =", (vui128_t) mq.vx0);
+  print_vint128x ("    rmq=", (vui128_t) mq.R);
+  print_vint128x ("       =", (vui128_t) mq.Q);
 #endif
   // 10**30-1
   er = (vui128_t) CONST_VINT128_W (0x0000000c, 0x9f2c9cd0, 0x4674edea, 0x3fffffff);
   eq = (vui128_t) CONST_VINT128_W (0x2261d969, 0xf7ac94ca, 0x3fffffff, 0xffffffff);
 
-  rc += check_vuint128x ("moddiv i er:", (vui128_t)mq.vx1, (vui128_t) er);
-  rc += check_vuint128x ("moddiv i eq:", (vui128_t)mq.vx0, (vui128_t) eq);
+  rc += check_vuint128x ("moddiv i er:", (vui128_t)mq.R, (vui128_t) er);
+  rc += check_vuint128x ("moddiv i eq:", (vui128_t)mq.Q, (vui128_t) eq);
   // record 4th (QW) quotient digit
-  qx[0] = mq.vx0;
+  qx[0] = mq.Q;
 
 #ifdef __DEBUG_PRINT__
   // record 3th (QW) remainder digit
-  rx[2] = mq.vx1;
+  rx[2] = mq.R;
 
   print_vint128x ("      Q ", (vui128_t) qx[3]);
   print_vint128x ("        ", (vui128_t) qx[2]);
@@ -12463,23 +12484,23 @@ test_vec_moddiv_QW (void)
   print_vint128x (" moddiv ", (vui128_t) ix[0]);
   print_vint128x ("        ", (vui128_t) ix[1]);
   print_vint128x ("        ", (vui128_t) ix[2]);
-  print_vint128x ("    rmq=", (vui128_t) mq.vx1);
-  print_vint128x ("       =", (vui128_t) mq.vx0);
+  print_vint128x ("    rmq=", (vui128_t) mq.R);
+  print_vint128x ("       =", (vui128_t) mq.Q);
 #endif
   // 10**30-1
   er = (vui128_t) CONST_VINT128_W (0x0000000c, 0x9f2c9cd0, 0x4674edea, 0x3fffffff);
   eq = (vui128_t) CONST_VINT128_W (0x000004ee, 0x2d6d415b, 0x85acef80, 0xffffffff);
 
-  rc += check_vuint128x ("moddiv j er:", (vui128_t)mq.vx1, (vui128_t) er);
-  rc += check_vuint128x ("moddiv j eq:", (vui128_t)mq.vx0, (vui128_t) eq);
+  rc += check_vuint128x ("moddiv j er:", (vui128_t)mq.R, (vui128_t) er);
+  rc += check_vuint128x ("moddiv j eq:", (vui128_t)mq.Q, (vui128_t) eq);
   // record 3rd (QW) quotient digit
   qx[1] =(vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
   // record 4th (QW) quotient digit
-  qx[0] = mq.vx0;
+  qx[0] = mq.Q;
 
 #ifdef __DEBUG_PRINT__
   // record 4th (QW) remainder digit
-  rx[3] = mq.vx1;
+  rx[3] = mq.R;
 
   print_vint128x ("      Q ", (vui128_t) qx[3]);
   print_vint128x ("        ", (vui128_t) qx[2]);
@@ -12500,22 +12521,22 @@ test_vec_moddiv_QW (void)
   print_vint128x (" moddiv ", (vui128_t) ix[0]);
   print_vint128x ("        ", (vui128_t) ix[1]);
   print_vint128x ("        ", (vui128_t) ix[2]);
-  print_vint128x ("    rmq=", (vui128_t) mq.vx1);
-  print_vint128x ("       =", (vui128_t) mq.vx0);
+  print_vint128x ("    rmq=", (vui128_t) mq.R);
+  print_vint128x ("       =", (vui128_t) mq.Q);
 #endif
   // 10**30-1
   er = (vui128_t) CONST_VINT128_W (0x0000000c, 0x9f2c9cd0, 0x4674edea, 0x3fffffff);
   eq = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000063);
 
-  rc += check_vuint128x ("moddiv k er:", (vui128_t)mq.vx1, (vui128_t) er);
-  rc += check_vuint128x ("moddiv k eq:", (vui128_t)mq.vx0, (vui128_t) eq);
+  rc += check_vuint128x ("moddiv k er:", (vui128_t)mq.R, (vui128_t) er);
+  rc += check_vuint128x ("moddiv k eq:", (vui128_t)mq.Q, (vui128_t) eq);
   // record 5th (QW) quotient digit
-  qx[0] = mq.vx0;
+  qx[0] = mq.R;
 
 #ifdef __DEBUG_PRINT__
   // record 5th (QW) remainder digit
-  rx[4] = mq.vx1;
-  rx[5] = mq.vx0;
+  rx[4] = mq.R;
+  rx[5] = mq.Q;
 
   print_vint128x ("      Q ", (vui128_t) qx[3]);
   print_vint128x ("        ", (vui128_t) qx[2]);
@@ -12550,7 +12571,7 @@ test_vec_divext_QW (void)
   ix[3] = (vui128_t)CONST_VINT128_DW128(0x0100000000000000UL, 0x0UL);
   er = (vui128_t)CONST_VINT128_DW128(0x0100000000000000UL, 0UL);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[0]);
@@ -12568,7 +12589,7 @@ test_vec_divext_QW (void)
   ix[2] = vec_adduqm (ix[2], ix[1]);
   er = (vui128_t)CONST_VINT128_DW128(0x0080000000000000UL, 0UL);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[0]);
@@ -12586,7 +12607,7 @@ test_vec_divext_QW (void)
   ix[2] = vec_adduqm (ix[2], ix[1]);
   er = (vui128_t)CONST_VINT128_DW128(0x002aaaaaaaaaaaaaUL, 0xaaaaaaaaaaaaaaaaUL);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[0]);
@@ -12604,7 +12625,7 @@ test_vec_divext_QW (void)
   ix[2] = vec_adduqm (ix[2], ix[1]);
   er = (vui128_t)CONST_VINT128_DW128(0x000aaaaaaaaaaaaaUL, 0xaaaaaaaaaaaaaac0UL);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[0]);
@@ -12622,7 +12643,7 @@ test_vec_divext_QW (void)
   ix[2] = vec_adduqm (ix[2], ix[1]);
   er = (vui128_t)CONST_VINT128_DW128(0x0002222222222222UL, 0x2222222222222233UL);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[0]);
@@ -12640,7 +12661,7 @@ test_vec_divext_QW (void)
   ix[2] = vec_adduqm (ix[2], ix[1]);
   er = (vui128_t)CONST_VINT128_DW128(0x00005b05b05b05b0UL, 0x5b05b05b05b05b00UL);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[0]);
@@ -12658,7 +12679,7 @@ test_vec_divext_QW (void)
   ix[2] = vec_adduqm (ix[2], ix[1]);
   er = (vui128_t)CONST_VINT128_DW128(0x00000d00d00d00d0UL, 0x0d00d00d00d00d00UL);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[0]);
@@ -12676,7 +12697,7 @@ test_vec_divext_QW (void)
   ix[2] = vec_adduqm (ix[2], ix[1]);
   er = (vui128_t)CONST_VINT128_DW128(0x000001a01a01a01aUL, 0x01a01a01a01a01a0UL);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[0]);
@@ -12694,7 +12715,7 @@ test_vec_divext_QW (void)
   ix[2] = vec_adduqm (ix[2], ix[1]);
   er = (vui128_t)CONST_VINT128_DW128(0x0000002e3bc74aadUL, 0x8e671f5583911caaUL);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[0]);
@@ -12712,7 +12733,7 @@ test_vec_divext_QW (void)
   ix[2] = vec_adduqm (ix[2], ix[1]);
   er = (vui128_t)CONST_VINT128_DW128(0x000000049f93eddeUL, 0x27d71cbbc05b4fb3UL);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
 #ifdef __DEBUG_PRINT__
   print_vint128x (" divuqe ", (vui128_t) ix[0]);

--- a/src/testsuite/vec_int128_dummy.c
+++ b/src/testsuite/vec_int128_dummy.c
@@ -27,9 +27,9 @@
 #include <testsuite/arith128_print.h>
 
 
-vui128_t test_divuqe (vui128_t x, vui128_t z)
+vui128_t test_diveuq (vui128_t x, vui128_t z)
 {
-  return vec_vdivuqe_inline (x, z);
+  return vec_vdiveuq_inline (x, z);
 }
 
 vui128_t test_divuq (vui128_t y, vui128_t z)
@@ -45,16 +45,16 @@ vui128_t test_moduq (vui128_t y, vui128_t z)
 vui128_t
 test_divduq (vui128_t x, vui128_t y, vui128_t z)
 {
-  return vec_divduq (x, y, z);
+  return vec_divduq_inline (x, y, z);
 }
 
 vui128_t
 test_modduq (vui128_t x, vui128_t y, vui128_t z)
 {
-  return vec_modduq (x, y, z);
+  return vec_modduq_inline (x, y, z);
 }
 
-__VEC_U_128P
+__VEC_U_128RQ
 test_divdqu (vui128_t x, vui128_t y, vui128_t z)
 {
   return vec_divdqu_inline (x, y, z);
@@ -185,7 +185,7 @@ vui128_t test_vec_xxx_V0 (vui128_t k, vui128_t k1, vui128_t u1, vui128_t q0)
   return q0;
 }
 
-vui128_t test_vec_divuqe (vui128_t x, vui128_t z)
+vui128_t test_vec_diveuq (vui128_t x, vui128_t z)
 {
 #if defined (_ARCH_PWR10)  && (__GNUC__ >= 10)
   vui128_t res;
@@ -589,7 +589,7 @@ vui128_t test_vec_divduq (vui128_t x, vui128_t y, vui128_t z)
   // Based on the PowerISA, Programming Note for
   // Divide Word Extended [Unsigned] but vectorized
   // for vector __int128
-  q1 = test_vec_divuqe (x, z);
+  q1 = test_vec_diveuq (x, z);
   q2 = test_vec_divuq  (y, z);
   r1 = vec_mulluq (q1, z);
 
@@ -665,9 +665,9 @@ vui128_t test_vec_divduq (vui128_t x, vui128_t y, vui128_t z)
 #endif
 }
 
-__VEC_U_128P test_vec_divdqu (vui128_t x, vui128_t y, vui128_t z)
+__VEC_U_128RQ test_vec_divdqu (vui128_t x, vui128_t y, vui128_t z)
 {
-  __VEC_U_128P result;
+  __VEC_U_128RQ result;
 #if defined (_ARCH_PWR8)
   vui128_t Q, R;
   vui128_t r1, r2, q1, q2;
@@ -677,7 +677,7 @@ __VEC_U_128P test_vec_divdqu (vui128_t x, vui128_t y, vui128_t z)
   // Based on the PowerISA, Programming Note for
   // Divide Word Extended [Unsigned] but vectorized
   // for vector __int128
-  q1 = test_vec_divuqe (x, z);
+  q1 = test_vec_diveuq (x, z);
   q2 = test_vec_divuq  (y, z);
   r1 = vec_mulluq (q1, z);
 
@@ -698,12 +698,12 @@ __VEC_U_128P test_vec_divdqu (vui128_t x, vui128_t y, vui128_t z)
   vui128_t Qt;
   Qt = vec_adduqm (Q, ones);
   Q = vec_seluq (Q, Qt, CC);
-  result.vx0 = Q;
+  result.Q = Q;
 // Corrected Remainder not returned for divduq.
   vui128_t Rt;
   Rt = vec_subuqm (R, z);
   R = vec_seluq (R, Rt, CC);
-  result.vx1 = R;
+  result.R = R;
 #else
   /* Based on Hacker's Delight (2nd Edition) Figure 9-2.
    * "Divide long unsigned shift-and-subtract algorithm."
@@ -741,8 +741,8 @@ __VEC_U_128P test_vec_divdqu (vui128_t x, vui128_t y, vui128_t z)
       y = vec_addeuqm (y, y, t);
       x = vec_seluq (x, xt, ge);
     }
-  result.vx0 = y; // Q
-  result.vx1 = x; // R
+  result.Q = y; // Q
+  result.R = x; // R
 #endif
   return result;
 }
@@ -993,7 +993,7 @@ vui128_t test_vec_modduq (vui128_t x, vui128_t y, vui128_t z)
   // Based on the PowerISA, Programming Note for
   // Divide Word Extended [Unsigned] but vectorized
   // for vector  __int128
-  q1 = test_vec_divuqe (x, z);
+  q1 = test_vec_diveuq (x, z);
   q2 = test_vec_divuq  (y, z);
   r1 = vec_mulluq (q1, z);
 

--- a/src/testsuite/vec_perf_i128.c
+++ b/src/testsuite/vec_perf_i128.c
@@ -60,20 +60,31 @@ static const vui128_t c152[] = {
 #if 0
 extern vui128_t test_vec_moduq (vui128_t y, vui128_t z);
 extern vui128_t test_vec_modduq (vui128_t x, vui128_t y, vui128_t z);
-extern __VEC_U_128P test_vec_moddivduq (vui128_t x, vui128_t y, vui128_t z);
+extern __VEC_U_128RQ test_vec_moddivduq (vui128_t x, vui128_t y, vui128_t z);
 #define test_divdqu	test_vec_moddivduq
 #define test_moduq	test_vec_moduq
 #define test_modduq	test_vec_modduq
 #else
+#if 1
+// Use static lib implementations.
+extern vui128_t  __VEC_PWR_IMP(vec_moduq) (vui128_t y, vui128_t z);
+#define test_moduq __VEC_PWR_IMP(vec_moduq)
+extern vui128_t  __VEC_PWR_IMP(vec_modduq) (vui128_t x, vui128_t y, vui128_t z);
+#define test_modduq __VEC_PWR_IMP(vec_modduq)
+extern __VEC_U_128RQ  __VEC_PWR_IMP(vec_divdqu) (vui128_t x, vui128_t y, vui128_t z);
+#define test_divdqu __VEC_PWR_IMP(vec_divdqu)
+#else
+// use implementations from vec_int128_dummy compile tests.
 extern vui128_t test_moduq (vui128_t y, vui128_t z);
 extern vui128_t test_modduq (vui128_t x, vui128_t y, vui128_t z);
-extern __VEC_U_128P test_divdqu (vui128_t x, vui128_t y, vui128_t z);
+extern __VEC_U_128RQ test_divdqu (vui128_t x, vui128_t y, vui128_t z);
+#endif
 #endif
 // Reduce a 150+ digit (4xQW) value into 5x 30-digit values that can be printed
 int
 timed_vec_divdqu ()
 {
-__VEC_U_128P mq;
+__VEC_U_128RQ mq;
 vui128_t ix[4], qx[4];
 #ifdef __DEBUG_PRINT__
 vui128_t rx[5];
@@ -93,32 +104,32 @@ ix[2] = c30;
 mq = test_divdqu (ix[0], ix[1], ix[2]);
 
 // record 1st (QW) quotient digit
-qx[3] = mq.vx0;
+qx[3] = mq.Q;
 // Remainder and next (QW) digit
-ix[0] = mq.vx1;
+ix[0] = mq.R;
 ix[1] = dx[2];
 
 mq = test_divdqu (ix[0], ix[1], ix[2]);
 // record 2st (QW) quotient digit
-qx[2] = mq.vx0;
+qx[2] = mq.Q;
 // Remainder and next (QW) digit
-ix[0] = mq.vx1;
+ix[0] = mq.R;
 ix[1] = dx[1];
 
 mq = test_divdqu (ix[0], ix[1], ix[2]);
 // record 3rd (QW) quotient digit
-qx[1] = mq.vx0;
+qx[1] = mq.Q;
 // Remainder and next (QW) digit
-ix[0] = mq.vx1;
+ix[0] = mq.R;
 ix[1] = dx[0];
 
 mq = test_divdqu (ix[0], ix[1], ix[2]);
 
 // record 4th (QW) quotient digit
-qx[0] = mq.vx0;
+qx[0] = mq.Q;
 #ifdef __DEBUG_PRINT__
 // record 1th (QW) remainder digit
-rx[0] = mq.vx1;
+rx[0] = mq.R;
 #endif
 // Remainder and next (QW) digit
 ix[0] = qx[3];
@@ -128,25 +139,25 @@ mq = test_divdqu (ix[0], ix[1], ix[2]);
 
 // record 1st (QW) quotient digit
 qx[3] =(vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
-qx[2] = mq.vx0;
+qx[2] = mq.Q;
 // Remainder and next (QW) digit
-ix[0] = mq.vx1;
+ix[0] = mq.R;
 ix[1] = qx[1];
 
 mq = test_divdqu (ix[0], ix[1], ix[2]);
 
-qx[1] = mq.vx0;
+qx[1] = mq.Q;
 // Remainder and next (QW) digit
-ix[0] = mq.vx1;
+ix[0] = mq.R;
 ix[1] = qx[0];
 
 mq = test_divdqu (ix[0], ix[1], ix[2]);
 
 // record 4th (QW) quotient digit
-qx[0] = mq.vx0;
+qx[0] = mq.Q;
 #ifdef __DEBUG_PRINT__
 // record 2th (QW) remainder digit
-rx[1] = mq.vx1;
+rx[1] = mq.R;
 #endif
 // Remainder and next (QW) digit
 ix[0] = qx[2];
@@ -156,19 +167,19 @@ mq = test_divdqu (ix[0], ix[1], ix[2]);
 
 // record 2st (QW) quotient digit
 qx[2] =(vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
-qx[1] = mq.vx0;
+qx[1] = mq.Q;
 // Remainder and next (QW) digit
-ix[0] = mq.vx1;
+ix[0] = mq.R;
 ix[1] = qx[0];
 
 mq = test_divdqu (ix[0], ix[1], ix[2]);
 
 // record 4th (QW) quotient digit
-qx[0] = mq.vx0;
+qx[0] = mq.Q;
 
 #ifdef __DEBUG_PRINT__
 // record 3th (QW) remainder digit
-rx[2] = mq.vx1;
+rx[2] = mq.R;
 #endif
 // Remainder and next (QW) digit
 ix[0] = qx[1];
@@ -179,10 +190,10 @@ mq = test_divdqu (ix[0], ix[1], ix[2]);
 // record 3rd (QW) quotient digit
 qx[1] =(vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000000);
 // record 4th (QW) quotient digit
-qx[0] = mq.vx0;
+qx[0] = mq.Q;
 #ifdef __DEBUG_PRINT__
 // record 4th (QW) remainder digit
-rx[3] = mq.vx1;
+rx[3] = mq.R;
 #endif
 
 // Remainder and next (QW) digit
@@ -192,17 +203,17 @@ ix[1] = qx[0];
 mq = test_divdqu (ix[0], ix[1], ix[2]);
 
 // record 5th (QW) quotient digit
-qx[0] = mq.vx0;
+qx[0] = mq.Q;
 #ifdef __DEBUG_PRINT__
 // record 5th (QW) remainder digit
-rx[4] = mq.vx1;
+rx[4] = mq.R;
 #endif
 // 10**30-1
 er = (vui128_t) CONST_VINT128_W (0x0000000c, 0x9f2c9cd0, 0x4674edea, 0x3fffffff);
 eq = (vui128_t) CONST_VINT128_W (0x00000000, 0x00000000, 0x00000000, 0x00000063);
 
-rc += check_vuint128x ("moddiv k er:", (vui128_t)mq.vx1, (vui128_t) er);
-rc += check_vuint128x ("moddiv k eq:", (vui128_t)mq.vx0, (vui128_t) eq);
+rc += check_vuint128x ("moddiv k er:", (vui128_t)mq.R, (vui128_t) er);
+rc += check_vuint128x ("moddiv k eq:", (vui128_t)mq.Q, (vui128_t) eq);
 
 #ifdef __DEBUG_PRINT__
 print_vint128x ("      Q ", (vui128_t) qx[3]);
@@ -219,19 +230,30 @@ print_vint128x ("        ", (vui128_t) rx[0]);
 return (rc);
 }
 
-
 #if 0
 // extern vui128_t test_vec_divduq (vui128_t x, vui128_t y, vui128_t z);
 // #define test_divduq	test_vec_divduq
 extern vui128_t test_vec_divuqe (vui128_t x, vui128_t z);
-#define test_divuqe	test_vec_divuqe
+#define test_diveuq	test_vec_diveuq
 extern vui128_t test_vec_divuq (vui128_t y, vui128_t z);
 #define test_divuq	test_vec_divuq
 #else
+#if 1
+// Use static lib implementations.
+// extern vui128_t  __VEC_PWR_IMP(vec_divduq) (vui128_t x, vui128_t y, vui128_t z);
+// #define test_divduq __VEC_PWR_IMP(vec_divduq)
+extern vui128_t  __VEC_PWR_IMP(vec_diveuq) (vui128_t x, vui128_t z);
+#define test_diveuq __VEC_PWR_IMP(vec_diveuq)
+extern vui128_t  __VEC_PWR_IMP(vec_divuq) (vui128_t y, vui128_t z);
+#define test_divuq __VEC_PWR_IMP(vec_divuq)
+#else
+// use implementations from vec_int128_dummy compile tests.
 // extern vui128_t test_divduq (vui128_t x, vui128_t y, vui128_t z);
-extern vui128_t test_divuqe (vui128_t x, vui128_t z);
+extern vui128_t test_diveuq (vui128_t x, vui128_t z);
 extern vui128_t test_divuq (vui128_t y, vui128_t z);
 #endif
+#endif
+
 int
 timed_vec_divuqe (void)
 {
@@ -249,7 +271,7 @@ timed_vec_divuqe (void)
   ix[2] = (vui128_t)CONST_VINT128_DW128(0x0100000000000000UL, 0UL);
   ix[3] = (vui128_t)CONST_VINT128_DW128(0x0100000000000000UL, 0x0UL);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
   ix[3] = vec_adduqm (ix[3], rq); // next term
   // round and normalize
@@ -257,7 +279,7 @@ timed_vec_divuqe (void)
   ix[0] = vec_srqi (rq, 8);
   ix[2] = vec_adduqm (ix[2], ix[1]);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
   ix[3] = vec_adduqm (ix[3], rq); // next term
   // round and normalize
@@ -265,7 +287,7 @@ timed_vec_divuqe (void)
   ix[0] = vec_srqi (rq, 8);
   ix[2] = vec_adduqm (ix[2], ix[1]);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
   ix[3] = vec_adduqm (ix[3], rq); // next term
   // round and normalize
@@ -274,7 +296,7 @@ timed_vec_divuqe (void)
   ix[0] = vec_srqi (rq, 8);
   ix[2] = vec_adduqm (ix[2], ix[1]);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
   ix[3] = vec_adduqm (ix[3], rq); // next term
   // round and normalize
@@ -282,7 +304,7 @@ timed_vec_divuqe (void)
   ix[0] = vec_srqi (rq, 8);
   ix[2] = vec_adduqm (ix[2], ix[1]);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
   ix[3] = vec_adduqm (ix[3], rq); // next term
   // round and normalize
@@ -290,7 +312,7 @@ timed_vec_divuqe (void)
   ix[0] = vec_srqi (rq, 8);
   ix[2] = vec_adduqm (ix[2], ix[1]);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
   ix[3] = vec_adduqm (ix[3], rq); // next term
   // round and normalize
@@ -298,7 +320,7 @@ timed_vec_divuqe (void)
   ix[0] = vec_srqi (rq, 8);
   ix[2] = vec_adduqm (ix[2], ix[1]);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
   ix[3] = vec_adduqm (ix[3], rq); // next term
   // round and normalize
@@ -306,7 +328,7 @@ timed_vec_divuqe (void)
   ix[0] = vec_srqi (rq, 8);
   ix[2] = vec_adduqm (ix[2], ix[1]);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
   ix[3] = vec_adduqm (ix[3], rq); // next term
   // round and normalize
@@ -314,7 +336,7 @@ timed_vec_divuqe (void)
   ix[0] = vec_srqi (rq, 8);
   ix[2] = vec_adduqm (ix[2], ix[1]);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
   ix[3] = vec_adduqm (ix[3], rq); // next term
   // round and normalize
@@ -322,7 +344,7 @@ timed_vec_divuqe (void)
   ix[0] = vec_srqi (rq, 8);
   ix[2] = vec_adduqm (ix[2], ix[1]);
 
-  rq = test_divuqe (ix[0], ix[2]);
+  rq = test_diveuq (ix[0], ix[2]);
 
   ix[3] = vec_adduqm (ix[3], rq); // last term
   es = (vui128_t)CONST_VINT128_DW128(0x02b7e150ed3c569dUL, 0x975c4df261fe4d9aUL);
@@ -691,8 +713,6 @@ timed_gcc_divuq2 (void)
 #if 1
 // use implementations from vec_int64_dummy compile tests.
 extern vui64_t test_divmodud (vui64_t *r, vui64_t y, vui64_t z);
-extern __VEC_U_128P test_divdqu (vui128_t x, vui128_t y, vui128_t z);
-//#define test_moddivduq	test_divdqu
 #endif
 #if 1
 // Use static lib implementations.

--- a/src/testsuite/vec_pwr10_dummy.c
+++ b/src/testsuite/vec_pwr10_dummy.c
@@ -38,9 +38,9 @@
 #include <pveclib/vec_f32_ppc.h>
 #include <pveclib/vec_bcd_ppc.h>
 
-vui128_t test_divuqe_PWR10 (vui128_t x, vui128_t z)
+vui128_t test_diveuq_PWR10 (vui128_t x, vui128_t z)
 {
-  return vec_vdivuqe_inline (x, z);
+  return vec_vdiveuq_inline (x, z);
 }
 
 vui128_t test_divuq_PWR10 (vui128_t y, vui128_t z)
@@ -63,7 +63,7 @@ vui128_t test_modduq_PWR10 (vui128_t x, vui128_t y, vui128_t z)
   return vec_modduq (x, y, z);
 }
 
-__VEC_U_128P test_divdqu_PWR10 (vui128_t x, vui128_t y, vui128_t z)
+__VEC_U_128RQ test_divdqu_PWR10 (vui128_t x, vui128_t y, vui128_t z)
 {
   return vec_divdqu_inline (x, y, z);
 }
@@ -1055,9 +1055,9 @@ vui64_t test_vec_divdud_PWR10 (vui64_t x, vui64_t y, vui64_t z)
   return Q;
 }
 
-__VEC_U_128P test_vec_moddivduq_PWR10 (vui128_t x, vui128_t y, vui128_t z)
+__VEC_U_128RQ test_vec_moddivduq_PWR10 (vui128_t x, vui128_t y, vui128_t z)
 {
-  __VEC_U_128P result;
+  __VEC_U_128RQ result;
 #if defined (_ARCH_PWR8)
   vui128_t Q, R;
   vui128_t r1, r2, q1, q2;
@@ -1067,7 +1067,7 @@ __VEC_U_128P test_vec_moddivduq_PWR10 (vui128_t x, vui128_t y, vui128_t z)
   // Based on the PowerISA, Programming Note for
   // Divide Word Extended [Unsigned] but vectorized
   // for vector __int128
-  q1 = vec_vdivuqe_inline (x, z);
+  q1 = vec_vdiveuq_inline (x, z);
   q2 = vec_vdivuq_inline  (y, z);
   r1 = vec_mulluq (q1, z);
 
@@ -1088,12 +1088,12 @@ __VEC_U_128P test_vec_moddivduq_PWR10 (vui128_t x, vui128_t y, vui128_t z)
   vui128_t Qt;
   Qt = vec_adduqm (Q, ones);
   Q = vec_seluq (Q, Qt, CC);
-  result.vx0 = Q;
+  result.Q = Q;
 // Corrected Remainder not returned for divduq.
   vui128_t Rt;
   Rt = vec_subuqm (R, z);
   R = vec_seluq (R, Rt, CC);
-  result.vx1 = R;
+  result.R = R;
 #else
   /* Based on Hacker's Delight (2nd Edition) Figure 9-2.
    * "Divide long unsigned shift-and-subtract algorithm."

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -3242,9 +3242,9 @@ test_divqud_PWR9 (vui128_t x_y, vui64_t z)
   return vec_divqud_inline (x_y, z);
 }
 
-vui128_t test_divuqe_PWR9 (vui128_t x, vui128_t z)
+vui128_t test_diveuq_PWR9 (vui128_t x, vui128_t z)
 {
-  return vec_vdivuqe_inline (x, z);
+  return vec_vdiveuq_inline (x, z);
 }
 
 vui128_t test_divuq_PWR9 (vui128_t y, vui128_t z)
@@ -3267,7 +3267,7 @@ vui128_t test_modduq_PWR9 (vui128_t x, vui128_t y, vui128_t z)
   return vec_modduq (x, y, z);
 }
 
-__VEC_U_128P test_divdqu_PWR9 (vui128_t x, vui128_t y, vui128_t z)
+__VEC_U_128RQ test_divdqu_PWR9 (vui128_t x, vui128_t y, vui128_t z)
 {
   return vec_divdqu_inline (x, y, z);
 }
@@ -3453,9 +3453,9 @@ vui64_t test_vec_divdud_PWR9 (vui64_t x, vui64_t y, vui64_t z)
   return Q;
 }
 
-__VEC_U_128P test_vec_moddivduq_PWR9 (vui128_t x, vui128_t y, vui128_t z)
+__VEC_U_128RQ test_vec_moddivduq_PWR9 (vui128_t x, vui128_t y, vui128_t z)
 {
-  __VEC_U_128P result;
+  __VEC_U_128RQ result;
 #if defined (_ARCH_PWR8)
   vui128_t Q, R;
   vui128_t r1, r2, q1, q2;
@@ -3465,7 +3465,7 @@ __VEC_U_128P test_vec_moddivduq_PWR9 (vui128_t x, vui128_t y, vui128_t z)
   // Based on the PowerISA, Programming Note for
   // Divide Word Extended [Unsigned] but vectorized
   // for vector __int128
-  q1 = vec_vdivuqe_inline (x, z);
+  q1 = vec_vdiveuq_inline (x, z);
   q2 = vec_vdivuq_inline  (y, z);
   r1 = vec_mulluq (q1, z);
 
@@ -3486,12 +3486,12 @@ __VEC_U_128P test_vec_moddivduq_PWR9 (vui128_t x, vui128_t y, vui128_t z)
   vui128_t Qt;
   Qt = vec_adduqm (Q, ones);
   Q = vec_seluq (Q, Qt, CC);
-  result.vx0 = Q;
+  result.Q = Q;
 // Corrected Remainder not returned for divduq.
   vui128_t Rt;
   Rt = vec_subuqm (R, z);
   R = vec_seluq (R, Rt, CC);
-  result.vx1 = R;
+  result.R = R;
 #else
   /* Based on Hacker's Delight (2nd Edition) Figure 9-2.
    * "Divide long unsigned shift-and-subtract algorithm."

--- a/src/vec_int128_runtime.c
+++ b/src/vec_int128_runtime.c
@@ -1,0 +1,63 @@
+/*
+ Copyright (c) [2024] Steven Munroe.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ vec_int64_runtime.c
+
+ Contributors:
+      Steven Munroe
+      Created on: Feb 7, 2024
+ */
+
+#include <pveclib/vec_int128_ppc.h>
+
+vui128_t
+__VEC_PWR_IMP (vec_diveuq) (vui128_t x, vui128_t z)
+{
+  return vec_vdiveuq_inline (x, z);
+}
+
+vui128_t
+__VEC_PWR_IMP (vec_divuq) (vui128_t x, vui128_t z)
+{
+  return vec_vdivuq_inline (x, z);
+}
+
+vui128_t
+__VEC_PWR_IMP (vec_moduq) (vui128_t x, vui128_t z)
+{
+  return vec_vmoduq_inline (x, z);
+}
+
+__VEC_U_128RQ
+__VEC_PWR_IMP (vec_divdqu) (vui128_t x, vui128_t y, vui128_t z)
+{
+  return vec_divdqu_inline (x, y, z);
+}
+
+vui128_t
+__VEC_PWR_IMP (vec_divduq) (vui128_t x, vui128_t y, vui128_t z)
+{
+    __VEC_U_128RQ result = vec_divdqu_inline (x, y, z);
+    return result.Q;
+}
+
+vui128_t
+__VEC_PWR_IMP (vec_modduq) (vui128_t x, vui128_t y, vui128_t z)
+{
+    __VEC_U_128RQ result = vec_divdqu_inline (x, y, z);
+    return result.R;
+}
+
+

--- a/src/vec_runtime_DYN.c
+++ b/src/vec_runtime_DYN.c
@@ -50,8 +50,9 @@
  * appropriate (for the platform endian) base platform.
  */
 
-#include <pveclib/vec_int64_ppc.h>
 #include <pveclib/vec_int512_ppc.h>
+#include <pveclib/vec_int128_ppc.h>
+#include <pveclib/vec_int64_ppc.h>
 #include <pveclib/vec_f128_ppc.h>
 #if 1
 /*! \brief Macro to expand the parameterize resolver.
@@ -143,6 +144,14 @@ extern vui64_t vec_diveud ## _TARGET (vui64_t, vui64_t); \
 extern vui64_t vec_divud ## _TARGET (vui64_t, vui64_t); \
 extern vui64_t vec_modud ## _TARGET (vui64_t, vui64_t);
 
+#define VEC_INT128_LIB_LIST(_TARGET) \
+extern __VEC_U_128RQ vec_divdqu ## _TARGET (vui128_t, vui128_t, vui128_t); \
+extern vui128_t vec_divduq ## _TARGET (vui128_t, vui128_t, vui128_t); \
+extern vui128_t vec_modduq ## _TARGET (vui128_t, vui128_t, vui128_t); \
+extern vui128_t vec_diveuq ## _TARGET (vui128_t, vui128_t); \
+extern vui128_t vec_divuq ## _TARGET (vui128_t, vui128_t); \
+extern vui128_t vec_moduq ## _TARGET (vui128_t, vui128_t);
+
 #define VEC_F128_LIB_LIST(_TARGET) \
 extern __binary128 vec_xsaddqpo ## _TARGET (__binary128, __binary128); \
 extern __binary128 vec_xssubqpo ## _TARGET (__binary128, __binary128); \
@@ -169,6 +178,8 @@ extern void vec_mul512_byMN ## _TARGET (__VEC_U_512 *p, \
 // POWER7 supports only BIG Endian. So declare PWR7 externs only for BE.
 VEC_INT64_LIB_LIST (_PWR7)
 
+VEC_INT128_LIB_LIST (_PWR7)
+
 VEC_INT512_LIB_LIST (_PWR7)
 
 VEC_F128_LIB_LIST (_PWR7)
@@ -176,6 +187,8 @@ VEC_F128_LIB_LIST (_PWR7)
 
 // POWER8 supports both Endians. So declare PWR8 externs unconditionally.
 VEC_INT64_LIB_LIST (_PWR8)
+
+VEC_INT128_LIB_LIST (_PWR8)
 
 VEC_INT512_LIB_LIST (_PWR8)
 
@@ -187,6 +200,8 @@ VEC_F128_LIB_LIST (_PWR8)
 
 VEC_INT64_LIB_LIST (_PWR9)
 
+VEC_INT128_LIB_LIST (_PWR9)
+
 VEC_INT512_LIB_LIST (_PWR9)
 
 VEC_F128_LIB_LIST (_PWR9)
@@ -197,6 +212,8 @@ VEC_F128_LIB_LIST (_PWR9)
  * So declare PWR9 externs only for LE.  */
 
 VEC_INT64_LIB_LIST (_PWR10)
+
+VEC_INT128_LIB_LIST (_PWR10)
 
 VEC_INT512_LIB_LIST (_PWR10)
 
@@ -277,6 +294,18 @@ VEC_RESOLVER_2 (__binary128, vec_xsmulqpo, __binary128, __binary128);
 VEC_RESOLVER_2 (__binary128, vec_xssubqpo, __binary128, __binary128);
 VEC_RESOLVER_3 (__binary128, vec_xsmaddqpo, __binary128, __binary128, __binary128);
 VEC_RESOLVER_3 (__binary128, vec_xsmsubqpo, __binary128, __binary128, __binary128);
+
+/* Declare the required static resolvers and ifunc aliases for dynamic
+ * selection of CPU specific implementations supporting
+ * vec_int128_ppc.h
+ * */
+
+VEC_RESOLVER_2 (vui128_t, vec_diveuq, vui128_t, vui128_t);
+VEC_RESOLVER_2 (vui128_t, vec_divuq, vui128_t, vui128_t);
+VEC_RESOLVER_2 (vui128_t, vec_moduq, vui128_t, vui128_t);
+VEC_RESOLVER_3 (__VEC_U_128RQ, vec_divdqu, vui128_t, vui128_t, vui128_t);
+VEC_RESOLVER_3 (vui128_t, vec_divduq, vui128_t, vui128_t, vui128_t);
+VEC_RESOLVER_3 (vui128_t, vec_modduq, vui128_t, vui128_t, vui128_t);
 
 /* Declare the required static resolvers and ifunc aliases for dynamic
  * selection of CPU specific implementations supporting

--- a/src/vec_runtime_PWR10.c
+++ b/src/vec_runtime_PWR10.c
@@ -24,6 +24,7 @@
 /* Older Linux distros running Big Endian are unlikely to support
    PWR10.  */
 
+#include "vec_int128_runtime.c"
 #include "vec_int64_runtime.c"
 #include "vec_int512_runtime.c"
 #include "vec_f128_runtime.c"

--- a/src/vec_runtime_PWR7.c
+++ b/src/vec_runtime_PWR7.c
@@ -23,6 +23,7 @@
 #ifndef PVECLIB_DISABLE_POWER7
 // POWER7 supports only BIG Endian. So build PWR7 runtime for BE only.
 
+#include "vec_int128_runtime.c"
 #include "vec_int64_runtime.c"
 #include "vec_int512_runtime.c"
 #include "vec_f128_runtime.c"

--- a/src/vec_runtime_PWR8.c
+++ b/src/vec_runtime_PWR8.c
@@ -20,6 +20,7 @@
       Created on: Aug 20, 2019
  */
 
+#include "vec_int128_runtime.c"
 #include "vec_int64_runtime.c"
 #include "vec_int512_runtime.c"
 #include "vec_f128_runtime.c"

--- a/src/vec_runtime_PWR9.c
+++ b/src/vec_runtime_PWR9.c
@@ -24,6 +24,7 @@
 /* Older Linux distros running Big Endian are unlikely to support
    PWR9.  */
 
+#include "vec_int128_runtime.c"
 #include "vec_int64_runtime.c"
 #include "vec_int512_runtime.c"
 #include "vec_f128_runtime.c"


### PR DESCRIPTION
POWER10 added vector divide/divide-extended/modulo instructions. This patch adds static and IFUNC enabled dynamic callable functions to the PVECLIB executable library. This is restricted to the subset of operations that have significant code size or runtime. This is basically the divide/modulo operations; vec_divduq, vec_diveuq, vec_divdqu, vec_divuq, vec_modduq, vec_moduq.

	* src/Makefile.am: Add vec_int128_runtime.c to dependency for PWR library builds. Add Automake regenerated.
	* src/Makefile.in: Automake regenerated.

	* src/pveclib/vec_int128_ppc.h: Update copyright dates. Various doxygen text updates for POWER10. Includes correcting the spelling of vec_diveuq many times. Also renamed __VEC_U_128P to the more descriptive __VEC_U_128RQ. [__VEC_U_128RQ]: Renamed from __VEC_U_128P. (vec_vmulhud_inline, vec_vmulld_inline): New Forward function prototypes. (vec_divdqu, vec_divduq, vec_diveuq, vec_divuq, vec_modduq, vec_moduq): New extern for dynamic library functions. (vec_divdqu_inline, vec_divduq_inline, vec_modduq_inline): Renamed static inline. (vec_msumcud): Use vec_vmsumcud_inline as primary implementation. (vec_msumudm): Use vec_vmsumudm_inline as primary implementation. (vec_mulhud): Use vec_vmulhud_inline as primary implementation. (vec_muludm): Use vec_vmulld_inline as primary implementation. (vec_rlqi, vec_srqi): Move octet (shb % 8) == 0) rotate code before _ARCH_PWR10 specific. Optimise for instruction immediate. (vec_sraqi): Wall clean up. (vec_vdiveuq_inline): Correct operation name. (vec_vmulld_inline): Replace shift/rotate by 32-bits with merge word to avoid rodata const loads. (vec_vmsumudm_inline): Use _ARCH_PWR10 enabled vec_vmuleud and vec_vmuloud.

	* src/testsuite/arith128_test_i128.c: Correcting spelling of vec_diveuq many times. [__VEC_PWR_IMP()]: Define extern and map unit tests to library implementations. (__VEC_U_128RQ): Changes to use new typedef and R/Q fields.

	* src/testsuite/vec_int128_dummy.c (test_diveuq): Rename from test_divuqe. (test_divduq): Use vec_divduq_inline. (test_modduq): Use vec_modduq_inline. (test_vec_diveuq): Rename from test_vec_divuqe. (test_vec_divdqu): Rename return type to __VEC_U_128RQ and use R/Q fields. (test_vec_modduq): Replace test_vec_divuqe with test_vec_diveuq.
	* src/testsuite/vec_pwr10_dummy.c (test_diveuq_PWR10): Rename from test_divuqe_PWR10. (test_divdqu_PWR10, test_vec_moddivduq_PWR10): Rename return type to __VEC_U_128RQ and use R/Q fields.
	* src/testsuite/vec_pwr9_dummy.c (test_diveuq_PWR9): Rename from test_divuqe_PWR9. (test_divdqu_PWR9, test_vec_moddivduq_PWR9): Rename return type to __VEC_U_128RQ and use R/Q fields.

	* src/testsuite/vec_perf_i128.c (__VEC_U_128RQ): Changes to use new typedef and R/Q fields. [__VEC_PWR_IMP()]: Define extern and map timed tests to library implementations.

	* src/vec_int128_runtime.c: New file.
	* src/vec_runtime_DYN.c: Include <pveclib/vec_int128_ppc.h>. [VEC_INT128_LIB_LIST(_TARGET)]: Define list of int128 target specific functions. [PVECLIB_DISABLE_POWER7]: Add VEC_INT128_LIB_LIST (_PWR7). Add VEC_INT128_LIB_LIST (_PWR8). [PVECLIB_DISABLE_POWER9]: Add VEC_INT128_LIB_LIST (_PWR9). [PVECLIB_DISABLE_POWER10]: Add VEC_INT128_LIB_LIST (_PWR10). [VEC_RESOLVER_2]: vec_diveuq, vec_divuq, vec_moduq. [VEC_RESOLVER_3]: vec_divdqu, vec_divduq, vec_modduq.
	* src/vec_runtime_PWR10.c: Include vec_int128_runtime.c.
	* src/vec_runtime_PWR7.c: Include vec_int128_runtime.c.
	* src/vec_runtime_PWR8.c: Include vec_int128_runtime.c.
	* src/vec_runtime_PWR9.c: Include vec_int128_runtime.c.