### PR TITLE
Add char/byte operations introduced in P9/10. Part 4 close #201

### DIFF
--- a/src/pveclib/vec_common_ppc.h
+++ b/src/pveclib/vec_common_ppc.h
@@ -196,6 +196,154 @@
  *
  * \sa \ref i32_endian_issues_0_0
  * \sa \ref mainpage_endian_issues_1_1
+ *
+ * \section common_operation_issues_0_0 Issues with common operations.
+ *
+ * Some operations are common components of more complex operations.
+ * It is common for wider element operations (doubleword/quadword) to
+ * use narrower (word/halfword/byte) element operations within their
+ * implementations. Especially when the target processor does
+ * not support the operation directly.
+ *
+ * The PVECLIB implementation <I>stacks</I> the headers so that each
+ * type and element width always starts by including the header for
+ * the next smaller element width of that type.
+ * So vec_int128_ppc.h includes vec_int64_ppc.h, which includes
+ * vec_int32_ppc.h and so on down to vec_char_ppc.h.
+ * The vec_char_ppc.h header includes this (vec_common_ppc.h) header
+ * to pick up the type definitions required for all supported element
+ * widths.
+ *
+ * Sometimes an operation implies an operation over a wider element
+ * then parameters imply. For example the POWER10 Vector String
+ * Isolate Left/Right-justified operations imply a quadword count
+ * leading/trailing zeros (clz/ctz) operation to generate the required
+ * vector char mask. Quadword count leading/trailing zeros are not
+ * (yet) it the current PowerISA. The PVECLIB quadword operation
+ * depends on the corresponding word/doubleword vec_clz()/Vec_ctz()
+ * operations.
+ *
+ * While word/doubleword vec_clz() was introduced for POWER8,
+ * vec_ctz() was not available until POWER9. So the _ARCH_PWR8
+ * implementations of vec_ctzd() uses a trailing zeros conversion
+ * (!vra & (vra - 1)) and vector population count (vec_popcntd()).
+ * The vec_popcnt() intrinsic was also introduced for POWER8 along
+ * with doubleword vec_add()/vec_sub() support.
+ *
+ * None of these vector intrinsics are available for POWER7. None of
+ * corresponding word/doubleword PVECLIB operations are in scope
+ * for vec_char_ppc.h implementations.
+ * This quickly cascades into a large set of circular dependencies.
+ *
+ * This is becoming more common for newer (POWER9/10) operations
+ * where the compile target is POWER7/8. In this case we find that the
+ * desired operations is missing or out of scope for the required
+ * element width.
+ *
+ * Implementations for specific targets
+ * can be provided in this header and used as needed
+ * at any other PVECLIB header.
+ * These are intended for internal usage by PVECLIB operations
+ * and must avoid conflicts with the intrinsics or PVECLIB public
+ * name-space.
+ *
+ * \note Proposal: Common operations will use the form:
+ * vec_<opcode>_<arch_suffix>.
+ * The \<opcode\> will match the ISA mnemonic including the element width
+ * suffix (ie. clzw, popcntb, ...).
+ * The \<arch_suffix\> will match the suffix of compiler generated
+ * \_ARCH\_ macros. For example; vec_clzd_PWR8.
+ *
+ * Implementations at this level can only use intrinsic operations
+ * provided by altivec.h and/or in-line assembler instructions.
+ * Any common implementation can use other implementations from
+ * vec_common_ppc.h.
+ * Any assembler codes or altivec.h intrinsic/element widths
+ * introduced for POWER7/VSX (PowerISA 2.06 or later) must be guarded
+ * by appropriate target conditionals.
+ *
+ * Implementation for different ISA levels should be isolated in
+ * separate functions. The top level implementation will start with
+ * the intrinsic or opcode that was introduced into the ISA and with
+ * the appropriate \_ARCH suffix.
+ * Additional operation implementations for previous ISA levels will
+ * be separate functions for each \_ARCH level. Each level should
+ * tail-call to next lower implementation for that operation.
+ * For example:
+ * \code
+static inline vui32_t
+vec_popcntw_PWR8 (vui32_t vra)
+{
+  vui32_t r;
+#ifdef _ARCH_PWR8
+#if defined (vec_vpopcntw)
+  r = vec_vpopcntw (vra);
+#elif defined (__clang__)
+  r = vec_popcnt (vra);
+#else
+  __asm__(
+      "vpopcntw %0,%1;"
+      : "=v" (r)
+      : "v" (vra)
+      : );
+#endif
+#else
+  r = vec_popcntw_PWR7 (vra);
+#endif
+  return (r);
+}
+ * \endcode
+ * If the target is not at least -mcpu=power8 the implementation
+ * tail-calls to vec_popcntw_PWR7().
+ * For example:
+ * \code
+static inline vui32_t
+vec_popcntw_PWR7 (vui32_t vra)
+{
+  const vui32_t vzero = vec_splat_u32 (0);
+  vui8_t bytepop;
+  // Generate byte pop counts
+  bytepop = vec_popcntb_PWR7 ((vui8_t) vra);
+  // sum across adjacent bytes into words for pop count
+  return  vec_sum4s (bytepop, vzero);
+}
+ * \endcode
+ * Which depends on the common implementation vec_popcntb_PWR7() and
+ * intrinsic vec_sum4s(). The Vector Sum across Quarter Unsigned Byte
+ * Saturate (vec_sum4s()) yields the word population counts.
+ * \note vec_sum4s() is a saturating sum. Saturation is not needed for
+ * this use case. But the range of values (0-32) is small and will
+ * never saturate the 32-bit sum.
+ *
+ * And finally a vec_popcntb_PWR7() implementation is needed.
+ * For example:
+ * \code
+static inline vui8_t
+vec_popcntb_PWR7 (vui8_t vra)
+{
+  const vui8_t nibmask = vec_splat_u8 (15);
+  const vui8_t nibshft = vec_splat_u8 (4);
+  const vui8_t popc_perm = { 0, 1, 1, 2, 1, 2, 2, 3,
+                             1, 2, 2, 3, 2, 3, 3, 4};
+  vui8_t nib_h, nib_l; // High and low nibbles by byte.
+  vui8_t rh, rl; // High and low nibble popcnt.
+
+  nib_l = vec_and (vra, nibmask);
+  nib_h = vec_sr  (vra, nibshft);
+  rl = vec_perm (popc_perm, popc_perm, nib_l);
+  rh = vec_perm (popc_perm, popc_perm, nib_h);
+  return vec_add (rh, rl);
+}
+ * \endcode
+ * Which depends only on original (PowerISA 2.03) <altivec.h>
+ * intrinsics. Here we use vector permute as a table look-up to
+ * convert nibbles into into a population count (0-4). The sum
+ * (vec_add()) of the nibble population counts yields the byte wide
+ * population counts.
+ *
+ *
+ * (See vec_popcntb_PWR7(), vec_popcnth_PWR7(), vec_popcntw_PWR7(),
+ * vec_popcntd_PWR7(), vec_popcntq_PWR7())
  */
 
 /*! \brief Macro to add platform suffix for static calls.
@@ -417,6 +565,1162 @@ extern const vui128_t vtifrexpof10[];
 /*! \brief table powers of 2 [0-1077] in _Decimal128 format.  */
 extern const _Decimal128 decpowof2[];
 #endif
+
+///@cond INTERNAL
+static inline vui32_t vec_popcntw_PWR7 (vui32_t);
+static inline vui32_t vec_popcntw_PWR8 (vui32_t);
+static inline vui64_t vec_popcntd_PWR7 (vui64_t);
+static inline vui64_t vec_popcntd_PWR8 (vui64_t);
+static inline vui128_t vec_popcntq_PWR8 (vui128_t);
+static inline vui128_t vec_popcntq_PWR9 (vui128_t);
+///@endcond
+
+/** \brief Vector Add Unsigned Doubleword Modulo for POWER7 and earlier.
+ *
+ *  Add two vector long int values and return modulo 64-bits result.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power7   | 8-16  |   NA     |
+ *
+ *  @param a 128-bit vector long long int.
+ *  @param b 128-bit vector long long int.
+ *  @return vector long long int sums of a and b.
+ */
+static inline vui64_t
+vec_addudm_PWR7 (vui64_t a, vui64_t b)
+{
+  const vui32_t vone = vec_splat_u32 (1);
+  // vui32_t cm= { 0,1,0,1};
+  const vui32_t cm = (vui32_t) vec_unpackh ((vi16_t) vone);
+  vui32_t r;
+  vui32_t c;
+
+  // propagate carry from words 1/3 into words 0/2
+  c = vec_vaddcuw ((vui32_t)a, (vui32_t)b);
+  r = vec_vadduwm ((vui32_t)a, (vui32_t)b);
+  // Ignore carry's from words 0/2
+  c = vec_and (c, cm);
+  // rotate Words 1/3 carry's into position for words 0/2 extend.
+  c = vec_sld (c, c, 4);
+  // Add/extend carry's to words 0/2
+  return ((vui64_t) vec_vadduwm (r, c));
+}
+
+/** \brief Vector Add Unsigned Quadword Modulo for POWER7 and earlier.
+ *
+ *  Add two vector __int128 values and return result modulo 128-bits.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power7   | 14-16 |   NA     |
+ *
+ *  @param vra 128-bit vector treated as a __int128.
+ *  @param vrb 128-bit vector treated as a __int128.
+ *  @return __int128 sum of a and b.
+ */
+static inline vui128_t
+vec_adduqm_PWR7 (vui128_t vra, vui128_t vrb)
+{
+  const vui32_t z = vec_splat_u32 (0);
+  vui32_t t;
+  vui32_t c, c2;
+
+  c = vec_vaddcuw ((vui32_t)vra, (vui32_t)vrb);
+  t = vec_vadduwm ((vui32_t)vra, (vui32_t)vrb);
+  c = vec_sld (c, z, 4);
+  c2 = vec_vaddcuw (t, c);
+  t = vec_vadduwm (t, c);
+  c = vec_sld (c2, z, 4);
+  c2 = vec_vaddcuw (t, c);
+  t = vec_vadduwm (t, c);
+  c = vec_sld (c2, z, 4);
+  t = vec_vadduwm (t, c);
+  return ((vui128_t) t);
+}
+
+/** \brief Vector Add Unsigned Quadword Modulo for POWER8 and earlier.
+ *
+ *  Add two vector __int128 values and return result modulo 128-bits.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power7   | 14-16 |   NA     |
+ *  |power8   | 4     |2/2 cycles|
+ *  |power9   | 3     | 2/cycle  |
+ *
+ *  @param a 128-bit vector treated as a __int128.
+ *  @param b 128-bit vector treated as a __int128.
+ *  @return __int128 sum of a and b.
+ */
+static inline vui128_t
+vec_adduqm_PWR8 (vui128_t a, vui128_t b)
+{
+  vui32_t t;
+#ifdef _ARCH_PWR8
+#if defined (vec_vadduqm)
+  t = (vui32_t) vec_vadduqm (a, b);
+#elif defined (__clang__)
+  t = (vui32_t) vec_add (a, b);
+#else
+  __asm__(
+      "vadduqm %0,%1,%2;"
+      : "=v" (t)
+      : "v" (a),
+      "v" (b)
+      : );
+#endif
+#else
+  t = (vui32_t) vec_adduqm_PWR7 (a, b);
+#endif
+  return ((vui128_t) t);
+}
+
+/** \brief Vector Count Leading Zeros word for POWER7 and earlier.
+ *
+ *  Count the number of leading '0' bits (0-32) within each word
+ *  element of a 128-bit vector.
+ *
+ *  For POWER8 (PowerISA 2.07B) or later use the Vector Count Leading
+ *  Zeros Word instruction <B>vclzw</B>. Otherwise use sequence of pre
+ *  2.07 VMX instructions.
+ *  SIMDized count leading zeros inspired by:
+ *
+ *  Warren, Henry S. Jr and <I>Hacker's Delight</I>, 2nd Edition,
+ *  Addison Wesley, 2013. Chapter 5 Counting Bits, Floating-Point
+ *  Methods.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power7   | 16-26 |   NA     |
+ *
+ *  @param vra 128-bit vector treated as 4 x 32-bit integer (words)
+ *  elements.
+ *  @return 128-bit vector with the Leading Zeros count for each word
+ *  element.
+ */
+static inline vui32_t
+vec_clzw_PWR7 (vui32_t vra)
+{
+  // generated const (vui32_t) {23, 23, 23, 23}
+  const vui32_t v15 = vec_splat_u32 (15);
+  const vui32_t v8 = vec_splat_u32 (8);
+  const vui32_t v23 = vec_add (v15, v8);
+  // fp5 = 1.0 / 2.0 == 0.5
+  const vui32_t vone = vec_splat_u32 (1);
+  const vf32_t fp5 = vec_ctf (vone, 1);
+  // need a word vector of 158 which is the exponent for 2**31
+  // const vui32_t v2_31 = ones & ~(ones>>1);
+  const vui32_t ones = vec_splat_u32 (-1);
+  const vui32_t v2_31 = vec_vslw (ones, ones);
+  // f2_31 = (vector float) 2**31
+  const vf32_t f2_31 =  vec_ctf (v2_31, 0);
+  vui32_t k, n;
+  vf32_t kf;
+  // Avoid rounding in floating point conversion
+  k = vra & ~(vra >> 1);
+  // Handle all 0s case by insuring min exponent is 158-32
+  kf = vec_ctf (k, 0) + fp5;
+  // Exponent difference is the leading zeros count
+  n = (vui32_t) f2_31 - (vui32_t) kf;
+  // right justify exponent for int
+  n = vec_vsrw(n, v23);
+  return n;
+}
+
+/** \brief Vector Count Leading Zeros Doubleword for POWER7 and earlier.
+ *
+ *  Count the number of leading '0' bits (0-64) within each doubleword
+ *  element of a 128-bit vector.
+ *
+ *  For POWER8 (PowerISA 2.07B) or later use the Vector Count Leading
+ *  Zeros Doubleword instruction <B>vclzd</B>. Otherwise use sequence of
+ *  pre 2.07 VMX instructions.
+ *  SIMDized count leading zeros inspired by:
+ *
+ *  Warren, Henry S. Jr and <I>Hacker's Delight</I>, 2nd Edition,
+ *  Addison Wesley, 2013. Chapter 5 Counting Bits, Floating-Point
+ *  Methods.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power7   | 22-33 |   NA     |
+ *
+ *  @param vra a 128-bit vector treated as 2 x 64-bit unsigned
+ *  long long int (doubleword) elements.
+ *  @return 128-bit vector with the leading zeros count for each
+ *  doubleword element.
+ */
+static inline vui64_t
+vec_clzd_PWR7 (vui64_t vra)
+{
+  const vui32_t zero = vec_splat_u32 (0);
+  // generated const (vui32_t) {20, 20, 20, 20}
+  const vui32_t v10 = vec_splat_u32 (10);
+  const vui32_t v20 = vec_add (v10, v10);
+  // need a dword vector of 1086 which is the exponent for 2**63
+  // f2_63 = (vector double) 2**63
+  const vf64_t f2_63 =  (vf64_t) {0x1.0p63, 0x1.0p63};
+  // Generate expmask = (vui32_t) {0, 0xffffffff, 0, 0xffffffff}
+  const vui32_t ones = vec_splat_u32 (-1);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  // Only for testing only, PWR7 is BE only
+  const vui32_t expmask = vec_mergel (ones, zero);
+#else
+  const vui32_t expmask = vec_mergeh (zero, ones);
+#endif
+  // Generate const (vui32_t) {64, 64, 64, 64}
+  const vui32_t v4 = vec_splat_u32 (4);
+  const vui32_t v64 = vec_sl (v4, v4);
+  vb32_t zmask;
+  vui32_t k, n;
+  vf64_t kf;
+
+  // Avoid rounding in floating point conversion
+  k = (vui32_t) vra & ~((vui32_t) vra >> 1);
+  kf = vec_double ((vui64_t) k);
+  // Exponent difference is the leading zeros count
+  n = (vui32_t) f2_63 - (vui32_t) kf;
+  // right justify exponent for long int
+  n = vec_sld (n, n, 12);
+  n = vec_vsrw(n, v20);
+  // clear extraneous data from words 0/2
+  n = vec_and (n, (vui32_t) expmask);
+  // Fix-up: vra=0 case where the exponent is zero and diff is 1086
+  zmask = vec_cmpgt (n, v64);
+  n = vec_sel (n, v64, zmask);
+
+  return ((vui64_t) n);
+}
+
+/** \brief Vector Count Leading Zeros Doubleword for unsigned
+ *  long long elements.
+ *
+ *  Count the number of leading '0' bits (0-64) within each doubleword
+ *  element of a 128-bit vector.
+ *
+ *  For POWER8 (PowerISA 2.07B) or later use the Vector Count Leading
+ *  Zeros Doubleword instruction <B>vclzd</B>. Otherwise use
+ *  vec_clzd_PWR7().
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power7   | 22-33 |   NA     |
+ *  |power8   |   2   | 2/cycle  |
+ *
+ *  @param vra a 128-bit vector treated as 2 x 64-bit unsigned
+ *  long long (doubleword) elements.
+ *  @return 128-bit vector with the leading zeros count for each
+ *  doubleword element.
+ */
+static inline vui64_t
+vec_clzd_PWR8 (vui64_t vra)
+{
+  vui64_t r;
+#ifdef _ARCH_PWR8
+#if defined (vec_vclzd)
+  r = vec_vclzd (vra);
+#elif defined (__clang__)
+  r = vec_cntlz (vra);
+#else
+  __asm__(
+      "vclzd %0,%1;"
+      : "=v" (r)
+      : "v" (vra)
+      : );
+#endif
+#else
+  r = vec_clzd_PWR7 (vra);
+#endif
+  return (r);
+}
+
+/** \brief Vector Count Leading Zeros Quadword for POWER7 and earlier.
+ *
+ *  Count leading zeros for a vector __int128 and return the count in a
+ *  vector suitable for use with vector shift (left|right) and vector
+ *  shift (left|right) by octet instructions.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   |  8-10 | 1/cycle  |
+ *
+ *  @param vra a 128-bit vector treated as unsigned __int128.
+ *  @return a 128-bit vector with bits 121:127 containing the count of
+ *  leading zeros.
+ */
+static inline vui128_t
+vec_clzq_PWR7 (vui128_t vra)
+{
+  vui32_t result;
+  /* vector clz instructions were introduced in power8. For power7 and
+   * earlier, use the pveclib vec_clzw_PWR7 implementation.  For a quadword
+   * clz, this requires pre-conditioning the input before computing the
+   * the word clz and sum across.   */
+  vui32_t c0, clz;
+  vui32_t r32, gt32, gt32sr32, gt64sr64;
+
+  c0 = vec_splat_u32 (0);
+  gt32 = (vui32_t) vec_cmpgt ((vui32_t) vra, c0);
+  gt32sr32 = vec_sld (c0, gt32, 12);
+  gt64sr64 = vec_sld (c0, gt32, 8);
+  gt32 = vec_sld (c0, gt32, 4);
+
+  gt32sr32 = vec_or (gt32sr32, gt32);
+  gt64sr64 = vec_or (gt64sr64, (vui32_t) vra);
+  r32 = vec_or (gt32sr32, gt64sr64);
+
+  clz = vec_clzw_PWR7 (r32);
+  result = (vui32_t) vec_sums ((vi32_t) clz, (vi32_t) c0);
+
+  return ((vui128_t) result);
+}
+
+/** \brief Vector Count Leading Zeros Quadword for POWER8.
+ *
+ *  Count leading zeros for a vector __int128 and return the count in a
+ *  vector suitable for use with vector shift (left|right) and vector
+ *  shift (left|right) by octet instructions.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   |  8-10 | 1/cycle  |
+ *
+ *  @param vra a 128-bit vector treated as unsigned __int128.
+ *  @return a 128-bit vector with bits 121:127 containing the count of
+ *  leading zeros.
+ */
+static inline vui128_t
+vec_clzq_PWR8 (vui128_t vra)
+{
+  vui32_t result;
+
+#ifdef _ARCH_PWR8
+  /*
+   * Use the Vector Count Leading Zeros Double Word instruction to get
+   * the count for the left and right vector halves.  If the left vector
+   * doubleword of the input is nonzero then only the left count is
+   * included and we need to mask off the right count.
+   * Otherwise the left count is 64 and we need to add 64 to the right
+   * count. After masking we sum across the left and right counts to
+   * get the final 128-bit vector count (0-128).
+   */
+  vui32_t vt1, vt2, vt3, h64, l64;
+  const vui32_t vzero = { 0, 0, 0, 0 };
+  vt1 = (vui32_t) vec_clzd_PWR8 ((vui64_t) vra);
+  vt2 = (vui32_t) vec_cmpeq((vui64_t) vra, (vui64_t) vzero);
+  vt3 = vec_sld ((vui32_t)vzero, vt2, 8);
+  h64 = vec_sld ((vui32_t)vzero, vt1, 8);
+  l64 = vec_and (vt1, vt3);
+  result = vec_add (h64, l64);
+#else
+  result = (vui32_t) vec_clzq_PWR7 (vra);
+#endif
+  return ((vui128_t) result);
+}
+
+/** \brief Vector Count Trailing Zeros Word for POWER7 and earlier.
+ *
+ *  Count the number of trailing '0' bits (0-32) within each word
+ *  element of a 128-bit vector.
+ *
+ *  For POWER9 (PowerISA 3.0B) or later use the Vector Count Trailing
+ *  Zeros Word instruction <B>vctzw</B>. Otherwise use a sequence of
+ *  pre ISA 3.0 VMX instructions.
+ *  SIMDized count Trailing zeros inspired by:
+ *
+ *  Warren, Henry S. Jr and <I>Hacker's Delight</I>, 2nd Edition,
+ *  Addison Wesley, 2013. Chapter 5 Counting Bits, Section 5-4.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power7   | 17-26 |   NA     |
+ *
+ *  @param vra 128-bit vector treated as 4 x 32-bit integer (words)
+ *  elements.
+ *  @return 128-bit vector with the Trailng Zeros count for each word
+ *  element.
+ */
+static inline vui32_t
+vec_ctzw_PWR7 (vui32_t vra)
+{
+  vui32_t r;
+// For _ARCH_PWR7 and earlier. Generate 1's for the trailing zeros
+// and 0's otherwise. Then count (popcnt) the 1's. _ARCH_PWR7 and
+// earlier use the PVECLIB vec_popcntw_PWR7 implementation.
+  const vui32_t mone = vec_splat_u32 (-1);
+  vui32_t tzmask;
+  // tzmask = (!vra & (vra - 1))
+  tzmask = vec_andc (vec_add (vra, mone), vra);
+  // return = vec_popcnt (!vra & (vra - 1))
+  r = vec_popcntw_PWR7 (tzmask);
+  return ((vui32_t) r);
+}
+
+/** \brief Vector Count Trailing Zeros Word for POWER8 and earlier.
+ *
+ *  Count the number of trailing '0' bits (0-32) within each word
+ *  element of a 128-bit vector.
+ *
+ *  For POWER9 (PowerISA 3.0B) or later use the Vector Count Trailing
+ *  Zeros Word instruction <B>vctzw</B>. Otherwise use a sequence of
+ *  pre ISA 3.0 VMX instructions.
+ *  SIMDized count Trailing zeros inspired by:
+ *
+ *  Warren, Henry S. Jr and <I>Hacker's Delight</I>, 2nd Edition,
+ *  Addison Wesley, 2013. Chapter 5 Counting Bits, Section 5-4.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power7   | 17-26 |   NA     |
+ *  |power8   |  6-8  | 2/cycle  |
+ *
+ *  @param vra 128-bit vector treated as 4 x 32-bit integer (words)
+ *  elements.
+ *  @return 128-bit vector with the Trailng Zeros count for each word
+ *  element.
+ */
+static inline vui32_t
+vec_ctzw_PWR8 (vui32_t vra)
+{
+  vui32_t r;
+// For _ARCH_PWR8 and earlier. Generate 1's for the trailing zeros
+// and 0's otherwise. Then count (popcnt) the 1's. _ARCH_PWR8 uses
+// the hardware vpopcntw instruction. _ARCH_PWR7 and earlier use the
+// PVECLIB vec_popcntw_PWR7 implementation which runs ~13-20 cycles.
+  const vui32_t mone = vec_splat_u32 (-1);
+  vui32_t tzmask;
+  // tzmask = (!vra & (vra - 1))
+  tzmask = vec_andc (vec_add (vra, mone), vra);
+  // return = vec_popcnt (!vra & (vra - 1))
+  r = vec_popcntw_PWR8 (tzmask);
+  return ((vui32_t) r);
+}
+
+/** \brief Vector Count Trailing Zeros Word for POWER9 and earlier.
+ *
+ *  Count the number of trailing '0' bits (0-32) within each word
+ *  element of a 128-bit vector.
+ *
+ *  For POWER9 (PowerISA 3.0B) or later use the Vector Count Trailing
+ *  Zeros Word instruction <B>vctzw</B>. Otherwise use a sequence of
+ *  pre ISA 3.0 VMX instructions.
+ *  SIMDized count Trailing zeros inspired by:
+ *
+ *  Warren, Henry S. Jr and <I>Hacker's Delight</I>, 2nd Edition,
+ *  Addison Wesley, 2013. Chapter 5 Counting Bits, Section 5-4.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power7   | 17-26 |   NA     |
+ *  |power8   |  6-8  | 2/cycle  |
+ *  |power9   |   3   | 2/cycle  |
+ *
+ *  @param vra 128-bit vector treated as 4 x 32-bit integer (words)
+ *  elements.
+ *  @return 128-bit vector with the Trailng Zeros count for each word
+ *  element.
+ */
+static inline vui32_t
+vec_ctzw_PWR9 (vui32_t vra)
+{
+  vui32_t r;
+#ifdef _ARCH_PWR9
+#if defined (vec_cnttz) || defined (__clang__)
+  r = vec_cnttz (vra);
+#else
+  __asm__(
+      "vctzw %0,%1;"
+      : "=v" (r)
+      : "v" (vra)
+      : );
+#endif
+#else
+  r = vec_ctzw_PWR8 (vra);
+#endif
+  return ((vui32_t) r);
+}
+
+/** \brief Vector Count Trailing Zeros Doubleword for POWER7 and earlier.
+ *
+ *  Count the number of trailing '0' bits (0-64) within each doubleword
+ *  element of a 128-bit vector.
+ *
+ *  For POWER9 (PowerISA 3.0B) or later use the Vector Count Trailing
+ *  Zeros Doubleword instruction <B>vctzd</B>. Otherwise use a sequence of
+ *  pre ISA 3.0 VMX instructions leveraging the PVECLIB popcntd operation.
+ *  SIMDized count Trailing zeros inspired by:
+ *
+ *  Warren, Henry S. Jr and <I>Hacker's Delight</I>, 2nd Edition,
+ *  Addison Wesley, 2013. Chapter 5 Counting Bits, Section 5-4.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 8-10  |2/2 cycles|
+ *  |power9   |   3   | 2/cycle  |
+ *
+ *  @param vra 128-bit vector treated as 2 x 64-bit integer
+ *  (doublewords) elements.
+ *  @return 128-bit vector with the trailng zeros count for each
+ *  doubleword element.
+ */
+static inline vui64_t
+vec_ctzd_PWR7 (vui64_t vra)
+{
+  vui64_t result;
+  /* vector ctz instructions were introduced in power9. For power8 and
+   * earlier, use the pveclib vec_popcntd_PWR8 implementation.  */
+  const vui64_t mone = (vui64_t) vec_splat_u32 (-1);
+  vui64_t tzmask;
+
+  // This allows quadword ctz to be a simple sum across of the dwords
+  // tzmask = (!r64 & (r64 - 1))
+  tzmask = vec_andc (vec_addudm_PWR7 (vra, mone), vra);
+  result = vec_popcntd_PWR7 (tzmask);
+
+  return (result);
+}
+
+/** \brief Vector Count Trailing Zeros Doubleword for POWER8 and earlier.
+ *
+ *  Count the number of trailing '0' bits (0-64) within each doubleword
+ *  element of a 128-bit vector.
+ *
+ *  For POWER9 (PowerISA 3.0B) or later use the Vector Count Trailing
+ *  Zeros Doubleword instruction <B>vctzd</B>. Otherwise use a sequence of
+ *  pre ISA 3.0 VMX instructions leveraging the PVECLIB popcntd operation.
+ *  SIMDized count Trailing zeros inspired by:
+ *
+ *  Warren, Henry S. Jr and <I>Hacker's Delight</I>, 2nd Edition,
+ *  Addison Wesley, 2013. Chapter 5 Counting Bits, Section 5-4.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 8-10  |2/2 cycles|
+ *
+ *  @param vra 128-bit vector treated as 2 x 64-bit integer
+ *  (doublewords) elements.
+ *  @return 128-bit vector with the trailng zeros count for each
+ *  doubleword element.
+ */
+static inline vui64_t
+vec_ctzd_PWR8 (vui64_t vra)
+{
+  vui64_t result;
+
+#ifdef _ARCH_PWR8
+  /* vector ctz instructions were introduced in power9. For power8 and
+   * earlier, use the pveclib vec_popcntd_PWR8 implementation.  */
+  const vui64_t mone = (vui64_t) vec_splat_u32 (-1);
+  vui64_t tzmask;
+  // tzmask = (!r64 & (r64 - 1))
+  tzmask = vec_andc (vec_add (vra, mone), vra);
+  result = vec_popcntd_PWR8 (tzmask);
+#else
+  result = vec_ctzd_PWR7 (vra);
+#endif
+
+  return (result);
+}
+
+/** \brief Vector Count Trailing Zeros Doubleword for POWER9 and earlier.
+ *
+ *  Count the number of trailing '0' bits (0-64) within each doubleword
+ *  element of a 128-bit vector.
+ *
+ *  For POWER9 (PowerISA 3.0B) or later use the Vector Count Trailing
+ *  Zeros Doubleword instruction <B>vctzd</B>. Otherwise use a sequence of
+ *  pre ISA 3.0 VMX instructions leveraging the PVECLIB popcntd operation.
+ *  SIMDized count Trailing zeros inspired by:
+ *
+ *  Warren, Henry S. Jr and <I>Hacker's Delight</I>, 2nd Edition,
+ *  Addison Wesley, 2013. Chapter 5 Counting Bits, Section 5-4.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 8-10  |2/2 cycles|
+ *  |power9   |   3   | 2/cycle  |
+ *
+ *  @param vra 128-bit vector treated as 2 x 64-bit integer
+ *  (doublewords) elements.
+ *  @return 128-bit vector with the trailng zeros count for each
+ *  doubleword element.
+ */
+static inline vui64_t
+vec_ctzd_PWR9 (vui64_t vra)
+{
+  vui64_t result;
+#ifdef _ARCH_PWR9
+#if defined (vec_cnttz) || defined (__clang__)
+  result = vec_cnttz (vra);
+#else
+  __asm__(
+      "vctzd %0,%1;"
+      : "=v" (result)
+      : "v" (vra)
+      : );
+#endif
+#else
+  result = vec_ctzd_PWR8 (vra);
+#endif
+  return (result);
+}
+
+/** \brief Vector Count Trailing Zeros Quadword for POWER7 and earlier.
+ *
+ *  Count trailing zeros for a vector __int128 and return the count in a
+ *  vector suitable for use with vector shift (left|right) and vector
+ *  shift (left|right) by octet instructions.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power7   | 32-41 | 1/cycle  |
+ *  |power8   | 15-17 | 1/cycle  |
+ *  |power9   | 13-16 | 1/cycle  |
+ *
+ *  @param vra a 128-bit vector treated as unsigned __int128.
+ *  @return a 128-bit vector with bits 121:127 containing the count of
+ *  trailing zeros.
+ */
+static inline vui128_t
+vec_ctzq_PWR7 (vui128_t vra)
+{
+  vui32_t result;
+  /* vector ctz instructions were introduced in power9. For power7 and
+   * earlier, use the pveclib vec_ctzw_PWR7 implementation.  For a quadword
+   * clz, this requires pre-conditioning the input before computing the
+   * the word ctz and sum across.   */
+  const vui32_t vzero = vec_splat_u32 (0);
+  vui32_t clz;
+  vui32_t r32, gt32, gt32sr32, gt64sr64;
+
+  // From right to left, any word to the left of the 1st nonzero word
+  // is set to 0xffffffff (ctz(0xffffffff) = 0)
+  gt32 = (vui32_t) vec_cmpgt ((vui32_t) vra, vzero);
+  gt32sr32 = vec_sld (gt32, vzero, 12);
+  gt64sr64 = vec_sld (gt32, vzero, 8);
+  gt32 = vec_sld (gt32, vzero, 4);
+
+  gt32sr32 = vec_or (gt32sr32, gt32);
+  gt64sr64 = vec_or (gt64sr64, (vui32_t) vra);
+  r32 = vec_or (gt32sr32, gt64sr64);
+
+  // This allows quadword ctz to be a simple sum across the words
+  clz = vec_ctzw_PWR7 (r32);
+  result = (vui32_t) vec_sums ((vi32_t) clz, (vi32_t) vzero);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  // undo endian for PWR8 testing only, work around!
+  result = vec_sld (result, result, 4);
+#endif
+
+  return ((vui128_t) result);
+}
+
+/** \brief Vector Count Trailing Zeros Quadword for POWER7 and earlier.
+ *
+ *  Count trailing zeros for a vector __int128 and return the count in a
+ *  vector suitable for use with vector shift (left|right) and vector
+ *  shift (left|right) by octet instructions.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 14-16 | 1/cycle  |
+ *
+ *  @param vra a 128-bit vector treated as unsigned __int128.
+ *  @return a 128-bit vector with bits 121:127 containing the count of
+ *  trailing zeros.
+ */
+static inline vui128_t
+vec_ctzq_PWR8 (vui128_t vra)
+{
+#ifdef _ARCH_PWR8
+  const vui128_t ones = (vui128_t) vec_splat_s32(-1);
+  vui128_t tzmask;
+
+  // tzmask = (!vra & (vra - 1))
+  tzmask = (vui128_t) vec_andc ((vui64_t) vec_adduqm_PWR8 (vra, ones),
+				(vui64_t) vra);
+  // return = vec_popcnt (!vra & (vra - 1))
+  return vec_popcntq_PWR8 (tzmask);
+#else
+  return vec_ctzq_PWR7 (vra);
+#endif
+}
+
+/** \brief Vector Count Trailing Zeros Quadword for POWER9 and earlier.
+ *
+ *  Count trailing zeros for a vector __int128 and return the count in a
+ *  vector suitable for use with vector shift (left|right) and vector
+ *  shift (left|right) by octet instructions.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power9   | 13-16 | 1/cycle  |
+ *
+ *  @param vra a 128-bit vector treated as unsigned __int128.
+ *  @return a 128-bit vector with bits 121:127 containing the count of
+ *  trailing zeros.
+ */
+static inline vui128_t
+vec_ctzq_PWR9 (vui128_t vra)
+{
+  vui64_t result;
+
+#ifdef _ARCH_PWR9
+  const vui128_t ones = (vui128_t) vec_splat_s32(-1);
+  vui128_t tzmask;
+
+  // tzmask = (!vra & (vra - 1))
+  tzmask = (vui128_t) vec_andc ((vui64_t) vec_adduqm_PWR8 (vra, ones),
+				(vui64_t) vra);
+  // return = vec_popcnt (!vra & (vra - 1))
+  return vec_popcntq_PWR9 (tzmask);
+#else
+  result = (vui64_t) vec_ctzq_PWR8 (vra);
+#endif
+
+  return ((vui128_t) result);
+}
+
+/** \brief Vector Population Count byte for POWER7 and earlier.
+ *
+ *  Count the number of '1' bits (0-8) within each byte element of
+ *  a 128-bit vector.
+ *
+ *  For POWER8 (PowerISA 2.07B) or later use vec_popcntb()
+ *  operation. Otherwise use this implementation requiring
+ *  only simple Vector (VMX) instructions.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power7   | 6-13  |   NA     |
+ *
+ *  @param vra 128-bit vector treated as 16 x 8-bit integers (byte)
+ *  elements.
+ *  @return 128-bit vector with the population count for each byte
+ *  element.
+ */
+static inline vui8_t
+vec_popcntb_PWR7 (vui8_t vra)
+{
+  const vui8_t nibmask = vec_splat_u8 (15);
+  const vui8_t nibshft = vec_splat_u8 (4);
+  const vui8_t popc_perm = { 0, 1, 1, 2, 1, 2, 2, 3,
+                             1, 2, 2, 3, 2, 3, 3, 4};
+  vui8_t nib_h, nib_l;
+  vui8_t rh, rl;
+
+  nib_l = vec_and (vra, nibmask);
+  nib_h = vec_sr  (vra, nibshft);
+  rl = vec_perm (popc_perm, popc_perm, nib_l);
+  rh = vec_perm (popc_perm, popc_perm, nib_h);
+  return  vec_add (rh, rl);
+}
+
+/** \brief Vector Population Count halfword for POWER7 and earlier.
+ *
+ *  Count the number of '1' bits (0-16) within each byte element of
+ *  a 128-bit vector.
+ *
+ *  For POWER8 (PowerISA 2.07B) or later use the vec_popcnth()
+ *  operation. Otherwise use this implementation requiring
+ *  only simple Vector (VMX) instructions.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power7   | 13-22 |   NA     |
+ *
+ *  @param vra 128-bit vector treated as 8 x 16-bit integers (halfword)
+ *  elements.
+ *  @return 128-bit vector with the population count for each halfword
+ *  element.
+ */
+static inline vui16_t
+vec_popcnth_PWR7 (vui16_t vra)
+{
+  const vui8_t vone = vec_splat_u8 (1);
+  vui16_t result, rl, rh;
+  vui8_t bytepop;
+  // Generate byte pop counts
+  bytepop = vec_popcntb_PWR7 ((vui8_t) vra);
+  // unpack and sum adjacent bytes into halfwords for pop count
+  rl = vec_mulo (bytepop, vone);
+  rh = vec_mule (bytepop, vone);
+  result = vec_add (rh, rl);
+
+  return result;
+}
+
+/** \brief Vector Population Count word for POWER7 and earlier.
+ *
+ *  Count the number of '1' bits (0-32) within each word element of
+ *  a 128-bit vector.
+ *
+ *  For POWER8 (PowerISA 2.07B) or later use the vec_popcntw()
+ *  operation. Otherwise use this implementation requiring
+ *  only simple Vector (VMX) instructions.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power7   | 13-20 |   NA     |
+ *
+ *  @param vra 128-bit vector treated as 4 x 32-bit integer (words)
+ *  elements.
+ *  @return 128-bit vector with the population count for each word
+ *  element.
+ */
+static inline vui32_t
+vec_popcntw_PWR7 (vui32_t vra)
+{
+  const vui32_t vzero = vec_splat_u32 (0);
+  vui8_t bytepop;
+  // Generate byte pop counts
+  bytepop = vec_popcntb_PWR7 ((vui8_t) vra);
+  // Sum across adjacent bytes into words for pop count
+  return  vec_sum4s (bytepop, vzero);
+}
+
+/** \brief Vector Population Count word for POWER7/8 and earlier.
+ *
+ *  Count the number of '1' bits (0-32) within each word element of
+ *  a 128-bit vector.
+ *
+ *  For POWER8 (PowerISA 2.07B) or later use the Vector Population
+ *  Count Word instruction. Otherwise use the pveclib vec_popcntb_PWR7
+ *  to count each byte then sum across with Vector Sum across Quarter
+ *  Unsigned Byte Saturate.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power7   | 13-20 |   NA     |
+ *  |power8   |   2   | 2/cycle  |
+ *
+ *  @param vra 128-bit vector treated as 4 x 32-bit integer (words)
+ *  elements.
+ *  @return 128-bit vector with the population count for each word
+ *  element.
+ */
+static inline vui32_t
+vec_popcntw_PWR8 (vui32_t vra)
+{
+  vui32_t r;
+#ifdef _ARCH_PWR8
+#if defined (vec_vpopcntw)
+  r = vec_vpopcntw (vra);
+#elif defined (__clang__)
+  r = vec_popcnt (vra);
+#else
+  __asm__(
+      "vpopcntw %0,%1;"
+      : "=v" (r)
+      : "v" (vra)
+      : );
+#endif
+#else
+  r = vec_popcntw_PWR7 (vra);
+#endif
+  return (r);
+}
+
+/** \brief Vector Population Count doubleword for POWER7 and earlier.
+ *
+ *  Count the number of '1' bits (0-64) within each doubleword element
+ *  of a 128-bit vector.
+ *
+ *  For POWER8 (PowerISA 2.07B) or later use the vec_popcntd()
+ *  operation. Otherwise use this implementation
+ *  requiring only simple Vector (VMX) instructions.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power7   | 20-27 |   NA     |
+ *
+ *  @param vra 128-bit vector treated as 2 x 64-bit integer (dwords)
+ *  elements.
+ *  @return 128-bit vector with the population count for each dword
+ *  element.
+ */
+static inline vui64_t
+vec_popcntd_PWR7 (vui64_t vra)
+{
+  const vui32_t vzero = vec_splat_u32 (0);
+  vui8_t bytepop;
+  vui32_t wordpop;
+  vi32_t dwordpop;
+  // Generate byte pop counts
+  bytepop = vec_popcntb_PWR7 ((vui8_t) vra);
+  // unpack and sum adjacent bytes into words for pop count
+  wordpop = vec_sum4s (bytepop, vzero);
+  // unpack and sum adjacent words into dwords for pop count
+  dwordpop = vec_sum2s ((vi32_t) wordpop, (vi32_t) vzero);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  // undo endian for PWR8 testing only, work around!
+  dwordpop = vec_sld (dwordpop, dwordpop, 12);
+#endif
+  return ((vui64_t) dwordpop);
+}
+
+/** \brief Vector Population Count doublewordfor POWER7 and earlier.
+ *
+ *  Count the number of '1' bits (0-64) within each doubleword element
+ *  of a 128-bit vector.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   |   4   |2/2 cycles|
+ *  |power9   |   3   | 2/cycle  |
+ *
+ *  For POWER8 (PowerISA 2.07B) or later use the Vector Population
+ *  Count DoubleWord (<B>vpopcntd</B>) instruction. Otherwise use the
+ *  pveclib vec_popcntd_PWR7.
+ *
+ *  @param vra 128-bit vector treated as 2 x 64-bit integer (dwords)
+ *  elements.
+ *  @return 128-bit vector with the population count for each dword
+ *  element.
+ */
+static inline vui64_t
+vec_popcntd_PWR8 (vui64_t vra)
+{
+  vui64_t r;
+#ifdef _ARCH_PWR8
+#if defined (vec_vpopcntd)
+  r = vec_vpopcntd (vra);
+#elif defined (__clang__)
+  r = vec_popcnt (vra);
+#else
+  __asm__(
+      "vpopcntd %0,%1;"
+      : "=v" (r)
+      : "v" (vra)
+      : );
+#endif
+#else
+  r = vec_popcntd_PWR7 (vra);
+#endif
+  return (r);
+}
+
+/** \brief Vector Population Count Quadword for POWER7 and earlier.
+ *
+ *  Count the number of '1' bits within a vector unsigned __int128
+ *  and return the count (0-128) in a vector unsigned __int128.
+ *
+ *  For POWER8 (PowerISA 2.07B) or later use the vec_popcntq()
+ *  operation. Otherwise use this implementation
+ *  requiring only simple Vector (VMX) instructions.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power7   | 20-27 |   NA     |
+ *
+ *  @param vra a 128-bit vector treated as unsigned __int128.
+ *  @return a 128-bit vector with bits 121:127 containing the
+ *  population count.
+ */
+static inline vui128_t
+vec_popcntq_PWR7 (vui128_t vra)
+{
+  const vui32_t vzero = vec_splat_u32 (0);
+  vui8_t bytepop;
+  vui32_t wordpop;
+  vi32_t qwordpop;
+  // Generate byte pop counts
+  bytepop = vec_popcntb_PWR7 ((vui8_t) vra);
+  // unpack and sum adjacent bytes into words for pop count
+  wordpop = vec_sum4s (bytepop, vzero);
+  // unpack and sum adjacent words into quadword for pop count
+  qwordpop = vec_sums ((vi32_t) wordpop, (vi32_t) vzero);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  // undo endian for PWR8 testing only, work around!
+  qwordpop = vec_sld (qwordpop, qwordpop, 4);
+#endif
+  return ((vui128_t) qwordpop);
+}
+
+/** \brief Vector Population Count Quadword for POWER8 and earlier.
+ *
+ *  Count the number of '1' bits within a vector unsigned __int128
+ *  and return the count (0-128) in a vector unsigned __int128.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power7   | 20-27 |   NA     |
+ *  |power8   |  8-10 | 1/cycle  |
+ *
+ *  @param vra a 128-bit vector treated as unsigned __int128.
+ *  @return a 128-bit vector with bits 121:127 containing the
+ *  population count.
+ */
+static inline vui128_t
+vec_popcntq_PWR8 (vui128_t vra)
+{
+  vui128_t result;
+
+#if defined(_ARCH_PWR8)
+  /*
+   * Use the Vector Population Count Doubleword instruction to get the
+   * count for each DW.  Then sum across the DWs to get the final
+   * 128-bit vector count (0-128). For P8 popcntw is 2 cycles faster
+   * then popcntd but requires vsumsws (7 cycles). Using popcntd
+   *  allows a faster sum and saves a cycle over all.
+   */
+  vui32_t vt1, h64, l64;
+  const vui32_t vzero = { 0, 0, 0, 0 };
+
+  vt1 = (vui32_t) vec_popcntd_PWR8 ((vui64_t)  vra);
+  // Note high words 0,1,2 of vt1 are zero
+  // h64 = { vzero [0] | vt1 [0] | vzero [1] | vt1 [1] }
+  // l64 = { vzero [2] | vt1 [2] | vzero [3] | vt1 [3] }
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  // Undo the endian transform
+  h64 = vec_mergel (vt1, vzero);
+  l64 = vec_mergeh (vt1, vzero);
+#else
+  h64 = vec_mergeh (vzero, vt1);
+  l64 = vec_mergel (vzero, vt1);
+#endif
+  result = (vui128_t) vec_add (h64, l64);
+#else
+  result = vec_popcntq_PWR7 (vra);
+#endif
+  return result;
+}
+
+/** \brief Vector Population Count Quadword for POWER8 and earlier.
+ *
+ *  Count the number of '1' bits within a vector unsigned __int128
+ *  and return the count (0-128) in a vector unsigned __int128.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   |  8-10 | 1/cycle  |
+ *  |power9   |  9-12 | 2/cycle  |
+ *
+ *  @param vra a 128-bit vector treated as unsigned __int128.
+ *  @return a 128-bit vector with bits 121:127 containing the
+ *  population count.
+ */
+static inline vui128_t
+vec_popcntq_PWR9 (vui128_t vra)
+{
+  vui128_t result;
+
+#ifdef _ARCH_PWR9
+  /*
+   * Use the Vector Population Count Doubleword instruction to get
+   * the count for the left and right vector halves.  Then sum across
+   * the left and right counts to get the final 128-bit vector count
+   * (0-128).
+   */
+  vui32_t vt1, h64, l64;
+  const vui32_t vzero = { 0, 0, 0, 0 };
+
+  vt1 = (vui32_t) vec_popcntd_PWR8 ((vui64_t)  vra);
+  // Note high words 0,1,2 of vt1 are zero
+  // h64 = { vzero [0] | vt1 [0] | vzero [1] | vt1 [1] }
+  // l64 = { vzero [2] | vt1 [2] | vzero [3] | vt1 [3] }
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  // Undo the endian transform
+  h64 = vec_mergel (vt1, vzero);
+  l64 = vec_mergeh (vt1, vzero);
+#else
+  h64 = vec_mergeh (vzero, vt1);
+  l64 = vec_mergel (vzero, vt1);
+#endif
+  result = (vui128_t) vec_add (h64, l64);
+#else
+  result = (vui128_t) vec_popcntq_PWR8 (vra);
+#endif
+  return ((vui128_t) result);
+}
+
+/** \brief Vector Subtract Unsigned Doubleword Modulo for POWER7 and earlier.
+ *
+ *  For each unsigned long (64-bit) integer element c[i] = a[i] +
+ *  NOT(b[i]) + 1.
+ *
+ *  For POWER8 (PowerISA 2.07B) or later use the Vector Subtract
+ *  Unsigned Doubleword Modulo (<B>vsubudm</B>) instruction.
+ *  Otherwise use this implementation
+ *  requiring only simple Vector (VMX) instructions.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power7   | 20-27 |   NA     |
+ *
+ *  @param vra 128-bit vector treated as 2 X unsigned long long int.
+ *  @param vrb 128-bit vector treated as 2 X unsigned long long int.
+ *  @return  vector unsigned long int sum of a[0] + NOT(b[0]) + 1
+ *  and a[1] + NOT(b[1]) + 1.
+ */
+static inline vui64_t
+vec_subudm_PWR7 (vui64_t vra, vui64_t vrb)
+{
+  const vui32_t vone = vec_splat_u32 (1);
+  // vui32_t cm= { 0,1,0,1};
+  const vui32_t cm = (vui32_t) vec_unpackh ((vi16_t) vone);
+  vui32_t r;
+  vui32_t c;
+
+  // propagate carry/borrow from words 1/3 into words 0/2
+  c = vec_vsubcuw ((vui32_t)vra, (vui32_t)vrb);
+  r = vec_vsubuwm ((vui32_t)vra, (vui32_t)vrb);
+  // Ignore carry's from words 0/2
+  c = vec_and (c, cm);
+  // rotate Words 1/3 carry's into position for words 0/2 extend.
+  c = vec_sld (c, c, 4);
+  // Add/extend carry's to words 0/2
+  return ((vui64_t) vec_vsubuwm (r, c));
+}
+
+/** \brief Vector Subtract Unsigned Quadword Modulo for POWER7 and earlier.
+ *
+ *  Subtract two vector __int128 values and return result modulo 128-bits.
+ *
+ *  For POWER8 (PowerISA 2.07B) or later use the Vector Subtract
+ *  Unsigned Doubleword Modulo (<B>vsubuqm</B>) instruction.
+ *  Otherwise use this implementation
+ *  requiring only simple Vector (VMX) instructions.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power7   | 24-31 |   NA     |
+ *
+ *  @param vra 128-bit vector treated as unsigned __int128.
+ *  @param vrb 128-bit vector treated as unsigned __int128.
+ *  @return __int128 unsigned difference of vra minus vrb.
+ */
+static inline vui128_t
+vec_subuqm_PWR7 (vui128_t vra, vui128_t vrb)
+{
+  vui32_t t;
+  vui32_t c2, c;
+  vui32_t z  = { 0,0,0,0};
+  vui32_t co = { 1,1,1,1};
+  vui32_t _b = vec_nor ((vui32_t) vrb, (vui32_t) vrb);
+
+  /* vsubuqm is defined as vra + NOT(vrb) + 1.
+  // or vec_addeuqm (vra, (vui128_t) _b, (vui128_t) {1}); */
+
+  c2 = vec_vaddcuw ((vui32_t)vra, (vui32_t)_b);
+  t = vec_vadduwm ((vui32_t)vra, (vui32_t)_b);
+  // inject the extend carry.
+  c = vec_sld (c2, co, 4);
+  c2 = vec_vaddcuw (t, c);
+  t = vec_vadduwm (t, c);
+  c = vec_sld (c2, z, 4);
+  c2 = vec_vaddcuw (t, c);
+  t = vec_vadduwm (t, c);
+  c = vec_sld (c2, z, 4);
+  c2 = vec_vaddcuw (t, c);
+  t = vec_vadduwm (t, c);
+  c = vec_sld (c2, z, 4);
+  t = vec_vadduwm (t, c);
+
+  return ((vui128_t) t);
+}
+
 /** \brief Transfer a vector unsigned __int128 to __int128 scalar.
 *
 *  The compiler does not allow direct transfer (assignment or type

--- a/src/pveclib/vec_f64_ppc.h
+++ b/src/pveclib/vec_f64_ppc.h
@@ -1499,7 +1499,7 @@ vec_vlxsfdx (const signed long long ra, const double *rb)
   __VEC_U_128 t;
   unsigned long long *p = (unsigned long long *)((char *)rb + ra);
   t.ulong.upper = *p;
-  xt = t.vx1;
+  xt = t.vf2;
 #else
   if (__builtin_constant_p (ra) && (ra < 32760) && (ra >= -32768)
       && ((ra & 3) == 0))
@@ -1590,7 +1590,7 @@ vec_vstxsfdx (vf64_t xs, const signed long long ra, double *rb)
 #if defined (__clang__)
   __VEC_U_128 t;
   unsigned long long *p = (unsigned long long *)((char *)rb + ra);
-  t.vx1 = xs;
+  t.vf2 = xs;
   *p = t.ulong.upper;
 #else
   if (__builtin_constant_p (ra) && (ra <= 32760) && (ra >= -32768)

--- a/src/pveclib/vec_int128_ppc.h
+++ b/src/pveclib/vec_int128_ppc.h
@@ -4197,6 +4197,7 @@ vec_addeuqm (vui128_t a, vui128_t b, vui128_t ci)
 #endif
   return ((vui128_t) t);
 #else
+  vui32_t t;
   vui32_t c2, c;
   vui32_t z  = { 0,0,0,0};
   vui32_t co = { 1,1,1,1};

--- a/src/pveclib/vec_int128_ppc.h
+++ b/src/pveclib/vec_int128_ppc.h
@@ -4180,8 +4180,8 @@ vec_addcuq (vui128_t a, vui128_t b)
 static inline vui128_t
 vec_addeuqm (vui128_t a, vui128_t b, vui128_t ci)
 {
-  vui32_t t;
 #ifdef _ARCH_PWR8
+  vui32_t t;
 #if defined (vec_vaddeuqm)
   t = (vui32_t) vec_vaddeuqm (a, b, ci);
 #elif defined (__clang__)
@@ -4195,6 +4195,7 @@ vec_addeuqm (vui128_t a, vui128_t b, vui128_t ci)
       "v" (ci)
       : );
 #endif
+  return ((vui128_t) t);
 #else
   vui32_t c2, c;
   vui32_t z  = { 0,0,0,0};
@@ -4215,8 +4216,8 @@ vec_addeuqm (vui128_t a, vui128_t b, vui128_t ci)
   t = vec_vadduwm (t, c);
   c = vec_sld (c2, z, 4);
   t = vec_vadduwm (t, c);
-#endif
   return ((vui128_t) t);
+#endif
 }
 
 /** \brief Vector Add Unsigned Quadword Modulo.
@@ -4454,7 +4455,7 @@ vec_clzq (vui128_t vra)
   gt64sr64 = vec_or (gt64sr64, (vui32_t) vra);
   r32 = vec_or (gt32sr32, gt64sr64);
 
-  clz = vec_clzw (r32);
+  clz = vec_clzw_PWR7 (r32);
   result = (vui64_t) vec_sums ((vi32_t) clz, (vi32_t) c0);
 #endif
 
@@ -8154,11 +8155,8 @@ vec_popcntq (vui128_t vra)
   result = (vui64_t) vec_vsumsw ((vi32_t) vt1,
                                  (vi32_t) vzero);
 #else
-  //#warning Implememention pre power8
-  vui32_t z= { 0,0,0,0};
-  vui32_t x;
-  x = vec_popcntw ((vui32_t)vra);
-  result = (vui64_t) vec_sums ((vi32_t) x, (vi32_t) z);
+  // vec_common_ppc.h implementation will handle PWR7
+  result = (vui64_t) vec_popcntq_PWR7 (vra);
 #endif
   return ((vui128_t) result);
 }

--- a/src/pveclib/vec_int64_ppc.h
+++ b/src/pveclib/vec_int64_ppc.h
@@ -1994,13 +1994,12 @@ static inline
 vui64_t
 vec_addudm(vui64_t a, vui64_t b)
 {
-  vui32_t r;
-
 #ifdef _ARCH_PWR8
+  vui64_t r;
 #if defined (vec_vaddudm)
-  r = (vui32_t) vec_vaddudm (a, b);
+  r = vec_vaddudm (a, b);
 #elif defined (__clang__)
-  r = (vui32_t) vec_add (a, b);
+  r = vec_add (a, b);
 #else
   __asm__(
       "vaddudm %0,%1,%2;"
@@ -2009,18 +2008,11 @@ vec_addudm(vui64_t a, vui64_t b)
       "v" (b)
       : );
 #endif
+  return (r);
 #else
-  vui32_t c;
-  vui32_t z= { 0,0,0,0};
-  vui32_t cm= { 0,1,0,1};
-
-  c = vec_vaddcuw ((vui32_t)a, (vui32_t)b);
-  r = vec_vadduwm ((vui32_t)a, (vui32_t)b);
-  c = vec_and (c, cm);
-  c = vec_sld (c, z, 4);
-  r = vec_vadduwm (r, c);
+  // vec_common_ppc.h implementation will handle PWR7
+  return vec_addudm_PWR7 (a, b);
 #endif
-  return ((vui64_t) r);
 }
 
 /** \brief Vector Count Leading Zeros Doubleword for unsigned
@@ -2060,19 +2052,8 @@ vec_clzd (vui64_t vra)
       : );
 #endif
 #else
-  vui32_t n, nt, y, x, m;
-  vui32_t z = { 0, 0, 0, 0 };
-  vui32_t dlwm = { 0, -1, 0, -1 };
-
-  x = (vui32_t) vra;
-
-  m = (vui32_t) vec_cmpgt (x, z);
-  n = vec_sld (z, m, 12);
-  y = vec_and (n, dlwm);
-  nt = vec_or (x, y);
-
-  n = vec_clzw (nt);
-  r = (vui64_t) vec_vsum2sw ((vi32_t) n, (vi32_t) z);
+  // vec_common_ppc.h implementation will handle PWR7
+  r = vec_clzd_PWR7 (vra);
 #endif
   return (r);
 }
@@ -2119,13 +2100,9 @@ vec_ctzd (vui64_t vra)
 // For _ARCH_PWR8 and earlier. Generate 1's for the trailing zeros
 // and 0's otherwise. Then count (popcnt) the 1's. _ARCH_PWR8 uses
 // the hardware vpopcntd instruction. _ARCH_PWR7 and earlier use the
-// PVECLIB vec_popcntd implementation which runs ~24-33 instructions.
-  const vui64_t ones = { -1, -1 };
-  vui64_t tzmask;
-  // tzmask = (!vra & (vra - 1))
-  tzmask = vec_andc (vec_addudm (vra, ones), vra);
-  // return = vec_popcnt (!vra & (vra - 1))
-  r = vec_popcntd (tzmask);
+// PVECLIB vec_popcntd implementation.
+// vec_common_ppc.h implementation will handle PWR8/7
+  r = vec_ctzd_PWR8 (vra);
 #endif
   return ((vui64_t) r);
 }
@@ -4348,10 +4325,8 @@ vec_popcntd (vui64_t vra)
       : );
 #endif
 #else
-  vui32_t z= { 0,0,0,0};
-  vui32_t x;
-  x = vec_popcntw ((vui32_t) vra);
-  r = (vui64_t) vec_vsum2sw ((vi32_t) x, (vi32_t) z);
+  // vec_common_ppc.h implementation will handle PWR7
+  r = vec_popcntd_PWR7 (vra);
 #endif
   return (r);
 }
@@ -5016,9 +4991,8 @@ vec_sradi (vi64_t vra, const unsigned int shb)
 static inline vui64_t
 vec_subudm(vui64_t a, vui64_t b)
 {
-  vui32_t r;
-
 #ifdef _ARCH_PWR8
+  vui32_t r;
 #if defined (vec_vsubudm)
   r = (vui32_t) vec_vsubudm (a, b);
 #elif defined (__clang__)
@@ -5031,18 +5005,11 @@ vec_subudm(vui64_t a, vui64_t b)
       "v" (b)
       : );
 #endif
-#else
-  vui32_t c;
-  vui32_t z= { 0,0,0,0};
-  vui32_t cm= { 0,1,0,1};
-
-  c = vec_vsubcuw ((vui32_t)a, (vui32_t)b);
-  r = vec_vsubuwm ((vui32_t)a, (vui32_t)b);
-  c = vec_andc (cm, c);
-  c = vec_sld (c, z, 4);
-  r = vec_vsubuwm (r, c);
-#endif
   return ((vui64_t) r);
+#else
+  // vec_common_ppc.h implementation will handle PWR7
+  return vec_subudm_PWR7 (a, b);
+#endif
 }
 
 /** \brief Vector doubleword swap.

--- a/src/testsuite/arith128_test_char.c
+++ b/src/testsuite/arith128_test_char.c
@@ -350,6 +350,21 @@ test_ctzb (void)
   return (rc);
 }
 
+//#define __DEBUG_PRINT__ 1
+#if 1
+#if 0
+// test directly from vec_char_ppc.h
+#define test_popcnt_b(_l)	vec_popcntb(_l)
+#else
+// test from vec_char_ppc.h via vec_char_dummy.c
+extern vui8_t test_vec_popcntb (vui8_t);
+#define test_popcnt_b(_l)	test_vec_popcntb(_l)
+#endif
+#else
+// test from vec_char_dummy.c
+extern vui8_t test_vec_popcntb_PWR7 (vui8_t);
+#define test_popcnt_b(_j)	test_vec_popcntb_PWR7(_j)
+#endif
 int
 test_popcntb (void)
 {
@@ -361,7 +376,7 @@ test_popcntb (void)
 
   i = (vui8_t){0,1,2,3, 4,5,6,7, 8,9,10,11, 12,13,14,15};
   e = (vui8_t){0,1,1,2, 1,2,2,3, 1,2,2,3, 2,3,3,4};
-  j = vec_popcntb((vui8_t)i);
+  j = test_popcnt_b((vui8_t)i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntb({0,1,2,3, 4,5,6,7, 8,9,10,11, 12,13,14,15}) ", (vui128_t)j);
@@ -370,7 +385,7 @@ test_popcntb (void)
 
   i = (vui8_t){0,1,2,4, 8,16,32,64, 128,136,34,17, 240,255,170,85};
   e = (vui8_t){0,1,1,1, 1,1,1,1, 1,2,2,2, 4,8,4,4};
-  j = vec_popcntb((vui8_t)i);
+  j = test_popcnt_b((vui8_t)i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntb({0,1,2,4, 8,16,32,64, 128,136,34,17, 240,255,170,85}) ", (vui128_t)j);
@@ -379,7 +394,7 @@ test_popcntb (void)
 
   i = (vui8_t){7,224,168,133, 15,240,225,170, 31,248,79,229, 63,245,235,190};
   e = (vui8_t){3,3,3,3, 4,4,4,4, 5,5,5,5, 6,6,6,6};
-  j = vec_popcntb((vui8_t)i);
+  j = test_popcnt_b((vui8_t)i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntb({7,224,168,133, 15,240,225,170, 31,248,79,229, 63,245,235,190}) ", (vui128_t)j);
@@ -388,7 +403,7 @@ test_popcntb (void)
 
   i = (vui8_t){127,251,223,239, 255,0,255,0, 24,130,138,176, 49,165,23,60};
   e = (vui8_t){7,7,7,7, 8,0,8,0, 2,2,3,3, 3,4,4,4};
-  j = vec_popcntb((vui8_t)i);
+  j = test_popcnt_b((vui8_t)i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntb({127,251,223,239, 255,0,255,0, 24,130,138,176, 49,165,23,60}) ", (vui128_t)j);
@@ -1902,6 +1917,472 @@ test_lsbb (void)
     return (rc);
   }
 
+//#define __DEBUG_PRINT__ 1
+#if 1
+#if 1
+// test directly from vec_char_ppc.h
+#define test_clrlb(_l,_k)	vec_vclrlb(_l,_k)
+#else
+// test from vec_char_ppc.h via vec_char_dummy.c
+extern vui8_t test_vec_vclrlb (vui8_t, unsigned int);
+#define test_clrlb(_l,_k)	test_vec_vclrlb(_l,_k)
+#endif
+#else
+// test from vec_char_dummy.c
+extern vui8_t test_vclrlb (vui8_t, unsigned int);
+#define test_clrlb(_j,_k)	test_vclrlb(_j,_k)
+#endif
+
+int
+test_clear_left(void)
+{
+    vui8_t i, j, e;
+    unsigned int rb;
+    int rc = 0;
+    printf ("\n%s\n", __FUNCTION__);
+
+    i = CONST_VINT128_B (0x20, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x44,
+                         0x61, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x5d);
+    rb = 8;
+
+    e = CONST_VINT128_B (0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                         0x61, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x5d);
+    j = (vui8_t) test_clrlb (i,rb);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x ("vec_clrlb  of ", i);
+    printf       ("            , ", rb);
+    print_vint8x ("            = ", k);
+#endif
+    rc += check_vui8 ("vec_clrlb 8", j, e);
+
+    i = CONST_VINT128_B (0x20, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x44,
+                         0x61, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x5d);
+    rb = 7;
+
+    e = CONST_VINT128_B (0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			 0x00, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x5d);
+    j = (vui8_t) test_clrlb (i,rb);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x ("vec_clrlb  of ", i);
+    printf       ("            , ", rb);
+    print_vint8x ("            = ", k);
+#endif
+    rc += check_vui8 ("vec_clrlb 7", j, e);
+
+    i = CONST_VINT128_B (0x20, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x44,
+                         0x61, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x5d);
+    rb = 9;
+
+    e = CONST_VINT128_B (0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x44,
+	                 0x61, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x5d);
+    j = (vui8_t) test_clrlb (i,rb);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x ("vec_clrlb  of ", i);
+    printf       ("            , ", rb);
+    print_vint8x ("            = ", k);
+#endif
+    rc += check_vui8 ("vec_clrlb 9", j, e);
+
+    i = CONST_VINT128_B (0x20, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x44,
+                         0x61, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x5d);
+    rb = 16;
+
+    e = i;
+    j = (vui8_t) test_clrlb (i,rb);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x ("vec_clrlb  of ", i);
+    printf       ("            , %i", rb);
+    print_vint8x ("            = ", k);
+#endif
+    rc += check_vui8 ("vec_clrlb 16", j, e);
+
+    i = CONST_VINT128_B (0x20, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x44,
+                         0x61, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x5d);
+    rb = 0;
+
+    e = (vui8_t){0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+    j = (vui8_t) test_clrlb (i,rb);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x ("vec_clrlb  of ", i);
+    printf       ("            , ", rb);
+    print_vint8x ("            = ", k);
+#endif
+    rc += check_vui8 ("vec_clrlb 0", j, e);
+
+    return (rc);
+  }
+//#define __DEBUG_PRINT__ 1
+#if 1
+#if 1
+// test directly from vec_char_ppc.h
+#define test_clrrb(_l,_k)	vec_vclrrb(_l,_k)
+#else
+// test from vec_char_ppc.h via vec_char_dummy.c
+extern vui8_t test_vec_vclrrb (vui8_t, unsigned int);
+#define test_clrrb(_l,_k)	test_vec_vclrrb(_l,_k)
+#endif
+#else
+// test from vec_char_dummy.c
+extern vui8_t test_vclrrb (vui8_t, unsigned int);
+#define test_clrrb(_j,_k)	test_vclrrb(_j,_k)
+#endif
+
+int
+test_clear_right(void)
+{
+    vui8_t i, j, e;
+    unsigned int rb;
+    int rc = 0;
+    printf ("\n%s\n", __FUNCTION__);
+
+    i = CONST_VINT128_B (0x20, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x44,
+                         0x61, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x5d);
+    rb = 8;
+
+    e = CONST_VINT128_B (0x20, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x44,
+			 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+    j = (vui8_t) test_clrrb (i,rb);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x ("vec_clrrb  of ", i);
+    printf       ("            , ", rb);
+    print_vint8x ("            = ", k);
+#endif
+    rc += check_vui8 ("vec_clrrb 8", j, e);
+
+    i = CONST_VINT128_B (0x20, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x44,
+                         0x61, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x5d);
+    rb = 7;
+
+    e = CONST_VINT128_B (0x20, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x00,
+			 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+    j = (vui8_t) test_clrrb (i,rb);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x ("vec_clrrb  of ", i);
+    printf       ("            , ", rb);
+    print_vint8x ("            = ", k);
+#endif
+    rc += check_vui8 ("vec_clrrb 7", j, e);
+
+    i = CONST_VINT128_B (0x20, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x44,
+                         0x61, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x5d);
+    rb = 9;
+
+    e = CONST_VINT128_B (0x20, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x44,
+	                 0x61, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+    j = (vui8_t) test_clrrb (i,rb);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x ("vec_clrrb  of ", i);
+    printf       ("            , ", rb);
+    print_vint8x ("            = ", k);
+#endif
+    rc += check_vui8 ("vec_clrrb 9", j, e);
+
+    i = CONST_VINT128_B (0x20, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x44,
+                         0x61, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x5d);
+    rb = 16;
+
+    e = i;
+    j = (vui8_t) test_clrrb (i,rb);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x ("vec_clrrb  of ", i);
+    printf       ("            , %i", rb);
+    print_vint8x ("            = ", k);
+#endif
+    rc += check_vui8 ("vec_clrrb 16", j, e);
+
+    i = CONST_VINT128_B (0x20, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x44,
+                         0x61, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x5d);
+    rb = 0;
+
+    e = (vui8_t){0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+    j = (vui8_t) test_clrrb (i,rb);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x ("vec_clrrb  of ", i);
+    printf       ("            , ", rb);
+    print_vint8x ("            = ", k);
+#endif
+    rc += check_vui8 ("vec_clrrb 0", j, e);
+
+    i = CONST_VINT128_B (0x20, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x44,
+                         0x61, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x5d);
+    rb = 17;
+
+    e = i;
+    j = (vui8_t) test_clrrb (i,rb);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x ("vec_clrrb  of ", i);
+    printf       ("            , %i", rb);
+    print_vint8x ("            = ", k);
+#endif
+    rc += check_vui8 ("vec_clrrb 17", j, e);
+
+    return (rc);
+  }
+
+//#define __DEBUG_PRINT__ 1
+#if 1
+#if 0
+// test directly from vec_char_ppc.h
+#define test_stribl(_l)	vec_vstribl(_l)
+#else
+// test from vec_char_ppc.h via vec_char_dummy.c
+extern vui8_t test_vec_vstribl (vui8_t);
+#define test_stribl(_l)	test_vec_vstribl(_l)
+#endif
+#else
+// test from vec_char_dummy.c
+extern vui8_t test_vstribl (vui8_t);
+#define test_stribl(_j)	test_vstribl(_j)
+#endif
+
+int
+test_clear_left_justified(void)
+{
+    vui8_t i, j, e;
+    int rc = 0;
+    printf ("\n%s\n", __FUNCTION__);
+
+    i = CONST_VINT128_B (0x20, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x44,
+                         0x00, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x5d);
+
+    e = CONST_VINT128_B (0x20, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x44,
+			 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+    j = (vui8_t) test_stribl (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x ("vec_vstribl  of ", i);
+    print_vint8x ("            = ", j);
+#endif
+    rc += check_vui8 ("vec_vstribl 1", j, e);
+
+    i = CONST_VINT128_B (0x20, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x44,
+			 0x61, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x00);
+
+    e = CONST_VINT128_B (0x20, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x44,
+			 0x61, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x00);
+    j = (vui8_t) test_stribl (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x ("vec_vstribl  of ", i);
+    print_vint8x ("            = ", j);
+#endif
+    rc += check_vui8 ("vec_vstribl 2", j, e);
+
+    i = CONST_VINT128_B (0x00, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x44,
+                         0x61, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x5d);
+
+    e = CONST_VINT128_B (0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+    j = (vui8_t) test_stribl (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x ("vec_vstribl  of ", i);
+    print_vint8x ("            = ", j);
+#endif
+    rc += check_vui8 ("vec_vstribl 3", j, e);
+
+    i = CONST_VINT128_B (0x20, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x44,
+                         0x61, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x5d);
+
+    e = CONST_VINT128_B (0x20, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x44,
+                         0x61, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x5d);
+    j = (vui8_t) test_stribl (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x ("vec_vstribl  of ", i);
+    print_vint8x ("            = ", j);
+#endif
+    rc += check_vui8 ("vec_vstribl 4", j, e);
+
+    return (rc);
+  }
+
+//#define __DEBUG_PRINT__ 1
+#if 1
+#if 0
+// test directly from vec_char_ppc.h
+#define test_stribr(_l)	vec_vstribr(_l)
+#else
+// test from vec_char_ppc.h via vec_char_dummy.c
+extern vui8_t test_vec_vstribr (vui8_t);
+#define test_stribr(_l)	test_vec_vstribr(_l)
+#endif
+#else
+// test from vec_char_dummy.c
+extern vui8_t test_vstribr (vui8_t);
+#define test_stribr(_j)	test_vstribr(_j)
+#endif
+int
+test_clear_right_justified(void)
+{
+    vui8_t i, j, e;
+    int rc = 0;
+    printf ("\n%s\n", __FUNCTION__);
+
+    i = CONST_VINT128_B (0x20, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x44,
+                         0x00, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x5d);
+
+    e = CONST_VINT128_B (0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			 0x00, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x5d);
+    j = (vui8_t) test_stribr (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x ("vec_vstribr  of ", i);
+    print_vint8x ("            = ", j);
+#endif
+    rc += check_vui8 ("vec_vstribr 1", j, e);
+
+    i = CONST_VINT128_B (0x20, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x44,
+			 0x61, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x00);
+
+    e = CONST_VINT128_B (0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+    j = (vui8_t) test_stribr (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x ("vec_vstribr  of ", i);
+    print_vint8x ("            = ", j);
+#endif
+    rc += check_vui8 ("vec_vstribr 2", j, e);
+
+    i = CONST_VINT128_B (0x00, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x44,
+                         0x61, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x5d);
+
+    e = CONST_VINT128_B (0x00, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x44,
+                         0x61, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x5d);
+    j = (vui8_t) test_stribr (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x ("vec_vstribr  of ", i);
+    print_vint8x ("            = ", j);
+#endif
+    rc += check_vui8 ("vec_vstribr 3", j, e);
+
+    i = CONST_VINT128_B (0x20, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x44,
+                         0x61, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x5d);
+
+    e = CONST_VINT128_B (0x20, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x44,
+                         0x61, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x5d);
+    j = (vui8_t) test_stribr (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x ("vec_vstribr  of ", i);
+    print_vint8x ("            = ", j);
+#endif
+    rc += check_vui8 ("vec_vstribr 4", j, e);
+
+    return (rc);
+  }
+
+// #define __DEBUG_PRINT__ 0
+#if 1
+#if 0
+// test directly from vec_char_ppc.h
+#define test_stribr_p(_l)	vec_vstribr_p(_l)
+#else
+// test from vec_char_ppc.h via vec_char_dummy.c
+extern int test_vec_vstribr_p (vui8_t);
+#define test_stribr_p(_l)	test_vec_vstribr_p(_l)
+#endif
+#else
+// test from vec_char_dummy.c
+extern int test_vstribr_p (vui8_t);
+#define test_stribr_p(_j)	test_vstribr_p(_j)
+#endif
+int
+test_isolate_right_justified_p(void)
+{
+    vui8_t i;
+    int r, er;
+    int rc = 0;
+    printf ("\n%s\n", __FUNCTION__);
+
+    i = CONST_VINT128_B (0x20, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x44,
+                         0x61, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x5d);
+    er = 0;
+    r = test_stribr_p (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x ("vec_vec_vstrir_p of ", i);
+    print_int64x ("                = ", r);
+#endif
+    rc += check_uint64 ("vec_vec_vstrir_p 1", r, er);
+
+
+    i = CONST_VINT128_B (0x20, 0x40, 0x5a, 0x5b, 0x41, 0x00, 0x43, 0x44,
+                         0x00, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x5d);
+    er = 1;
+    r = test_stribr_p (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x ("vec_vec_vstrir_p of ", i);
+    print_int64x ("                = ", r);
+#endif
+    rc += check_uint64 ("vec_vec_vstrir_p 2", r, er);
+    return (rc);
+  }
+
+#define __DEBUG_PRINT__ 0
+#if 1
+#if 0
+// test directly from vec_char_ppc.h
+#define test_stribl_p(_l)	vec_vstribl_p(_l)
+#else
+// test from vec_char_ppc.h via vec_char_dummy.c
+extern int test_vec_vstribl_p (vui8_t);
+#define test_stribl_p(_l)	test_vec_vstribl_p(_l)
+#endif
+#else
+// test from vec_char_dummy.c
+extern int test_vstribl_p (vui8_t);
+#define test_stribl_p(_j)	test_vstribl_p(_j)
+#endif
+int
+test_isolate_left_justified_p(void)
+{
+    vui8_t i;
+    int r, er;
+    int rc = 0;
+    printf ("\n%s\n", __FUNCTION__);
+
+    i = CONST_VINT128_B (0x20, 0x40, 0x5a, 0x5b, 0x41, 0x42, 0x43, 0x44,
+                         0x61, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x5d);
+    er = 0;
+    r = test_stribl_p (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x ("vec_vec_vstrir_p of ", i);
+    print_int64x ("                = ", r);
+#endif
+    rc += check_uint64 ("vec_vec_vstrir_p 1", r, er);
+
+
+    i = CONST_VINT128_B (0x20, 0x40, 0x5a, 0x5b, 0x41, 0x00, 0x43, 0x44,
+                         0x00, 0x62, 0x63, 0x64, 0x31, 0x39, 0x5c, 0x5d);
+    er = 1;
+    r = test_stribl_p (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x ("vec_vec_vstrir_p of ", i);
+    print_int64x ("                = ", r);
+#endif
+    rc += check_uint64 ("vec_vec_vstrir_p 2", r, er);
+    return (rc);
+  }
+
 int
 test_vec_char (void)
 {
@@ -1929,6 +2410,12 @@ test_vec_char (void)
   rc += test_first_mismatch ();
   rc += test_first_mismatch_or_eos ();
   rc += test_lsbb ();
+  rc += test_clear_left ();
+  rc += test_clear_right ();
+  rc += test_clear_left_justified ();
+  rc += test_clear_right_justified ();
+  rc += test_isolate_right_justified_p ();
+  rc += test_isolate_left_justified_p ();
 #endif
   return (rc);
 }

--- a/src/testsuite/arith128_test_i128.c
+++ b/src/testsuite/arith128_test_i128.c
@@ -3837,6 +3837,27 @@ test_revbq (void)
   return (rc);
 }
 
+//#define __DEBUG_PRINT__ 1
+#if 0
+#if 0
+// test directly from vec_int128_ppc.h
+#define test_popcnt_q(_l)	vec_popcntq(_l)
+#else
+// test from vec_int128_ppc.h via vec_int128_dummy.c
+extern vui128_t test_vec_popcntq (vui128_t);
+#define test_popcnt_q(_l)	test_vec_popcntq(_l)
+#endif
+#else
+// test from vec_int128_dummy.c
+#if 0
+extern vui128_t test_vec_popcntq_PWR7 (vui128_t);
+#define test_popcnt_q(_j)	test_vec_popcntq_PWR7(_j)
+#else
+extern vui128_t test_popcntq_PWR8 (vui128_t);
+#define test_popcnt_q(_j)	test_popcntq_PWR8(_j)
+#endif
+#endif
+
 int
 test_popcntq (void)
 {
@@ -3848,7 +3869,7 @@ test_popcntq (void)
 
   i = CONST_VINT128_DW128(0, 0);
   e = CONST_VINT128_DW128(0, 0);
-  j = vec_popcntq(i);
+  j = test_popcnt_q(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntq({0, 0) ", (vui128_t)j);
@@ -3857,7 +3878,7 @@ test_popcntq (void)
 
   i = CONST_VINT128_DW128(0, -1);
   e = CONST_VINT128_DW128(0, 64);
-  j = vec_popcntq(i);
+  j = test_popcnt_q(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntq({0, -1) ", (vui128_t)j);
@@ -3866,7 +3887,7 @@ test_popcntq (void)
 
   i = CONST_VINT128_DW128(-1, 0);
   e = CONST_VINT128_DW128(0, 64);
-  j = vec_popcntq(i);
+  j = test_popcnt_q(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntq({-1, 0) ", (vui128_t)j);
@@ -3875,7 +3896,7 @@ test_popcntq (void)
 
   i = CONST_VINT128_DW128(-1, -1);
   e = CONST_VINT128_DW128(0, 128);
-  j = vec_popcntq(i);
+  j = test_popcnt_q(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntq({-1, -1) ", (vui128_t)j);
@@ -3884,7 +3905,7 @@ test_popcntq (void)
 
   i = CONST_VINT128_DW128(10000000000, 1000000000);
   e = CONST_VINT128_DW128(0, 24);
-  j = vec_popcntq(i);
+  j = test_popcnt_q(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntq({10000000000, 1000000000) ", (vui128_t)j);
@@ -3893,7 +3914,7 @@ test_popcntq (void)
 
   i = CONST_VINT128_DW128(1000000000, 10000000000);
   e = CONST_VINT128_DW128(0, 24);
-  j = vec_popcntq(i);
+  j = test_popcnt_q(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntq({1000000000, 10000000000) ", (vui128_t)j);
@@ -3906,7 +3927,19 @@ test_popcntq (void)
 #ifdef __DEBUG_PRINT__
 #define test_vec_clzq(_l)	db_vec_clzq(_l)
 #else
+#if 1
+#if 0
+// test directly from vec_int128_ppc.h
 #define test_vec_clzq(_l)	vec_clzq(_l)
+#else
+// test from vec_int128_ppc.h via vec_int128_dummy.c
+extern vui128_t test_vec_clzq (vui128_t);
+#endif
+#else
+// test from vec_int128_dummy.c
+extern vui128_t test_vec_clzq_PWR7 (vui128_t);
+#define test_vec_clzq(_j)	test_vec_clzq_PWR7(_j)
+#endif
 #endif
 //#undef __DEBUG_PRINT__
 int
@@ -4002,7 +4035,24 @@ test_clzq (void)
   return (rc);
 }
 
+#if 0
+#if 0
+// test directly from vec_int128_ppc.h
 #define test_vec_ctzq(_l)	vec_ctzq(_l)
+#else
+// test from vec_int128_ppc.h via vec_int128_dummy.c
+extern vui128_t test_vec_ctzq (vui128_t);
+#endif
+#else
+// test from vec_int128_dummy.c
+#if 1
+extern vui128_t test_ctzq_PWR9 (vui128_t);
+#define test_vec_ctzq(_j)	test_ctzq_PWR9(_j)
+#else
+extern vui128_t test_ctzq_PWR7 (vui128_t);
+#define test_vec_ctzq(_j)	test_ctzq_PWR7(_j)
+#endif
+#endif
 //#define __DEBUG_PRINT__ 1
 int
 test_ctzq (void)

--- a/src/testsuite/arith128_test_i16.c
+++ b/src/testsuite/arith128_test_i16.c
@@ -31,7 +31,7 @@
 #include <testsuite/arith128_test_i16.h>
 
 int
-test_clzh (void)
+test_clz_hw (void)
 {
   vui16_t i, e, j;
   int rc = 0;
@@ -87,7 +87,7 @@ test_clzh (void)
 }
 
 int
-test_ctzh (void)
+test_ctz_hw (void)
 {
   vui16_t i, e, j;
   int rc = 0;
@@ -142,8 +142,24 @@ test_ctzh (void)
   return (rc);
 }
 
+//#define __DEBUG_PRINT__ 1
+#if 1
+#if 0
+// test directly from vec_int16_ppc.h
+#define test_popcnt_h(_l)	vec_popcnth(_l)
+#else
+// test from vec_int16_ppc.h via vec_int16_dummy.c
+extern vui16_t test_vec_popcnth (vui16_t);
+#define test_popcnt_h(_l)	test_vec_popcnth(_l)
+#endif
+#else
+// test from vec_int16_dummy.c
+extern vui16_t test_vec_popcnth_PWR7 (vui16_t);
+#define test_popcnt_h(_j)	test_vec_popcnth_PWR7(_j)
+#endif
+
 int
-test_popcnth (void)
+test_popcnt_hw (void)
 {
   vui16_t i, e;
   vui16_t j;
@@ -153,7 +169,7 @@ test_popcnth (void)
 
   i = (vui16_t){0, 1, 2, 4, 8, 16, 32, 64};
   e = (vui16_t){0, 1, 1, 1, 1, 1, 1, 1};
-  j = vec_popcnth(i);
+  j = test_popcnt_h(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcnth({0, 1, 2, 4, 8, 16, 32, 64}) ", (vui128_t)j);
@@ -162,7 +178,7 @@ test_popcnth (void)
 
   i = (vui16_t){128, 256, 256, 512, 1024, 2048, 4096, 8192};
   e = (vui16_t){1, 1, 1, 1, 1, 1, 1, 1};
-  j = vec_popcnth(i);
+  j = test_popcnt_h(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcnth({128, 256, 256, 512, 1024, 2048, 4096, 8192}) ", (vui128_t)j);
@@ -171,7 +187,7 @@ test_popcnth (void)
 
   i = (vui16_t){16384, 32768, 61440, 65280, 65520, 65535, 43690, 21845};
   e = (vui16_t){1, 1, 4, 8, 12, 16, 8, 8};
-  j = vec_popcnth(i);
+  j = test_popcnt_h(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcnth({16384, 32768, 61440, 65280, 65520, 65535, 43690, 21845}) ", (vui128_t)j);
@@ -180,7 +196,7 @@ test_popcnth (void)
 
   i = (vui16_t){1, 516, 2064, 8256, 32904, 8721, 61695, 43605};
   e = (vui16_t){1, 2, 2, 2, 3, 4, 12, 8};
-  j = vec_popcnth(i);
+  j = test_popcnt_h(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcnth({1, 516, 2064, 8256, 32904, 8721, 61695, 43605}) ", (vui128_t)j);
@@ -189,7 +205,7 @@ test_popcnth (void)
 
   i = (vui16_t){2016, 43141, 4080, 57770, 8184, 20453, 16373, 60350};
   e = (vui16_t){6, 6, 8, 8, 10, 10, 12, 12};
-  j = vec_popcnth(i);
+  j = test_popcnt_h(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcnth({2016, 43141, 4080, 57770, 8184, 20453, 16373, 60350}) ", (vui128_t)j);
@@ -198,7 +214,7 @@ test_popcnth (void)
 
   i = (vui16_t){32763, 57327, 65280, 65280, 6274, 35504, 12709, 5948};
   e = (vui16_t){14, 14, 8, 8, 4, 6, 7, 8};
-  j = vec_popcnth(i);
+  j = test_popcnt_h(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcnth({32763, 57327, 65280, 65280, 6274, 35504, 12709, 5948}) ", (vui128_t)j);
@@ -626,9 +642,9 @@ test_vec_i16 (void)
   printf ("\n%s\n", __FUNCTION__);
 #if 1
   rc += test_revbh ();
-  rc += test_clzh ();
-  rc += test_ctzh ();
-  rc += test_popcnth();
+  rc += test_clz_hw ();
+  rc += test_ctz_hw ();
+  rc += test_popcnt_hw();
   rc += test_mrgeoh();
   rc += test_mrgahlh();
   rc += test_mulhuh();

--- a/src/testsuite/arith128_test_i32.c
+++ b/src/testsuite/arith128_test_i32.c
@@ -80,6 +80,22 @@ test_revbw (void)
   return (rc);
 }
 
+//#define __DEBUG_PRINT__ 1
+#if 1
+#if 0
+// test directly from vec_int32_ppc.h
+#define test_popcnt_w(_l)	vec_popcntw(_l)
+#else
+// test from vec_int32_ppc.h via vec_int32_dummy.c
+extern vui32_t test_vec_popcntw (vui32_t);
+#define test_popcnt_w(_l)	test_vec_popcntw(_l)
+#endif
+#else
+// test from vec_int32_dummy.c
+extern vui32_t test_vec_popcntw_PWR7 (vui32_t);
+#define test_popcnt_w(_j)	test_vec_popcntw_PWR7(_j)
+#endif
+
 int
 test_popcntw (void)
 {
@@ -90,7 +106,7 @@ test_popcntw (void)
 
   i = (vui32_t)CONST_VINT32_W(0, 1, 2, 4);
   e = (vui32_t)CONST_VINT32_W(0, 1, 1, 1);
-  j = vec_popcntw(i);
+  j = test_popcnt_w(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntw({0, 1, 2, 4}) ", (vui128_t)j);
@@ -99,7 +115,7 @@ test_popcntw (void)
 
   i = (vui32_t)CONST_VINT32_W(8, 16, 32, 64);
   e = (vui32_t)CONST_VINT32_W(1, 1, 1, 1);
-  j = vec_popcntw(i);
+  j = test_popcnt_w(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntw({8, 16, 32, 64}) ", (vui128_t)j);
@@ -108,7 +124,7 @@ test_popcntw (void)
 
   i = (vui32_t)CONST_VINT32_W(128, 256, 512, 1024);
   e = (vui32_t)CONST_VINT32_W(1, 1, 1, 1);
-  j = vec_popcntw(i);
+  j = test_popcnt_w(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntw({128, 256, 512, 1024}) ", (vui128_t)j);
@@ -117,7 +133,7 @@ test_popcntw (void)
 
   i = (vui32_t)CONST_VINT32_W(2048, 4096, 8192, 16384);
   e = (vui32_t)CONST_VINT32_W(1, 1, 1, 1);
-  j = vec_popcntw(i);
+  j = test_popcnt_w(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntw({2048, 4096, 8192, 16384}) ", (vui128_t)j);
@@ -126,7 +142,7 @@ test_popcntw (void)
 
   i = (vui32_t)CONST_VINT32_W(32768, 65536, 131072, 262144);
   e = (vui32_t)CONST_VINT32_W(1, 1, 1, 1);
-  j = vec_popcntw(i);
+  j = test_popcnt_w(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntw({32768, 65536, 131072, 262144}) ", (vui128_t)j);
@@ -135,7 +151,7 @@ test_popcntw (void)
 
   i = (vui32_t)CONST_VINT32_W(134217728, 268435456, 536870912, 1073741824);
   e = (vui32_t)CONST_VINT32_W(1, 1, 1, 1);
-  j = vec_popcntw(i);
+  j = test_popcnt_w(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntw({134217728, 268435456, 536870912, 1073741824}) ", (vui128_t)j);
@@ -144,7 +160,7 @@ test_popcntw (void)
 
   i = (vui32_t)CONST_VINT32_W(-2147483648, -268435456, -16777216, -1048576);
   e = (vui32_t)CONST_VINT32_W(1, 4, 8, 12);
-  j = vec_popcntw(i);
+  j = test_popcnt_w(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntw({-2147483648, -268435456, -16777216, -1048576}) ", (vui128_t)j);
@@ -153,7 +169,7 @@ test_popcntw (void)
 
   i = (vui32_t)CONST_VINT32_W(-2132741936, 521078531, -219024136, 1311448462);
   e = (vui32_t)CONST_VINT32_W(11, 14, 20, 16);
-  j = vec_popcntw(i);
+  j = test_popcnt_w(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntw({-2132741936, 521078531, -219024136, 1311448462}) ", (vui128_t)j);
@@ -162,7 +178,7 @@ test_popcntw (void)
 
   i = (vui32_t)CONST_VINT32_W(-2143281136, 270549120, 540037232, 1081127120);
   e = (vui32_t)CONST_VINT32_W(4, 4, 8, 10);
-  j = vec_popcntw(i);
+  j = test_popcnt_w(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntw({-2143281136, 270549120, 540037232, 1081127120}) ", (vui128_t)j);
@@ -171,7 +187,7 @@ test_popcntw (void)
 
   i = (vui32_t)CONST_VINT32_W(-1177168454, -1789281621, -1700158118, -1044208472);
   e = (vui32_t)CONST_VINT32_W(20, 18, 16, 12);
-  j = vec_popcntw(i);
+  j = test_popcnt_w(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntw({-1177168454, -1789281621, -1700158118, -1044208472}) ", (vui128_t)j);
@@ -180,7 +196,7 @@ test_popcntw (void)
 
   i = (vui32_t)CONST_VINT32_W(-1143095845, -1957965135, -2008800751, 134480385);
   e = (vui32_t)CONST_VINT32_W(24, 16, 8, 4);
-  j = vec_popcntw(i);
+  j = test_popcnt_w(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntw({-1143095845, -1957965135, -2008800751, 134480385}) ", (vui128_t)j);
@@ -189,7 +205,7 @@ test_popcntw (void)
 
   i = (vui32_t)CONST_VINT32_W(-1, -1, -1, -1);
   e = (vui32_t)CONST_VINT32_W(32, 32, 32, 32);
-  j = vec_popcntw(i);
+  j = test_popcnt_w(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntw({-1, -1, -1, -1}) ", (vui128_t)j);
@@ -199,17 +215,32 @@ test_popcntw (void)
   return (rc);
 }
 
+//#define __DEBUG_PRINT__ 1
+#if 0
+#if 0
+// test directly from vec_int32_ppc.h
+#define test_clz_w(_l)	vec_clzw(_l)
+#else
+// test from vec_int32_ppc.h via vec_i32_dummy.c
+extern vui32_t test_vec_clzw (vui32_t);
+#define test_clz_w(_l)	test_vec_clzw(_l)
+#endif
+#else
+// test from vec_int32_dummy.c
+extern vui32_t test_clzw_PWR7 (vui32_t);
+#define test_clz_w(_j)	test_clzw_PWR7(_j)
+#endif
 int
-test_clzw (void)
+test_clz_word (void)
 {
   vui32_t i, e, j;
   int rc = 0;
 
-  printf ("\ntest_clzw Vector Count Leading Zeros in words\n");
+  printf ("\ntest_clz_w Vector Count Leading Zeros in words\n");
 
   i = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
   e = (vui32_t)CONST_VINT32_W(32, 32, 32, 32);
-  j = vec_clzw(i);
+  j = test_clz_w(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("clz(0) ", j);
@@ -218,7 +249,7 @@ test_clzw (void)
 
   i = (vui32_t)CONST_VINT32_W(-1, 0, -1, 0);
   e = (vui32_t)CONST_VINT32_W(0, 32, 0, 32);
-  j = vec_clzw(i);
+  j = test_clz_w(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("clz(-1, 0, -1, 0) ", j);
@@ -227,7 +258,7 @@ test_clzw (void)
 
   i = (vui32_t)CONST_VINT32_W(0, 1, 2, 4);
   e = (vui32_t)CONST_VINT32_W(32, 31, 30, 29);
-  j = vec_clzw(i);
+  j = test_clz_w(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("clz(0, 1, 2, 4) ", j);
@@ -236,7 +267,7 @@ test_clzw (void)
 
   i = (vui32_t)CONST_VINT32_W(8, 16, 32, 64);
   e = (vui32_t)CONST_VINT32_W(28, 27, 26, 25);
-  j = vec_clzw(i);
+  j = test_clz_w(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("clz(8, 16, 32, 64) ", j);
@@ -245,7 +276,7 @@ test_clzw (void)
 
   i = (vui32_t)CONST_VINT32_W(128, 256, 512, 1024);
   e = (vui32_t)CONST_VINT32_W(24, 23, 22, 21);
-  j = vec_clzw(i);
+  j = test_clz_w(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("clz(128, 256, 512, 1024) ", j);
@@ -254,7 +285,7 @@ test_clzw (void)
 
   i = (vui32_t)CONST_VINT32_W(2048, 4096, 8192, 16384);
   e = (vui32_t)CONST_VINT32_W(20, 19, 18, 17);
-  j = vec_clzw(i);
+  j = test_clz_w(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("clz(2048, 4096, 8192, 16384) ", j);
@@ -263,7 +294,7 @@ test_clzw (void)
 
   i = (vui32_t)CONST_VINT32_W(32768, 65536, 131072, 262144);
   e = (vui32_t)CONST_VINT32_W(16, 15, 14, 13);
-  j = vec_clzw(i);
+  j = test_clz_w(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("clz(32768, 65536, 131072, 262144) ", j);
@@ -272,7 +303,7 @@ test_clzw (void)
 
   i = (vui32_t)CONST_VINT32_W(524288, 1048576, 2097152, 4194304);
   e = (vui32_t)CONST_VINT32_W(12, 11, 10, 9);
-  j = vec_clzw(i);
+  j = test_clz_w(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("clz(524288, 1048576, 2097152, 4194304) ", j);
@@ -281,7 +312,7 @@ test_clzw (void)
 
   i = (vui32_t)CONST_VINT32_W(8388608, 16777216, 33554432, 67108864);
   e = (vui32_t)CONST_VINT32_W(8, 7, 6, 5);
-  j = vec_clzw(i);
+  j = test_clz_w(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("clz(8388608, 16777216, 33554432, 67108864) ", j);
@@ -290,7 +321,7 @@ test_clzw (void)
 
   i = (vui32_t)CONST_VINT32_W(134217728, 268435456, 536870912, 1073741824);
   e = (vui32_t)CONST_VINT32_W(4, 3, 2, 1);
-  j = vec_clzw(i);
+  j = test_clz_w(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("clz(134217728, 268435456, 536870912, 1073741824) ", j);
@@ -299,10 +330,19 @@ test_clzw (void)
 
   i = (vui32_t)CONST_VINT32_W(-2147483648, -268435456, -16777216, -1048576);
   e = (vui32_t)CONST_VINT32_W(0, 0, 0, 0);
-  j = vec_clzw(i);
+  j = test_clz_w(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("clz(-2147483648, -268435456, -16777216, -1048576) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzw:", (vui128_t)j, (vui128_t) e);
+
+  i = (vui32_t)CONST_VINT32_W(4294967295, 2147483647, 1073741823, 536870911);
+  e = (vui32_t)CONST_VINT32_W(0, 1, 2, 3);
+  j = test_clz_w(i);
+
+#ifdef __DEBUG_PRINT__
+  print_vint128 ("clz(4294967295, 2147483647, 1073741823, 536870911) ", j);
 #endif
   rc += check_vuint128x ("vec_clzw:", (vui128_t)j, (vui128_t) e);
 
@@ -310,7 +350,7 @@ test_clzw (void)
 }
 
 int
-test_ctzw (void)
+test_ctz_word (void)
 {
   vui32_t i, e, j;
   int rc = 0;
@@ -1744,8 +1784,8 @@ test_vec_i32 (void)
   printf ("\n%s\n", __FUNCTION__);
 
   rc += test_revbw ();
-  rc += test_clzw ();
-  rc += test_ctzw ();
+  rc += test_ctz_word ();
+  rc += test_ctz_word ();
   rc += test_popcntw();
   rc += test_sumsw ();
   rc += test_sum2sw ();

--- a/src/testsuite/arith128_test_i64.c
+++ b/src/testsuite/arith128_test_i64.c
@@ -1656,6 +1656,22 @@ test_revbd (void)
   return (rc);
 }
 
+//#define __DEBUG_PRINT__ 1
+#if 1
+#if 0
+// test directly from vec_int64_ppc.h
+#define test_popcnt_d(_l)	vec_popcntd(_l)
+#else
+// test from vec_int64_ppc.h via vec_int64_dummy.c
+extern vui64_t test_vec_popcntd (vui64_t);
+#define test_popcnt_d(_l)	test_vec_popcntd(_l)
+#endif
+#else
+// test from vec_int64_dummy.c
+extern vui64_t test_vec_popcntd_PWR7 (vui64_t);
+#define test_popcnt_d(_j)	test_vec_popcntd_PWR7(_j)
+#endif
+
 int
 test_popcntd (void)
 {
@@ -1667,7 +1683,7 @@ test_popcntd (void)
 
   i = (vui64_t) CONST_VINT64_DW (0, 0);
   e = (vui64_t) CONST_VINT64_DW (0, 0);
-  j = vec_popcntd(i);
+  j = test_popcnt_d(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntd({0, 0) ", (vui128_t) j);
@@ -1676,7 +1692,7 @@ test_popcntd (void)
 
   i = (vui64_t) CONST_VINT64_DW (0, -1);
   e = (vui64_t) CONST_VINT64_DW (0, 64);
-  j = vec_popcntd(i);
+  j = test_popcnt_d(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntd({0, -1) ", (vui128_t) j);
@@ -1685,7 +1701,7 @@ test_popcntd (void)
 
   i = (vui64_t) CONST_VINT64_DW (-1, 0);
   e = (vui64_t) CONST_VINT64_DW (64, 0);
-  j = vec_popcntd(i);
+  j = test_popcnt_d(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntd({-1, 0) ", (vui128_t) j);
@@ -1694,7 +1710,7 @@ test_popcntd (void)
 
   i = (vui64_t) CONST_VINT64_DW (-1, -1);
   e = (vui64_t) CONST_VINT64_DW (64, 64);
-  j = vec_popcntd(i);
+  j = test_popcnt_d(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntd({-1, -1) ", (vui128_t) j);
@@ -1703,7 +1719,7 @@ test_popcntd (void)
 
   i = (vui64_t) CONST_VINT64_DW (1, 8589934596);
   e = (vui64_t) CONST_VINT64_DW (1, 2);
-  j = vec_popcntd(i);
+  j = test_popcnt_d(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntd({1, 8589934596) ", (vui128_t) j);
@@ -1712,7 +1728,7 @@ test_popcntd (void)
 
   i = (vui64_t) CONST_VINT64_DW (34359738384, 137438953536);
   e = (vui64_t) CONST_VINT64_DW (2, 2);
-  j = vec_popcntd(i);
+  j = test_popcnt_d(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntd({34359738384, 137438953536) ", (vui128_t) j);
@@ -1721,7 +1737,7 @@ test_popcntd (void)
 
   i = (vui64_t) CONST_VINT64_DW (549755814144, 2199023256576);
   e = (vui64_t) CONST_VINT64_DW (2, 2);
-  j = vec_popcntd(i);
+  j = test_popcnt_d(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntd({549755814144, 2199023256576) ", (vui128_t) j);
@@ -1730,7 +1746,7 @@ test_popcntd (void)
 
   i = (vui64_t) CONST_VINT64_DW (8796093026304, 35184372105216);
   e = (vui64_t) CONST_VINT64_DW (2, 2);
-  j = vec_popcntd(i);
+  j = test_popcnt_d(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntd({8796093026304, 35184372105216) ", (vui128_t) j);
@@ -1739,7 +1755,7 @@ test_popcntd (void)
 
   i = (vui64_t) CONST_VINT64_DW (140737488420864, 562949953683456);
   e = (vui64_t) CONST_VINT64_DW (2, 2);
-  j = vec_popcntd(i);
+  j = test_popcnt_d(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntd({140737488420864, 562949953683456) ", (vui128_t) j);
@@ -1748,7 +1764,7 @@ test_popcntd (void)
 
   i = (vui64_t) CONST_VINT64_DW (2251799814733824, 9007199258935296);
   e = (vui64_t) CONST_VINT64_DW (2, 2);
-  j = vec_popcntd(i);
+  j = test_popcnt_d(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntd({2251799814733824, 9007199258935296) ", (vui128_t) j);
@@ -1757,7 +1773,7 @@ test_popcntd (void)
 
   i = (vui64_t) CONST_VINT64_DW (36028797035741184, 144115188142964736);
   e = (vui64_t) CONST_VINT64_DW (2, 2);
-  j = vec_popcntd(i);
+  j = test_popcnt_d(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntd({36028797035741184, 144115188142964736) ", (vui128_t) j);
@@ -1766,7 +1782,7 @@ test_popcntd (void)
 
   i = (vui64_t) CONST_VINT64_DW (576460752571858944, 2305843010287435776);
   e = (vui64_t) CONST_VINT64_DW (2, 2);
-  j = vec_popcntd(i);
+  j = test_popcnt_d(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntd({576460752571858944, 2305843010287435776) ", (vui128_t) j);
@@ -1775,7 +1791,7 @@ test_popcntd (void)
 
   i = (vui64_t) CONST_VINT64_DW (429496725405032703, 429496725405032703);
   e = (vui64_t) CONST_VINT64_DW (38, 38);
-  j = vec_popcntd(i);
+  j = test_popcnt_d(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntd({429496725405032703, 429496725405032703) ", (vui128_t) j);
@@ -1784,7 +1800,7 @@ test_popcntd (void)
 
   i = (vui64_t) CONST_VINT64_DW (381774867026695736, 381774867026695736);
   e = (vui64_t) CONST_VINT64_DW (24, 24);
-  j = vec_popcntd(i);
+  j = test_popcnt_d(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntd({381774867026695736, 381774867026695736) ", (vui128_t) j);
@@ -1793,7 +1809,7 @@ test_popcntd (void)
 
   i = (vui64_t) CONST_VINT64_DW (1000000000, 1000000000);
   e = (vui64_t) CONST_VINT64_DW (13, 13);
-  j = vec_popcntd(i);
+  j = test_popcnt_d(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntd({1000000000, 1000000000) ", (vui128_t) j);
@@ -1802,7 +1818,7 @@ test_popcntd (void)
 
   i = (vui64_t) CONST_VINT64_DW (10000000000, 1000000000);
   e = (vui64_t) CONST_VINT64_DW (11, 13);
-  j = vec_popcntd(i);
+  j = test_popcnt_d(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntd({10000000000, 1000000000) ", (vui128_t) j);
@@ -1811,7 +1827,7 @@ test_popcntd (void)
 
   i = (vui64_t) CONST_VINT64_DW (1000000000, 10000000000);
   e = (vui64_t) CONST_VINT64_DW (13, 11);
-  j = vec_popcntd(i);
+  j = test_popcnt_d(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntd({1000000000, 10000000000) ", (vui128_t) j);
@@ -1820,7 +1836,7 @@ test_popcntd (void)
 
   i = (vui64_t) CONST_VINT64_DW (1000000000000000000, 0);
   e = (vui64_t) CONST_VINT64_DW (24, 0);
-  j = vec_popcntd(i);
+  j = test_popcnt_d(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntd({1000000000000000000, 0) ", (vui128_t) j);
@@ -1829,7 +1845,7 @@ test_popcntd (void)
 
   i = (vui64_t) CONST_VINT64_DW (0, 1000000000000000000);
   e = (vui64_t) CONST_VINT64_DW (0, 24);
-  j = vec_popcntd(i);
+  j = test_popcnt_d(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntd({0, 1000000000000000000) ", (vui128_t) j);
@@ -1838,7 +1854,7 @@ test_popcntd (void)
 
   i = (vui64_t) CONST_VINT64_DW (0, 1000000000000000000);
   e = (vui64_t) CONST_VINT64_DW (0, 24);
-  j = vec_popcntd(i);
+  j = test_popcnt_d(i);
 
 #ifdef __DEBUG_PRINT__
   print_vint128 ("popcntd({0, 1000000000000000000) ", (vui128_t) j);
@@ -1849,6 +1865,23 @@ test_popcntd (void)
 }
 
 //#undef __DEBUG_PRINT__
+
+// #define __DEBUG_PRINT__ 1
+#if 1
+#if 0
+// test directly from vec_int64_ppc.h
+#define test_clz_d(_l)	vec_clzd(_l)
+#else
+// test from vec_int64_ppc.h via vec_i64_dummy.c
+extern vui64_t test_vec_clzd (vui64_t);
+#define test_clz_d(_l)	test_vec_clzd(_l)
+#endif
+#else
+// test from vec_i64_dummy.c
+extern vui64_t test_vec_clzd_PWR7 (vui64_t);
+#define test_clz_d(_j)	test_vec_clzd_PWR7(_j)
+#endif
+
 int
 test_clzd (void)
 {
@@ -1860,116 +1893,116 @@ test_clzd (void)
 
   i = (vui64_t) CONST_VINT64_DW (0, 0);
   e = (vui64_t) CONST_VINT64_DW (64, 64);
-  j = vec_clzd((vui64_t)i);
+  j = test_clz_d((vui64_t)i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(0, 0) ", j);
+  print_v2int64 ("clz(0, 0) ", j);
 #endif
-  rc += check_vuint128x ("vec_clzd:", (vui128_t) j, (vui128_t) e);
+  rc += check_vuint128x ("vec_clzd 1:", (vui128_t) j, (vui128_t) e);
 
   i = (vui64_t) CONST_VINT64_DW (-1, -1);
   e = (vui64_t) CONST_VINT64_DW (0, 0);
-  j = vec_clzd((vui64_t)i);
+  j = test_clz_d((vui64_t)i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(-1, -1) ", j);
+  print_v2int64 ("clz(-1, -1) ", j);
 #endif
-  rc += check_vuint128x ("vec_clzd:", (vui128_t) j, (vui128_t) e);
+  rc += check_vuint128x ("vec_clzd 2:", (vui128_t) j, (vui128_t) e);
 
   i = (vui64_t) CONST_VINT64_DW (0, -1);
   e = (vui64_t) CONST_VINT64_DW (64, 0);
-  j = vec_clzd((vui64_t)i);
+  j = test_clz_d((vui64_t)i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(0, -1) ", j);
+  print_v2int64 ("clz(0, -1) ", j);
 #endif
-  rc += check_vuint128x ("vec_clzd:", (vui128_t) j, (vui128_t) e);
+  rc += check_vuint128x ("vec_clzd 3:", (vui128_t) j, (vui128_t) e);
 
   i = (vui64_t) CONST_VINT64_DW (-1, 0);
   e = (vui64_t) CONST_VINT64_DW (0, 64);
-  j = vec_clzd((vui64_t)i);
+  j = test_clz_d((vui64_t)i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(-1, 0) ", j);
+  print_v2int64 ("clz(-1, 0) ", j);
 #endif
-  rc += check_vuint128x ("vec_clzd:", (vui128_t) j, (vui128_t) e);
+  rc += check_vuint128x ("vec_clzd 4:", (vui128_t) j, (vui128_t) e);
 
   i = (vui64_t) CONST_VINT64_DW (1, 8589934596);
   e = (vui64_t) CONST_VINT64_DW (63, 30);
-  j = vec_clzd((vui64_t)i);
+  j = test_clz_d((vui64_t)i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(1, 8589934596) ", j);
+  print_v2int64 ("clz(1, 8589934596) ", j);
 #endif
-  rc += check_vuint128x ("vec_clzd:", (vui128_t) j, (vui128_t) e);
+  rc += check_vuint128x ("vec_clzd 5:", (vui128_t) j, (vui128_t) e);
 
   i = (vui64_t) CONST_VINT64_DW (34359738384, 137438953536);
   e = (vui64_t) CONST_VINT64_DW (28, 26);
-  j = vec_clzd((vui64_t)i);
+  j = test_clz_d((vui64_t)i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(34359738384, 137438953536) ", j);
+  print_v2int64 ("clz(34359738384, 137438953536) ", j);
 #endif
-  rc += check_vuint128x ("vec_clzd:", (vui128_t) j, (vui128_t) e);
+  rc += check_vuint128x ("vec_clzd 6:", (vui128_t) j, (vui128_t) e);
 
   i = (vui64_t) CONST_VINT64_DW (549755814144, 2199023256576);
   e = (vui64_t) CONST_VINT64_DW (24, 22);
-  j = vec_clzd((vui64_t)i);
+  j = test_clz_d((vui64_t)i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(549755814144, 2199023256576) ", j);
+  print_v2int64 ("clz(549755814144, 2199023256576) ", j);
 #endif
-  rc += check_vuint128x ("vec_clzd:", (vui128_t) j, (vui128_t) e);
+  rc += check_vuint128x ("vec_clzd 7:", (vui128_t) j, (vui128_t) e);
 
   i = (vui64_t) CONST_VINT64_DW (8796093026304, 35184372105216);
   e = (vui64_t) CONST_VINT64_DW (20, 18);
-  j = vec_clzd((vui64_t)i);
+  j = test_clz_d((vui64_t)i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(8796093026304, 35184372105216) ", j);
+  print_v2int64 ("clz(8796093026304, 35184372105216) ", j);
 #endif
-  rc += check_vuint128x ("vec_clzd:", (vui128_t) j, (vui128_t) e);
+  rc += check_vuint128x ("vec_clzd 8:", (vui128_t) j, (vui128_t) e);
 
   i = (vui64_t) CONST_VINT64_DW (140737488420864, 562949953683456);
   e = (vui64_t) CONST_VINT64_DW (16, 14);
-  j = vec_clzd((vui64_t)i);
+  j = test_clz_d((vui64_t)i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(140737488420864, 562949953683456) ", j);
+  print_v2int64 ("clz(140737488420864, 562949953683456) ", j);
 #endif
-  rc += check_vuint128x ("vec_clzd:", (vui128_t) j, (vui128_t) e);
+  rc += check_vuint128x ("vec_clzd 9:", (vui128_t) j, (vui128_t) e);
 
   i = (vui64_t) CONST_VINT64_DW (2251799814733824, 9007199258935296);
   e = (vui64_t) CONST_VINT64_DW (12, 10);
-  j = vec_clzd((vui64_t)i);
+  j = test_clz_d((vui64_t)i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(2251799814733824, 9007199258935296) ", j);
+  print_v2int64 ("clz(2251799814733824, 9007199258935296) ", j);
 #endif
-  rc += check_vuint128x ("vec_clzd:", (vui128_t) j, (vui128_t) e);
+  rc += check_vuint128x ("vec_clzd 10:", (vui128_t) j, (vui128_t) e);
 
   i = (vui64_t) CONST_VINT64_DW (36028797035741184, 144115188142964736);
   e = (vui64_t) CONST_VINT64_DW (8, 6);
-  j = vec_clzd((vui64_t)i);
+  j = test_clz_d((vui64_t)i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(36028797035741184, 144115188142964736) ", j);
+  print_v2int64 ("clz(36028797035741184, 144115188142964736) ", j);
 #endif
-  rc += check_vuint128x ("vec_clzd:", (vui128_t) j, (vui128_t) e);
+  rc += check_vuint128x ("vec_clzd 11:", (vui128_t) j, (vui128_t) e);
 
   i = (vui64_t) CONST_VINT64_DW (576460752571858944, 2305843010287435776);
   e = (vui64_t) CONST_VINT64_DW (4, 2);
-  j = vec_clzd((vui64_t)i);
+  j = test_clz_d((vui64_t)i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(576460752571858944, 2305843010287435776) ", j);
+  print_v2int64 ("clz(576460752571858944, 2305843010287435776) ", j);
 #endif
-  rc += check_vuint128x ("vec_clzd:", (vui128_t) j, (vui128_t) e);
+  rc += check_vuint128x ("vec_clzd 12:", (vui128_t) j, (vui128_t) e);
 
   return (rc);
 }
 
-//#undef __DEBUG_PRINT__
+#undef __DEBUG_PRINT__
 int
 test_ctzd (void)
 {
@@ -1977,7 +2010,7 @@ test_ctzd (void)
   vui64_t j;
   int rc = 0;
 
-  printf ("\ntest_ctzd Vector Count Leading Zeros in Doublewords\n");
+  printf ("\ntest_ctzd Vector Count Trailing Zeros in Doublewords\n");
 
   i = (vui64_t) CONST_VINT64_DW (0, 0);
   e = (vui64_t) CONST_VINT64_DW (64, 64);

--- a/src/testsuite/vec_int16_dummy.c
+++ b/src/testsuite/vec_int16_dummy.c
@@ -22,6 +22,18 @@
 
 #include <pveclib/vec_int16_ppc.h>
 
+vui16_t
+test_vec_popcnth (vui16_t vra)
+{
+  return vec_popcnth (vra);
+}
+
+vui16_t
+test_vec_popcnth_PWR7 (vui16_t vra)
+{
+  return vec_popcnth_PWR7 (vra);
+}
+
 vb16_t
 test_setb_sh (vi16_t vra)
 {

--- a/src/testsuite/vec_int32_dummy.c
+++ b/src/testsuite/vec_int32_dummy.c
@@ -22,6 +22,174 @@
 
 #include <pveclib/vec_int128_ppc.h>
 
+vui32_t
+test_vec_popcntw (vui32_t vra)
+{
+  return vec_popcntw (vra);
+}
+
+vui32_t
+test_vec_popcntw_PWR7 (vui32_t vra)
+{
+  return vec_popcntw_PWR7 (vra);
+}
+
+vui32_t
+test_vec_clzw (vui32_t vra)
+{
+  return vec_clzw (vra);
+}
+
+vui32_t
+test_vec_clzw_PWR7 (vui32_t vra)
+{
+  return vec_clzw_PWR7 (vra);
+}
+
+vui32_t
+test_clzw_PWR7 (vui32_t vra)
+{
+  const vui32_t vone = vec_splat_u32 (1);
+  const vui32_t ones = vec_splat_u32 (-1);
+  // generated const (vui32_t) {23, 23, 23, 23}
+  const vui32_t v15 = vec_splat_u32 (15);
+  const vui32_t v8 = vec_splat_u32 (8);
+  const vui32_t v23 = vec_add (v15, v8);
+  // fp5 = 1.0 / 2.0 == 0.5
+  const vf32_t fp5 = vec_ctf (vone, 1);
+  // need a word vector of 158 which is the exponent for 2**31
+  // const vui32_t v2_31 = ones & ~(ones>>1);
+  const vui32_t v2_31 = vec_vslw (ones, ones);
+  // f2_31 = (vector float) 2**31
+  const vf32_t f2_31 =  vec_ctf (v2_31, 0);
+
+  vui32_t k, n;
+  vf32_t kf;
+  // Avoid rounding in floating point conversion
+  k = vra & ~(vra >> 1);
+  // Handle all 0s case by insuring min exponent is 158-32
+  kf = vec_ctf (k, 0) + fp5;
+  // Exponent difference is the leading zeros count
+  n = (vui32_t) f2_31 - (vui32_t) kf;
+  // right justify exponent for int
+  n = vec_vsrw(n, v23);
+  return n;
+}
+
+vui32_t
+test_clzw_PWR7_V2 (vui32_t vra)
+{
+  const vui32_t vone = vec_splat_u32 (1);
+  const vui32_t ones = vec_splat_u32 (-1);
+  // const vui32_t vzero = vec_splat_u32 (0);
+#if 0
+  const vui32_t v3 = vec_splat_u32 (3);
+  const vui32_t v24 = vec_vslw (v3, v3);
+  //const vui32_t v23 = vec_sub (v24, vone);
+  vui32_t v23 = vec_sub (v24, vone);
+#else
+  const vui32_t v15 = vec_splat_u32 (15);
+  const vui32_t v8 = vec_splat_u32 (8);
+  // const vui32_t v9 = vec_splat_u32 (9);
+  // const vui32_t v2 = vec_splat_u32 (2);
+  // const vui32_t v32 = vec_vslw (v8, v2);
+  const vui32_t v23 = vec_add (v15, v8);
+  // const vui32_t fsigmask = vec_vsrw (ones, v9);
+#endif
+  // fp5 = 1.0 / 2.0 == 0.5
+  const vf32_t fp5 = vec_ctf (vone, 1);
+  // need a word vector of 158 which is the exponent for 2**31
+  // const vui32_t v2_31 = ones & ~(ones>>1);
+  const vui32_t v2_31 = vec_vslw (ones, ones);
+  // f2_31 = (vector float) 2**31
+  const vf32_t f2_31 =  vec_ctf (v2_31, 0);
+
+  vui32_t k, n;
+  vf32_t kf;
+  // Avoid rounding in floating point conversion
+  k = vra & ~(vra >> 1);
+  // Handle all 0s case by insuring min exponent is 158-32
+#if 1
+  kf = vec_ctf (k, 0) + fp5;
+#else
+  vb32_t zmask = vec_cmpeq (vra, vzero);
+  kf = vec_ctf (k, 0);
+  kf = vec_sel (kf, fp5, zmask);
+#endif
+#if 1
+#if 0
+  n = vec_andc ((vui32_t) f2_31, fsigmask)
+      - vec_andc ((vui32_t) kf, fsigmask);
+  n = vec_rl (n, v9);
+#else
+  n = (vui32_t) f2_31 - (vui32_t) kf;
+#if 0
+  n = vec_andc (n, fsigmask);
+  n = vec_rl (n, v9);
+#else
+  n = vec_vsrw(n, v23);
+#endif
+#endif
+#else
+  ki = (vui32_t) kf;
+#if 1
+  const vui32_t v158 =  (vec_vsrw((vui32_t) f2_31, v23));
+  n = v158 - (vec_vsrw(ki, v23));
+  // n = vec_sel (n, v32, zmask);
+#else
+  n = 158 - (vec_vsrw(ki, v23));
+#endif
+#endif
+  return n;
+}
+
+vui32_t
+test_clzw_PWR7_v1 (vui32_t vra)
+{
+  const vui32_t vone = vec_splat_u32 (1);
+  const vui32_t ones = vec_splat_u32 (-1);
+  const vui32_t vzero = vec_splat_u32 (0);
+#if 0
+  const vui32_t v3 = vec_splat_u32 (3);
+  const vui32_t v24 = vec_vslw (v3, v3);
+  //const vui32_t v23 = vec_sub (v24, vone);
+  vui32_t v23 = vec_sub (v24, vone);
+#else
+  const vui32_t v15 = vec_splat_u32 (15);
+  const vui32_t v8 = vec_splat_u32 (8);
+  vui32_t v23 = vec_add (v15, v8);
+#endif
+  // 0.5 Substituted for vec_clzw(0) which returns 32.
+  // fp5 = 1.0 / 2.0 == 0.5
+  const vf32_t fp5 = vec_ctf (vone, 1);
+  // f2_31 = 2**31
+  const vui32_t v2_31 = vec_vslw (ones, ones);
+  const vf32_t f2_31 =  vec_ctf (v2_31, 0);
+  const vui32_t v158 =  (vec_vsrw((vui32_t) f2_31, v23));;
+  vui32_t k, k1, ki, n;
+  vb32_t zmask = vec_cmpeq (vra, vzero);
+  vf32_t kf;
+#if 1
+  k1 = ~(vra >> 1);
+#else
+  k1 = -(vra >> 1);
+#endif
+  k = vra & k1;
+#if 0
+  kf = vec_ctf (k, 0) + fp5;
+#else
+  kf = vec_ctf (k, 0);
+  kf = vec_sel (kf, fp5, zmask);
+#endif
+  ki = (vui32_t) kf;
+#if 1
+  n = v158 - (vec_vsrw(ki, v23));
+#else
+  n = 158 - (vec_vsrw(ki, v23));
+#endif
+  return n;
+}
+
 vb32_t
 test_setb_sw (vi32_t vra)
 {
@@ -677,13 +845,13 @@ test_cmpuw_all_le (vui32_t a, vui32_t b)
 }
 
 vui32_t
-__test_popcntw (vui32_t a)
+__test_vec_popcntw (vui32_t a)
 {
   return (vec_popcntw (a));
 }
 
 vui32_t
-__test_clzw (vui32_t a)
+__test_vec_clzw (vui32_t a)
 {
   return (vec_clzw (a));
 }

--- a/src/testsuite/vec_pwr10_dummy.c
+++ b/src/testsuite/vec_pwr10_dummy.c
@@ -38,6 +38,61 @@
 #include <pveclib/vec_f32_ppc.h>
 #include <pveclib/vec_bcd_ppc.h>
 
+#if defined(_ARCH_PWR10) && \
+    ((__GNUC__ > 10) || (defined(__clang__) && (__clang_major__ > 12)))
+
+vui64_t
+test_vec_ctzd_PWR10 (vui64_t vra)
+{
+  return vec_ctzd (vra);
+}
+
+vui128_t
+test_vec_ctzq_PWR10 (vui128_t vra)
+{
+  return vec_ctzq (vra);
+}
+
+vui8_t
+test_intrn_clr_first_PWR10 (vui8_t vra)
+{
+  // vec_clr_first LE
+  return vec_clrr (vra, 14);
+}
+
+vui8_t
+test_intrn_clr_last_PWR10 (vui8_t vra)
+{
+  // vec_clr_last LE
+  return vec_clrl (vra, 7);
+}
+
+vui8_t
+test_intrn_stril_PWR10 (vui8_t vra)
+{
+  return vec_stril (vra);
+}
+
+vui8_t
+test_intrn_strir_PWR10 (vui8_t vra)
+{
+  return vec_strir (vra);
+}
+
+int
+test_intrn_stril_p_PWR10 (vui8_t vra)
+{
+  return vec_stril_p (vra);
+}
+
+int
+test_intrn_strir_p_PWR10 (vui8_t vra)
+{
+  return vec_strir_p (vra);
+}
+
+#endif
+
 int
 test_vec_lsbb_all_ones_PWR10 (vui8_t vra)
 {

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -40,6 +40,12 @@
 #include <pveclib/vec_f32_ppc.h>
 #include <pveclib/vec_bcd_ppc.h>
 
+vui128_t
+test_vec_popcntq_PWR9 (vui128_t vra)
+{
+  return vec_popcntq_PWR9 (vra);
+}
+
 int
 test_first_match_index_PWR9 (vui8_t vra, vui8_t vrb)
 {
@@ -119,6 +125,25 @@ test_first_mismatch_byte_or_eos_index_PWR9 (vui8_t vra, vui8_t vrb)
 
 #if defined(_ARCH_PWR9) && \
     ((__GNUC__ > 10) || (defined(__clang__) && __clang_major__ > 7))
+
+vui32_t
+test_intrn_parity_lsbb_word_PWR9 (vui32_t vra)
+{
+  return vec_parity_lsbb (vra);
+}
+
+vui64_t
+test_intrn_parity_lsbb_dword_PWR9 (vui64_t vra)
+{
+  return vec_parity_lsbb (vra);
+}
+
+vui128_t
+test_intrn_parity_lsbb_qword_PWR9 (vui128_t vra)
+{
+  return vec_parity_lsbb (vra);
+}
+
 int
 test_intrn_first_match_byte_index_PWR9 (vui8_t vra, vui8_t vrb)
 {
@@ -213,15 +238,6 @@ test_intrn_cntlz_lsbb_PWR9 (vui8_t vra)
 #if defined(_ARCH_PWR9) && \
     ((__GNUC__ > 9) || (defined(__clang__) && __clang_major__ > 7))
   return vec_cntlz_lsbb (vra);
-#endif
-}
-
-vui32_t
-test_intrn_parity_lsbb_word_PWR9 (vui32_t vra)
-{
-#if defined(_ARCH_PWR9) && \
-    ((__GNUC__ > 9) || (defined(__clang__) && __clang_major__ > 7))
-  return vec_parity_lsbb (vra);
 #endif
 }
 


### PR DESCRIPTION
Set out to implement the POWER10 string operations Vector Clear Leftmost/Rightmost Bytes, Vector String Isolate Byte Left/Right-justified, and Vector String Isolate Byte (Predicate) operations. Quickly discovered P9/8/7 implementation requires the equivalent of clz/ctz quadword with circular dependencies on vec_int128_ppc.h

Decided the only way out was to drag some of the implementation (and associated dependencies) down to vec_common_ppc.h. The effort grew in size to avoid dependencies on vec_int64_ppc.h and vec_int32_ppc.h. Without access to those implementation needed new implementations with dependencies only on vec_common_ppc.h, and altivec.h. This is the result of that work.

This caused some rethinking of implementation. This lead to some cleanup and simplification of the of existing clz/ctz/popcnt implementation and necessitated additional compile and unit tests.

	* src/pveclib/vec_char_ppc.h (vec_popcntb): Replace PWR7 implementation with vec_popcntb_PWR7 call. (vec_vclrlb, vec_vclrrb): New Operation. (vec_vstribl, vec_vstribl_p, vec_vstribr, vec_vstribr_p): New Operation.
	* src/pveclib/vec_common_ppc.h [common_operation_issues_0_0]: New doxygen section "Issues with common operations". (vec_popcntw_PWR7, vec_popcntw_PWR8, vec_popcntd_PWR7, vec_popcntd_PWR8, vec_popcntq_PWR8, vec_popcntq_PWR9 [cond INTERNAL]): Function Prototypes. (vec_addudm_PWR7, vec_adduqm_PWR7, vec_adduqm_PWR8, vec_clzw_PWR7, vec_clzd_PWR7, vec_clzd_PWR8, vec_clzq_PWR7, vec_clzq_PWR8, vec_ctzw_PWR7, vec_ctzw_PWR8, vec_ctzw_PWR9, vec_ctzd_PWR7, vec_ctzd_PWR8, vec_ctzd_PWR9, vec_ctzq_PWR7, vec_ctzq_PWR8, vec_ctzq_PWR9, vec_popcntb_PWR7, vec_popcnth_PWR7, vec_popcntw_PWR7, vec_popcntw_PWR8, vec_popcntd_PWR7, vec_popcntd_PWR8, vec_popcntq_PWR7, vec_popcntq_PWR8, vec_popcntq_PWR9, vec_subudm_PWR7, vec_subuqm_PWR7): New Common Operation.

	* src/pveclib/vec_f64_ppc.h (vec_vlxsfdx, vec_vstxsfdx): Fix for clang detected type mismatch.
	* src/pveclib/vec_int128_ppc.h (vec_clzq): Replace vec_clzw with vec_clzw_PWR7. (vec_popcntq): replace vec_popcntw/vec_sums with vec_popcntq_PWR7.
	* src/pveclib/vec_int32_ppc.h (vec_clzw): Replace PWR7 implementation with call to vec_clzw_PWR7. (vec_ctzw): Replace _ARCH_PWR8 implmentation with vec_ctzw_PWR8. (vec_popcntw): Replace _ARCH_PWR7 implmentation with vec_popcntw_PWR7. (vec_vgl4wwo): Remove test only conditional. src/pveclib/vec_int64_ppc.h (vec_addudm): Replace _ARCH_PWR7 implmentation with vec_addudm_PWR7. (vec_clzd): Replace _ARCH_PWR7 implmentation with vec_clzd_PWR7. (vec_ctzd): Replace _ARCH_PWR8 implmentation with vec_ctzd_PWR8. (vec_popcntd): Replace _ARCH_PWR7 implmentation with vec_popcntd_PWR7. (vec_subudm): Replace _ARCH_PWR7 implmentation with vec_subudm_PWR7.

	* src/testsuite/arith128_test_char.c (test_popcntb): Add macros for unit test from compiler tests. (test_clear_left, test_clear_right, test_clear_left_justified, test_clear_right_justified, test_isolate_right_justified_p, test_isolate_left_justified_p): New unit test functions. (test_vec_char): Add new unit test ro driver.
	* src/testsuite/arith128_test_i128.c (test_popcntq): Add macros for unit test from compiler tests. (test_clzq): Add macros for unit test from compiler tests. (test_ctzq): Add macros for unit test from compiler tests.
	* src/testsuite/arith128_test_i16.c (test_clzh): Rename to test_clz_hw. (test_ctzh): Rename to test_ctz_hw. (test_popcnth): Rename to test_popcnt_hw.  Add macros for unit test from compiler tests. (test_vec_i16): Update driver for renamed unit tests.
	* src/testsuite/arith128_test_i32.c (test_popcntw): Add macros for unit test from compiler tests. (test_clzw): rename to test_clz_word. Add macros for unit test from compiler tests. (test_ctzw): rename to test_ctz_word. Add macros for unit test from compiler tests. (test_vec_i32): Update driver for renamed unit tests.
	* src/testsuite/arith128_test_i64.c (test_popcntd): Add macros for unit test from compiler tests. (test_clzd): Add macros for unit test from compiler tests. (test_ctzd): Add macros for unit test from compiler tests.
	* src/testsuite/vec_char_dummy.c (test_vec_popcntb, test_vec_popcntb_PWR7, test_popcntb_PWR7. test_vec_vstribr, test_vec_vstribr_p. test_vstribr_p, test_vstribr, test_vec_vstribl, test_vec_vstribl_p, test_vstribl_p, test_vstribl, test_vec_vclrlb, test_vec_vclrrb, test_vec_vclrxb_rb79, test_vclrlb, test_vclrlb_rb0, test_vclrlb_rb1, test_vclrlb_rb15. test_vclrlb_rb16, test_vclrrb, test_vclrrb_rb0, test_vclrrb_rb1, test_vclrrb_rb8. test_vclrrb_rb15. test_vclrrb_rb16, test_vclrxb_rb79, test_vclrxb_rb79x): New compile tests.
	* src/testsuite/vec_int128_dummy.c (test_vec_ctzq_PWR7, test_vec_ctzq_loop7, test_vec_ctzq_PWR8, test_vec_ctzq_loop8, test_vec_ctzq_PWR9, test_ctzq_PWR7, test_ctzq_PWR8, test_ctzq_PWR9, test_vec_clzq, test_vec_clzq_PWR7, __test_clzq_PWR7, test_vec_popcntq, test_vec_popcntq_PWR7, test_vec_popcntq_PWR8, test_popcntq_PWR8. test_vstribl_V0): New compile tests.
	* src/testsuite/vec_int16_dummy.c (test_vec_popcnth, test_vec_popcnth_PWR7): New compile tests.
	* /src/testsuite/vec_int32_dummy.c (test_vec_popcntw, test_vec_popcntw_PWR7, test_vec_clzw, test_vec_clzw_PWR7, test_clzw_PWR7, test_clzw_PWR7_V2: New compile tests. (__test_popcntw): Renamed to __test_vec_popcntw. (__test_clzw): Renamed to __test_vec_clzw.
	* src/testsuite/vec_int64_dummy.c (test_vec_clzd, test_vec_clzd_PWR7, test_clzd_PWR7, test_clzd_PWR7_V1, test_clzd_PWR7_V0, test_vec_popcntd, test_vec_popcntd_PWR7, test_addudm_PWR7): New compile tests.
	* src/testsuite/vec_pwr10_dummy.c (test_vec_ctzd_PWR10, test_vec_ctzq_PWR10, test_intrn_clr_first_PWR10, test_intrn_clr_last_PWR10, test_intrn_stril_PWR10, test_intrn_strir_PWR10, test_intrn_stril_p_PWR10, test_intrn_strir_p_PWR10 [_ARCH_PWR10]): New compile tests.
	* src/testsuite/vec_pwr9_dummy.c (test_vec_popcntq_PWR9): New compile tests. (test_intrn_parity_lsbb_word_PWR9, test_intrn_parity_lsbb_dword_PWR9, test_intrn_parity_lsbb_qword_PWR9): New compile tests.