### PR TITLE
Add exploit common parts for short/halfword and P10.

### DIFF
--- a/src/pveclib/vec_int16_ppc.h
+++ b/src/pveclib/vec_int16_ppc.h
@@ -1028,8 +1028,10 @@ vec_rlhi (vui16_t vra, const unsigned  shb)
  *
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
- *  |power8   | 2-4   | 2/cycle  |
- *  |power9   | 2-5   | 2/cycle  |
+ *  |power7   | 2 - 4 | 2/cycle  |
+ *  |power8   | 2 - 4 | 2/cycle  |
+ *  |power9   | 3 - 6 | 2/cycle  |
+ *  |power10  | 3 - 4 | 4/cycle  |
  *
  *  @param vra Vector signed short.
  *  @return vector bool short reflecting the sign bit of each
@@ -1039,24 +1041,7 @@ vec_rlhi (vui16_t vra, const unsigned  shb)
 static inline vb16_t
 vec_setb_sh (vi16_t vra)
 {
-  vb16_t result;
-
-#if defined (_ARCH_PWR10)  && (__GNUC__ >= 10)
-#if (__GNUC__ >= 12)
-      result = (vb16_t) vec_expandm ((vui16_t) vra);
-#else
-  __asm__(
-      "vexpandhm %0,%1"
-      : "=v" (result)
-      : "v" (vra)
-      : );
-#endif
-#else
-  const vui16_t rshift =  vec_splat_u16( 15 );
-  // Vector Shift Right Algebraic Halfwords 15-bits.
-  result = (vb16_t) vec_sra (vra, rshift);
-#endif
-  return result;
+  return (vb16_t) vec_expandm_halfword ((vui16_t) vra);
 }
 
 /** \brief Vector Sign Extent to Short (from byte).
@@ -1065,12 +1050,13 @@ vec_setb_sh (vi16_t vra)
  *  in the result vector. Each halfword element is the sign-extending
  *  low-order byte of the corresponding halfword element of vra.
  *
- *  \Note This implementation matches the Endian-Sensitive semantics
+ *  \note This implementation matches the Endian-Sensitive semantics
  *  of the Intrinsic Reference. As if you loaded vra from an array
  *  of char.
  *
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
+ *  |power7   | 4 - 6 | 2/cycle  |
  *  |power8   | 4 - 6 | 2/cycle  |
  *  |power9   | 4 - 7 | 2/cycle  |
  *  |power10  | 2 - 10| 4/cycle  |
@@ -1098,7 +1084,7 @@ vec_signexts_byte (vi8_t vra)
  *  in the result vector. Each halfword element is the sign-extending
  *  low-order byte of the corresponding halfword element of vra.
  *
- *  \Note This implementation matches the Big-Endian register semantics
+ *  \note This implementation matches the Big-Endian register semantics
  *  of the PowerISA 3.1C Vector Extend Sign instructions. As if you
  *  loaded vra from an array of short int.
  *

--- a/src/testsuite/arith128_test_i16.c
+++ b/src/testsuite/arith128_test_i16.c
@@ -634,6 +634,88 @@ test_setbh (void)
   return (rc);
 }
 
+//#define __DEBUG_PRINT__ 1
+#if 0
+// test directly from vec_char_ppc.h
+#define test_expandm(_l)	vec_expandm_halfword(_l)
+#else
+// test from vec_char_ppc.h via vec_char_dummy.c
+extern vui16_t test_vec_expandm_halfword (vui16_t);
+#define test_expandm(_l)	test_vec_expandm_halfword(_l)
+#endif
+
+int
+test_expandm_halfword(void)
+{
+    vui16_t i, j, e;
+    int rc = 0;
+
+    printf ("\n%s\n", __FUNCTION__);
+
+    i = CONST_VINT128_H (0x0000, 0x8000, 0x0001, 0xc000,
+			 0x0002, 0xe000, 0x0004, 0xf000);
+
+    e = CONST_VINT128_H (0x0000, 0xffff, 0x0000, 0xffff,
+			 0x0000, 0xffff, 0x0000, 0xffff);
+    j = test_expandm (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint16x ("vec_expandm of ", i);
+    print_vint16x ("             = ", j);
+#endif
+    rc += check_vuint128x ("vec_expandm:", (vui128_t) j, (vui128_t) e);
+
+    i = CONST_VINT128_H (0x0fff, 0x8001, 0x1fff, 0xc002,
+			 0x3fff, 0xe007, 0x7fff, 0xf00f);
+
+    e = CONST_VINT128_H (0x0000, 0xffff, 0x0000, 0xffff,
+			 0x0000, 0xffff, 0x0000, 0xffff);
+    j = test_expandm (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint16x ("vec_expandm of ", i);
+    print_vint16x ("             = ", j);
+#endif
+    rc += check_vuint128x ("vec_expandm:", (vui128_t) j, (vui128_t) e);
+
+    return (rc);
+  }
+
+//#define __DEBUG_PRINT__ 1
+#if 0
+// test directly from vec_char_ppc.h
+#define test_signextsb(_l)	vec_signexts_byte(_l)
+#else
+// test from vec_char_ppc.h via vec_char_dummy.c
+extern vui16_t test_vec_signexts_byte (vui8_t);
+#define test_signextsb(_l)	test_vec_signexts_byte(_l)
+#endif
+
+int
+test_signexts_b(void)
+{
+    vui8_t i;
+    vui16_t j, e;
+    int rc = 0;
+
+    printf ("\n%s\n", __FUNCTION__);
+
+    i = (vui8_t)  {0x00, 0x00, 0x80, 0x00, 0x01, 0x00, 0xc0, 0xe0,
+	           0xff, 0x00, 0xe0, 0xc0, 0x04, 0x00, 0xf0, 0xf0};
+    e = (vui16_t) {0x0000, 0xff80, 0x0001, 0xffc0,
+		   0xffff, 0xffe0, 0x0004, 0xfff0};
+    j = test_signextsb (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint16x ("vec_expandm of ", i);
+    print_vint16x ("             = ", j);
+#endif
+    rc += check_vuint128x ("vec_signexts:", (vui128_t) j, (vui128_t) e);
+
+    return (rc);
+  }
+
+
 int
 test_vec_i16 (void)
 {
@@ -652,6 +734,8 @@ test_vec_i16 (void)
   rc += test_muluhm();
   rc += test_vmadduh();
   rc += test_setbh();
+  rc += test_expandm_halfword();
+  rc += test_signexts_b();
 #endif
   return (rc);
 }

--- a/src/testsuite/arith128_test_i16.c
+++ b/src/testsuite/arith128_test_i16.c
@@ -636,10 +636,10 @@ test_setbh (void)
 
 //#define __DEBUG_PRINT__ 1
 #if 0
-// test directly from vec_char_ppc.h
+// test directly from vec_int16_ppc.h
 #define test_expandm(_l)	vec_expandm_halfword(_l)
 #else
-// test from vec_char_ppc.h via vec_char_dummy.c
+// test from vec_int16_ppc.h via vec_int16_dummy.c
 extern vui16_t test_vec_expandm_halfword (vui16_t);
 #define test_expandm(_l)	test_vec_expandm_halfword(_l)
 #endif
@@ -683,10 +683,10 @@ test_expandm_halfword(void)
 
 //#define __DEBUG_PRINT__ 1
 #if 0
-// test directly from vec_char_ppc.h
+// test directly from vec_int16_ppc.h
 #define test_signextsb(_l)	vec_signexts_byte(_l)
 #else
-// test from vec_char_ppc.h via vec_char_dummy.c
+// test from vec_int16_ppc.h via vec_int16_dummy.c
 extern vui16_t test_vec_signexts_byte (vui8_t);
 #define test_signextsb(_l)	test_vec_signexts_byte(_l)
 #endif
@@ -707,7 +707,7 @@ test_signexts_b(void)
     j = test_signextsb (i);
 
 #ifdef __DEBUG_PRINT__
-    print_vint16x ("vec_expandm of ", i);
+    print_vint16x ("vec_signexts of ", i);
     print_vint16x ("             = ", j);
 #endif
     rc += check_vuint128x ("vec_signexts:", (vui128_t) j, (vui128_t) e);

--- a/src/testsuite/vec_int16_dummy.c
+++ b/src/testsuite/vec_int16_dummy.c
@@ -22,6 +22,99 @@
 
 #include <pveclib/vec_int16_ppc.h>
 
+vi16_t
+test_vec_vextsb2h (vi8_t vra)
+{
+  return vec_vextsb2h (vra);
+}
+
+vi16_t
+test_vec_signexts_byte (vi8_t vra)
+{
+  return vec_signexts_byte (vra);
+}
+
+vi16_t
+test_signexts_byte_V1 (vi8_t vra)
+{
+  const vui16_t vshb = vec_splat_u16(8);
+  vi16_t result;
+
+  result = vec_sl ((vi16_t) vra, vshb);
+  result = vec_sra (result, vshb);
+
+  return result;
+}
+
+vi16_t
+test_signexts_byte_V0 (vi8_t vra)
+{
+  const vi8_t vone = vec_splat_s8(1);
+  vi16_t result;
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  result = vec_mule (vra, vone);
+#else
+  result = vec_mulo (vra, vone);
+#endif
+
+  return result;
+}
+
+vui16_t
+test_vec_expandm_halfword (vui16_t vra)
+{
+  return vec_expandm_halfword (vra);
+}
+
+vui16_t
+test_vec_rlhi_4 (vui16_t a)
+{
+  return vec_rlhi (a, 4);
+}
+
+vui16_t
+test_vec_slhi_4 (vui16_t a)
+{
+  return vec_slhi (a, 4);
+}
+
+vi16_t
+test_vec_srahi_4 (vi16_t a)
+{
+  return vec_srahi (a, 4);
+}
+
+vui16_t
+test_vec_srhi_4 (vui16_t a)
+{
+  return vec_srhi (a, 4);
+}
+
+vui16_t
+test_vec_rlhi_15 (vui16_t a)
+{
+  return vec_rlhi (a, 15);
+}
+
+vui16_t
+test_vec_slhi_15 (vui16_t a)
+{
+  return vec_slhi (a, 15);
+}
+
+vi16_t
+test_vec_srahi_15 (vi16_t a)
+{
+  return vec_srahi (a, 15);
+}
+
+vui16_t
+test_vec_srhi_15 (vui16_t a)
+{
+  return vec_srhi (a, 15);
+}
+
 vui16_t
 test_vec_popcnth (vui16_t vra)
 {


### PR DESCRIPTION
	* src/pveclib/vec_int16_ppc.h (vec_expandm_halfword): New inline operation.
	- (vec_popcnth[!_ARCH_PWR7]): Leverage vec_common_ppch vec_popcnth_PWR7 implementation.
	- (vec_rlhi): New inline operation.
	- (vec_signexts_byte, vec_vextsb2h): New inline operation.
	- (vec_slhi): Doxygen add P10 latency. Remove unnecessary cast.
	- (vec_srhi): Doxygen add P10 latency. Rename lshift to rshift.
	- (vec_srahi): Doxygen add P10 latency. Rename lshift to rshift.

	* src/testsuite/arith128_test_i16.c (test_expandm_halfword, test_signexts_b): New unit tests.
	- (test_vec_i16): Update driver to call new unit tests.

	* src/testsuite/vec_int16_dummy.c
	- (test_vec_vextsb2h, test_vec_signexts_byte, test_signexts_byte_V1, test_signexts_byte_V0, test_vec_expandm_halfword): New compile tests.
	- (test_vec_rlhi_4, test_vec_slhi_4, test_vec_srahi_4, test_vec_srhi_4, test_vec_rlhi_15, test_vec_slhi_15, test_vec_srahi_15, test_vec_srhi_15): New compile tests.