### PR TITLE
This updates char/byte operations introduced in P9. Fix #194

### DIFF
--- a/src/testsuite/arith128_test_char.c
+++ b/src/testsuite/arith128_test_char.c
@@ -886,7 +886,7 @@ extern int test_vclzlsbb (vui8_t);
 int
 test_vec_clzlsbb (void)
 {
-    vui8_t i, j, k, e;
+    vui8_t i;
     int r, er;
     int rc = 0;
     printf ("\n%s\n", __FUNCTION__);
@@ -1047,7 +1047,7 @@ extern int test_vctzlsbb (vui8_t);
 int
 test_vec_ctzlsbb (void)
 {
-    vui8_t i, j, k, e;
+    vui8_t i;
     int r, er;
     int rc = 0;
     printf ("\n%s\n", __FUNCTION__);
@@ -1210,7 +1210,7 @@ extern int test_cntlz_lsbb_bi (vui8_t);
 int
 test_vec_cntlz_lsbb (void)
 {
-    vui8_t i, j, k, e;
+    vui8_t i;
     int r, er;
     int rc = 0;
     printf ("\n%s\n", __FUNCTION__);
@@ -1271,7 +1271,7 @@ extern int test_cnttz_lsbb_bi (vui8_t);
 int
 test_vec_cnttz_lsbb (void)
 {
-    vui8_t i, j, k, e;
+    vui8_t i;
     int r, er;
     int rc = 0;
     printf ("\n%s\n", __FUNCTION__);


### PR DESCRIPTION
Failing compiler tests for;
- Vector Count Leading Zero Least-Significant Bits Byte,
- Vector Count Trailing Zero Least-Significant Bits Byte,
- Vector Compare Not Equal or Zero Byte.

The Power vector intrinsic reference specifies type generic vec_cmpne and vec_popcnt.

Older compilers may not implement vec_cmpne but do implement vec_cmpeq which can be combined with vec_not/vec_nor or vec_andc/vec_orc to get the some effect.

Older GCC compilers supporting power8 will provide vec_vpopcntb/vec_vpopcnth but may not provide the generic vec_popcnt for byte/halfword. Newer GCC compilers still support vec_vpopcntb/vec_vpopcnth and the generic vec_popcnt. Clang compilers that support power8 and vpopcntb/h instructions only support the generic vec_popcnt.

PVECLIB's vec_char_ppc.h implementations must work around this while not depending on vec_int16_ppc.h/vec_int32_ppc.h implementations (circular dependency).

	* src/pveclib/vec_char_ppc.h [int8_P9_10_0_0]: New doxygen section "Implementations for POWER9/10 Intrinsics". [int8_P9_10_0_0_1]: New doxygen subsection "Vector Compare Not Equal or Zero Byte". [int8_P9_10_0_0_2]: New doxygen subsection "Vector Count Leading/Trailing Zero LSBB etc", (vec_vctzlsbb[_ARCH_PWR8]): Correct vec_popcnt() usaged for GCC/Clang. (vec_vcmpnezb[_ARCH_PWR8]): Correct for vec_cmpne()/vec_orc() usage with P8/P7 targets.

	* src/testsuite/vec_char_dummy.c (test_vclzlsbb): Update compile test for issue #194 (test_vctzlsbb_V0): Rename orignal compile test. (test_vcmpnezb_v0): Update compile test.