### PR TITLE
Add exploit common parts for long long /doubleword and P10.

### DIFF
--- a/src/testsuite/arith128_test_i64.c
+++ b/src/testsuite/arith128_test_i64.c
@@ -12525,6 +12525,15 @@ test_splatisd (void)
   e = (vi64_t)CONST_VINT64_DW(-16, -16);
   rc += check_v2ui64x ("vec_splat_s64 :", (vui64_t) k, (vui64_t) e);
 
+  k = (vi64_t) vec_splat_s64 (-32);
+
+#ifdef __DEBUG_PRINT__
+  printf         ("vec_splat_s64 ( -32 ) \n");
+  print_v2xint64 ("        =", (vui64_t) k);
+#endif
+  e = (vi64_t)CONST_VINT64_DW(-32, -32);
+  rc += check_v2ui64x ("vec_splat_s64 :", (vui64_t) k, (vui64_t) e);
+
   k = (vi64_t) vec_splat_s64 (-128);
 
 #ifdef __DEBUG_PRINT__
@@ -12543,6 +12552,24 @@ test_splatisd (void)
   e = (vi64_t)CONST_VINT64_DW(-129, -129);
   rc += check_v2ui64x ("vec_splat_s64 :", (vui64_t) k, (vui64_t) e);
 
+  k = (vi64_t) vec_splat_s64 (-256);
+
+#ifdef __DEBUG_PRINT__
+  printf         ("vec_splat_s64 ( -256 ) \n");
+  print_v2xint64 ("        =", (vui64_t) k);
+#endif
+  e = (vi64_t)CONST_VINT64_DW(-256, -256);
+  rc += check_v2ui64x ("vec_splat_s64 :", (vui64_t) k, (vui64_t) e);
+
+  k = (vi64_t) vec_splat_s64 (-1024);
+
+#ifdef __DEBUG_PRINT__
+  printf         ("vec_splat_s64 ( -1024 ) \n");
+  print_v2xint64 ("        =", (vui64_t) k);
+#endif
+  e = (vi64_t)CONST_VINT64_DW(-1024, -1024);
+  rc += check_v2ui64x ("vec_splat_s64 :", (vui64_t) k, (vui64_t) e);
+
   k = (vi64_t) vec_splat_s64 (15);
 
 #ifdef __DEBUG_PRINT__
@@ -12550,6 +12577,15 @@ test_splatisd (void)
   print_v2xint64 ("        =", (vui64_t) k);
 #endif
   e = (vi64_t)CONST_VINT64_DW(15, 15);
+  rc += check_v2ui64x ("vec_splat_s64 :", (vui64_t) k, (vui64_t) e);
+
+  k = (vi64_t) vec_splat_s64 (30);
+
+#ifdef __DEBUG_PRINT__
+  printf         ("vec_splat_s64 ( 30 ) \n");
+  print_v2xint64 ("        =", (vui64_t) k);
+#endif
+  e = (vi64_t)CONST_VINT64_DW(30, 30);
   rc += check_v2ui64x ("vec_splat_s64 :", (vui64_t) k, (vui64_t) e);
 
   k = (vi64_t) vec_splat_s64 (127);
@@ -12568,6 +12604,33 @@ test_splatisd (void)
   print_v2xint64 ("        =", (vui64_t) k);
 #endif
   e = (vi64_t)CONST_VINT64_DW(128, 128);
+  rc += check_v2ui64x ("vec_splat_s64 :", (vui64_t) k, (vui64_t) e);
+
+  k = (vi64_t) vec_splat_s64 (246);
+
+#ifdef __DEBUG_PRINT__
+  printf         ("vec_splat_s64 ( 246 ) \n");
+  print_v2xint64 ("        =", (vui64_t) k);
+#endif
+  e = (vi64_t)CONST_VINT64_DW(246, 246);
+  rc += check_v2ui64x ("vec_splat_s64 :", (vui64_t) k, (vui64_t) e);
+
+  k = (vi64_t) vec_splat_s64 (255);
+
+#ifdef __DEBUG_PRINT__
+  printf         ("vec_splat_s64 ( 255 ) \n");
+  print_v2xint64 ("        =", (vui64_t) k);
+#endif
+  e = (vi64_t)CONST_VINT64_DW(255, 255);
+  rc += check_v2ui64x ("vec_splat_s64 :", (vui64_t) k, (vui64_t) e);
+
+  k = (vi64_t) vec_splat_s64 (1024);
+
+#ifdef __DEBUG_PRINT__
+  printf         ("vec_splat_s64 ( 1024 ) \n");
+  print_v2xint64 ("        =", (vui64_t) k);
+#endif
+  e = (vi64_t)CONST_VINT64_DW(1024, 1024);
   rc += check_v2ui64x ("vec_splat_s64 :", (vui64_t) k, (vui64_t) e);
 
   return (rc);
@@ -12601,6 +12664,24 @@ test_splatiud (void)
   e = (vui64_t)CONST_VINT64_DW(15, 15);
   rc += check_v2ui64x ("vec_splat_u64 :", (vui64_t) k, (vui64_t) e);
 
+  k = (vui64_t) vec_splat_u64 (32);
+
+#ifdef __DEBUG_PRINT__
+  printf         ("vec_splat_u64 ( 32 ) \n");
+  print_v2xint64 ("        =", (vui64_t) k);
+#endif
+  e = (vui64_t)CONST_VINT64_DW(32, 32);
+  rc += check_v2ui64x ("vec_splat_u64 :", (vui64_t) k, (vui64_t) e);
+
+  k = (vui64_t) vec_splat_u64 (64);
+
+#ifdef __DEBUG_PRINT__
+  printf         ("vec_splat_u64 ( 64 ) \n");
+  print_v2xint64 ("        =", (vui64_t) k);
+#endif
+  e = (vui64_t)CONST_VINT64_DW(64, 64);
+  rc += check_v2ui64x ("vec_splat_u64 :", (vui64_t) k, (vui64_t) e);
+
   k = (vui64_t) vec_splat_u64 (127);
 
 #ifdef __DEBUG_PRINT__
@@ -12617,6 +12698,24 @@ test_splatiud (void)
   print_v2xint64 ("        =", (vui64_t) k);
 #endif
   e = (vui64_t)CONST_VINT64_DW(128, 128);
+  rc += check_v2ui64x ("vec_splat_u64 :", (vui64_t) k, (vui64_t) e);
+
+  k = (vui64_t) vec_splat_u64 (1024);
+
+#ifdef __DEBUG_PRINT__
+  printf         ("vec_splat_u64 ( 1024 ) \n");
+  print_v2xint64 ("        =", (vui64_t) k);
+#endif
+  e = (vui64_t)CONST_VINT64_DW(1024, 1024);
+  rc += check_v2ui64x ("vec_splat_u64 :", (vui64_t) k, (vui64_t) e);
+
+  k = (vui64_t) vec_splat_u64 (0x7FFFFFFF);
+
+#ifdef __DEBUG_PRINT__
+  printf         ("vec_splat_u64 ( 0x7FFFFFFF ) \n");
+  print_v2xint64 ("        =", (vui64_t) k);
+#endif
+  e = (vui64_t)CONST_VINT64_DW(0x7FFFFFFF, 0x7FFFFFFF);
   rc += check_v2ui64x ("vec_splat_u64 :", (vui64_t) k, (vui64_t) e);
 
   return (rc);

--- a/src/testsuite/arith128_test_i64.c
+++ b/src/testsuite/arith128_test_i64.c
@@ -1878,8 +1878,13 @@ extern vui64_t test_vec_clzd (vui64_t);
 #endif
 #else
 // test from vec_i64_dummy.c
+#if 1
 extern vui64_t test_vec_clzd_PWR7 (vui64_t);
 #define test_clz_d(_j)	test_vec_clzd_PWR7(_j)
+#else
+extern vui64_t test_clzd_PWR7 (vui64_t);
+#define test_clz_d(_j)	test_clzd_PWR7(_j)
+#endif
 #endif
 
 int
@@ -1998,6 +2003,44 @@ test_clzd (void)
   print_v2int64 ("clz(576460752571858944, 2305843010287435776) ", j);
 #endif
   rc += check_vuint128x ("vec_clzd 12:", (vui128_t) j, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW (0x0800000000000000ULL, 0x2000000000000000ULL);
+  e = (vui64_t) CONST_VINT64_DW (4, 2);
+  j = test_clz_d((vui64_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_v2int64 ("clz(0x0800000000000000ULL, 0x2000000000000000ULL) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzd 13:", (vui128_t) j, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW (0x000004ee2d6d415bULL, 0x85acef8100000000ULL);
+  e = (vui64_t) CONST_VINT64_DW (21, 0);
+  j = test_clz_d((vui64_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_v2int64 ("clz(0x000004ee2d6d415bULL, 0x85acef8100000000ULL) ", j);
+#endif
+
+  rc += check_vuint128x ("vec_clzd 14:", (vui128_t) j, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW (0x4b3b4ca85a86c47aULL, 0x098a224000000000ULL);
+  e = (vui64_t) CONST_VINT64_DW (1, 4);
+  j = test_clz_d((vui64_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_v2int64 ("clz(0x4b3b4ca85a86c47aULL, 0x098a224000000000ULL) ", j);
+#endif
+  rc += check_vuint128x ("vec_clzd 15:", (vui128_t) j, (vui128_t) e);
+
+  i = (vui64_t) CONST_VINT64_DW (0x100000000ULL, 0x1ffffffffULL);
+  e = (vui64_t) CONST_VINT64_DW (31, 31);
+  j = test_clz_d((vui64_t)i);
+
+#ifdef __DEBUG_PRINT__
+  print_v2int64 ("clz(0x100000000ULL, 0x1ffffffffULL) ", j);
+#endif
+
+  rc += check_vuint128x ("vec_clzd 16:", (vui128_t) j, (vui128_t) e);
 
   return (rc);
 }
@@ -12984,6 +13027,277 @@ test_vec_divide_qud (void)
   return (rc);
 }
 
+//#define __DEBUG_PRINT__ 1
+#if 0
+// test directly from vec_char_ppc.h
+#define test_expandm(_l)	vec_expandm_doubleword(_l)
+#else
+// test from vec_char_ppc.h via vec_int32_dummy.c
+extern vui64_t test_vec_expandm_doubleword (vui64_t);
+#define test_expandm(_l)	test_vec_expandm_doubleword(_l)
+#endif
+
+int
+test_expandm_doubleword(void)
+{
+  vui64_t i, j, e;
+    int rc = 0;
+
+    printf ("\n%s\n", __FUNCTION__);
+
+    i = CONST_VINT128_DW (0x00000000c0000000UL,
+			  0x00020000f0000000UL);
+
+    e = CONST_VINT128_DW (0x0000000000000000ULL,
+			  0x0000000000000000ULL);
+    j = test_expandm (i);
+
+#ifdef __DEBUG_PRINT__
+    print_v2xint64 ("vec_expandm of ", i);
+    print_v2xint64 ("             = ", j);
+#endif
+    rc += check_vuint128x ("vec_expandm:", (vui128_t) j, (vui128_t) e);
+
+    i = CONST_VINT128_DW (0x00000000c0000000UL,
+			  0x80020000f0000000UL);
+
+    e = CONST_VINT128_DW (0x0000000000000000ULL,
+			  0xffffffffffffffffULL);
+    j = test_expandm (i);
+
+#ifdef __DEBUG_PRINT__
+    print_v2xint64 ("vec_expandm of ", i);
+    print_v2xint64 ("             = ", j);
+#endif
+    rc += check_vuint128x ("vec_expandm:", (vui128_t) j, (vui128_t) e);
+
+    i = CONST_VINT128_DW (0xf0000000c0000000UL,
+			  0x80020000f0000000UL);
+
+    e = CONST_VINT128_DW (0xffffffffffffffffULL,
+			  0xffffffffffffffffULL);
+    j = test_expandm (i);
+
+#ifdef __DEBUG_PRINT__
+    print_v2xint64 ("vec_expandm of ", i);
+    print_v2xint64 ("             = ", j);
+#endif
+    rc += check_vuint128x ("vec_expandm:", (vui128_t) j, (vui128_t) e);
+
+    i = CONST_VINT128_DW (0xf0000000c0000000UL,
+			  0x70020000f0000000UL);
+
+    e = CONST_VINT128_DW (0xffffffffffffffffULL,
+			  0x0000000000000000ULL);
+    j = test_expandm (i);
+
+#ifdef __DEBUG_PRINT__
+    print_v2xint64 ("vec_expandm of ", i);
+    print_v2xint64 ("             = ", j);
+#endif
+    rc += check_vuint128x ("vec_expandm:", (vui128_t) j, (vui128_t) e);
+
+    return (rc);
+  }
+
+//#define __DEBUG_PRINT__ 1
+#if 0
+// test directly from vec_char_ppc.h
+#define test_signextllb(_l)	vec_signextll_byte(_l)
+#else
+// test from vec_char_ppc.h via vec_char_dummy.c
+extern vi64_t test_vec_signextll_byte (vi8_t);
+#define test_signextllb(_l)	test_vec_signextll_byte(_l)
+#endif
+
+int
+test_signextll_b(void)
+{
+    vi8_t i;
+    vi64_t j, e;
+    int rc = 0;
+
+    printf ("\n%s\n", __FUNCTION__);
+
+    i = (vi8_t)  {0x00, 0x01, 0x02, 0x03, 0x80, 0xc0, 0xe0, 0xf0,
+                  0x08, 0x0c, 0x0e, 0x0f, 0x8f, 0xcf, 0xef, 0xff};
+    e = (vi64_t) {0x0000000000000000, 0x0000000000000008};
+    j = test_signextllb (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x   ("vec_signextll of ", (vui8_t)i);
+    print_v2xint64 ("               = ", (vui64_t)j);
+#endif
+    rc += check_vuint128x ("vec_signextll:", (vui128_t) j, (vui128_t) e);
+
+    i = (vi8_t)  {0x00, 0x01, 0x02, 0x03, 0x08, 0x0c, 0x0e, 0x0f,
+                  0x80, 0xc0, 0xe0, 0xf0, 0x8f, 0xcf, 0xef, 0xff};
+    e = (vi64_t) { 0x0000000000000000, 0xffffffffffffff80};
+    j = test_signextllb (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x   ("vec_signextll of ", (vui8_t)i);
+    print_v2xint64 ("               = ", (vui64_t)j);
+#endif
+    rc += check_vuint128x ("vec_signextll:", (vui128_t) j, (vui128_t) e);
+
+    i = (vi8_t)  {0x8f, 0xcf, 0xef, 0xff, 0x80, 0xc0, 0xe0, 0xf0,
+                  0x08, 0x0c, 0x0e, 0x0f, 0x00, 0x01, 0x02, 0x03};
+    e = (vi64_t) {0xffffffffffffff8f, 0x0000000000000008};
+    j = test_signextllb (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x   ("vec_signextll of ", (vui8_t)i);
+    print_v2xint64 ("               = ", (vui64_t)j);
+#endif
+    rc += check_vuint128x ("vec_signextll:", (vui128_t) j, (vui128_t) e);
+
+    i = (vi8_t)  {0x8f, 0xcf, 0xef, 0xff, 0x08, 0x0c, 0x0e, 0x0f,
+                  0x80, 0xc0, 0xe0, 0xf0, 0x00, 0x01, 0x02, 0x03};
+    e = (vi64_t) {0xffffffffffffff8f, 0xffffffffffffff80};
+    j = test_signextllb (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x   ("vec_signextll of ", (vui8_t)i);
+    print_v2xint64 ("               = ", (vui64_t)j);
+#endif
+    rc += check_vuint128x ("vec_signextll:", (vui128_t) j, (vui128_t) e);
+
+    return (rc);
+  }
+
+//#define __DEBUG_PRINT__ 1
+#if 0
+// test directly from vec_char_ppc.h
+#define test_signextllh(_l)	vec_signextll_halfword(_l)
+#else
+// test from vec_char_ppc.h via vec_char_dummy.c
+extern vi64_t test_vec_signextll_halfword (vi16_t);
+#define test_signextllh(_l)	test_vec_signextll_halfword(_l)
+#endif
+
+int
+test_signextll_h(void)
+{
+    vi16_t i;
+    vi64_t j, e;
+    int rc = 0;
+
+    printf ("\n%s\n", __FUNCTION__);
+
+    i = (vi16_t) {0x0001, 0x0203, 0x80c0, 0xe0f0,
+                  0x080c, 0x0e0f, 0x8fcf, 0xefff};
+    e = (vi64_t) {0x0000000000000001, 0x000000000000080c};
+    j = test_signextllh (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint16x  ("vec_signextll of ", (vui16_t)i);
+    print_v2xint64 ("               = ", (vui64_t)j);
+#endif
+    rc += check_vuint128x ("vec_signextll:", (vui128_t) j, (vui128_t) e);
+
+    i = (vi16_t) {0x0001, 0x0203, 0x080c, 0x0e0f,
+                  0x80c0, 0xe0f0, 0x8fcf, 0xefff};
+    e = (vi64_t) {0x0000000000000001, 0xffffffffffff80c0};
+    j = test_signextllh (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint16x  ("vec_signextll of ", (vui16_t)i);
+    print_v2xint64 ("               = ", (vui64_t)j);
+#endif
+    rc += check_vuint128x ("vec_signextll:", (vui128_t) j, (vui128_t) e);
+
+    i = (vi16_t) {0x8fcf, 0xefff, 0x80c0, 0xe0f0,
+                  0x080c, 0x0e0f, 0x0001, 0x0203};
+    e = (vi64_t) {0xffffffffffff8fcf, 0x000000000000080c};
+    j = test_signextllh (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint16x  ("vec_signextll of ", (vui16_t)i);
+    print_v2xint64 ("               = ", (vui64_t)j);
+#endif
+    rc += check_vuint128x ("vec_signextll:", (vui128_t) j, (vui128_t) e);
+
+    i = (vi16_t) {0x8fcf, 0xefff, 0x080c, 0x0e0f,
+                  0x80c0, 0xe0f0, 0x0001, 0x0203};
+    e = (vi64_t) {0xffffffffffff8fcf, 0xffffffffffff80c0};
+    j = test_signextllh (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint16x  ("vec_signextll of ", (vui16_t)i);
+    print_v2xint64 ("               = ", (vui64_t)j);
+#endif
+    rc += check_vuint128x ("vec_signextll:", (vui128_t) j, (vui128_t) e);
+
+    return (rc);
+  }
+
+//#define __DEBUG_PRINT__ 1
+#if 0
+// test directly from vec_char_ppc.h
+#define test_signextllw(_l)	vec_signextll_word(_l)
+#else
+// test from vec_char_ppc.h via vec_char_dummy.c
+extern vi64_t test_vec_signextll_word (vi32_t);
+#define test_signextllw(_l)	test_vec_signextll_word(_l)
+#endif
+
+int
+test_signextll_w(void)
+{
+    vi32_t i;
+    vi64_t j, e;
+    int rc = 0;
+
+    printf ("\n%s\n", __FUNCTION__);
+
+    i = (vi32_t) {0x00010203, 0x80c0e0f0,
+                  0x080c0e0f, 0x8fcfefff};
+    e = (vi64_t) {0x0000000000010203, 0x00000000080c0e0f};
+    j = test_signextllw (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint32x  ("vec_signextll of ", (vui32_t)i);
+    print_v2xint64 ("               = ", (vui64_t)j);
+#endif
+    rc += check_vuint128x ("vec_signextll:", (vui128_t) j, (vui128_t) e);
+
+    i = (vi32_t) {0x00010203, 0x080c0e0f,
+                  0x80c0e0f0, 0x8fcfefff};
+    e = (vi64_t) {0x0000000000010203, 0xffffffff80c0e0f0};
+    j = test_signextllw (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint32x  ("vec_signextll of ", (vui32_t)i);
+    print_v2xint64 ("               = ", (vui64_t)j);
+#endif
+    rc += check_vuint128x ("vec_signextll:", (vui128_t) j, (vui128_t) e);
+
+    i = (vi32_t) {0x8fcfefff, 0x80c0e0f0,
+                  0x080c0e0f, 0x00010203};
+    e = (vi64_t) {0xffffffff8fcfefff, 0x0000000080c0e0f};
+    j = test_signextllw (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint32x  ("vec_signextll of ", (vui32_t)i);
+    print_v2xint64 ("               = ", (vui64_t)j);
+#endif
+    rc += check_vuint128x ("vec_signextll:", (vui128_t) j, (vui128_t) e);
+
+    i = (vi32_t) {0x8fcfefff, 0x080c0e0f,
+                  0x80c0e0f0, 0x00010203};
+    e = (vi64_t) {0xffffffff8fcfefff, 0xffffffff80c0e0f0};
+    j = test_signextllw (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint32x  ("vec_signextll of ", (vui32_t)i);
+    print_v2xint64 ("               = ", (vui64_t)j);
+#endif
+    rc += check_vuint128x ("vec_signextll:", (vui128_t) j, (vui128_t) e);
+
+    return (rc);
+  }
+
 int
 test_vec_i64 (void)
 {
@@ -12991,6 +13305,10 @@ test_vec_i64 (void)
 
   printf ("\n%s\n", __FUNCTION__);
 
+  rc += test_signextll_b ();
+  rc += test_signextll_h ();
+  rc += test_signextll_w ();
+  rc += test_expandm_doubleword ();
   rc += test_permdi ();
   rc += test_xxspltd ();
   rc += test_mrgahld ();

--- a/src/testsuite/vec_int64_dummy.c
+++ b/src/testsuite/vec_int64_dummy.c
@@ -24,6 +24,220 @@
 #include <pveclib/vec_int128_ppc.h>
 
 vui64_t
+test_vec_expandm_doubleword (vui64_t vra)
+{
+  return vec_expandm_doubleword (vra);
+}
+
+vui64_t
+test_vexpanddm_PWR (vui64_t vra)
+{
+  return vec_vexpanddm_PWR10 (vra);
+}
+
+vi64_t
+test_vec_signextll_byte (vi8_t vra)
+{
+  return vec_signextll_byte (vra);
+}
+
+vi64_t
+test_vec_vextsb2d (vi8_t vra)
+{
+  return vec_vextsb2d (vra);
+}
+
+vi64_t
+test_vec_signextll_halfword (vi16_t vra)
+{
+  return vec_signextll_halfword (vra);
+}
+
+vi64_t
+test_vec_vextsh2d (vi16_t vra)
+{
+  return vec_vextsh2d (vra);
+}
+
+vi64_t
+test_vec_signextll_word (vi32_t vra)
+{
+  return vec_signextll_word (vra);
+}
+
+vi64_t
+test_vec_vextsw2d (vi32_t vra)
+{
+  return vec_vextsw2d (vra);
+}
+
+vi64_t
+test_vextsb2d_v0 (vi8_t vra)
+{
+  vi64_t tmp;
+
+  tmp = (vi64_t) vec_sldi ((vui64_t) vra, 56);
+  return vec_sradi (tmp, 56);
+}
+
+vi64_t
+test_splat6_s64_1 ()
+{
+  return vec_splat6_s64 (1);
+}
+
+vi64_t
+test_splat6_s64_1_V1 ()
+{
+  const vi32_t rword = vec_splat_s32 (1);
+#if defined(_ARCH_PWR8)
+  return (vi64_t) vec_unpackh ((vi32_t)rword);
+#else
+  return (vi64_t) vec_unpackh ((vi16_t)rword);
+#endif
+}
+
+vi64_t
+test_splat6_s64_1_V0 ()
+{
+  const vui32_t rword = vec_splat_u32 (1);
+#if defined(_ARCH_PWR8)
+  return (vi64_t) vec_vupklsw ((vi32_t)rword);
+#else
+  return (vi64_t) vec_vupklsh ((vi16_t)rword);
+#endif
+}
+
+vui64_t
+test_splat6_u64_1_V2 ()
+{
+  const vui32_t rword = vec_splat_u32 (1);
+#if defined(_ARCH_PWR8)
+  return (vui64_t) vec_vupklsw ((vi32_t)rword);
+#else
+  return (vui64_t) vec_vupklsh ((vi16_t)rword);
+#endif
+}
+
+vui64_t
+test_splat6_u64_1_V1 ()
+{
+  const vui32_t rword = vec_splat_u32 (1);
+#if defined(_ARCH_PWR8)
+  return (vui64_t) vec_unpackl ((vi32_t)rword);
+#else
+  return (vui64_t) vec_unpackl ((vi16_t)rword);
+#endif
+}
+
+vui64_t
+test_splat6_u64_1_V0 ()
+{
+  const vui32_t rword = vec_splat_u32 (1);
+#if defined(_ARCH_PWR8)
+  return (vui64_t) vec_vupklsw ((vi32_t)rword);
+#else
+  return (vui64_t) vec_vupklsh ((vi16_t)rword);
+#endif
+}
+
+vi64_t
+test_splat6_s64_15 ()
+{
+  return vec_splat6_s64 (15);
+}
+
+vi64_t
+test_splat6_s64_m16 ()
+{
+  return vec_splat6_s64 (-16);
+}
+
+vi64_t
+test_splat6_s64_m1 ()
+{
+  return vec_splat6_s64 (-1);
+}
+
+vui64_t
+test_splat6_u64_1 ()
+{
+  return vec_splat6_u64 (1);
+}
+
+vui64_t
+test_splat6_u64_15 ()
+{
+  return vec_splat6_u64 (15);
+}
+
+vui64_t
+test_splat6_u64_16 ()
+{
+  return vec_splat6_u64 (16);
+}
+
+vui64_t
+test_splat6_u64_30 ()
+{
+  return vec_splat6_u64 (30);
+}
+
+vui64_t
+test_splat6_u64_31 ()
+{
+  return vec_splat6_u64 (31);
+}
+
+vui64_t
+test_splat6_u64_32 ()
+{
+  return vec_splat6_u64 (32);
+}
+
+vui64_t
+test_splat6_u64_33 ()
+{
+  return vec_splat6_u64 (33);
+}
+
+vui64_t
+test_splat6_u64_34 ()
+{
+  return vec_splat6_u64 (34);
+}
+
+vui64_t
+test_splat6_u64_46 ()
+{
+  return vec_splat6_u64 (46);
+}
+
+vui64_t
+test_splat6_u64_47 ()
+{
+  return vec_splat6_u64 (47);
+}
+
+vui64_t
+test_splat6_u64_48 ()
+{
+  return vec_splat6_u64 (48);
+}
+
+vui64_t
+test_splat6_u64_52 ()
+{
+  return vec_splat6_u64 (52);
+}
+
+vui64_t
+test_splat6_u64_63 ()
+{
+  return vec_splat6_u64 (63);
+}
+
+vui64_t
 test_vec_clzd (vui64_t a)
 {
   return vec_clzd (a);
@@ -37,6 +251,52 @@ test_vec_clzd_PWR7 (vui64_t a)
 
 vui64_t
 test_clzd_PWR7 (vui64_t vra)
+{
+  // generated const (vui32_t) {20, 20, 20, 20}
+  const vui32_t v20 = vec_splat_u32 (20-32);
+  // need a dword vector of 1086 which is the exponent for 2**63
+  // f2_63 = (vector double) 2**63
+  // const vf64_t f2_63 =  (vf64_t) {0x1.0p63D, 0x1.0p63D};
+  // i2_63 = exponent for (vector double) 2**63
+  const vui64_t i2_63 =  (vui64_t) {1086, 1086};
+  // Generate mask = (vui32_t) {0, 0xffffffff, 0, 0xffffffff}
+  const vui32_t zero = vec_splat_u32 (0);
+  const vui32_t ones = vec_splat_u32 (-1);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  // Only for testing only, PWR7 is BE only
+  const vui32_t mask = vec_mergel (ones, zero);
+#else
+  const vui32_t mask = vec_mergeh (zero, ones);
+#endif
+  // Generate const (vui32_t) {64, 64, 64, 64}
+  const vui32_t v4 = vec_splat_u32 (4);
+  const vui32_t v64 = vec_sl (v4, v4);
+  vb32_t zmask;
+  vui32_t k, n;
+  vf64_t kf;
+
+  // Avoid rounding in floating point conversion
+  k = (vui32_t) vra & ~((vui32_t) vra >> 1);
+  kf = vec_double ((vui64_t) k);
+  // right justify exponent for long int
+  // Which is tricky because we dont have DW shift.
+  // clear extraneous data from words 1/3
+  n = vec_andc ((vui32_t) kf, (vui32_t) mask);
+  // Rotate right quadword 32-bits, exponents in words 1/3
+  n = vec_sld (n, n, 12);
+  // Shift exponent into low 11-bits of words 1, 3
+  n = vec_vsrw(n, v20);
+  // clzd == 1086 - exponent
+  n = (vui32_t) i2_63 - (vui32_t) n;
+  // Fix-up: DW[i]==0 case where the exponent is zero and diff is 1086
+  zmask = vec_cmpgt (n, v64);
+  n = vec_sel (n, v64, zmask);
+
+  return ((vui64_t) n);
+}
+
+vui64_t
+test_clzd_PWR7_V2 (vui64_t vra)
 {
   const vui32_t zero = vec_splat_u32 (0);
   // generated const (vui32_t) {20, 20, 20, 20}
@@ -878,45 +1138,114 @@ test_vec_ctzd (vui64_t vra)
 }
 
 vui64_t
-__test_vrld (vui64_t a, vui64_t b)
+__test_vrld_builtin (vui64_t a, vui64_t b)
 {
   return vec_vrld (a, b);
 }
 
 vui64_t
-__test_vsld (vui64_t a, vui64_t b)
+__test_vsld_builtin (vui64_t a, vui64_t b)
 {
   return vec_vsld (a, b);
 }
 
 vui64_t
-__test_vsrd (vui64_t a, vui64_t b)
+__test_vsrd_builtin (vui64_t a, vui64_t b)
 {
   return vec_vsrd (a, b);
 }
 
 vi64_t
-__test_vsrad (vi64_t a, vui64_t b)
+__test_vsrad_builtin (vi64_t a, vui64_t b)
 {
   return vec_vsrad (a, b);
 }
 
 vui64_t
+__test_vrld_V1 (vui64_t a, vui8_t b)
+{
+  return vec_vrld_PWR8 (a, b);
+}
+
+vui64_t
 test_rldi_1 (vui64_t a)
 {
-  return vec_rldi (a, 1);
+  return vec_rldi_PWR8 (a, 1);
 }
 
 vui64_t
 test_rldi_15 (vui64_t a)
 {
-  return vec_rldi (a, 15);
+  return vec_rldi_PWR8 (a, 15);
 }
 
 vui64_t
-test_rldi_32 (vui64_t a)
+test_vec_rldi_31 (vui64_t a)
 {
-  return vec_rldi (a, 32);
+  return vec_rldi_PWR8 (a, 31);
+}
+
+vui64_t
+test_vec_rldi_32 (vui64_t a)
+{
+  return vec_rldi_PWR8 (a, 32);
+}
+
+vui64_t
+test_vec_rldi_33 (vui64_t a)
+{
+  return vec_rldi_PWR8 (a, 33);
+}
+
+vui64_t
+test_vec_rldi_48 (vui64_t a)
+{
+  return vec_rldi_PWR8 (a, 48);
+}
+
+vui64_t
+test_vec_rldi_52 (vui64_t a)
+{
+  return vec_rldi_PWR8 (a, 52);
+}
+
+vui64_t
+test_vec_rldi_63 (vui64_t a)
+{
+  return vec_rldi_PWR8 (a, 63);
+}
+
+vui64_t
+test_rldi_32_V0 (vui64_t a)
+{
+  vui8_t shft = vec_splat6_u8 (32);
+  return vec_vrld_PWR8 (a, shft);
+}
+
+vui64_t
+test_rldi_52_V0 (vui64_t a)
+{
+  vui8_t shft = vec_splat6_u8 (52);
+  return vec_vrld_PWR8 (a, shft);
+}
+
+vui64_t
+test_rldi_63_V0 (vui64_t a)
+{
+  vui8_t shft = vec_splat6_u8 (63);
+  return vec_vrld_PWR8 (a, shft);
+}
+
+vui64_t
+__test_vsld_PWR7 (vui64_t a, vui8_t b)
+{
+  return vec_vsld_PWR7 (a, b);
+}
+
+vui64_t
+__test_vsld_PWR8 (vui64_t a, vui8_t b)
+{
+  return vec_vsld_PWR8 (a, b);
 }
 
 vui64_t
@@ -938,6 +1267,54 @@ test_sldi_16 (vui64_t a)
 }
 
 vui64_t
+test_sldi_24 (vui64_t a)
+{
+  return vec_sldi (a, 24);
+}
+
+vui64_t
+test_sldi_31 (vui64_t a)
+{
+  return vec_sldi (a, 31);
+}
+
+vui64_t
+test_vec_sldi_32 (vui64_t a)
+{
+  return vec_sldi (a, 32);
+}
+
+vui64_t
+test_sldi_33 (vui64_t a)
+{
+  return vec_sldi (a, 33);
+}
+
+vui64_t
+test_sldi_46 (vui64_t a)
+{
+  return vec_sldi (a, 46);
+}
+
+vui64_t
+test_sldi_47 (vui64_t a)
+{
+  return vec_sldi (a, 47);
+}
+
+vui64_t
+test_sldi_48 (vui64_t a)
+{
+  return vec_sldi (a, 48);
+}
+
+vui64_t
+test_vec_sldi_52 (vui64_t a)
+{
+  return vec_sldi (a, 52);
+}
+
+vui64_t
 test_sldi_63 (vui64_t a)
 {
   return vec_sldi (a, 63);
@@ -947,6 +1324,34 @@ vui64_t
 test_sldi_64 (vui64_t a)
 {
   return vec_sldi (a, 64);
+}
+
+vui64_t
+__test_sldi_24_V0 (vui64_t a)
+{
+  vui8_t shft = vec_splat6_u8 (24);
+  return vec_vsld_PWR8 (a, shft);
+}
+
+vui64_t
+__test_sldi_31_V0 (vui64_t a)
+{
+  vui8_t shft = vec_splat6_u8 (31);
+  return vec_vsld_PWR8 (a, shft);
+}
+
+vui64_t
+test_sldi_32_V0 (vui64_t a)
+{
+  vui8_t shft = vec_splat6_u8 (32);
+  return vec_vsld_PWR8(a, shft);
+}
+
+vui64_t
+test_sldi_52_V0 (vui64_t a)
+{
+  vui8_t shft = vec_splat6_u8 (52);
+  return vec_vsld_PWR8 (a, shft);
 }
 
 vui64_t
@@ -974,7 +1379,7 @@ test_srdi_31 (vui64_t a)
 }
 
 vui64_t
-test_srdi_32 (vui64_t a)
+test_vec_srdi_32 (vui64_t a)
 {
   return vec_srdi (a, 32);
 }
@@ -989,6 +1394,26 @@ vui64_t
 test_srdi_64 (vui64_t a)
 {
   return vec_srdi (a, 64);
+}
+
+vui64_t
+__test_vsrd_b (vui64_t a, vui8_t b)
+{
+  return vec_vsrd_PWR8 (a, b);
+}
+
+vui64_t
+test_srdi_32_V0 (vui64_t a)
+{
+  vui8_t shft = vec_splat6_u8 (32);
+  return vec_vsrd_PWR8 (a, shft);
+}
+
+vui64_t
+test_srdi_52_V0 (vui64_t a)
+{
+  vui8_t shft = vec_splat6_u8 (52);
+  return vec_vsrd_PWR8 (a, shft);
 }
 
 vi64_t
@@ -1019,6 +1444,26 @@ vi64_t
 test_sradi_64 (vi64_t a)
 {
   return vec_sradi (a, 64);
+}
+
+vi64_t
+__test_vsrad_b (vi64_t a, vui8_t b)
+{
+  return vec_vsrad_PWR8 (a, b);
+}
+
+vi64_t
+test_sradi_32 (vi64_t a)
+{
+  vui8_t shft = vec_splat6_u8 (32);
+  return vec_vsrad_PWR8 (a, shft);
+}
+
+vi64_t
+test_sradi_52 (vi64_t a)
+{
+  vui8_t shft = vec_splat6_u8 (52);
+  return vec_vsrad_PWR8 (a, shft);
 }
 
 int

--- a/src/testsuite/vec_pwr10_dummy.c
+++ b/src/testsuite/vec_pwr10_dummy.c
@@ -38,6 +38,198 @@
 #include <pveclib/vec_f32_ppc.h>
 #include <pveclib/vec_bcd_ppc.h>
 
+// latency 4-7
+vi64_t
+__test_splatisd_PWR10_V3 (void)
+{
+  const int sim = -128;
+#if defined (_ARCH_PWR10) && (defined (__GNUC__) && (__GNUC__ >= 11))
+  if (__builtin_constant_p (sim) && (-128 <= sim) && (sim < 128))
+    { // Saves a word of code space
+      vi8_t vbyte;
+      vbyte = vec_splats ((signed char)sim);
+      return  vec_signextll_byte (vbyte);
+    }
+  else if (__builtin_constant_p (sim))
+    {
+      vi32_t vword;
+      vi64_t vdw;
+      vword = vec_splati (sim);
+      return  vec_signextll_word (vword);
+    }
+  else
+    return vec_splats ((signed long long) sim);
+#else
+  vui128_t tmp_PWR10 = CONST_VUINT128_QxW (-1, -1, -1, -128);
+  return (vi64_t) tmp_PWR10;
+#endif
+}
+
+// latency 4-7 , throughput 4
+vui64_t
+__test_splatiud_PWR10_V2 (void)
+{
+  const int sim = 125;
+#if defined (_ARCH_PWR10) && (defined (__GNUC__) && (__GNUC__ >= 11))
+  if (__builtin_constant_p (sim) && (sim <= 127))
+    { // Saves a word of code space
+      vi8_t vbyte;
+      vbyte = vec_splats ((signed char)sim);
+      return (vui64_t) vec_signextll_byte (vbyte);
+    }
+  else if (__builtin_constant_p (sim) && (sim <= 2147483647))
+    {
+      vi32_t vw;
+      vi64_t vdw;
+      vw = vec_splati (sim);
+      vdw = vec_signextll_word (vw);
+      return (vui64_t) vdw;
+    }
+  else
+  return vec_splats ((unsigned long long) sim);
+#else
+  return vec_splats ((unsigned long long) sim);
+#endif
+}
+
+// latency 4-7 , throughput 4
+vui64_t
+__test_splatiud_PWR10_V1 (void)
+{
+  const int sim = 1023;
+#if defined (_ARCH_PWR10) && (defined (__GNUC__) && (__GNUC__ >= 11))
+  if (__builtin_constant_p (sim) && (sim <= 2147483647))
+    {
+      vi32_t vw;
+      vi64_t vdw;
+      vw = vec_splati (sim);
+      vdw = vec_signextll_word (vw);
+      return (vui64_t) vdw;
+    }
+  else
+  return vec_splats ((unsigned long long) sim);
+#else
+  return vec_splats ((unsigned long long) sim);
+#endif
+}
+
+// latency 5-10
+vi128_t
+__test_splatisq_PWR10_V3 (void)
+{
+  const int sim = -2147483648;
+#if defined (_ARCH_PWR10) && (defined (__GNUC__) && (__GNUC__ >= 11))
+  if (__builtin_constant_p (sim) && (-128 <= sim) && (sim < 128))
+    { // Saves a word of code space
+      vi8_t vbyte;
+      vi64_t vdw;
+      vbyte = vec_splats ((signed char)sim);
+      vdw   = vec_signextll_byte (vbyte);
+      return vec_signextq_doubleword (vdw);
+    }
+  else if (__builtin_constant_p (sim))
+    {
+      vi32_t vword;
+      vi64_t vdw;
+      vword = vec_splati (sim);
+      vdw   = vec_signextll_word (vword);
+      return vec_signextq_doubleword (vdw);
+    }
+  else
+    return vec_splats ((signed __int128) sim);
+#else
+  vui128_t tmp_PWR10 = CONST_VUINT128_QxW (-1, -1, -1, -128);
+  return (vi128_t) tmp_PWR10;
+#endif
+}
+
+// latency 5-10
+vui128_t
+__test_splatiuq_PWR10_V3 (void)
+{
+  const int sim = 248;
+#if defined (_ARCH_PWR10) && (defined (__GNUC__) && (__GNUC__ >= 11))
+  if (__builtin_constant_p (sim) && (sim < 128))
+    { // Saves a word of code space
+      vi8_t vbyte;
+      vi64_t vdw;
+      vbyte = vec_splats ((signed char)sim);
+      vdw   = vec_signextll_byte (vbyte);
+      return (vui128_t) vec_signextq_doubleword (vdw);
+    }
+  else if (__builtin_constant_p (sim) && (sim <= 2147483647))
+    {
+      vi32_t vword;
+      vi64_t vdw;
+      vword = vec_splati (sim);
+      vdw   = vec_signextll_word (vword);
+      return (vui128_t) vec_signextq_doubleword (vdw);
+    }
+  else
+    return vec_splats ((unsigned __int128) sim);
+#else
+  vui128_t tmp_PWR10 = CONST_VUINT128_QxW (0, 0, 0, 1023);
+  return tmp_PWR10;
+#endif
+}
+
+// latency 6-8
+vui128_t
+__test_splatiuq_PWR10_V2 (void)
+{
+  const int sim = 248;
+#if defined (_ARCH_PWR10) && (defined (__GNUC__) && (__GNUC__ >= 11))
+  if (__builtin_constant_p (sim) && (sim < 256))
+    { // Saves a word of code space
+      const vui8_t q_zero = vec_splat_u8(0);
+      vui8_t vai = vec_splats ((unsigned char)sim);
+      return (vui128_t) vec_sld (q_zero, vai, 1);
+    }
+  else if (__builtin_constant_p (sim) && (sim <= 2147483647))
+    {
+  // For ((sim < 256)) use vec_splats()
+  const vui32_t q_zero = vec_splat_u32(0);
+  vui32_t vai = (vui32_t) vec_splati (sim);
+  return (vui128_t) vec_sldw (q_zero, vai, 1);
+    }
+  else
+    return vec_splats ((unsigned __int128) sim);
+#else
+  vui128_t tmp_PWR10 = CONST_VUINT128_QxW (0, 0, 0, 1023);
+  return tmp_PWR10;
+#endif
+}
+
+// latency 6-8
+vui128_t
+__test_splatiuq_PWR10_V1 (void)
+{
+  const int sim = 1023;
+#if defined (_ARCH_PWR10) && (defined (__GNUC__) && (__GNUC__ >= 11))
+  // For ((sim < 256)) use vec_splats()
+  const vui32_t q_zero = vec_splat_u32(0);
+  vui32_t vai = (vui32_t) vec_splati (sim);
+  //return (vui128_t) vec_sld (q_zero, vai, 4);
+  return (vui128_t) vec_sldw (q_zero, vai, 1);
+#else
+  vui128_t tmp_PWR10 = CONST_VUINT128_QxW (0, 0, 0, 1023);
+  return tmp_PWR10;
+#endif
+}
+
+// latency 4-6
+vui128_t
+__test_splatiuq_PWR10_V0 (void)
+{
+  const int sim = 127;
+#if (__GNUC__ > 6) // AT11 (GCC 7) for splats __int128
+  return vec_splats ((unsigned __int128) sim);
+#else
+  vui128_t tmp_PWR10 = CONST_VUINT128_QxW (0, 0, 0, 127);
+  return tmp_PWR10;
+#endif
+}
+
 #if defined(_ARCH_PWR10) && \
     ((__GNUC__ > 10) || (defined(__clang__) && (__clang_major__ > 12)))
 
@@ -667,43 +859,37 @@ __test_cmsumudm_V2_PWR10 (vui128_t * carry, vui64_t a, vui64_t b, vui128_t c)
 vui128_t
 test_vec_srdbi_PWR10  (vui128_t a, vui128_t b, const unsigned int  sh)
 {
-  return (vec_vsrdbi (a, b, sh));
+  return ((vui128_t) vec_srdbi_PWR10 ((vui8_t) a, (vui8_t) b, sh));
 }
 
 vui128_t
 test_vec_srdbi_PWR10_0  (vui128_t a, vui128_t b)
 {
-  return (vec_vsrdbi (a, b, 0));
+  return ((vui128_t) vec_srdbi_PWR10 ((vui8_t) a, (vui8_t) b, 0));
 }
 
 vui128_t
 test_vec_srdbi_PWR10_7  (vui128_t a, vui128_t b)
 {
-  return (vec_vsrdbi (a, b, 7));
-}
-
-vui128_t
-test_vec_sldbi_PWR10  (vui128_t a, vui128_t b, const unsigned int  sh)
-{
-  return (vec_vsldbi (a, b, sh));
+  return ((vui128_t) vec_srdbi_PWR10 ((vui8_t) a, (vui8_t) b, 7));
 }
 
 vui128_t
 test_vec_sldbi_PWR10_0  (vui128_t a, vui128_t b)
 {
-  return (vec_vsldbi (a, b, 0));
+  return ((vui128_t) vec_sldbi_PWR10 ((vui8_t) a, (vui8_t) b, 0));
 }
 
 vui128_t
 test_vec_sldbi_PWR10_7  (vui128_t a, vui128_t b)
 {
-  return (vec_vsldbi (a, b, 7));
+  return ((vui128_t) vec_sldbi_PWR10 ((vui8_t) a, (vui8_t) b, 7));
 }
 
 vui128_t
 test_vec_sldbi_PWR10_8  (vui128_t a, vui128_t b)
 {
-  return (vec_vsldbi (a, b, 8));
+  return ((vui128_t) vec_sldbi_PWR10 ((vui8_t) a, (vui8_t) b, 8));
 }
 
 vui128_t

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -40,6 +40,216 @@
 #include <pveclib/vec_f32_ppc.h>
 #include <pveclib/vec_bcd_ppc.h>
 
+vi64_t
+__test_splatisd_PWR9_V3 (void)
+{
+  // latency 7, throughput 2
+  const int sim = -128;
+#if defined(_ARCH_PWR9) && (__GNUC__ > 9)
+  if (__builtin_constant_p (sim) && (sim >= -128) && (sim < 127))
+    {
+      vi8_t vbyte;
+      vbyte = vec_splats ((signed char)(sim-256));
+      // right shift in 56 leading 0's
+      return vec_sradi ((vi64_t) vbyte, 56);
+      //return (vui64_t) vec_signextll_byte (vbyte);
+    }
+  else
+  return vec_splats ((signed long long) sim);
+#else
+  // latency 9+, throughput 2
+  return vec_splats ((signed long long) sim);
+#endif
+}
+
+vui64_t
+__test_splatisd_PWR9_V2 (void)
+{
+  // latency 7, throughput 2
+  const int sim = -254;
+#if defined(_ARCH_PWR9) && (__GNUC__ > 9)
+  if (__builtin_constant_p (sim) && (-256 <= sim) && (sim < 256) && (sim % 2 == 0))
+    {
+      vi8_t vbyte;
+      vi64_t vdw;
+      vbyte = vec_splats ((signed char)(sim/2));
+      vdw = vec_signextll_byte (vbyte);
+      return (vui64_t) vec_add (vdw, vdw);
+    }
+  else
+  return vec_splats ((unsigned long long) sim);
+#else
+  // latency 9+, throughput 2
+  return vec_splats ((unsigned long long) sim);
+#endif
+}
+
+vui64_t
+__test_splatisd_PWR9_254_V2 (void)
+{
+  // latency 7, throughput 2
+  const int sim = 254;
+#if defined(_ARCH_PWR9) && (__GNUC__ > 9)
+  if (__builtin_constant_p (sim) && (-256 <= sim) && (sim < 256) && (sim % 2 == 0))
+    {
+      vi8_t vbyte;
+      vi64_t vdw;
+      vbyte = vec_splats ((signed char)(sim/2));
+      vdw = vec_signextll_byte (vbyte);
+      return (vui64_t) vec_add (vdw, vdw);
+    }
+  else
+  return vec_splats ((unsigned long long) sim);
+#else
+  // latency 9+, throughput 2
+  return vec_splats ((unsigned long long) sim);
+#endif
+}
+
+vui64_t
+__test_splatiud_PWR9_V3 (void)
+{
+  // latency 7, throughput 2
+  const int sim = 192;
+#if defined(_ARCH_PWR9) && (__GNUC__ > 9)
+  if (__builtin_constant_p (sim) && (sim < 256))
+    {
+      vi8_t vbyte;
+      if (sim < 128)
+      vbyte = vec_splats ((signed char)(sim));
+      else
+      vbyte = vec_splats ((signed char)(sim-256));
+      // right shift in 56 leading 0's
+      return (vui64_t) vec_srdi_PWR8 ((vui64_t) vbyte, 56);
+      //return (vui64_t) vec_signextll_byte (vbyte);
+    }
+  else
+  return vec_splats ((unsigned long long) sim);
+#else
+  // latency 9+, throughput 2
+  return vec_splats ((unsigned long long) sim);
+#endif
+}
+
+vui64_t
+__test_splatiud_PWR9_V2 (void)
+{
+  // latency 7, throughput 2
+  const int sim = 254;
+#if defined(_ARCH_PWR9) && (__GNUC__ > 9)
+  if (__builtin_constant_p (sim) && (sim < 256) && (sim % 2 == 0))
+    {
+      vi8_t vbyte;
+      vi64_t vdw;
+      vbyte = vec_splats ((signed char)(sim/2));
+      vdw = vec_signextll_byte (vbyte);
+      return (vui64_t) vec_add (vdw, vdw);
+    }
+  else
+  return vec_splats ((unsigned long long) sim);
+#else
+  // latency 9+, throughput 2
+  return vec_splats ((unsigned long long) sim);
+#endif
+}
+
+vui64_t
+__test_splatiud_PWR9_V1 (void)
+{
+  // latency 5, throughput 2
+  const int sim = 127;
+#if defined(_ARCH_PWR9) && (__GNUC__ > 9)
+  if (__builtin_constant_p (sim) && (sim < 128))
+    {
+      vi8_t vbyte;
+      vbyte = vec_splats ((signed char)sim);
+      return (vui64_t) vec_signextll_byte (vbyte);
+    }
+  else
+  return vec_splats ((unsigned long long) sim);
+#else
+  // latency 9+, throughput 2
+  return vec_splats ((unsigned long long) sim);
+#endif
+}
+
+vui64_t
+__test_splatiud_PWR9_255_V1 (void)
+{
+  const int sim = 255;
+#if defined(_ARCH_PWR9) && (__GNUC__ > 9)
+  if (__builtin_constant_p (sim) && (sim < 128))
+    {
+      vi8_t vbyte;
+      vbyte = vec_splats ((signed char)sim);
+      return (vui64_t) vec_signextll_byte (vbyte);
+    }
+  else
+  return vec_splats ((unsigned long long) sim);
+#else
+  return vec_splats ((unsigned long long) sim);
+#endif
+}
+
+vui64_t
+__test_splatiud_PWR9_V0 (void)
+{
+  const int sim = 127;
+#if (__GNUC__ > 6) // AT11 (GCC 7) for splats __int128
+  return vec_splats ((unsigned long long) sim);
+#else
+  vui128_t tmp_PWR9 = CONST_VUINT128_QxW (0, 127, 0, 127);
+  return tmp_PWR9;
+#endif
+}
+
+// latency 13-16
+vui128_t
+__test_splatiuq_PWR9_V2 (void)
+{
+  const int sim = 1023;
+#if defined(_ARCH_PWR9) && (__GNUC__ > 9)
+  // For ((sim < 1024)) use vec_splats(unsigned char)
+  const vui32_t q_zero = vec_splat_u32(0);
+  const vui8_t va = vec_splats ((unsigned char) (sim/4));
+  const vui32_t vb = vec_splat_u32 ((sim%4));
+  vui32_t tmp = vec_sum4s (va, vb);
+  //return (vui128_t) vec_sld (q_zero, tmp, 4);
+  return (vui128_t) vec_sldw (q_zero, tmp, 1);
+#else
+  vui128_t tmp_PWR9 = CONST_VUINT128_QxW (0, 0, 0, 1023);
+  return tmp_PWR9;
+#endif
+}
+
+// latency 6-9
+vui128_t
+__test_splatiuq_PWR9_V1 (void)
+{
+  const int sim = 127;
+#if defined(_ARCH_PWR9) && (__GNUC__ > 9)
+  // For ((sim < 256)) use vec_splats(unsigned char)
+  const vui8_t q_zero = vec_splat_u8(0);
+  vui8_t vbi = vec_splats ((unsigned char) sim);
+  return (vui128_t) vec_sld (q_zero, vbi, 1);
+#else
+  vui128_t tmp_PWR9 = CONST_VUINT128_QxW (0, 0, 0, 127);
+  return tmp_PWR9;
+#endif
+}
+
+vui128_t
+__test_splatiuq_PWR9_V0 (void)
+{
+  const int sim = 127;
+#if (__GNUC__ > 6) // AT11 (GCC 7) for splats __int128
+  return vec_splats ((unsigned __int128) sim);
+#else
+  vui128_t tmp_PWR9 = CONST_VUINT128_QxW (0, 0, 0, 127);
+  return tmp_PWR9;
+#endif
+}
+
 vui8_t
 test_vexpandbm_PWR9 (vui8_t vra)
 {
@@ -258,6 +468,8 @@ test_intrn_cnttz_lsbb_PWR9 (vui8_t vra)
 #if defined(_ARCH_PWR9) && \
     ((__GNUC__ > 9) || (defined(__clang__) && __clang_major__ > 7))
   return vec_cnttz_lsbb (vra);
+#else
+  return 0;
 #endif
 }
 
@@ -268,6 +480,8 @@ test_intrn_cntlz_lsbb_PWR9 (vui8_t vra)
 #if defined(_ARCH_PWR9) && \
     ((__GNUC__ > 9) || (defined(__clang__) && __clang_major__ > 7))
   return vec_cntlz_lsbb (vra);
+#else
+  return 0;
 #endif
 }
 


### PR DESCRIPTION
	* src/pveclib/vec_int64_ppc.h (vec_sradi): Forward declare prototype.
	- (vec_addudm, vec_clzd, vec_ctzd):  Update latency.
	- (vec_expandm_doubleword): New inline operation.
	- (vec_popcntd): Update latency.
	- (vec_setb_sd): Update latency. Use vec_expandm_doubleword for implementation.
	- (vec_rldi): Update latency. Replace implementation with vec_rldi_PWR8 (vra, (shb%64)).
	- (vec_sldi): Update latency. Replace implementation with vec_vsld_PWR8 (vra, vec_splat6_u8 (shb)).
	- (vec_signextll_byte, vec_signextll_halfword, vec_signextll_word): New inline operations.
	- (vec_srdi): Update latency. Replace implementation with vec_vsrd_PWR8 (vra, vec_splat6_u8 (shb).
	- (vec_sradi): Update latency. Replace implementation with vec_vsrad_PWR8 (vra, vec_splat6_u8 (shb)) and vec_vexpanddm_PWR10.
	- (vec_subudm):  Update latency.
	- (vec_vrld): Update latency.
	- (vec_vrld_dep): Deprecated. Replaced with vec_rldi_PWR8 from vec_common_ppc.
	- (vec_vsld): Update latency.
	- (vec_vsld_dep): Deprecated. Replaced with vec_sldi_PWR8 from vec_common_ppc.
	- (vec_vsrad): Update latency.
	- (vec_vsrad_dep): Deprecated. Replaced with vec_sradi_PWR8 from vec_common_ppc.
	- (vec_vsrd): Update latency.
	- (vec_vsrd_dep): Deprecated. Replaced with vec_srdi_PWR8 from vec_common_ppc.
	- (vec_vextsb2d, vec_vextsh2d, vec_vextsw2d): New inline operations.

	* src/testsuite/arith128_test_i64.c (test_clzd): Update unit test.
	- (test_expandm_doubleword, test_signextll_b, test_signextll_h, test_signextll_w): New unit tests.
	- (test_vec_i64): Add new unit tests to driver.

	* src/testsuite/vec_int64_dummy.c (test_vec_expandm_doubleword, test_vexpanddm_PWR, test_vec_signextll_byte, test_vec_vextsb2d, test_vec_signextll_halfword, test_vec_vextsh2d, test_vec_signextll_word, test_vec_vextsw2d, test_vextsb2d_v0): New compile tests. (test_splat6_s64_*): New compile tests. (test_splat6_u64_*): New compile tests. (test_clzd_PWR7, test_clzd_PWR7_V2): New compile tests. (__test_vrld_builtin, __test_vsld_builtin, __test_vsrd_builtin, __test_vsrad_builtin): Renamed to avoid ambiguity. (__test_vrld_V1): Compile test for vec_vrld_PWR8. (test_rldi_*): Use vec_rldi_PWR8 from vec_common_ppc. (__test_vsld_PWR7): Compile test for vec_vsld_PWR7. (__test_vsld_PWR8): Compile test for vec_vsld_PWR8. (test_sldi_*): Additional compile tests. (__test_sldi_24_V0, __test_sldi_31_V0, test_sldi_32_V0, test_sldi_52_V0): Compile tests for vec_common_ppc. (test_vec_srdi_32): Additional compile test. (__test_vsrd_b): Compile tests for vec_vsrd_PWR8. (test_srdi_32_V0, test_srdi_52_V0): Compile tests for vec_common_ppc. (__test_vsrad_b): Compile tests for vec_vsrad_PWR8. (test_sradi_32_V0, test_sradi_52_V0): Compile tests for vec_common_ppc.