### PR TITLE
Add exploit common parts for char/byte and P10.

### DIFF
--- a/src/pveclib/vec_char_ppc.h
+++ b/src/pveclib/vec_char_ppc.h
@@ -1433,8 +1433,10 @@ vec_rlbi (vui8_t vra, const unsigned  shb)
  *
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
- *  |power8   | 2-4   | 2/cycle  |
- *  |power9   | 2-5   | 2/cycle  |
+ *  |power7   | 2 - 4 | 2/cycle  |
+ *  |power8   | 2 - 4 | 2/cycle  |
+ *  |power9   | 3 - 6 | 2/cycle  |
+ *  |power10  | 3 - 4 | 4/cycle  |
  *
  *  @param vra Vector signed char.
  *  @return vector bool char reflecting the sign bit of each
@@ -1444,24 +1446,7 @@ vec_rlbi (vui8_t vra, const unsigned  shb)
 static inline vb8_t
 vec_setb_sb (vi8_t vra)
 {
-  vb8_t result;
-
-#if defined (_ARCH_PWR10)  && (__GNUC__ >= 10)
-#if (__GNUC__ >= 12)
-      result = (vb8_t) vec_expandm ((vui8_t) vra);
-#else
-  __asm__(
-      "vexpandbm %0,%1"
-      : "=v" (result)
-      : "v" (vra)
-      : );
-#endif
-#else
-  const vui8_t rshift =  vec_splat_u8( 7 );
-  // Vector Shift Right Algebraic Bytes 7-bits.
-  result = (vb8_t) vec_sra (vra, rshift);
-#endif
-  return result;
+  return (vb8_t) vec_expandm_byte ((vui8_t) vra);
 }
 
 /** \brief Vector Shift left Byte Immediate.

--- a/src/pveclib/vec_char_ppc.h
+++ b/src/pveclib/vec_char_ppc.h
@@ -721,29 +721,18 @@ vec_ctzb (vui8_t vra)
       : "v" (vra)
       : );
 #endif
-#elif _ARCH_PWR8
-// For _ARCH_PWR8. Generate 1's for the trailing zeros
-// and 0's otherwise. Then count (popcnt) the 1's.
-// _ARCH_PWR8 uses the hardware vpopcntb instruction.
+#else
+  // For _ARCH_PWR8 and earlier. Generate 1's for the trailing zeros
+  // and 0's otherwise. Then count (popcnt) the 1's. _ARCH_PWR8 uses
+  // the hardware vpopcntb instruction.
+  // _ARCH_PWR7 use the PVECLIB vec_common_ppc.h implementation
+  // which runs ~6-13 cycles.
   const vui8_t ones = vec_splat_u8 (1);
   vui8_t tzmask;
   // tzmask = (!vra & (vra - 1))
   tzmask = vec_andc (vec_sub (vra, ones), vra);
   // return = vec_popcnt (!vra & (vra - 1))
   r = vec_popcntb (tzmask);
-#else
-  // For _ARCH_PWR7 and earlier (without hardware clz or popcnt).
-  // Generate 1's for the trailing zeros and 0's otherwise.
-  // Then count leading 0's using the PVECLIB vec_clzb implementation
-  // which minimizes the number of constant loads (vs popcntb).
-  // Finally subtract this count from 8.
-  const vui8_t ones = vec_splat_u8 (1);
-  const vui8_t c8s = vec_splat_u8 (8);
-  vui8_t term;
-  // term = (!vra & (vra - 1))
-  term = vec_andc (vec_sub (vra, ones), vra);
-  // return = 8 - vec_clz (!vra & (vra - 1))
-  return vec_sub (c8s, vec_clzb (term));
 #endif
   return ((vui8_t) r);
 }
@@ -774,6 +763,27 @@ vec_cntlz_lsbb_bi (vui8_t vra)
 #else
   return vec_vclzlsbb (vra);
 #endif
+}
+
+/** \brief Vector Expand Mask Byte.
+ *
+ *  Create byte element masks based on high-order (sign) bit of
+ *  each byte element.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power7   | 2 - 4 | 2/cycle  |
+ *  |power8   | 2 - 4 | 2/cycle  |
+ *  |power9   | 3 - 6 | 2/cycle  |
+ *  |power10  | 3 - 4 | 4/cycle  |
+ *
+ *  @param vra a 128-bit vector treated as unsigned char.
+ *  @return vector byte mask from the sign bit.
+ */
+static inline vui8_t
+vec_expandm_byte (vui8_t vra)
+{
+  return vec_vexpandbm_PWR10 (vra);
 }
 
 /** \brief Vector Count Trailing Zero Least-Significant Bits Byte.
@@ -950,7 +960,7 @@ vec_first_mismatch_byte_index (vui8_t vra, vui8_t vrb)
 static inline int
 vec_first_mismatch_byte_or_eos_index (vui8_t vra, vui8_t vrb)
 {
-#ifdef _ARCH_PWR9
+#if defined (_ARCH_PWR9) && defined (__VSX__) && (__GNUC__ > 7)
 #if (__GNUC__ > 13)
   return vec_first_mismatch_or_eos_index (vra, vrb);
 #else
@@ -1376,6 +1386,45 @@ vec_popcntb (vui8_t vra)
 #define vec_popcntb __builtin_vec_vpopcntb
 #endif
 
+/** \brief Vector Rotate left Byte Immediate.
+ *
+ *  Rotate left each word element [0-15], 0-7 bits,
+ *  as specified by an immediate value.
+ *  The shift amount is a const unsigned int in the range 0-7.
+ *  A shift count of 0 returns the original value of vra.
+ *  Shift counts greater then 31 bits return zero.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power8   | 4-11  | 2/cycle  |
+ *  |power9   | 5-11  | 2/cycle  |
+ *  |power10  | 4-7   | 4/cycle  |
+ *
+ *  @param vra a 128-bit vector treated as a vector unsigned char.
+ *  @param shb shift amount in the range 0-7.
+ *  @return 128-bit vector unsigned char, rotated left shb bits.
+ */
+static inline vui8_t
+vec_rlbi (vui8_t vra, const unsigned  shb)
+{
+  vui8_t lshift;
+  vui8_t result;
+  /* Load the shift const in a vector.  The element shifts require
+     a shift amount for each element. For the immediate form the
+     shift constant is splatted to all elements of the
+     shift control.  */
+  if (__builtin_constant_p (shb) && (shb < 8))
+    lshift = vec_splat_u8(shb);
+  else
+    lshift = vec_splats ((unsigned char) shb);
+
+  /* Vector Rotate Left halfword based on the lower 3-bits of
+     corresponding element of lshift.  */
+  result = vec_vrlb (vra, lshift);
+
+  return result;
+}
+
 /*! \brief Vector Set Bool from Signed Byte.
  *
  *  For each byte, propagate the sign bit to all 8-bits of that
@@ -1427,6 +1476,7 @@ vec_setb_sb (vi8_t vra)
  *  |--------:|:-----:|:---------|
  *  |power8   | 4-11  | 2/cycle  |
  *  |power9   | 5-11  | 2/cycle  |
+ *  |power10  | 4-7   | 4/cycle  |
  *
  *  @param vra a 128-bit vector treated as a vector unsigned char.
  *  @param shb Shift amount in the range 0-7.
@@ -1445,7 +1495,7 @@ vec_slbi (vui8_t vra, const unsigned int shb)
          shift constant is splatted to all elements of the
          shift control.  */
       if (__builtin_constant_p(shb))
-	lshift = (vui8_t) vec_splat_s8(shb);
+	lshift = vec_splat_u8(shb);
       else
 	lshift = vec_splats ((unsigned char) shb);
 
@@ -1474,6 +1524,7 @@ vec_slbi (vui8_t vra, const unsigned int shb)
  *  |--------:|:-----:|:---------|
  *  |power8   | 4-11  | 2/cycle  |
  *  |power9   | 5-11  | 2/cycle  |
+ *  |power10  | 4-7   | 4/cycle  |
  *
  *  @param vra a 128-bit vector treated as a vector signed char.
  *  @param shb Shift amount in the range 0-7.
@@ -1482,7 +1533,7 @@ vec_slbi (vui8_t vra, const unsigned int shb)
 static inline vi8_t
 vec_srabi (vi8_t vra, const unsigned int shb)
 {
-  vui8_t lshift;
+  vui8_t rshift;
   vi8_t result;
 
   if (shb < 8)
@@ -1492,20 +1543,20 @@ vec_srabi (vi8_t vra, const unsigned int shb)
          shift constant is splatted to all elements of the
          shift control.  */
       if (__builtin_constant_p(shb))
-	lshift = (vui8_t) vec_splat_s8(shb);
+	rshift = vec_splat_u8(shb);
       else
-	lshift = vec_splats ((unsigned char) shb);
+	rshift = vec_splats ((unsigned char) shb);
 
       /* Vector Shift Right Algebraic Bytes based on the lower 3-bits
          of corresponding element of lshift.  */
-      result = vec_vsrab (vra, lshift);
+      result = vec_vsrab (vra, rshift);
     }
   else
     { /* shifts greater then 7 bits returns the sign bit propagated to
          all bits.   This is equivalent to shift Right Algebraic of
          7 bits.  */
-      lshift = (vui8_t) vec_splat_s8(7);
-      result = vec_vsrab (vra, lshift);
+      rshift = vec_splat_u8(7);
+      result = vec_vsrab (vra, rshift);
     }
 
   return (vi8_t) result;
@@ -1523,6 +1574,7 @@ vec_srabi (vi8_t vra, const unsigned int shb)
  *  |--------:|:-----:|:---------|
  *  |power8   | 4-11  | 2/cycle  |
  *  |power9   | 5-11  | 2/cycle  |
+ *  |power10  | 4-7   | 4/cycle  |
  *
  *  @param vra a 128-bit vector treated as a vector unsigned char.
  *  @param shb Shift amount in the range 0-7.
@@ -1531,7 +1583,7 @@ vec_srabi (vi8_t vra, const unsigned int shb)
 static inline vui8_t
 vec_srbi (vui8_t vra, const unsigned int shb)
 {
-  vui8_t lshift;
+  vui8_t rshift;
   vui8_t result;
 
   if (shb < 8)
@@ -1541,13 +1593,13 @@ vec_srbi (vui8_t vra, const unsigned int shb)
          shift constant is splatted to all elements of the
          shift control.  */
       if (__builtin_constant_p(shb))
-	lshift = (vui8_t) vec_splat_s8(shb);
+	rshift = vec_splat_u8(shb);
       else
-	lshift = vec_splats ((unsigned char) shb);
+	rshift = vec_splats ((unsigned char) shb);
 
       /* Vector Shift right bytes based on the lower 3-bits of
          corresponding element of lshift.  */
-      result = vec_vsrb (vra, lshift);
+      result = vec_vsrb (vra, rshift);
     }
   else
     { /* shifts greater then 7 bits return zeros.  */

--- a/src/pveclib/vec_common_ppc.h
+++ b/src/pveclib/vec_common_ppc.h
@@ -1691,7 +1691,7 @@ static inline vi128_t vec_vsraq_PWR10 (vi128_t vra, vui8_t vrb);
  *
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
- *  |power7   | 8-16  |   NA     |
+ *  |power7   | 8-12  |   NA     |
  *
  *  @param a 128-bit vector long long int.
  *  @param b 128-bit vector long long int.
@@ -5771,7 +5771,7 @@ vec_splat6_s64 (const signed int sim6)
  *
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
- *  |power7   | 20-27 |   NA     |
+ *  |power7   | 8-12  |   NA     |
  *
  *  @param vra 128-bit vector treated as 2 X unsigned long long int.
  *  @param vrb 128-bit vector treated as 2 X unsigned long long int.
@@ -6051,7 +6051,7 @@ vec_vexpanddm_PWR7 (vui64_t vra)
   const vi8_t zero = vec_splat_s8 (0);
   // Splat the doubleword sign byte across the quadwords
   vi8_t vra_sign_h = vec_splat ((vi8_t) vra, VEC_BYTE_H_DWH);
-  vi8_t vra_sign_l = vec_splat ((vi8_t) vra, VEC_BYTE_L_DWH);
+  vi8_t vra_sign_l = vec_splat ((vi8_t) vra, VEC_BYTE_H_DWL);
   vi8_t vra_sign = (vi8_t) vec_xxpermdi ((vui64_t)vra_sign_h, (vui64_t)vra_sign_l, 0);
 
   vb8_t vsgn;

--- a/src/testsuite/arith128_test_char.c
+++ b/src/testsuite/arith128_test_char.c
@@ -2017,6 +2017,7 @@ test_clear_left(void)
 
     return (rc);
   }
+
 //#define __DEBUG_PRINT__ 1
 #if 1
 #if 1
@@ -2335,7 +2336,7 @@ test_isolate_right_justified_p(void)
     return (rc);
   }
 
-#define __DEBUG_PRINT__ 0
+// #define __DEBUG_PRINT__ 0
 #if 1
 #if 0
 // test directly from vec_char_ppc.h
@@ -2383,6 +2384,791 @@ test_isolate_left_justified_p(void)
     return (rc);
   }
 
+// #define __DEBUG_PRINT__ 1
+#if 1
+// test directly from vec_char_ppc.h
+#define test_splat6(_l)	vec_splat6_u8(_l)
+#else
+// test from vec_char_ppc.h via vec_char_dummy.c
+#endif
+
+int
+test_splat6_u8(void)
+{
+    vui8_t i, j, k, e, m6;
+    int rc = 0;
+    printf ("\n%s\n", __FUNCTION__);
+
+    m6 = (vui8_t) {63, 63, 63, 63, 63, 63, 63, 63,
+                   63, 63, 63, 63, 63, 63, 63, 63};
+
+    i = (vui8_t) {0, 1, 2, 3, 4, 5, 6, 7,
+                  8, 9, 10, 11, 12, 13, 14, 15};
+
+    e = vec_splat (i, 1);
+    j = test_splat6 (1);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_u8(%i)", e[0]);
+    print_vint8x ("               = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_u8 1", j, e);
+
+    e = vec_splat (i, 15);
+    j = test_splat6 (15);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_u8(%i)", e[0]);
+    print_vint8x ("               = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_u8 15", j, e);
+
+    i = (vui8_t) {16, 17, 18, 19, 20, 21, 22, 23,
+                  24, 25, 26, 27, 28, 29, 30, 31};
+
+    e = vec_splat (i, (16-16));
+    j = test_splat6 (16);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_u8(%i)", e[0]);
+    print_vint8x ("               = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_u8 16", j, e);
+
+    e = vec_splat (i, (17-16));
+    j = test_splat6 (17);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_u8(%i)", e[0]);
+    print_vint8x ("               = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_u8 17", j, e);
+
+    e = vec_splat (i, (24-16));
+    j = test_splat6 (24);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_u8(%i)", e[0]);
+    print_vint8x ("               = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_u8 24", j, e);
+
+    e = vec_splat (i, (30-16));
+    j = test_splat6 (30);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_u8(%i)", e[0]);
+    print_vint8x ("               = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_u8 30", j, e);
+
+    e = vec_splat (i, (31-16));
+    j = test_splat6 (31);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_u8(%i)", e[0]);
+    print_vint8x ("               = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_u8 31", j, e);
+
+    i = (vui8_t) {32, 33, 34, 35, 36, 37, 38, 39,
+                  40, 41, 42, 43, 44, 45, 46, 47};
+
+    e = vec_splat (i, (32-32));
+    k = test_splat6 (32);
+    j = vec_and (k, m6);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+    print_vint8x ("                  = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_u8 32", j, e);
+
+    e = vec_splat (i, (33-32));
+    k = test_splat6 (33);
+    j = vec_and (k, m6);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+    print_vint8x ("                  = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_u8 33", j, e);
+
+    e = vec_splat (i, (46-32));
+    k = test_splat6 (46);
+    j = vec_and (k, m6);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+    print_vint8x ("                  = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_u8 46", j, e);
+
+    e = vec_splat (i, (47-32));
+    k = test_splat6 (47);
+    j = vec_and (k, m6);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+    print_vint8x ("                  = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_u8 47", j, e);
+
+    i = (vui8_t) {48, 49, 50, 51, 52, 53, 54, 55,
+                  56, 57, 58, 59, 60, 61, 62, 63};
+
+    e = vec_splat (i, (48-48));
+    k = test_splat6 (48);
+    j = vec_and (k, m6);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+    print_vint8x ("                  = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_u8 48", j, e);
+
+    e = vec_splat (i, (52-48));
+    k = test_splat6 (52);
+    j = vec_and (k, m6);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+    print_vint8x ("                  = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_u8 52", j, e);
+
+    e = vec_splat (i, (55-48));
+    k = test_splat6 (55);
+    j = vec_and (k, m6);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+    print_vint8x ("                  = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_u8 55", j, e);
+
+    e = vec_splat (i, (56-48));
+    k = test_splat6 (56);
+    j = vec_and (k, m6);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+    print_vint8x ("                  = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_u8 56", j, e);
+
+    e = vec_splat (i, (63-48));
+    k = test_splat6 (63);
+    j = vec_and (k, m6);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+    print_vint8x ("                  = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_u8 53", j, e);
+
+    return (rc);
+  }
+
+// #define __DEBUG_PRINT__ 1
+#if 1
+// test directly from vec_char_ppc.h
+#define test_splats6(_l)	vec_splat6_s8(_l)
+#else
+// test from vec_char_ppc.h via vec_char_dummy.c
+#endif
+
+int
+test_splat6_s8(void)
+{
+    vi8_t i, j, e;
+    int rc = 0;
+    printf ("\n%s\n", __FUNCTION__);
+
+    i = (vi8_t) {0, 1, 2, 3, 4, 5, 6, 7,
+                 8, 9, 10, 11, 12, 13, 14, 15};
+
+    e = vec_splat (i, 1);
+    j = test_splats6 (1);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_s8(%i)", e[0]);
+    print_vint8x ("               = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_s8 1", (vui8_t) j, (vui8_t) e);
+
+    e = vec_splat (i, 15);
+    j = test_splats6 (15);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_s8(%i)", e[0]);
+    print_vint8x ("               = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_s8 15", (vui8_t) j, (vui8_t) e);
+
+    i = (vi8_t) {16, 17, 18, 19, 20, 21, 22, 23,
+                  24, 25, 26, 27, 28, 29, 30, 31};
+
+    e = vec_splat (i, (16-16));
+    j = test_splats6 (16);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_s8(%i)", e[0]);
+    print_vint8x ("               = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_s8 16", (vui8_t) j, (vui8_t) e);
+
+    e = vec_splat (i, (17-16));
+    j = test_splats6 (17);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_s8(%i)", e[0]);
+    print_vint8x ("               = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_s8 17", (vui8_t) j, (vui8_t) e);
+
+    e = vec_splat (i, (24-16));
+    j = test_splats6 (24);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_e8(%i)", e[0]);
+    print_vint8x ("               = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_e8 24", (vui8_t) j, (vui8_t) e);
+
+    e = vec_splat (i, (30-16));
+    j = test_splats6 (30);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_s8(%i)", e[0]);
+    print_vint8x ("               = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_s8 30",(vui8_t) j, (vui8_t) e);
+
+    e = vec_splat (i, (31-16));
+    j = test_splats6 (31);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_s8(%i)", e[0]);
+    print_vint8x ("               = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_s8 31",(vui8_t) j, (vui8_t) e);
+
+    i = (vi8_t) {-32, -31, -30, -29, -28, -27, -26, -25,
+                 -24, -23, -22, -21, -20, -19, -18, -17};
+
+    e = vec_splat (i, (32-32));
+    j = test_splats6 (-32);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_s8(%i)", e[0]);
+    print_vint8x ("               = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_s8 -32", (vui8_t) j, (vui8_t) e);
+
+    e = vec_splat (i, (32-25));
+    j = test_splats6 (-25);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_s8(%i)", e[0]);
+    print_vint8x ("               = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_s8 -25", (vui8_t) j, (vui8_t) e);
+
+    e = vec_splat (i, (32-24));
+    j = test_splats6 (-24);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_s8(%i)", e[0]);
+    print_vint8x ("               = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_s8 -24", (vui8_t) j, (vui8_t) e);
+
+    e = vec_splat (i, (32-23));
+    j = test_splats6 (-23);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_s8(%i)", e[0]);
+    print_vint8x ("               = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_s8 -23", (vui8_t) j, (vui8_t) e);
+
+    e = vec_splat (i, (32-17));
+    j = test_splats6 (-17);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_s8(%i)", e[0]);
+    print_vint8x ("               = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_s8 -17", (vui8_t) j, (vui8_t) e);
+
+    i = (vi8_t) {-16, -15, -14, -13, -12, -11, -10, -9,
+                 -8, -7, -6, -5, -4, -3, -2, -1};
+
+    e = vec_splat (i, (16-16));
+    j = test_splats6 (-16);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_s8(%i)", e[0]);
+    print_vint8x ("               = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_s8 -16", (vui8_t) j, (vui8_t) e);
+
+    e = vec_splat (i, (16-8));
+    j = test_splats6 (-8);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_s8(%i)", e[0]);
+    print_vint8x ("               = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_s8 -8", (vui8_t) j, (vui8_t) e);
+
+    e = vec_splat (i, (16-1));
+    j = test_splats6 (-1);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat6_s8(%i)", e[0]);
+    print_vint8x ("               = ", j);
+#endif
+    rc += check_vui8 ("vec_splat6_s8 -1", (vui8_t) j, (vui8_t) e);
+
+    return (rc);
+  }
+
+//#define __DEBUG_PRINT__ 1
+#if 1
+// test directly from vec_char_ppc.h
+#define test_splat7(_l)	vec_splat7_u8(_l)
+#else
+// test from vec_char_ppc.h via vec_char_dummy.c
+#endif
+
+int
+test_splat7_u8(void)
+{
+    vui8_t i, j, k, e, m7;
+    int rc = 0;
+    printf ("\n%s\n", __FUNCTION__);
+
+    m7 = (vui8_t) {127, 127, 127, 127, 127, 127, 127, 127,
+      127, 127, 127, 127, 127, 127, 127, 127};
+
+    i = (vui8_t) {0, 1, 2, 3, 4, 5, 6, 7,
+                  8, 9, 10, 11, 12, 13, 14, 15};
+    e = vec_splat (i, 1);
+    j = test_splat7 (1);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x ("               = ", j);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 1", j, e);
+
+    e = vec_splat (i, 15);
+    j = test_splat7 (15);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x ("               = ", j);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 15", j, e);
+
+    i = (vui8_t) {16, 17, 18, 19, 20, 21, 22, 23,
+                  24, 25, 26, 27, 28, 29, 30, 31};
+
+    e = vec_splat (i, (16-16));
+    j = test_splat7 (16);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x ("               = ", j);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 16", j, e);
+
+    e = vec_splat (i, (17-16));
+    j = test_splat7 (17);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x ("               = ", j);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 17", j, e);
+    e = vec_splat (i, (18-16));
+    j = test_splat7 (18);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x ("               = ", j);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 18", j, e);
+
+    e = vec_splat (i, (24-16));
+    j = test_splat7 (24);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x ("               = ", j);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 24", j, e);
+    e = vec_splat (i, (30-16));
+    j = test_splat7 (30);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x ("               = ", j);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 30", j, e);
+
+    e = vec_splat (i, (31-16));
+    j = test_splat7 (31);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x ("               = ", j);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 31", j, e);
+
+    i = (vui8_t) {32, 33, 34, 35, 36, 37, 38, 39,
+                  40, 41, 42, 43, 44, 45, 46, 47};
+
+    e = vec_splat (i, (32-32));
+    k = test_splat7 (32);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 32", k, e);
+
+    e = vec_splat (i, (33-32));
+    k = test_splat7 (33);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 33", k, e);
+
+    e = vec_splat (i, (40-32));
+    k = test_splat7 (40);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 40", k, e);
+
+    e = vec_splat (i, (47-32));
+    k = test_splat7 (47);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 47", k, e);
+
+    i = (vui8_t) {48, 49, 50, 51, 52, 53, 54, 55,
+                  56, 57, 58, 59, 60, 61, 62, 63};
+
+    e = vec_splat (i, (48-48));
+    k = test_splat7 (48);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 48", k, e);
+
+    e = vec_splat (i, (49-48));
+    k = test_splat7 (49);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 49", k, e);
+
+    e = vec_splat (i, (52-48));
+    k = test_splat7 (52);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 52", k, e);
+
+    e = vec_splat (i, (55-48));
+    k = test_splat7 (55);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 55", k, e);
+
+    e = vec_splat (i, (56-48));
+    k = test_splat7 (56);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 56", k, e);
+
+    e = vec_splat (i, (63-48));
+    k = test_splat7 (63);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 63", k, e);
+
+    i = (vui8_t) {64, 65, 66, 67, 68, 69, 70, 71,
+                  72, 73, 74, 75, 76, 77, 78, 79};
+
+    e = vec_splat (i, (64-64));
+    k = test_splat7 (64);
+    j = vec_and (k, m7);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+    print_vint8x ("                  = ", j);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 64", j, e);
+
+    e = vec_splat (i, (65-64));
+    k = test_splat7 (65);
+    j = vec_and (k, m7);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+    print_vint8x ("                  = ", j);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 65", j, e);
+
+    e = vec_splat (i, (72-64));
+    k = test_splat7 (72);
+    j = vec_and (k, m7);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+    print_vint8x ("                  = ", j);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 72", j, e);
+
+    e = vec_splat (i, (79-64));
+    k = test_splat7 (79);
+    j = vec_and (k, m7);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+    print_vint8x ("                  = ", j);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 79", j, e);
+
+    i = (vui8_t) {80, 81, 82, 83, 84, 85, 86, 87,
+                  88, 89, 90, 91, 92, 93, 94, 95};
+
+    e = vec_splat (i, (80-80));
+    k = test_splat7 (80);
+    j = vec_and (k, m7);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+    print_vint8x ("                  = ", j);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 80", j, e);
+
+    e = vec_splat (i, (81-80));
+    k = test_splat7 (81);
+    j = vec_and (k, m7);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+    print_vint8x ("                  = ", j);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 81", j, e);
+
+    e = vec_splat (i, (88-80));
+    k = test_splat7 (88);
+    j = vec_and (k, m7);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+    print_vint8x ("                  = ", j);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 88", j, e);
+
+    e = vec_splat (i, (95-80));
+    k = test_splat7 (95);
+    j = vec_and (k, m7);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+    print_vint8x ("                  = ", j);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 95", j, e);
+
+    i = (vui8_t) {96, 97, 98, 99, 100, 101, 102, 103,
+                  104, 105, 106, 107, 108, 109, 110, 111};
+
+    e = vec_splat (i, (96-96));
+    k = test_splat7 (96);
+    j = vec_and (k, m7);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+    print_vint8x ("                  = ", j);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 96", j, e);
+
+    e = vec_splat (i, (97-96));
+    k = test_splat7 (97);
+    j = vec_and (k, m7);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+    print_vint8x ("                  = ", j);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 97", j, e);
+
+    e = vec_splat (i, (98-96));
+    k = test_splat7 (98);
+    j = vec_and (k, m7);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+    print_vint8x ("                  = ", j);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 98", j, e);
+
+    e = vec_splat (i, (100-96));
+    k = test_splat7 (100);
+    j = vec_and (k, m7);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+    print_vint8x ("                  = ", j);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 100", j, e);
+
+    e = vec_splat (i, (102-96));
+    k = test_splat7 (102);
+    j = vec_and (k, m7);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+    print_vint8x ("                  = ", j);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 102", j, e);
+
+    e = vec_splat (i, (104-96));
+    k = test_splat7 (104);
+    j = vec_and (k, m7);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+    print_vint8x ("                  = ", j);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 104", j, e);
+
+    e = vec_splat (i, (111-96));
+    k = test_splat7 (111);
+    j = vec_and (k, m7);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+    print_vint8x ("                  = ", j);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 111", j, e);
+
+    i = (vui8_t) {112, 113, 114, 115, 116, 117, 118, 119,
+                  120, 121, 122, 123, 124, 125, 126, 127};
+
+    e = vec_splat (i, (112-112));
+    k = test_splat7 (112);
+    j = vec_and (k, m7);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+    print_vint8x ("                   = ", j);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 112", j, e);
+
+    e = vec_splat (i, (127-112));
+    k = test_splat7 (127);
+    j = vec_and (k, m7);
+
+#ifdef __DEBUG_PRINT__
+    printf       ("vec_splat7_u8(%i)", e[0]);
+    print_vint8x (" = ", k);
+    print_vint8x ("                   = ", j);
+#endif
+    rc += check_vui8 ("vec_splat7_u8 127", j, e);
+
+    return (rc);
+  }
+
+//#define __DEBUG_PRINT__ 1
+#if 0
+// test directly from vec_char_ppc.h
+#define test_expandm(_l)	vec_expandm_byte(_l)
+#else
+// test from vec_char_ppc.h via vec_char_dummy.c
+extern vui8_t test_vec_expandm_byte (vui8_t);
+#define test_expandm(_l)	test_vec_expandm_byte(_l)
+#endif
+
+int
+test_expandm_byte(void)
+{
+    vui8_t i, j, e;
+    int rc = 0;
+
+    printf ("\n%s\n", __FUNCTION__);
+
+    i = CONST_VINT128_B (0x00, 0x80, 0x01, 0xc0, 0x02, 0xe0, 0x04, 0xf0,
+                         0x08, 0x81, 0x10, 0x83, 0x20, 0x87, 0x40, 0x8f);
+
+    e = CONST_VINT128_B (0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff,
+			 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff);
+    j = (vui8_t) test_expandm (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x ("vec_expandm of ", i);
+    print_vint8x ("             = ", j);
+#endif
+    rc += check_vui8 ("vec_expandm", j, e);
+
+    return (rc);
+  }
+
 int
 test_vec_char (void)
 {
@@ -2416,6 +3202,10 @@ test_vec_char (void)
   rc += test_clear_right_justified ();
   rc += test_isolate_right_justified_p ();
   rc += test_isolate_left_justified_p ();
+  rc += test_splat6_u8 ();
+  rc += test_splat6_s8 ();
+  rc += test_splat7_u8 ();
+  rc += test_expandm_byte ();
 #endif
   return (rc);
 }

--- a/src/testsuite/vec_char_dummy.c
+++ b/src/testsuite/vec_char_dummy.c
@@ -12,6 +12,516 @@
 #include <pveclib/vec_char_ppc.h>
 
 vui8_t
+test_vec_expandm_byte (vui8_t vra)
+{
+  return vec_expandm_byte (vra);
+}
+
+vui8_t
+test_splat7_u8_15 ()
+{
+  return vec_splat7_u8 (15);
+}
+
+vui8_t
+test_splat7_u8_16 ()
+{
+  return vec_splat7_u8 (16);
+}
+
+vui8_t
+test_splat7_u8_18 ()
+{
+  return vec_splat7_u8 (18);
+}
+
+vui8_t
+test_splat7_u8_27 ()
+{
+  return vec_splat7_u8 (27);
+}
+
+vui8_t
+test_splat7_u8_30 ()
+{
+  return vec_splat7_u8 (30);
+}
+
+vui8_t
+test_splat7_u8_31 ()
+{
+  return vec_splat7_u8 (31);
+}
+
+vui8_t
+test_splat7_u8_32 ()
+{
+  return vec_splat7_u8 (32);
+}
+
+vui8_t
+test_splat7_u8_33 ()
+{
+  return vec_splat7_u8 (33);
+}
+
+vui8_t
+test_splat7_u8_34 ()
+{
+  return vec_splat7_u8 (34);
+}
+
+vui8_t
+test_splat7_u8_35 ()
+{
+  return vec_splat7_u8 (35);
+}
+
+vui8_t
+test_splat7_u8_36 ()
+{
+  return vec_splat7_u8 (36);
+}
+
+vui8_t
+test_splat7_u8_39 ()
+{
+  return vec_splat7_u8 (39);
+}
+
+vui8_t
+test_splat7_u8_40 ()
+{
+  return vec_splat7_u8 (40);
+}
+
+vui8_t
+test_splat7_u8_42 ()
+{
+  return vec_splat7_u8 (42);
+}
+
+vui8_t
+test_splat7_u8_44 ()
+{
+  return vec_splat7_u8 (44);
+}
+
+vui8_t
+test_splat7_u8_45 ()
+{
+  return vec_splat7_u8 (45);
+}
+
+vui8_t
+test_splat7_u8_48 ()
+{
+  return vec_splat7_u8 (48);
+}
+
+vui8_t
+test_splat7_u8_50 ()
+{
+  return vec_splat7_u8 (50);
+}
+
+vui8_t
+test_splat7_u8_51 ()
+{
+  return vec_splat7_u8 (51);
+}
+
+vui8_t
+test_splat7_u8_52 ()
+{
+  return vec_splat7_u8 (52);
+}
+
+vui8_t
+test_splat7_u8_54 ()
+{
+  return vec_splat7_u8 (54);
+}
+
+vui8_t
+test_splat7_u8_55 ()
+{
+  return vec_splat7_u8 (55);
+}
+
+vui8_t
+test_splat7_u8_60 ()
+{
+  return vec_splat7_u8 (60);
+}
+
+vui8_t
+test_splat7_u8_63 ()
+{
+  return vec_splat7_u8 (63);
+}
+
+vui8_t
+test_splat7_u8_64 ()
+{
+  return vec_splat7_u8 (64);
+}
+
+vui8_t
+test_splat7_u8_65 ()
+{
+  return vec_splat7_u8 (65);
+}
+
+vui8_t
+test_splat7_u8_67 ()
+{
+  return vec_splat7_u8 (67);
+}
+
+vui8_t
+test_splat7_u8_68 ()
+{
+  return vec_splat7_u8 (68);
+}
+
+vui8_t
+test_splat7_u8_72 ()
+{
+  return vec_splat7_u8 (72);
+}
+
+vui8_t
+test_splat7_u8_76 ()
+{
+  return vec_splat7_u8 (76);
+}
+
+vui8_t
+test_splat7_u8_79 ()
+{
+  return vec_splat7_u8 (79);
+}
+
+vui8_t
+test_splat7_u8_80 ()
+{
+  return vec_splat7_u8 (80);
+}
+
+vui8_t
+test_splat7_u8_81 ()
+{
+  return vec_splat7_u8 (81);
+}
+
+vui8_t
+test_splat7_u8_92 ()
+{
+  return vec_splat7_u8 (92);
+}
+
+vui8_t
+test_splat7_u8_94 ()
+{
+  return vec_splat7_u8 (94);
+}
+
+vui8_t
+test_splat7_u8_96 ()
+{
+  return vec_splat7_u8 (96);
+}
+
+vui8_t
+test_splat7_u8_97 ()
+{
+  return vec_splat7_u8 (97);
+}
+
+vui8_t
+test_splat7_u8_98 ()
+{
+  return vec_splat7_u8 (98);
+}
+
+vui8_t
+test_splat7_u8_100 ()
+{
+  return vec_splat7_u8 (100);
+}
+
+vui8_t
+test_splat7_u8_102 ()
+{
+  return vec_splat7_u8 (102);
+}
+
+vui8_t
+test_splat7_u8_104 ()
+{
+  return vec_splat7_u8 (104);
+}
+
+vui8_t
+test_splat7_u8_106 ()
+{
+  return vec_splat7_u8 (106);
+}
+
+vui8_t
+test_splat7_u8_108 ()
+{
+  return vec_splat7_u8 (108);
+}
+
+vui8_t
+test_splat7_u8_110 ()
+{
+  return vec_splat7_u8 (110);
+}
+
+vui8_t
+test_splat7_u8_111 ()
+{
+  return vec_splat7_u8 (111);
+}
+
+vui8_t
+test_splat7_u8_112 ()
+{
+  return vec_splat7_u8 (112);
+}
+
+vui8_t
+test_splat7_u8_127 ()
+{
+  return vec_splat7_u8 (127);
+}
+
+vi8_t
+test_splat6_s8_1 ()
+{
+  return vec_splat6_s8 (1);
+}
+
+vi8_t
+test_splat6_s8_16 ()
+{
+  return vec_splat6_s8 (16);
+}
+
+vi8_t
+test_splat6_s8_17 ()
+{
+  return vec_splat6_s8 (17);
+}
+
+vi8_t
+test_splat6_s8_30 ()
+{
+  return vec_splat6_s8 (30);
+}
+
+vi8_t
+test_splat6_s8_31 ()
+{
+  return vec_splat6_s8 (31);
+}
+
+vi8_t
+test_splat6_s8_m32 ()
+{
+  return vec_splat6_s8 (-32);
+}
+
+vi8_t
+test_splat6_s8_m31 ()
+{
+  return vec_splat6_s8 (-31);
+}
+
+vi8_t
+test_splat6_s8_m30 ()
+{
+  return vec_splat6_s8 (-30);
+}
+
+vi8_t
+test_splat6_s8_m18 ()
+{
+  return vec_splat6_s8 (-18);
+}
+
+vi8_t
+test_splat6_s8_m17 ()
+{
+  return vec_splat6_s8 (-17);
+}
+
+vi8_t
+test_splat6_s8_m16 ()
+{
+  return vec_splat6_s8 (-16);
+}
+
+vi8_t
+test_splat6_s8_m1 ()
+{
+  return vec_splat6_s8 (-1);
+}
+
+vui8_t
+test_splat6_u8_1 ()
+{
+  return vec_splat6_u8 (1);
+}
+
+vui8_t
+test_splat6_u8_15 ()
+{
+  return vec_splat6_u8 (15);
+}
+
+vui8_t
+test_splat6_u8_16 ()
+{
+  return vec_splat6_u8 (16);
+}
+
+vui8_t
+test_splat6_u8_17 ()
+{
+  return vec_splat6_u8 (17);
+}
+
+vui8_t
+test_splat6_u8_21 ()
+{
+  return vec_splat6_u8 (21);
+}
+
+vui8_t
+test_splat6_u8_25 ()
+{
+  return vec_splat6_u8 (25);
+}
+
+vui8_t
+test_splat6_u8_27 ()
+{
+  return vec_splat6_u8 (27);
+}
+
+vui8_t
+test_splat6_u8_30 ()
+{
+  return vec_splat6_u8 (30);
+}
+
+vui8_t
+test_splat6_u8_31 ()
+{
+  return vec_splat6_u8 (31);
+}
+
+vui8_t
+test_splat6_u8_32 ()
+{
+  return vec_splat6_u8 (32);
+}
+
+vui8_t
+test_splat6_u8_33 ()
+{
+  return vec_splat6_u8 (33);
+}
+
+vui8_t
+test_splat6_u8_39 ()
+{
+  return vec_splat6_u8 (39);
+}
+
+vui8_t
+test_splat6_u8_45 ()
+{
+  return vec_splat6_u8 (45);
+}
+
+vui8_t
+test_splat6_u8_46 ()
+{
+  return vec_splat6_u8 (46);
+}
+
+vui8_t
+test_splat6_u8_47 ()
+{
+  return vec_splat6_u8 (47);
+}
+
+vui8_t
+test_splat6_u8_48 ()
+{
+  return vec_splat6_u8 (48);
+}
+
+vui8_t
+test_splat6_u8_52 ()
+{
+  return vec_splat6_u8 (52);
+}
+
+vui8_t
+test_splat6_u8_54 ()
+{
+  return vec_splat6_u8 (54);
+}
+
+vui8_t
+test_splat6_u8_55 ()
+{
+  return vec_splat6_u8 (55);
+}
+
+vui8_t
+test_splat6_u8_56 ()
+{
+  return vec_splat6_u8 (56);
+}
+
+vui8_t
+test_splat6_u8_63 ()
+{
+  return vec_splat6_u8 (63);
+}
+
+vui8_t
+test_splat5_u8_1 ()
+{
+  return vec_splat5_u8 (1);
+}
+
+vui8_t
+test_splat5_u8_15 ()
+{
+  return vec_splat5_u8 (15);
+}
+
+vui8_t
+test_splat5_u8_16 ()
+{
+  return vec_splat5_u8 (16);
+}
+
+vui8_t
+test_splat5_u8_31 ()
+{
+  return vec_splat5_u8 (31);
+}
+
+vui8_t
 test_vec_popcntb (vui8_t vra)
 {
   return vec_popcntb (vra);
@@ -1033,6 +1543,58 @@ test_setb_sb (vi8_t vra)
 }
 
 vui8_t
+test_clzb_v1 (vui8_t vra)
+{
+  vui8_t x;
+  x = vra | (vra >> 1);
+  x = x | (x >> 2);
+  x = x | (x >> 4);
+  return vec_popcntb_PWR7 (x);
+}
+
+vui8_t
+test_clzb_v0 (vui8_t vra)
+{
+  //#warning Implememention pre power8
+    __vector unsigned char n, nt, y, x, s, m;
+    __vector unsigned char z= { 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0};
+    __vector unsigned char one = { 1,1,1,1, 1,1,1,1, 1,1,1,1, 1,1,1,1};
+
+    /* n = 8 s = 4 */
+    s = vec_splat_u8(4);
+    n = vec_splat_u8(8);
+    x = vra;
+
+    /* y=x>>4 if (y!=0) (n=n-4 x=y)  */
+    y = vec_sr(x, s);
+    nt = vec_sub(n,s);
+    m = (__vector unsigned char)vec_cmpgt(y, z);
+    s = vec_sr(s,one);
+    x = vec_sel (x , y, m);
+    n = vec_sel (n , nt, m);
+
+    /* y=x>>2 if (y!=0) (n=n-2 x=y)  */
+    y = vec_sr(x, s);
+    nt = vec_sub(n,s);
+    m = (__vector unsigned char)vec_cmpgt(y, z);
+    s = vec_sr(s,one);
+    x = vec_sel (x , y, m);
+    n = vec_sel (n , nt, m);
+
+    /* y=x>>1 if (y!=0) return (n=n-2)   */
+    y = vec_sr(x, s);
+    nt = vec_sub(n,s);
+    nt = vec_sub(nt,s);
+    m = (__vector unsigned char)vec_cmpgt(y, z);
+    n = vec_sel (n , nt, m);
+
+    /* else return (x-n)  */
+    nt = vec_sub (n, x);
+    n = vec_sel (nt , n, m);
+    return n;
+}
+
+vui8_t
 test_ctzb_v1 (vui8_t vra)
 {
   const vui8_t ones = vec_splat_u8 (1);
@@ -1117,6 +1679,12 @@ vui8_t
 __test_clzb (vui8_t a)
 {
   return (vec_clzb (a));
+}
+
+vui8_t
+test_vec_rlbi_4 (vui8_t a)
+{
+  return vec_rlbi (a, 4);
 }
 
 vui8_t

--- a/src/testsuite/vec_pwr10_dummy.c
+++ b/src/testsuite/vec_pwr10_dummy.c
@@ -41,6 +41,36 @@
 #if defined(_ARCH_PWR10) && \
     ((__GNUC__ > 10) || (defined(__clang__) && (__clang_major__ > 12)))
 
+vui8_t
+test_vexpandbm_PWR10 (vui8_t vra)
+{
+  return vec_vexpandbm_PWR10 (vra);
+}
+
+vui16_t
+test_vexpandhm_PWR10 (vui16_t vra)
+{
+  return vec_vexpandhm_PWR10 (vra);
+}
+
+vui32_t
+test_vexpandwm_PWR10 (vui32_t vra)
+{
+  return vec_vexpandwm_PWR10 (vra);
+}
+
+vui64_t
+test_vexpanddm_PWR10 (vui64_t vra)
+{
+  return vec_vexpanddm_PWR10 (vra);
+}
+
+vui128_t
+test_vexpandqm_PWR10 (vui128_t vra)
+{
+  return vec_vexpandqm_PWR10 (vra);
+}
+
 vui64_t
 test_vec_ctzd_PWR10 (vui64_t vra)
 {

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -40,6 +40,36 @@
 #include <pveclib/vec_f32_ppc.h>
 #include <pveclib/vec_bcd_ppc.h>
 
+vui8_t
+test_vexpandbm_PWR9 (vui8_t vra)
+{
+  return vec_vexpandbm_PWR7 (vra);
+}
+
+vui16_t
+test_vexpandhm_PWR9 (vui16_t vra)
+{
+  return vec_vexpandhm_PWR7 (vra);
+}
+
+vui32_t
+test_vexpandwm_PWR9 (vui32_t vra)
+{
+  return vec_vexpandwm_PWR7 (vra);
+}
+
+vui64_t
+test_vexpanddm_PWR9 (vui64_t vra)
+{
+  return vec_vexpanddm_PWR8 (vra);
+}
+
+vui128_t
+test_vexpandqm_PWR9 (vui128_t vra)
+{
+  return vec_vexpandqm_PWR7 (vra);
+}
+
 vui128_t
 test_vec_popcntq_PWR9 (vui128_t vra)
 {
@@ -2588,7 +2618,6 @@ __test_scalar_test_data_class_f128 (__binary128 val)
 {
   return scalar_test_data_class (val, 0x7f);
 }
-#endif
 int
 __test_scalar_test_data_class_f64 (double val)
 {
@@ -2600,6 +2629,7 @@ __test_scalar_test_data_class_f32 (float val)
 {
   return scalar_test_data_class (val, 0x7f);
 }
+#endif
 #endif
 
 #ifdef scalar_test_neg
@@ -2619,12 +2649,12 @@ __test_scalar_extract_exp_f128 (__binary128 val)
 {
   return scalar_extract_exp (val);
 }
-#endif
 int
 __test_scalar_extract_exp_f64 (double val)
 {
   return scalar_extract_exp (val);
 }
+#endif
 #endif
 
 #ifdef scalar_extract_sig
@@ -2634,12 +2664,12 @@ __test_scalar_extract_sig_f128 (__binary128 val)
 {
   return scalar_extract_sig (val);
 }
-#endif
 long long int
 __test_scalar_extract_sig_f64 (double val)
 {
   return scalar_extract_sig (val);
 }
+#endif
 #endif
 
 #ifdef scalar_insert_exp
@@ -2649,12 +2679,12 @@ __test_scalar_insert_exp_f128 (__binary128 sig, unsigned long long int exp)
 {
   return scalar_insert_exp (sig, exp);
 }
-#endif
 double
 __test_scalar_insert_exp_f64 (double sig, unsigned long long int exp)
 {
   return scalar_insert_exp (sig, exp);
 }
+#endif
 #endif
 
 #ifdef scalar_cmp_exp_eq
@@ -2666,15 +2696,16 @@ __test_scalar_cmp_exp_eq_f128 (__binary128 vra, __binary128 vrb)
 {
   return scalar_cmp_exp_eq (vra, vrb);
 }
-#endif
 int
 __test_scalar_cmp_exp_eq_f64 (double vra, double vrb)
 {
   return scalar_cmp_exp_eq (vra, vrb);
 }
 #endif
+#endif
 
 #ifdef vec_insert_exp
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 8)
 vf64_t
 __test_vec_insert_exp_f64b (vui64_t sig, vui64_t exp)
 {
@@ -2697,8 +2728,10 @@ __test_vec_insert_exp_f32 (vf32_t sig, vui32_t exp)
   return vec_insert_exp (sig, exp);
 }
 #endif
+#endif
 
 #ifdef vec_test_data_class
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 8)
 vb64_t
 __test_vec_test_data_class_f64 (vf64_t val)
 {
@@ -2711,8 +2744,10 @@ __test_vec_test_data_class_f32 (vf32_t val)
   return vec_test_data_class (val, 0x7f);
 }
 #endif
+#endif
 
 #ifdef vec_extract_exp
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 8)
 vui64_t
 __test_vec_extract_exp_f64 (vf64_t val)
 {
@@ -2724,8 +2759,10 @@ __test_vec_extract_exp_f32 (vf32_t val)
   return vec_extract_exp (val);
 }
 #endif
+#endif
 
 #ifdef vec_extract_sig
+#if defined (_ARCH_PWR9) && defined (__FLOAT128__) && (__GNUC__ > 8)
 vui64_t
 __test_vec_extract_sig_f64 (vf64_t val)
 {
@@ -2736,6 +2773,7 @@ __test_vec_extract_sig_f32 (vf32_t val)
 {
   return vec_extract_sig (val);
 }
+#endif
 #endif
 
 #ifndef PVECLIB_DISABLE_DFP


### PR DESCRIPTION
	* src/pveclib/vec_char_ppc.h (vec_ctzb[_ARCH_PWR8]): Use tzmask and popcntb for implementation.
	- (vec_expandm_byte): New inline operation.
	- (vec_first_mismatch_byte_or_eos_index[_ARCH_PWR9]): And (__VSX__) and (__GNUC__ > 7)
	- (vec_rlbi): New inline operation.
	- (vec_slbi): Update P10 latency. Eliminate unnecessary cast.
	- (vec_srabi): Update P10 latency. Rename var lshift to rshift.
	- (vec_srbi): Update P10 latency. Rename var lshift to rshift.

	* src/testsuite/arith128_test_char.c (test_splat6_u8, test_splat6_s8, test_splat7_u8, test_expandm_byte): New unit tests.
	- (test_vec_char): Add new unit tests to driver.

	* src/testsuite/vec_char_dummy.c
	- (test_vec_expandm_byte): New compile test.
	- (test_splat7_u8_15, test_splat7_u8_16, test_splat7_u8_18, test_splat7_u8_27, test_splat7_u8_30, test_splat7_u8_31, test_splat7_u8_32, test_splat7_u8_33, test_splat7_u8_34, test_splat7_u8_35, test_splat7_u8_36, test_splat7_u8_39, test_splat7_u8_40, test_splat7_u8_42, test_splat7_u8_44, test_splat7_u8_45, test_splat7_u8_48, test_splat7_u8_50, test_splat7_u8_51, test_splat7_u8_52, test_splat7_u8_54, test_splat7_u8_55, test_splat7_u8_60, test_splat7_u8_63, test_splat7_u8_64, test_splat7_u8_65, test_splat7_u8_67, test_splat7_u8_68, test_splat7_u8_72, test_splat7_u8_76, test_splat7_u8_79, test_splat7_u8_80, test_splat7_u8_81, test_splat7_u8_92, test_splat7_u8_94, test_splat7_u8_96, test_splat7_u8_97, test_splat7_u8_98, test_splat7_u8_100, test_splat7_u8_102, test_splat7_u8_104, test_splat7_u8_106, test_splat7_u8_108, test_splat7_u8_110, test_splat7_u8_111, test_splat7_u8_112, test_splat7_u8_127): Compile tests for 7-bit splat immediate byte.
	- (test_splat6_s8_1, test_splat6_s8_16, test_splat6_s8_17, test_splat6_s8_30, test_splat6_s8_31, test_splat6_s8_m32, test_splat6_s8_m31, test_splat6_s8_m30, test_splat6_s8_m18, test_splat6_s8_m17, test_splat6_s8_m16, test_splat6_s8_m1): Compile tests for 6-bit signed splat immediate byte.
	- (test_splat6_u8_1, test_splat6_u8_15, test_splat6_u8_16, test_splat6_u8_17, test_splat6_u8_21, test_splat6_u8_25, test_splat6_u8_27, test_splat6_u8_30, test_splat6_u8_31, test_splat6_u8_32, test_splat6_u8_33, test_splat6_u8_39, test_splat6_u8_45, test_splat6_u8_46, test_splat6_u8_47, test_splat6_u8_48, test_splat6_u8_52, test_splat6_u8_54, test_splat6_u8_55, test_splat6_u8_56, test_splat6_u8_63): Compile tests for 6-bit unsigned splat immediate byte.
	- (test_splat5_u8_1, test_splat5_u8_15, test_splat5_u8_16, test_splat5_u8_31): Compile tests for 6-bit unsigned splat immediate byte.
	- (test_clzb_v1, test_clzb_v0, test_vec_rlbi_4): More compile tests.

	* src/testsuite/vec_pwr10_dummy.c (test_vexpandbm_PWR10, test_vexpandhm_PWR10, test_vexpandwm_PWR10, test_vexpanddm_PWR10, test_vexpandqm_PWR10): More compile tests.

	* src/testsuite/vec_pwr9_dummy.c (test_vexpandbm_PWR9, test_vexpandhm_PWR9, test_vexpandwm_PWR9, test_vexpanddm_PWR9, test_vexpandqm_PWR9): More compile tests. [_ARCH_PWR9, __FLOAT128__, (__GNUC__ > 7)]: Expand guard for scalar_test intrinsics to keep clang happy.