### PR TITLE
Power9 provides round to odd versions for the QP arithmetic operations.

### DIFF
--- a/src/testsuite/arith128_test_f128.c
+++ b/src/testsuite/arith128_test_f128.c
@@ -13382,5 +13382,8 @@ test_vec_f128 (void)
   rc += test_msub_qpo_zero_c ();
   rc += test_msub_qpo_xtra ();
 #endif
+
+  rc += test_div_qpo ();
+  rc += test_div_qpo_xtra ();
   return (rc);
 }

--- a/src/testsuite/arith128_test_qpo.h
+++ b/src/testsuite/arith128_test_qpo.h
@@ -23,6 +23,9 @@
   extern int test_add_qpo ();
   extern int test_add_qpo_xtra ();
 
+  extern int test_div_qpo ();
+  extern int test_div_qpo_xtra ();
+
   extern int test_mul_qpo ();
   extern int test_mul_qpo_xtra ();
 

--- a/src/testsuite/pveclib_perf.c
+++ b/src/testsuite/pveclib_perf.c
@@ -976,6 +976,34 @@ test_time_f128 (void)
   printf ("\n%s mulqpn_lib tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
 	  t_delta, delta_sec);
 
+  printf ("\n%s divqpn_gcc start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_gcc_divqpn_f128 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s divqpn_gcc end", __FUNCTION__);
+  printf ("\n%s divqpn_gcc tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+	  t_delta, delta_sec);
+
+  printf ("\n%s divqpo_lib start, ...\n", __FUNCTION__);
+  t_start = __builtin_ppc_get_timebase ();
+  for (i = 0; i < TIMING_ITERATIONS; i++)
+    {
+      rc += timed_lib_divqpo_f128 ();
+    }
+  t_end = __builtin_ppc_get_timebase ();
+  t_delta = t_end - t_start;
+  delta_sec = TimeDeltaSec (t_delta);
+
+  printf ("\n%s divqpo_lib end", __FUNCTION__);
+  printf ("\n%s divqpo_lib tb delta = %lu, sec = %10.6g\n", __FUNCTION__,
+	  t_delta, delta_sec);
+
   printf ("\n%s addqpn_gcc start, ...\n", __FUNCTION__);
   t_start = __builtin_ppc_get_timebase ();
   for (i = 0; i < TIMING_ITERATIONS; i++)

--- a/src/testsuite/vec_perf_f128.c
+++ b/src/testsuite/vec_perf_f128.c
@@ -101,7 +101,22 @@ __float128 f128_invfact[] = {
     (1.0Q / 120.0Q),
     (1.0Q / 720.0Q),
     (1.0Q / 5040.0Q),
-    (1.0Q / 40320.0Q)
+    (1.0Q / 40320.0Q),
+    (1.0Q / 362880.0Q),
+    (1.0Q / 3628800.0Q)
+};
+
+__float128 f128_fact[] = {
+    1.0Q,
+    2.0Q,
+    6.0Q,
+    24.0Q,
+    120.0Q,
+    720.0Q,
+    5040.0Q,
+    40320.0Q,
+    362880.0Q,
+    3628800.0Q
 };
 
 const vui128_t i128fact1 = {1};
@@ -240,6 +255,13 @@ test_vec_qpdpo_f128 (vf64_t * vf128,
 
 extern void
 test_gcc_qpdpo_f128 (vf64_t * vf128,
+		    __binary128 vf1, __binary128 vf2,
+		    __binary128 vf3, __binary128 vf4,
+		    __binary128 vf5, __binary128 vf6,
+		    __binary128 vf7, __binary128 vf8);
+
+extern void
+test_gcc_divqpn_f128 (__binary128 * vf128,
 		    __binary128 vf1, __binary128 vf2,
 		    __binary128 vf3, __binary128 vf4,
 		    __binary128 vf5, __binary128 vf6,
@@ -461,6 +483,34 @@ test_lib_subqpo_f128 (__binary128 * vf128,
 
 #if 1
 // Test implementation from libpvecstatic
+extern __binary128 __VEC_PWR_IMP (vec_xsdivqpo) (__binary128 vfa, __binary128 vfb);
+#define test_vec_divqpo(_l,_k)	__VEC_PWR_IMP (vec_xsdivqpo)(_l,_k)
+#else
+// Test implementation from vec_f128_dummy.c
+extern __binary128 test_vec_divqpo (__binary128 vfa, __binary128 vfb);
+#endif
+
+void
+test_lib_divqpo_f128 (__binary128 * vf128,
+		      __binary128 vf1, __binary128 vf2,
+		      __binary128 vf3, __binary128 vf4,
+		      __binary128 vf5, __binary128 vf6,
+		      __binary128 vf7, __binary128 vf8)
+{
+  __binary128 result;
+  result = test_vec_divqpo (qpfact1, vf1);
+  result = test_vec_divqpo (result, vf2);
+  result = test_vec_divqpo (result, vf3);
+  result = test_vec_divqpo (result, vf4);
+  result = test_vec_divqpo (result, vf5);
+  result = test_vec_divqpo (result, vf6);
+  result = test_vec_divqpo (result, vf7);
+  result = test_vec_divqpo (result, vf8);
+  *vf128 = result;
+}
+
+#if 1
+// Test implementation from libpvecstatic
 extern __binary128 __VEC_PWR_IMP (vec_xsmulqpo) (__binary128 vfa, __binary128 vfb);
 #define test_vec_mulqpo(_l,_k)	__VEC_PWR_IMP (vec_xsmulqpo)(_l,_k)
 #else
@@ -629,6 +679,24 @@ int timed_lib_subqpo_f128 (void)
    return 0;
 }
 
+int timed_lib_divqpo_f128 (void)
+{
+#ifndef PVECLIB_DISABLE_F128MATH
+  __binary128 tbl[10];
+  int i;
+
+  for (i=0; i<N; i++)
+    {
+      test_lib_divqpo_f128 (tbl,
+			  qpfact1, qpfact2,
+			  qpfact3, qpfact4,
+			  qpfact5, qpfact6,
+			  qpfact7, qpfact8);
+    }
+#endif
+   return 0;
+}
+
 int timed_lib_mulqpo_f128 (void)
 {
 #ifndef PVECLIB_DISABLE_F128MATH
@@ -691,6 +759,24 @@ int timed_gcc_addqpn_f128 (void)
   for (i=0; i<N; i++)
     {
       test_gcc_addqpn_f128 (tbl,
+			  qpfact1, qpfact2,
+			  qpfact3, qpfact4,
+			  qpfact5, qpfact6,
+			  qpfact7, qpfact8);
+    }
+#endif
+   return 0;
+}
+
+int timed_gcc_divqpn_f128 (void)
+{
+#ifndef PVECLIB_DISABLE_F128MATH
+  __binary128 tbl[10];
+  int i;
+
+  for (i=0; i<N; i++)
+    {
+      test_gcc_divqpn_f128 (tbl,
 			  qpfact1, qpfact2,
 			  qpfact3, qpfact4,
 			  qpfact5, qpfact6,

--- a/src/testsuite/vec_perf_f128.h
+++ b/src/testsuite/vec_perf_f128.h
@@ -54,6 +54,9 @@ extern int timed_gcc_mulqpn_f128 (void);
 extern int timed_lib_mulqpo_f128 (void);
 extern int timed_lib_mulqpn_f128 (void);
 
+extern int timed_gcc_divqpn_f128 (void);
+extern int timed_lib_divqpo_f128 (void);
+
 extern int timed_gcc_addqpn_f128 (void);
 extern int timed_lib_addqpo_f128 (void);
 

--- a/src/vec_f128_runtime.c
+++ b/src/vec_f128_runtime.c
@@ -35,6 +35,12 @@ __VEC_PWR_IMP (vec_xssubqpo) (__binary128 vfa, __binary128 vfb)
 }
 
 __binary128
+__VEC_PWR_IMP (vec_xsdivqpo) (__binary128 vfa, __binary128 vfb)
+{
+  return vec_xsdivqpo_inline (vfa, vfb);
+}
+
+__binary128
 __VEC_PWR_IMP (vec_xsmulqpo) (__binary128 vfa, __binary128 vfb)
 {
   return vec_xsmulqpo_inline (vfa, vfb);

--- a/src/vec_runtime_DYN.c
+++ b/src/vec_runtime_DYN.c
@@ -155,6 +155,7 @@ extern vui128_t vec_moduq ## _TARGET (vui128_t, vui128_t);
 #define VEC_F128_LIB_LIST(_TARGET) \
 extern __binary128 vec_xsaddqpo ## _TARGET (__binary128, __binary128); \
 extern __binary128 vec_xssubqpo ## _TARGET (__binary128, __binary128); \
+extern __binary128 vec_xsdivqpo ## _TARGET (__binary128, __binary128); \
 extern __binary128 vec_xsmulqpo ## _TARGET (__binary128, __binary128); \
 extern __binary128 vec_xsmaddqpo ## _TARGET (__binary128, __binary128, __binary128); \
 extern __binary128 vec_xsmsubqpo ## _TARGET (__binary128, __binary128, __binary128);
@@ -290,6 +291,7 @@ __attribute__ ((ifunc ("resolve_vec_mul512_byMN")));
  * vec_f128_ppc.h
  * */
 VEC_RESOLVER_2 (__binary128, vec_xsaddqpo, __binary128, __binary128);
+VEC_RESOLVER_2 (__binary128, vec_xsdivqpo, __binary128, __binary128);
 VEC_RESOLVER_2 (__binary128, vec_xsmulqpo, __binary128, __binary128);
 VEC_RESOLVER_2 (__binary128, vec_xssubqpo, __binary128, __binary128);
 VEC_RESOLVER_3 (__binary128, vec_xsmaddqpo, __binary128, __binary128, __binary128);


### PR DESCRIPTION
This patch provides P9/8 implementation for Divide QP with round to odd. Includes compile, unit, and performance tests.

	* src/pveclib/vec_f128_ppc.h: Update into documentation for soft-float implementation. [f128_softfloat_0_0_3_6]: New subsubsection for Divide QP. [f128_softfloat_0_0_3_6_0, f128_softfloat_0_0_3_6_1, f128_softfloat_0_0_3_6_2]: New paragraph for; Soft-float divide QP, Special value handling, and custom divide extended. (vec_diveuqo_inline): New inline implementation. (vec_xsdivqpo): New dynamic call IFUNC implementation. (vec_xsdivqpo_inline): New inline implementation.

	* src/vec_f128_runtime.c (vec_xsdivqpo): New runtime implementation.
	* src/vec_runtime_DYN.c (vec_xsdivqpo): New CPU impementation externs and resolver.

	* src/testsuite/arith128_test_f128.c (test_div_qpo, test_div_qpo_xtra): Call new unit tests.
	* src/testsuite/arith128_test_qpo.c (db_vec_diveuqo): New debug implementation. (test_div_qpo, test_div_qpo_xtra): New unit tests.
	* src/testsuite/arith128_test_qpo.h (test_div_qpo, test_div_qpo_xtra): New extern.

	* src/testsuite/vec_f128_dummy.c (test_vec_diveuqo, test_vec_diveuqo_V0): New compile tests. (test_vec_xsdivqpo, test_vec_divqpo, test_vec_divqpo_V1, test_vec_divqpo_V0): New compile tests. (test_gcc_divqpn_f128): Timed test kernel.
	* src/testsuite/vec_pwr10_dummy.c (test_diveuqo_PWR10, test_vec_diveuqo_PWR10, test_divdqu_rto_PWR10): New compile tests

	* testsuite/pveclib_perf.c (test_time_f128): Add timed tests for timed_gcc_divqpn_f128, timed_lib_divqpo_f128.
	* src/testsuite/vec_perf_f128.c: Additional _Float128 constants. (test_lib_divqpo_f128): New Timed test kernel. (timed_lib_divqpo_f128, timed_gcc_divqpn_f128): New Timed tests.
	* src/testsuite/vec_perf_f128.h (timed_gcc_divqpn_f128, timed_lib_divqpo_f128): New timed tests externs.

	* src/testsuite/arith128_test_i128.c: Wall source clean up.