### PR TITLE
Add exploit common parts for int/word and P10.

### DIFF
--- a/src/pveclib/vec_int32_ppc.h
+++ b/src/pveclib/vec_int32_ppc.h
@@ -1278,7 +1278,7 @@ vec_setb_sw (vi32_t vra)
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
  *  |power8   | 4 - 6 | 2/cycle  |
- *  |power9   | 4 - 7 | 2/cycle  |
+ *  |power9   |   2   | 2/cycle  |
  *  |power10  | 1 - 3 | 4/cycle  |
  *
  *  @param vra a 128-bit vector treated as a vector signed char.
@@ -1288,7 +1288,7 @@ static inline vi32_t
 vec_signexti_byte (vi8_t vra)
 {
   vi32_t result;
-#if defined (_ARCH_PWR10)  && (__GNUC__ >= 10) \
+#if defined (_ARCH_PWR9)  && (__GNUC__ >= 10) \
   && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
 #if (__GNUC__ >= 11)
       result = vec_signexti (vra);
@@ -1323,7 +1323,7 @@ vec_signexti_byte (vi8_t vra)
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
  *  |power8   | 4 - 6 | 2/cycle  |
- *  |power9   | 4 - 7 | 2/cycle  |
+ *  |power9   |   2   | 2/cycle  |
  *  |power10  | 1 - 3 | 4/cycle  |
  *
  *  @param vra a 128-bit vector treated as a vector signed short.
@@ -1333,7 +1333,7 @@ static inline vi32_t
 vec_signexti_halfword (vi16_t vra)
 {
   vi32_t result;
-#if defined (_ARCH_PWR10)  && (__GNUC__ >= 10) \
+#if defined (_ARCH_PWR9) && (__GNUC__ >= 10) \
     && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
 #if (__GNUC__ >= 11)
       result = vec_signexti (vra);
@@ -1368,7 +1368,7 @@ vec_signexti_halfword (vi16_t vra)
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
  *  |power8   | 4 - 6 | 2/cycle  |
- *  |power9   | 4 - 7 | 2/cycle  |
+ *  |power9   |   2   | 2/cycle  |
  *  |power10  | 1 - 3 | 4/cycle  |
  *
  *  @param vra a 128-bit vector treated as a vector signed char.
@@ -1378,7 +1378,7 @@ static inline vi32_t
 vec_vextsb2w (vi8_t vra)
 {
   vi32_t result;
-#if defined (_ARCH_PWR10)  && (__GNUC__ >= 10)
+#if defined (_ARCH_PWR9)  && (__GNUC__ >= 10)
   __asm__(
       "vextsb2w %0,%1;\n"
       : "=v" (result)
@@ -1404,7 +1404,7 @@ vec_vextsb2w (vi8_t vra)
  *  |processor|Latency|Throughput|
  *  |--------:|:-----:|:---------|
  *  |power8   | 4 - 6 | 2/cycle  |
- *  |power9   | 4 - 7 | 2/cycle  |
+ *  |power9   |   2   | 2/cycle  |
  *  |power10  | 1 - 3 | 4/cycle  |
  *
  *  @param vra a 128-bit vector treated as a vector signed char.
@@ -1414,7 +1414,7 @@ static inline vi32_t
 vec_vextsh2w (vi16_t vra)
 {
   vi32_t result;
-#if defined (_ARCH_PWR10)  && (__GNUC__ >= 10)
+#if defined (_ARCH_PWR9)  && (__GNUC__ >= 10)
   __asm__(
       "vextsh2w %0,%1;\n"
       : "=v" (result)

--- a/src/testsuite/arith128_test_i32.c
+++ b/src/testsuite/arith128_test_i32.c
@@ -217,6 +217,146 @@ test_popcntw (void)
 
 //#define __DEBUG_PRINT__ 1
 #if 0
+// test directly from vec_char_ppc.h
+#define test_expandm(_l)	vec_expandm_word(_l)
+#else
+// test from vec_char_ppc.h via vec_int32_dummy.c
+extern vui32_t test_vec_expandm_word (vui32_t);
+#define test_expandm(_l)	test_vec_expandm_word(_l)
+#endif
+
+int
+test_expandm_word(void)
+{
+    vui32_t i, j, e;
+    int rc = 0;
+
+    printf ("\n%s\n", __FUNCTION__);
+
+    i = CONST_VINT128_W (0x00000000, 0xc0000000,
+			 0x00020000, 0xf0000000);
+
+    e = CONST_VINT128_W (0x00000000, 0xffffffff,
+			 0x00000000, 0xffffffff);
+    j = test_expandm (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint32x ("vec_expandm of ", i);
+    print_vint32x ("             = ", j);
+#endif
+    rc += check_vuint128x ("vec_expandm:", (vui128_t) j, (vui128_t) e);
+
+    i = CONST_VINT128_W (0x80000000, 0x00010000,
+			 0xe0000000, 0x00040000);
+
+    e = CONST_VINT128_W (0xffffffff, 0x00000000,
+			 0xffffffff, 0x00000000);
+    j = test_expandm (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint32x ("vec_expandm of ", i);
+    print_vint32x ("             = ", j);
+#endif
+    rc += check_vuint128x ("vec_expandm:", (vui128_t) j, (vui128_t) e);
+
+    i = CONST_VINT128_W (0x0fff0000, 0xc0020000,
+			 0x3fff0000, 0xf00f0000);
+
+    e = CONST_VINT128_W (0x00000000, 0xffffffff,
+			 0x00000000, 0xffffffff);
+    j = test_expandm (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint32x ("vec_expandm of ", i);
+    print_vint32x ("             = ", j);
+#endif
+    rc += check_vuint128x ("vec_expandm:", (vui128_t) j, (vui128_t) e);
+
+    i = CONST_VINT128_W (0x8001ffff, 0x1fffffff,
+			 0xe007ffff, 0x7fffffff);
+
+    e = CONST_VINT128_W (0xffffffff, 0x00000000,
+			 0xffffffff, 0x00000000);
+    j = test_expandm (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint32x ("vec_expandm of ", i);
+    print_vint32x ("             = ", j);
+#endif
+    rc += check_vuint128x ("vec_expandm:", (vui128_t) j, (vui128_t) e);
+
+    return (rc);
+  }
+#undef __DEBUG_PRINT__
+
+//#define __DEBUG_PRINT__ 1
+#if 0
+// test directly from vec_char_ppc.h
+#define test_signextib(_l)	vec_signexti_byte(_l)
+#else
+// test from vec_char_ppc.h via vec_char_dummy.c
+extern vi32_t test_vec_signexti_byte (vi8_t);
+#define test_signextib(_l)	test_vec_signexti_byte(_l)
+#endif
+
+int
+test_signexti_b(void)
+{
+    vi8_t i;
+    vi32_t j, e;
+    int rc = 0;
+
+    printf ("\n%s\n", __FUNCTION__);
+
+    i = (vi8_t)  {0x00, 0x01, 0x02, 0x03, 0x80, 0xc0, 0xe0, 0xf0,
+	           0x10, 0x20, 0x30, 0x30, 0x8f, 0xcf, 0xef, 0xff};
+    e = (vi32_t) {0x00000000, 0xffffff80, 0x00000010, 0xffffff8f};
+    j = test_signextib (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x  ("vec_signexti of ", (vui8_t) i);
+    print_vint32x ("              = ", (vui32_t) j);
+#endif
+    rc += check_vuint128x ("vec_signexti:", (vui128_t) j, (vui128_t) e);
+
+    return (rc);
+  }
+
+//#define __DEBUG_PRINT__ 1
+#if 0
+// test directly from vec_char_ppc.h
+#define test_signextih(_l)	vec_signexti_halfword(_l)
+#else
+// test from vec_char_ppc.h via vec_char_dummy.c
+extern vi32_t test_vec_signexti_halfword (vi16_t);
+#define test_signextih(_l)	test_vec_signexti_halfword(_l)
+#endif
+
+int
+test_signexti_h(void)
+{
+    vi16_t i;
+    vi32_t j, e;
+    int rc = 0;
+
+    printf ("\n%s\n", __FUNCTION__);
+
+    i = (vi16_t)  {0x0000, 0x0003, 0x8000, 0xf000,
+	           0x1000, 0x3000, 0x8fff, 0xffff};
+    e = (vi32_t) {0x00000000, 0xffff8000, 0x00001000, 0xffff8fff};
+    j = test_signextih (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x  ("vec_signexti of ", (vui8_t) i);
+    print_vint32x ("              = ", (vui32_t) j);
+#endif
+    rc += check_vuint128x ("vec_signexti:", (vui128_t) j, (vui128_t) e);
+
+    return (rc);
+  }
+
+//#define __DEBUG_PRINT__ 1
+#if 1
 #if 0
 // test directly from vec_int32_ppc.h
 #define test_clz_w(_l)	vec_clzw(_l)
@@ -227,8 +367,8 @@ extern vui32_t test_vec_clzw (vui32_t);
 #endif
 #else
 // test from vec_int32_dummy.c
-extern vui32_t test_clzw_PWR7 (vui32_t);
-#define test_clz_w(_j)	test_clzw_PWR7(_j)
+extern vui32_t test_vec_clzw_PWR7 (vui32_t);
+#define test_clz_w(_j)	test_vec_clzw_PWR7(_j)
 #endif
 int
 test_clz_word (void)
@@ -243,7 +383,7 @@ test_clz_word (void)
   j = test_clz_w(i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(0) ", j);
+  print_vint32x ("clz(0) ", j);
 #endif
   rc += check_vuint128x ("vec_clzw:", (vui128_t)j, (vui128_t) e);
 
@@ -252,7 +392,7 @@ test_clz_word (void)
   j = test_clz_w(i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(-1, 0, -1, 0) ", j);
+  print_vint32x ("clz(-1, 0, -1, 0) ", j);
 #endif
   rc += check_vuint128x ("vec_clzw:", (vui128_t)j, (vui128_t) e);
 
@@ -261,7 +401,7 @@ test_clz_word (void)
   j = test_clz_w(i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(0, 1, 2, 4) ", j);
+  print_vint32x ("clz(0, 1, 2, 4) ", j);
 #endif
   rc += check_vuint128x ("vec_clzw:", (vui128_t)j, (vui128_t) e);
 
@@ -270,7 +410,7 @@ test_clz_word (void)
   j = test_clz_w(i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(8, 16, 32, 64) ", j);
+  print_vint32x ("clz(8, 16, 32, 64) ", j);
 #endif
   rc += check_vuint128x ("vec_clzw:", (vui128_t)j, (vui128_t) e);
 
@@ -279,7 +419,7 @@ test_clz_word (void)
   j = test_clz_w(i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(128, 256, 512, 1024) ", j);
+  print_vint32x ("clz(128, 256, 512, 1024) ", j);
 #endif
   rc += check_vuint128x ("vec_clzw:", (vui128_t)j, (vui128_t) e);
 
@@ -288,7 +428,7 @@ test_clz_word (void)
   j = test_clz_w(i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(2048, 4096, 8192, 16384) ", j);
+  print_vint32x ("clz(2048, 4096, 8192, 16384) ", j);
 #endif
   rc += check_vuint128x ("vec_clzw:", (vui128_t)j, (vui128_t) e);
 
@@ -297,7 +437,7 @@ test_clz_word (void)
   j = test_clz_w(i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(32768, 65536, 131072, 262144) ", j);
+  print_vint32x ("clz(32768, 65536, 131072, 262144) ", j);
 #endif
   rc += check_vuint128x ("vec_clzw:", (vui128_t)j, (vui128_t) e);
 
@@ -306,7 +446,7 @@ test_clz_word (void)
   j = test_clz_w(i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(524288, 1048576, 2097152, 4194304) ", j);
+  print_vint32x ("clz(524288, 1048576, 2097152, 4194304) ", j);
 #endif
   rc += check_vuint128x ("vec_clzw:", (vui128_t)j, (vui128_t) e);
 
@@ -315,7 +455,7 @@ test_clz_word (void)
   j = test_clz_w(i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(8388608, 16777216, 33554432, 67108864) ", j);
+  print_vint32x ("clz(8388608, 16777216, 33554432, 67108864) ", j);
 #endif
   rc += check_vuint128x ("vec_clzw:", (vui128_t)j, (vui128_t) e);
 
@@ -324,7 +464,7 @@ test_clz_word (void)
   j = test_clz_w(i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(134217728, 268435456, 536870912, 1073741824) ", j);
+  print_vint32x ("clz(134217728, 268435456, 536870912, 1073741824) ", j);
 #endif
   rc += check_vuint128x ("vec_clzw:", (vui128_t)j, (vui128_t) e);
 
@@ -333,7 +473,7 @@ test_clz_word (void)
   j = test_clz_w(i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(-2147483648, -268435456, -16777216, -1048576) ", j);
+  print_vint32x ("clz(-2147483648, -268435456, -16777216, -1048576) ", j);
 #endif
   rc += check_vuint128x ("vec_clzw:", (vui128_t)j, (vui128_t) e);
 
@@ -342,7 +482,7 @@ test_clz_word (void)
   j = test_clz_w(i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(4294967295, 2147483647, 1073741823, 536870911) ", j);
+  print_vint32x ("clz(4294967295, 2147483647, 1073741823, 536870911) ", j);
 #endif
   rc += check_vuint128x ("vec_clzw:", (vui128_t)j, (vui128_t) e);
 
@@ -362,7 +502,7 @@ test_ctz_word (void)
   j = vec_ctzw(i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(0) ", j);
+  print_vint32d ("clz(0) ", j);
 #endif
   rc += check_vuint128x ("vec_ctzw:", (vui128_t)j, (vui128_t) e);
 
@@ -371,7 +511,7 @@ test_ctz_word (void)
   j = vec_ctzw(i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(-1, 0, -1, 0) ", j);
+  print_vint32d ("clz(-1, 0, -1, 0) ", j);
 #endif
   rc += check_vuint128x ("vec_ctzw:", (vui128_t)j, (vui128_t) e);
 
@@ -380,7 +520,7 @@ test_ctz_word (void)
   j = vec_ctzw(i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(0, 1, 2, 4) ", j);
+  print_vint32d ("clz(0, 1, 2, 4) ", j);
 #endif
   rc += check_vuint128x ("vec_ctzw:", (vui128_t)j, (vui128_t) e);
 
@@ -389,7 +529,7 @@ test_ctz_word (void)
   j = vec_ctzw(i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(8, 16, 32, 64) ", j);
+  print_vint32d ("clz(8, 16, 32, 64) ", j);
 #endif
   rc += check_vuint128x ("vec_ctzw:", (vui128_t)j, (vui128_t) e);
 
@@ -398,7 +538,7 @@ test_ctz_word (void)
   j = vec_ctzw(i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(128, 256, 512, 1024) ", j);
+  print_vint32d ("clz(128, 256, 512, 1024) ", j);
 #endif
   rc += check_vuint128x ("vec_ctzw:", (vui128_t)j, (vui128_t) e);
 
@@ -407,7 +547,7 @@ test_ctz_word (void)
   j = vec_ctzw(i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(2048, 4096, 8192, 16384) ", j);
+  print_vint32d ("clz(2048, 4096, 8192, 16384) ", j);
 #endif
   rc += check_vuint128x ("vec_ctzw:", (vui128_t)j, (vui128_t) e);
 
@@ -416,7 +556,7 @@ test_ctz_word (void)
   j = vec_ctzw(i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(32768, 65536, 131072, 262144) ", j);
+  print_vint32d ("clz(32768, 65536, 131072, 262144) ", j);
 #endif
   rc += check_vuint128x ("vec_ctzw:", (vui128_t)j, (vui128_t) e);
 
@@ -425,7 +565,7 @@ test_ctz_word (void)
   j = vec_ctzw(i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(524288, 1048576, 2097152, 4194304) ", j);
+  print_vint32d ("clz(524288, 1048576, 2097152, 4194304) ", j);
 #endif
   rc += check_vuint128x ("vec_ctzw:", (vui128_t)j, (vui128_t) e);
 
@@ -434,7 +574,7 @@ test_ctz_word (void)
   j = vec_ctzw(i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(8388608, 16777216, 33554432, 67108864) ", j);
+  print_vint32d ("clz(8388608, 16777216, 33554432, 67108864) ", j);
 #endif
   rc += check_vuint128x ("vec_ctzw:", (vui128_t)j, (vui128_t) e);
 
@@ -443,7 +583,7 @@ test_ctz_word (void)
   j = vec_ctzw(i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(134217728, 268435456, 536870912, 1073741824) ", j);
+  print_vint32d ("clz(134217728, 268435456, 536870912, 1073741824) ", j);
 #endif
   rc += check_vuint128x ("vec_ctzw:", (vui128_t)j, (vui128_t) e);
 
@@ -452,13 +592,14 @@ test_ctz_word (void)
   j = vec_ctzw(i);
 
 #ifdef __DEBUG_PRINT__
-  print_vint128 ("clz(-2147483648, -268435456, -16777216, -1048576) ", j);
+  print_vint32d ("clz(-2147483648, -268435456, -16777216, -1048576) ", j);
 #endif
   rc += check_vuint128x ("vec_ctzw:", (vui128_t)j, (vui128_t) e);
 
   return (rc);
 }
 
+#undef __DEBUG_PRINT__
 int
 test_sumsw (void)
 {
@@ -1784,7 +1925,10 @@ test_vec_i32 (void)
   printf ("\n%s\n", __FUNCTION__);
 
   rc += test_revbw ();
-  rc += test_ctz_word ();
+  rc += test_expandm_word ();
+  rc += test_signexti_b ();
+  rc += test_signexti_h ();
+  rc += test_clz_word ();
   rc += test_ctz_word ();
   rc += test_popcntw();
   rc += test_sumsw ();

--- a/src/testsuite/vec_int32_dummy.c
+++ b/src/testsuite/vec_int32_dummy.c
@@ -22,6 +22,386 @@
 
 #include <pveclib/vec_int128_ppc.h>
 
+vi32_t
+test_vec_vextsh2w (vi16_t vra)
+{
+  return vec_vextsh2w (vra);
+}
+
+vi32_t
+test_vec_signexti_halfword (vi16_t vra)
+{
+  return vec_signexti_halfword (vra);
+}
+
+vi32_t
+test_vec_vextsb2w (vi8_t vra)
+{
+  return vec_vextsb2w (vra);
+}
+
+vi32_t
+test_vec_signexti_byte (vi8_t vra)
+{
+  return vec_signexti_byte (vra);
+}
+
+vui32_t
+test_vec_expandm_word (vui32_t vra)
+{
+  return vec_expandm_word (vra);
+}
+
+vui32_t
+test_vexpandwm_PWR (vui32_t vra)
+{
+  return vec_vexpandwm_PWR10 (vra);
+}
+
+vui32_t
+test_splat7_u32_1 ()
+{
+  return vec_splat7_u32 (1);
+}
+
+vui32_t
+test_splat7_u32_15 ()
+{
+  return vec_splat7_u32 (15);
+}
+
+vui32_t
+test_splat7_u32_16 ()
+{
+  return vec_splat7_u32 (16);
+}
+
+vui32_t
+test_splat7_u32_17 ()
+{
+  return vec_splat7_u32 (17);
+}
+
+vui32_t
+test_splat7_u32_30 ()
+{
+  return vec_splat7_u32 (30);
+}
+
+vui32_t
+test_splat7_u32_31 ()
+{
+  return vec_splat7_u32 (31);
+}
+
+vui32_t
+test_splat7_u32_32 ()
+{
+  return vec_splat7_u32 (32);
+}
+
+vui32_t
+test_splat7_u32_33 ()
+{
+  return vec_splat7_u32 (33);
+}
+
+vui32_t
+test_splat7_u32_40 ()
+{
+  return vec_splat7_u32 (40);
+}
+
+vui32_t
+test_splat7_u32_47 ()
+{
+  return vec_splat7_u32 (47);
+}
+
+vui32_t
+test_splat7_u32_48 ()
+{
+  return vec_splat7_u32 (48);
+}
+
+vui32_t
+test_splat7_u32_49 ()
+{
+  return vec_splat7_u32 (49);
+}
+
+vui32_t
+test_splat7_u32_56 ()
+{
+  return vec_splat7_u32 (56);
+}
+
+vui32_t
+test_splat7_u32_63 ()
+{
+  return vec_splat7_u32 (63);
+}
+
+vui32_t
+test_splat7_u32_64 ()
+{
+  return vec_splat7_u32 (64);
+}
+
+vui32_t
+test_splat7_u32_65 ()
+{
+  return vec_splat7_u32 (65);
+}
+
+vui32_t
+test_splat7_u32_72 ()
+{
+  return vec_splat7_u32 (72);
+}
+
+vui32_t
+test_splat7_u32_79 ()
+{
+  return vec_splat7_u32 (79);
+}
+
+vui32_t
+test_splat7_u32_80 ()
+{
+  return vec_splat7_u32 (80);
+}
+
+vui32_t
+test_splat7_u32_81 ()
+{
+  return vec_splat7_u32 (81);
+}
+
+vui32_t
+test_splat7_u32_88 ()
+{
+  return vec_splat7_u32 (88);
+}
+
+vui32_t
+test_splat7_u32_95 ()
+{
+  return vec_splat7_u32 (95);
+}
+
+vui32_t
+test_splat7_u32_96 ()
+{
+  return vec_splat7_u32 (96);
+}
+
+vui32_t
+test_splat7_u32_97 ()
+{
+  return vec_splat7_u32 (97);
+}
+
+vui32_t
+test_splat7_u32_104 ()
+{
+  return vec_splat7_u32 (104);
+}
+
+vui32_t
+test_splat7_u32_111 ()
+{
+  return vec_splat7_u32 (111);
+}
+
+vui32_t
+test_splat7_u32_112 ()
+{
+  return vec_splat7_u32 (112);
+}
+
+vui32_t
+test_splat7_u32_127 ()
+{
+  return vec_splat7_u32 (127);
+}
+
+// Power8 implementation of vec_sigexti()
+vi32_t
+test_vextsb2w_V1 (vi8_t vra)
+{
+  const vui32_t v24 = vec_splat_u32 (24-32);
+  vi32_t tmp;
+
+  tmp = vec_sl ((vi32_t) vra, v24);
+  return vec_sra (tmp, v24);
+}
+
+vi32_t
+test_vextsb2w_v0 (vi8_t vra)
+{
+  vi32_t tmp;
+
+  tmp = (vi32_t) vec_slwi ((vui32_t) vra, 24);
+  return vec_srawi (tmp, 24);
+}
+
+vi32_t
+test_vextsh2w (vi16_t vra)
+{
+  vi32_t tmp;
+
+  tmp = (vi32_t) vec_slwi ((vui32_t) vra, 16);
+  return vec_srawi (tmp, 16);
+}
+
+vi32_t
+test_splat6_s32_1 ()
+{
+  return vec_splat6_s32 (1);
+}
+
+vi32_t
+test_splat6_s32_16 ()
+{
+  return vec_splat6_s32 (16);
+}
+
+vi32_t
+test_splat6_s32_30 ()
+{
+  return vec_splat6_s32 (30);
+}
+
+vi32_t
+test_splat6_s32_31 ()
+{
+  return vec_splat6_s32 (31);
+}
+
+vi32_t
+test_splat6_s32_m16 ()
+{
+  return vec_splat6_s32 (-16);
+}
+
+vi32_t
+test_splat6_s32_m31 ()
+{
+  return vec_splat6_s32 (-31);
+}
+
+vi32_t
+test_splat6_s32_m32 ()
+{
+  return vec_splat6_s32 (-32);
+}
+
+vui32_t
+test_splat6_u32_1 ()
+{
+  return vec_splat6_u32 (1);
+}
+
+vui32_t
+test_splat6_u32_15 ()
+{
+  return vec_splat6_u32 (15);
+}
+
+vui32_t
+test_splat6_u32_16 ()
+{
+  return vec_splat6_u32 (16);
+}
+
+vui32_t
+test_splat6_u32_32 ()
+{
+  return vec_splat6_u32 (32);
+}
+
+vui32_t
+test_splat6_u32_33 ()
+{
+  return vec_splat6_u32 (33);
+}
+
+vui32_t
+test_splat6_u32_46 ()
+{
+  return vec_splat6_u32 (46);
+}
+
+vui32_t
+test_splat6_u32_47 ()
+{
+  return vec_splat6_u32 (47);
+}
+
+vui32_t
+test_splat6_u32_48 ()
+{
+  return vec_splat6_u32 (48);
+}
+
+vui32_t
+test_splat6_u32_52 ()
+{
+  return vec_splat6_u32 (52);
+}
+
+vui32_t
+test_splat6_u32_63 ()
+{
+  return vec_splat6_u32 (63);
+}
+
+vi32_t
+test_vec_splati_V0_255 ()
+{
+#if defined (_ARCH_PWR10) && (defined (__GNUC__) && (__GNUC__ >= 11))
+  return vec_splati (255);
+#elif defined (__GNUC__) && (__GNUC__ >= 9)
+  return vec_splats ((int) 255);
+#else
+  return (vi32_t) {255};
+#endif
+}
+
+vi32_t
+test_vec_splati_V0_32 ()
+{
+#if defined (_ARCH_PWR10) && (defined (__GNUC__) && (__GNUC__ >= 11))
+  return vec_splati (32);
+#else //if defined (__GNUC__) && (__GNUC__ >= 9)
+  return vec_splats ((int) 32);
+#endif
+}
+
+vi32_t
+test_vec_splati_V0_15 ()
+{
+#if defined (_ARCH_PWR10) && (defined (__GNUC__) && (__GNUC__ >= 11))
+  return vec_splati (15);
+#else //if defined (__GNUC__) && (__GNUC__ >= 9)
+  return vec_splat_s32 (15);
+#endif
+}
+
+vi32_t
+test_vec_splati_V0_23 ()
+{
+#if defined (_ARCH_PWR10) && (defined (__GNUC__) && (__GNUC__ >= 11))
+  return vec_splati (23);
+#elif defined (_ARCH_PWR9) && (defined (__GNUC__) && (__GNUC__ >= 11))
+  vi8_t tmp = vec_splats ((signed char) 23);
+  return vec_signexti (tmp);
+#else
+  return vec_splats ((int) 23);
+#endif
+}
+
 vui32_t
 test_vec_popcntw (vui32_t vra)
 {
@@ -671,6 +1051,45 @@ test_mrgew (vui32_t a, vui32_t b)
 }
 
 vui32_t
+test_vec_mrgew_V0 (vui32_t vra, vui32_t vrb)
+{
+  vui32_t res;
+#ifdef _ARCH_PWR8
+#ifdef vec_vmrgew
+  res = vec_vmrgew (vra, vrb);
+#else
+  __asm__(
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+      "vmrgow %0,%2,%1;\n"
+#else
+      "vmrgew %0,%1,%2;\n"
+#endif
+      : "=v" (res)
+      : "v" (vra),
+      "v" (vrb)
+      : );
+#endif
+#elif defined (_ARCH_PWR7)
+  vui64_t tmph, tmpl;
+
+  // even words are in the high DW, Odd in the low DW
+  tmph = (vui64_t) vec_mergeh (vra, vrb);
+  tmpl = (vui64_t) vec_mergel (vra, vrb);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  // return the odd words with xxpermdi
+  res  = (vui32_t) vec_mergel (tmph, tmpl);
+#else
+  res  = (vui32_t) vec_mergeh (tmph, tmpl);
+#endif
+#else // _ARCH_PWR6/970
+  const vui32_t vconstp =
+      CONST_VINT32_W(0x00010203, 0x10111213, 0x08090a0b, 0x18191a1b);
+  res = (vui32_t) vec_perm ((vui8_t) vra, (vui8_t) vrb, (vui8_t) vconstp);
+#endif
+  return (res);
+}
+
+vui32_t
 test_mrgow (vui32_t a, vui32_t b)
 {
   return vec_mrgow (a, b);
@@ -728,6 +1147,24 @@ vui32_t
 __test_muluwm (vui32_t a, vui32_t b)
 {
   return vec_muluwm (a, b);
+}
+
+vui32_t
+test_rlwi_1 (vui32_t a)
+{
+  return vec_rlwi (a, 1);
+}
+
+vui32_t
+test_rlwi_16 (vui32_t a)
+{
+  return vec_rlwi (a, 16);
+}
+
+vui32_t
+test_rlwi_24 (vui32_t a)
+{
+  return vec_rlwi (a, 24);
 }
 
 vui32_t


### PR DESCRIPTION
	* src/pveclib/vec_int32_ppc.h (vec_slwi, vec_vrlw_byte, vec_vslw_byte, vec_vsraw_byte, vec_vsrw_byte): Forward declare prototype.
	- (vec_clzw, vec_ctzw): Update latency.
	- (vec_expandm_word): New inline operation.
	- (vec_mrgew[_ARCH_PWR7]): Add P7 specific implementation and associated latency.
	- (vec_mrgow[_ARCH_PWR7]): Add P7 specific implementation and associated latency.
	- (vec_popcntw): Update latency.
	- (vec_setb_sw): Update latency. Use vec_expandm_word() for implementation.
	- (vec_signexti_byte, vec_signexti_halfword): New inline operations.
	- (vec_vextsb2w, vec_vextsh2w): New inline operations.
	- (vec_rlwi): New inline operation.
	- (vec_slwi): Update latency. Replace implementation with vec_vslw_byte (vra, vec_splat5_u8 (shb)).
	- (vec_srawi): Update latency. Replace implementation with vec_vsraw_byte (vra, vec_splat5_u8 (shb)).
	- (vec_srwi): Update latency. Replace implementation with vec_vsrw_byte (vra, vec_splat5_u8 (shb)).
	- (vec_vrlw_byte, vec_vslw_byte, vec_vsrw_byte, vec_vsraw_byte): New inline shift/rotate operations that accepts byte shift-count.

	* src/testsuite/arith128_test_i32.c
	- (test_expandm_word, test_signexti_b, test_signexti_h): New unit test.
	- (test_clz_word): Link to test_vec_clzw_PWR7 for unit test.
	- (test_clz_word[__DEBUG_PRINT__]): Use print_vint32x().
	- (test_vec_i32): Replace dup test_ctz_word with test_clz_word. Add test_expandm_word, test_signexti_b. test_signexti_h to test driver.

	* src/testsuite/vec_int32_dummy.c (test_vec_vextsh2w, test_vec_signexti_halfword, test_vec_vextsb2w, test_vec_signexti_byte, test_vec_expandm_word, test_vexpandwm_PWR): New compile tests.
	- (test_splat7_u32_*): New compile tests.
	- (test_vextsb2w_V1, test_vextsb2w_v0, test_vextsh2w): New compile tests.
	- (test_splat6_s32_*): New compile tests.
	- (test_splat6_u32_*): New compile tests.
	- (test_vec_splati_V0_255, test_vec_splati_V0_32, test_vec_splati_V0_15, test_vec_splati_V0_23): New compile tests.
	- (test_vec_mrgew_V0):New compile test.
	- (test_rlwi_1, test_rlwi_16, test_rlwi_24): New compile tests.