### PR TITLE
Cleanup and optimizations for Float128. Part 1

### DIFF
--- a/src/testsuite/vec_f128_dummy.c
+++ b/src/testsuite/vec_f128_dummy.c
@@ -820,6 +820,14 @@ test_mask128_f128exp (void)
 }
 
 vui32_t
+test_mask128_f128exp_v3(void)
+{
+  const vui32_t mag = vec_mask128_f128mag ();
+  const vui32_t sig = vec_mask128_f128sig ();
+  return vec_andc (mag, sig);
+}
+
+vui32_t
 test_mask128_f128exp_V2 (void)
 {
   //  const vui32_t expmask = CONST_VINT128_W (0x7fff0000, 0, 0, 0);
@@ -883,6 +891,13 @@ vui32_t
 test_mask128_f128sign(void)
 {
   return vec_mask128_f128sign ();
+}
+
+vui32_t
+test_mask128_f128sign_v1(void)
+{
+  const vui32_t mag = vec_mask128_f128mag ();
+  return vec_nor (mag, mag);
 }
 
 vui32_t

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -2283,6 +2283,12 @@ test_vec_issubnormalf128_PWR9 (__binary128 f128)
 }
 
 vb128_t
+test_vec_isunorderedf128_PWR9 (__binary128 f128a, __binary128 f128b)
+{
+  return vec_isunorderedf128 (f128a, f128b);
+}
+
+vb128_t
 test_vec_iszerof128_PWR9 (__binary128 f128)
 {
   return vec_iszerof128 (f128);


### PR DESCRIPTION
The float128 implementations need various vector masks and integer constants. These can be loaded as initialized vector constants from storage (.rotate section). But this comes a cost (see "Loading constants for masking Float128 fields" in the vec-f128_ppc.h docs).

For many cases it is better to use short splat-immediate/shift/rotate sequences to generate these constants. The mask generator code is already on master, but I noticed the some older operations that can take advantage of these generators. This is one stage of the required cleanup.

	* src/pveclib/vec_f128_ppc.h [f128_softfloat_0_0_0_1]: New doxygen subsubsection for "Loading constants for masking Float128 fields". [f128_softfloat_0_0_0_2]: New doxygen subsubsection for "Alternative mask generation". (vec_mask128_f128sign): Correct @return constant. (vec_absf128[!_ARCH_PWR9]): Add POWER10 Latency to Doxygen. Replace signmask constant with vec_mask128_f128sign(). (vec_all_isinff128[!_ARCH_PWR9]): Replace magmask and expmask constants with vec_mask128_f128mag() and vec_mask128_f128exp(). (vec_copysignf128); Update POWER8 and Add POWER10 Latency to Doxygen. Replace signmask constant with vec_mask128_f128sign(). (vec_const_inff128): Replace posinf constant with vec_mask128_f128exp(). (vec_const_nanf128): New implementation. (vec_cmpeqtoqp):Update POWER9 and Add POWER10 Latency to Doxygen. (vec_isfinitef128[!_ARCH_PWR9]): Update POWER8 and Add POWER10 Latency to Doxygen. Replace expmask constant with vec_mask128_f128exp(). (vec_isinf_signf128[!_ARCH_PWR9]): Add POWER10 Latency to Doxygen. Replace magmask and expmask constants with vec_mask128_f128mag() and vec_mask128_f128exp(). (vec_isinff128[!_ARCH_PWR9]): Update POWER8 and Add POWER10 Latency to Doxygen. Replace signmask and expmask constants with vec_mask128_f128sign() and vec_mask128_f128exp(). (vec_isnanf128[!_ARCH_PWR9]): Update POWER8 and Add POWER10 Latency to Doxygen. Replace magmask and expmask constants with vec_mask128_f128mag() and vec_mask128_f128exp(). (vec_isnormalf128[!_ARCH_PWR9]): Update POWER8 and Add POWER10 Latency to Doxygen. Replace expmask constant with vec_mask128_f128exp(). (vec_issubnormalf128[!_ARCH_PWR9]): Update POWER8 and Add POWER10 Latency to Doxygen. Replace magmask and minnorm constants with vec_mask128_f128mag() and vec_mask128_f128Lbit(). (vec_isunorderedf128): Update POWER8 and Add POWER10 Latency to Doxygen. (vec_iszerof128[!_ARCH_PWR9]): Update POWER8 and Add POWER10 Latency to Doxygen. Replace magmask constants with vec_mask128_f128mag(). (vec_nabsf128[!_ARCH_PWR9]): Update POWER8 and Add POWER10 Latency to Doxygen. Replace signmask constants with vec_mask128_f128sign(). (vec_negf128[!_ARCH_PWR9]): Update POWER8 and Add POWER10 Latency to Doxygen. Replace signmask constants with vec_mask128_f128sign(). (vec_self128): Add POWER10 Latency to Doxygen. (vec_signbitf128[!_ARCH_PWR9]): Add POWER10 Latency to Doxygen. Replace signmask constants with vec_mask128_f128sign(). (vec_xsmaddqpo_inline): Cleanup. (vec_xsxsigqp[!_ARCH_PWR9]): Replace signmask, expmask, and hidden constants with vec_mask128_f128sign(), vec_mask128_f128exp(), and vec_mask128_f128Lbit().

	* src/testsuite/vec_f128_dummy.c (test_mask128_f128exp_v3, test_mask128_f128sign_v1): New compile tests.

	* src/testsuite/vec_pwr9_dummy.c (test_vec_isunorderedf128_PWR9): New compile tests.