### PR TITLE
Add exploit common parts for __int128 and P10.

### DIFF
--- a/src/pveclib/vec_int128_ppc.h
+++ b/src/pveclib/vec_int128_ppc.h
@@ -9263,6 +9263,13 @@ vec_splat_u128 (const int sim)
       vui32_t vwi = vec_splat6_u32 (sim);
       result = (vui128_t) vec_sld (q_zero, vwi, 4);
     }
+  else if (sim == 31)
+    {
+      const vui32_t q_zero = vec_splat_u32(0);
+      const vui32_t q_ones = vec_splat_u32(-1);
+      vui32_t tmp = vec_srwi (q_ones, (32-5));
+      result = (vui128_t) vec_sld (q_zero, tmp, 4);
+    }
 #ifdef _ARCH_PWR8
   else if (sim == 32)
     {
@@ -9271,6 +9278,13 @@ vec_splat_u128 (const int sim)
       result = (vui128_t) vec_sld (q_zero, v32, 4);
     }
 #endif
+  else if (sim == 63)
+    {
+      const vui32_t q_zero = vec_splat_u32(0);
+      const vui32_t q_ones = vec_splat_u32(-1);
+      vui32_t tmp = vec_srwi (q_ones, (32-6));
+      result = (vui128_t) vec_sld (q_zero, tmp, 4);
+    }
   else if (__builtin_constant_p (sim) && ((sim >= 16) && (sim < 64)))
     {
 #ifdef _ARCH_PWR8
@@ -9314,6 +9328,13 @@ vec_splat_u128 (const int sim)
       result = (vui128_t) vec_sld (q_zero, tmp, 4);
 #endif
     }
+  else if (sim == 127)
+    {
+      const vui32_t q_zero = vec_splat_u32(0);
+      const vui32_t q_ones = vec_splat_u32(-1);
+      vui32_t tmp = vec_srwi (q_ones, (32-7));
+      result = (vui128_t) vec_sld (q_zero, tmp, 4);
+    }
   else if (__builtin_constant_p (sim) && ((sim > 64) && (sim < 128)))
     {
       const vui32_t q_zero = vec_splat_u32(0);
@@ -9344,6 +9365,12 @@ vec_splat_u128 (const int sim)
       // Extend left with 120-bits of 0
       const vui32_t q_zero = {0, 0, 0, 0};
       result = (vui128_t) vec_sld ((vui8_t) q_zero, vbi, 1);
+    }
+  else if (sim == 255)
+    {
+      const vui32_t q_zero = vec_splat_u32(0);
+      const vui32_t q_ones = vec_splat_u32(-1);
+      result = (vui128_t) vec_sld (q_zero, q_ones, 1);
     }
   else if (__builtin_constant_p (sim) && ((sim > 128) && (sim < 256)))
     {

--- a/src/pveclib/vec_int64_ppc.h
+++ b/src/pveclib/vec_int64_ppc.h
@@ -5017,16 +5017,31 @@ vec_splat_u64 (const int sim)
       result = (vui64_t) vec_vupklsw_PWR8 (tmp);
     }
 #ifdef _ARCH_PWR8
+  else if (sim == 31)
+    {
+      const vui32_t q_ones = vec_splat_u32(-1);
+      result = vec_srdi_PWR8 ((vui64_t) q_ones, (64-5));
+    }
   else if (sim == 32)
     {
       const vui32_t q_zero = vec_splat_u32(0);
       vui32_t v32 = vec_clzw (q_zero);
       result = (vui64_t) vec_vupklsw_PWR8 ((vi32_t) v32);
     }
+  else if (sim == 63)
+    {
+      const vui32_t q_ones = vec_splat_u32(-1);
+      result = vec_srdi_PWR8 ((vui64_t) q_ones, (64-6));
+    }
   else if (sim == 64)
     {
       const vui64_t dw0 = {0, 0};
       return vec_clzd (dw0);
+    }
+  else if (sim == 127)
+    {
+      const vui32_t q_ones = vec_splat_u32(-1);
+      result = vec_srdi_PWR8 ((vui64_t) q_ones, (64-7));
     }
 #endif
   else if (__builtin_constant_p (sim) && (sim > 16 ) && (sim < 46 ))
@@ -5063,6 +5078,13 @@ vec_splat_u64 (const int sim)
 	  result = (vui64_t) vec_vsum2sws_PWR7 (vai, vbi);
 	}
     }
+#ifdef _ARCH_PWR8
+  else if (sim == 255)
+    {
+      const vui32_t q_ones = vec_splat_u32(-1);
+      result = vec_srdi_PWR8 ((vui64_t) q_ones, (64-8));
+    }
+#endif
   else if (__builtin_constant_p (sim) && ((sim > 45) && (sim < 256)))
     {
       vi32_t tmp;

--- a/src/testsuite/arith128_test_i128.c
+++ b/src/testsuite/arith128_test_i128.c
@@ -1875,7 +1875,7 @@ vui128_t db_vec_moduq (vui128_t y, vui128_t z)
       : );
 #endif
   return res;
-#elif  (_ARCH_PWR8)
+#elif  (_ARCH_PWR7)
   vui128_t u = y;
   vui128_t v = z;
   const vui64_t zeros = vec_splat_u64(0);
@@ -6848,6 +6848,7 @@ test_vsldqi (void)
 }
 #undef __DEBUG_PRINT__
 
+#define vec_sldqbi(_l,_k,_m)	vec_sldb_quadword(_l,_k,_m)
 int
 test_sldbi (void)
 {
@@ -6861,7 +6862,7 @@ test_sldbi (void)
 	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
 			   __UINT32_MAX__);
   j = (vui32_t) CONST_VINT32_W(0, 0, 0, 0);
-  l = vec_vsldbi ((vui128_t) i, (vui128_t) j, 0);
+  l = vec_sldqbi ((vui128_t) i, (vui128_t) j, 0);
 #ifdef __DEBUG_PRINT__
   print_vint128x (" w ", (vui128_t) i);
   print_vint128x (" x ", (vui128_t) j);
@@ -6872,7 +6873,7 @@ test_sldbi (void)
 			   __UINT32_MAX__);
   rc += check_vuint128x ("vec_vsldbi (  0):", (vui128_t) l, (vui128_t) e);
 
-  l = vec_vsldbi ((vui128_t) i, (vui128_t) j, 4);
+  l = vec_sldqbi ((vui128_t) i, (vui128_t) j, 4);
 #ifdef __DEBUG_PRINT__
   print_vint128x (" w ", (vui128_t) i);
   print_vint128x (" x ", (vui128_t) j);
@@ -6883,7 +6884,7 @@ test_sldbi (void)
 			   0xfffffff0);
   rc += check_vuint128x ("vec_vsldbi (  4):", (vui128_t) l, (vui128_t) e);
 
-  l = vec_vsldbi ((vui128_t) i, (vui128_t) j, 7);
+  l = vec_sldqbi ((vui128_t) i, (vui128_t) j, 7);
 #ifdef __DEBUG_PRINT__
   print_vint128x (" w ", (vui128_t) i);
   print_vint128x (" x ", (vui128_t) j);
@@ -6895,7 +6896,7 @@ test_sldbi (void)
   rc += check_vuint128x ("vec_vsldbi (  7):", (vui128_t) l, (vui128_t) e);
 
   j = (vui32_t) CONST_VINT32_W(0x55555555, 0, 0, 0);
-  l = vec_vsldbi ((vui128_t) i, (vui128_t) j, 7);
+  l = vec_sldqbi ((vui128_t) i, (vui128_t) j, 7);
 #ifdef __DEBUG_PRINT__
   print_vint128x (" w ", (vui128_t) i);
   print_vint128x (" x ", (vui128_t) j);
@@ -6909,6 +6910,7 @@ test_sldbi (void)
   return (rc);
 }
 
+#define vec_srdqbi(_l,_k,_m)	vec_srdb_quadword(_l,_k,_m)
 int
 test_srdbi (void)
 {
@@ -6922,7 +6924,7 @@ test_srdbi (void)
 	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
 			   __UINT32_MAX__);
   j = (vui32_t) CONST_VINT32_W(0, 0, 0, 0);
-  l = vec_vsrdbi ((vui128_t) i, (vui128_t) j, 0);
+  l = vec_srdqbi ((vui128_t) i, (vui128_t) j, 0);
 #ifdef __DEBUG_PRINT__
   print_vint128x (" w ", (vui128_t) i);
   print_vint128x (" x ", (vui128_t) j);
@@ -6932,7 +6934,7 @@ test_srdbi (void)
 	    CONST_VINT32_W(0, 0, 0, 0);
   rc += check_vuint128x ("vec_vsrdbi (  0):", (vui128_t) l, (vui128_t) e);
 
-  l = vec_vsrdbi ((vui128_t) i, (vui128_t) j, 4);
+  l = vec_srdqbi ((vui128_t) i, (vui128_t) j, 4);
 #ifdef __DEBUG_PRINT__
   print_vint128x (" w ", (vui128_t) i);
   print_vint128x (" x ", (vui128_t) j);
@@ -6942,7 +6944,7 @@ test_srdbi (void)
 	    CONST_VINT32_W(0xf0000000, 0, 0, 0);
   rc += check_vuint128x ("vec_vsrdbi (  4):", (vui128_t) l, (vui128_t) e);
 
-  l = vec_vsrdbi ((vui128_t) i, (vui128_t) j, 7);
+  l = vec_srdqbi ((vui128_t) i, (vui128_t) j, 7);
 #ifdef __DEBUG_PRINT__
   print_vint128x (" w ", (vui128_t) i);
   print_vint128x (" x ", (vui128_t) j);
@@ -6955,7 +6957,7 @@ test_srdbi (void)
   i = (vui32_t)
 	    CONST_VINT32_W(__UINT32_MAX__, __UINT32_MAX__, __UINT32_MAX__,
 			   0xaaaaaaaa);
-  l = vec_vsrdbi ((vui128_t) i, (vui128_t) j, 7);
+  l = vec_srdqbi ((vui128_t) i, (vui128_t) j, 7);
 #ifdef __DEBUG_PRINT__
   print_vint128x (" w ", (vui128_t) i);
   print_vint128x (" x ", (vui128_t) j);
@@ -8024,22 +8026,18 @@ test_setbq (void)
 
   return (rc);
 }
+
 int
-test_splat_128 (void)
+test_splat_s128 (void)
 {
-  vui128_t ek, k;
   vi128_t  el, l;
   int rc = 0;
 
-  printf ("\ntest_splat_128 Vector Splat Immediate Signed/Unsigned Quadword\n");
-
+  printf ("\ntest_splat_128 Vector Splat Immediate Signed Quadword\n");
+#if 1
   l =  vec_splat_s128 (0);
   el = (vi128_t) CONST_VINT128_DW128(0, 0);
   rc += check_vuint128x ("vec_splat_s128(0):", (vui128_t) l, (vui128_t) el);
-
-  k =  vec_splat_u128 (0);
-  ek = CONST_VINT128_DW128(0, 0);
-  rc += check_vuint128x ("vec_splat_u128(0):", k, ek);
 
   l =  vec_splat_s128 (-1);
   el = (vi128_t) CONST_VINT128_DW128(-1, -1);
@@ -8064,59 +8062,108 @@ test_splat_128 (void)
   l =  vec_splat_s128 (1);
   el = (vi128_t) CONST_VINT128_DW128(0, 1);
   rc += check_vuint128x ("vec_splat_s128(1):", (vui128_t) l, (vui128_t) el);
-
-  k =  vec_splat_u128 (1);
-  ek = CONST_VINT128_DW128(0, 1);
-  rc += check_vuint128x ("vec_splat_u128(1):", k, ek);
-
+#endif
   l =  vec_splat_s128 (15);
   el = (vi128_t) CONST_VINT128_DW128(0, 15);
   rc += check_vuint128x ("vec_splat_s128(15):", (vui128_t) l, (vui128_t) el);
 
-  k =  vec_splat_u128 (15);
-  ek = CONST_VINT128_DW128(0, 15);
-  rc += check_vuint128x ("vec_splat_u128(15):", k, ek);
-
+#if (__GNUC__ >= 10)
   l =  vec_splat_s128 (16);
   el = (vi128_t) CONST_VINT128_DW128(0, 16);
   rc += check_vuint128x ("vec_splat_s128(16):", (vui128_t) l, (vui128_t) el);
+#endif
 
-  k =  vec_splat_u128 (16);
-  ek = CONST_VINT128_DW128(0, 16);
-  rc += check_vuint128x ("vec_splat_u128(16):", k, ek);
+#if 1
 
   l =  vec_splat_s128 (127);
   el = (vi128_t) CONST_VINT128_DW128(0, 127);
   rc += check_vuint128x ("vec_splat_s128(127):", (vui128_t) l, (vui128_t) el);
 
-  k =  vec_splat_u128 (127);
-  ek = CONST_VINT128_DW128(0, 127);
-  rc += check_vuint128x ("vec_splat_u128(127):", k, ek);
-
   l =  vec_splat_s128 (128);
   el = (vi128_t) CONST_VINT128_DW128(0, 128);
   rc += check_vuint128x ("vec_splat_s128(128):", (vui128_t) l, (vui128_t) el);
-
-  k =  vec_splat_u128 (128);
-  ek = CONST_VINT128_DW128(0, 128);
-  rc += check_vuint128x ("vec_splat_u128(128):", k, ek);
 
   l =  vec_splat_s128 (255);
   el = (vi128_t) CONST_VINT128_DW128(0, 255);
   rc += check_vuint128x ("vec_splat_s128(255):", (vui128_t) l, (vui128_t) el);
 
+  l =  vec_splat_s128 (256);
+  el = (vi128_t) CONST_VINT128_DW128(0, 256);
+  rc += check_vuint128x ("vec_splat_s128(256):", (vui128_t) l, (vui128_t) el);
+#endif
+  return (rc);
+}
+
+int
+test_splat_u128 (void)
+{
+  vui128_t ek, k;
+  int rc = 0;
+
+  printf ("\ntest_splat_128 Vector Splat Immediate Unsigned Quadword\n");
+
+  k =  vec_splat_u128 (0);
+  ek = CONST_VINT128_DW128(0, 0);
+  rc += check_vuint128x ("vec_splat_u128(0):", k, ek);
+
+#if (__GNUC__ >= 10)
+  k =  vec_splat_u128 (1);
+  ek = CONST_VINT128_DW128(0, 1);
+  rc += check_vuint128x ("vec_splat_u128(1):", k, ek);
+
+  k =  vec_splat_u128 (15);
+  ek = CONST_VINT128_DW128(0, 15);
+  rc += check_vuint128x ("vec_splat_u128(15):", k, ek);
+
+  k =  vec_splat_u128 (16);
+  ek = CONST_VINT128_DW128(0, 16);
+  rc += check_vuint128x ("vec_splat_u128(16):", k, ek);
+#endif
+#if 1
+  k =  vec_splat_u128 (31);
+  ek = CONST_VINT128_DW128(0, 31);
+  rc += check_vuint128x ("vec_splat_u128(31):", k, ek);
+
+  k =  vec_splat_u128 (32);
+  ek = CONST_VINT128_DW128(0, 32);
+  rc += check_vuint128x ("vec_splat_u128(32):", k, ek);
+
+  k =  vec_splat_u128 (33);
+  ek = CONST_VINT128_DW128(0, 33);
+  rc += check_vuint128x ("vec_splat_u128(33):", k, ek);
+
+  k =  vec_splat_u128 (127);
+  ek = CONST_VINT128_DW128(0, 127);
+  rc += check_vuint128x ("vec_splat_u128(127):", k, ek);
+
+  k =  vec_splat_u128 (128);
+  ek = CONST_VINT128_DW128(0, 128);
+  rc += check_vuint128x ("vec_splat_u128(128):", k, ek);
+
+  k =  vec_splat_u128 (129);
+  ek = CONST_VINT128_DW128(0, 129);
+  rc += check_vuint128x ("vec_splat_u128(129):", k, ek);
+
+  k =  vec_splat_u128 (143);
+  ek = CONST_VINT128_DW128(0, 143);
+  rc += check_vuint128x ("vec_splat_u128(143):", k, ek);
+
+  k =  vec_splat_u128 (159);
+  ek = CONST_VINT128_DW128(0, 159);
+  rc += check_vuint128x ("vec_splat_u128(159):", k, ek);
+
+  k =  vec_splat_u128 (192);
+  ek = CONST_VINT128_DW128(0, 192);
+  rc += check_vuint128x ("vec_splat_u128(192):", k, ek);
+
   k =  vec_splat_u128 (255);
   ek = CONST_VINT128_DW128(0, 255);
   rc += check_vuint128x ("vec_splat_u128(255):", k, ek);
 
-  l =  vec_splat_s128 (256);
-  el = (vi128_t) CONST_VINT128_DW128(0, 256);
-  rc += check_vuint128x ("vec_splat_s128(256):", (vui128_t) l, (vui128_t) el);
-
   k =  vec_splat_u128 (256);
   ek = CONST_VINT128_DW128(0, 256);
   rc += check_vuint128x ("vec_splat_u128(256):", k, ek);
-
+#endif
   return (rc);
 }
 
@@ -12271,7 +12318,7 @@ extern vui128_t test_vec_modduq (vui128_t x, vui128_t y, vui128_t z);
 #if 0
 #define test_moddivduq	db_vec_divdqu
 #else
-extern __VEC_U_128P test_vec_divdqu (vui128_t x, vui128_t y, vui128_t z);
+extern __VEC_U_128RQ test_vec_divdqu (vui128_t x, vui128_t y, vui128_t z);
 #define test_moddivduq	test_vec_divdqu
 #endif
 #if 0
@@ -13577,15 +13624,322 @@ test_vec_div_QW (void)
   return (rc);
 }
 
+//#define __DEBUG_PRINT__ 1
+#if 0
+// test directly from vec_char_ppc.h
+#define test_signextqd(_l)	vec_signextq_doubleword(_l)
+#else
+// test from vec_char_ppc.h via vec_char_dummy.c
+extern vi128_t test_vec_signextq_doubleword (vi64_t);
+#define test_signextqd(_l)	test_vec_signextq_doubleword(_l)
+#endif
+
+int
+test_signextq_d(void)
+{
+    vi64_t i;
+    vi128_t j, e;
+    int rc = 0;
+
+    printf ("\n%s\n", __FUNCTION__);
+
+    i = (vi64_t) {0x0001020380c0e0f0LL,
+                  0x080c0e0f8fcfefffLL};
+    e = (vi128_t) CONST_VINT128_DW128(0x0000000000000000ULL,
+				      0x0001020380c0e0f0ULL);
+    j = test_signextqd (i);
+
+#ifdef __DEBUG_PRINT__
+    print_v2xint64  ("vec_signextq of ", (vui64_t)i);
+    print_v2xint64 ("               = ", (vui64_t)j);
+#endif
+    rc += check_vuint128x ("vec_signextq:", (vui128_t) j, (vui128_t) e);
+
+    i = (vi64_t) {0x00010203080c0e0fLL,
+                  0x80c0e0f08fcfefffLL};
+    e = (vi128_t) CONST_VINT128_DW128(0x0000000000000000ULL,
+				      0x00010203080c0e0fULL);
+
+    j = test_signextqd (i);
+
+#ifdef __DEBUG_PRINT__
+    print_v2xint64  ("vec_signextq of ", (vui64_t)i);
+    print_v2xint64 ("               = ", (vui64_t)j);
+#endif
+    rc += check_vuint128x ("vec_signextq:", (vui128_t) j, (vui128_t) e);
+
+    i = (vi64_t) {0x8fcfefff80c0e0f0LL,
+                  0x080c0e0f00010203LL};
+
+    e = (vi128_t) CONST_VINT128_DW128(0xffffffffffffffffULL,
+				      0x8fcfefff80c0e0f0ULL);
+
+    j = test_signextqd (i);
+
+#ifdef __DEBUG_PRINT__
+    print_v2xint64  ("vec_signextq of ", (vui64_t)i);
+    print_v2xint64 ("               = ", (vui64_t)j);
+#endif
+    rc += check_vuint128x ("vec_signextq:", (vui128_t) j, (vui128_t) e);
+
+    i = (vi64_t) {0x8fcfefff080c0e0fLL,
+                  0x80c0e0f000010203LL};
+
+    e = (vi128_t) CONST_VINT128_DW128(0xffffffffffffffffULL,
+				      0x8fcfefff080c0e0fULL);
+
+    j = test_signextqd (i);
+
+#ifdef __DEBUG_PRINT__
+    print_v2xint64  ("vec_signextq of ", (vui64_t)i);
+    print_v2xint64 ("               = ", (vui64_t)j);
+#endif
+    rc += check_vuint128x ("vec_signextq:", (vui128_t) j, (vui128_t) e);
+
+    return (rc);
+  }
+
+//#define __DEBUG_PRINT__ 1
+#if 0
+// test directly from vec_char_ppc.h
+#define test_signextqb(_l)	vec_signextq_byte(_l)
+#else
+// test from vec_char_ppc.h via vec_char_dummy.c
+extern vi128_t test_vec_signextq_byte (vi8_t);
+#define test_signextqb(_l)	test_vec_signextq_byte(_l)
+#endif
+
+int
+test_signextq_b(void)
+{
+    vi8_t i;
+    vi128_t j, e;
+    int rc = 0;
+
+    printf ("\n%s\n", __FUNCTION__);
+
+    i = (vi8_t)  {0x00, 0x01, 0x02, 0x03, 0x80, 0xc0, 0xe0, 0xf0,
+                  0x08, 0x0c, 0x0e, 0x0f, 0x8f, 0xcf, 0xef, 0xff};
+
+    e = (vi128_t) CONST_VINT128_DW128(0x0000000000000000ULL,
+				      0x0000000000000000ULL);
+    j = test_signextqb (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x   ("vec_signextq of ", (vui8_t)i);
+    print_vint128x ("              = ", (vui128_t)j);
+#endif
+    rc += check_vuint128x ("vec_signextq:", (vui128_t) j, (vui128_t) e);
+
+    i = (vi8_t)  {0x00, 0x01, 0x02, 0x03, 0x08, 0x0c, 0x0e, 0x0f,
+                  0x80, 0xc0, 0xe0, 0xf0, 0x8f, 0xcf, 0xef, 0xff};
+
+    e = (vi128_t) CONST_VINT128_DW128(0x0000000000000000ULL,
+				      0x0000000000000000ULL);
+    j = test_signextqb (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x   ("vec_signextq of ", (vui8_t)i);
+    print_vint128x ("              = ", (vui128_t)j);
+#endif
+    rc += check_vuint128x ("vec_signextq:", (vui128_t) j, (vui128_t) e);
+
+    i = (vi8_t)  {0x8f, 0xcf, 0xef, 0xff, 0x80, 0xc0, 0xe0, 0xf0,
+                  0x08, 0x0c, 0x0e, 0x0f, 0x00, 0x01, 0x02, 0x03};
+
+    e = (vi128_t) CONST_VINT128_DW128(0xffffffffffffffffULL,
+				      0xffffffffffffff8fULL);
+    j = test_signextqb (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x   ("vec_signextq of ", (vui8_t)i);
+    print_vint128x ("              = ", (vui128_t)j);
+#endif
+    rc += check_vuint128x ("vec_signextq:", (vui128_t) j, (vui128_t) e);
+
+    i = (vi8_t)  {0x8f, 0xcf, 0xef, 0xff, 0x08, 0x0c, 0x0e, 0x0f,
+                  0x80, 0xc0, 0xe0, 0xf0, 0x00, 0x01, 0x02, 0x03};
+
+    e = (vi128_t) CONST_VINT128_DW128(0xffffffffffffffffULL,
+				      0xffffffffffffff8fULL);
+    j = test_signextqb (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint8x   ("vec_signextq of ", (vui8_t)i);
+    print_vint128x ("              = ", (vui128_t)j);
+#endif
+    rc += check_vuint128x ("vec_signextq:", (vui128_t) j, (vui128_t) e);
+
+    return (rc);
+  }
+
+//#define __DEBUG_PRINT__ 1
+#if 0
+// test directly from vec_char_ppc.h
+#define test_signextqh(_l)	vec_signextq_halfword(_l)
+#else
+// test from vec_char_ppc.h via vec_char_dummy.c
+extern vi128_t test_vec_signextq_halfword (vi16_t);
+#define test_signextqh(_l)	test_vec_signextq_halfword(_l)
+#endif
+
+int
+test_signextq_h(void)
+{
+    vi16_t i;
+    vi128_t j, e;
+    int rc = 0;
+
+    printf ("\n%s\n", __FUNCTION__);
+
+    i = (vi16_t) {0x0001, 0x0203, 0x80c0, 0xe0f0,
+                  0x080c, 0x0e0f, 0x8fcf, 0xefff};
+
+    e = (vi128_t) CONST_VINT128_DW128(0x0000000000000000ULL,
+				      0x0000000000000001ULL);
+    j = test_signextqh (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint16x  ("vec_signextq of ", (vui16_t)i);
+    print_vint128x ("              = ", (vui128_t)j);
+#endif
+    rc += check_vuint128x ("vec_signextq:", (vui128_t) j, (vui128_t) e);
+
+    i = (vi16_t) {0x0001, 0x0203, 0x080c, 0x0e0f,
+                  0x80c0, 0xe0f0, 0x8fcf, 0xefff};
+
+    e = (vi128_t) CONST_VINT128_DW128(0x0000000000000000ULL,
+				      0x0000000000000001ULL);
+    j = test_signextqh (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint16x  ("vec_signextq of ", (vui16_t)i);
+    print_vint128x ("              = ", (vui128_t)j);
+#endif
+    rc += check_vuint128x ("vec_signextq:", (vui128_t) j, (vui128_t) e);
+
+    i = (vi16_t) {0x8fcf, 0xefff, 0x80c0, 0xe0f0,
+                  0x080c, 0x0e0f, 0x0001, 0x0203};
+
+    e = (vi128_t) CONST_VINT128_DW128(0xffffffffffffffffULL,
+				      0xffffffffffff8fcfULL);
+    j = test_signextqh (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint16x  ("vec_signextq of ", (vui16_t)i);
+    print_vint128x ("              = ", (vui128_t)j);
+#endif
+    rc += check_vuint128x ("vec_signextq:", (vui128_t) j, (vui128_t) e);
+
+    i = (vi16_t) {0x8fcf, 0xefff, 0x080c, 0x0e0f,
+                  0x80c0, 0xe0f0, 0x0001, 0x0203};
+
+    e = (vi128_t) CONST_VINT128_DW128(0xffffffffffffffffULL,
+				      0xffffffffffff8fcfULL);
+    j = test_signextqh (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint16x  ("vec_signextq of ", (vui16_t)i);
+    print_vint128x ("              = ", (vui128_t)j);
+#endif
+    rc += check_vuint128x ("vec_signextq:", (vui128_t) j, (vui128_t) e);
+
+    return (rc);
+  }
+
+//#define __DEBUG_PRINT__ 1
+#if 0
+// test directly from vec_char_ppc.h
+#define test_signextqw(_l)	vec_signextq_word(_l)
+#else
+// test from vec_char_ppc.h via vec_char_dummy.c
+extern vi128_t test_vec_signextq_word (vi32_t);
+#define test_signextqw(_l)	test_vec_signextq_word(_l)
+#endif
+
+int
+test_signextq_w(void)
+{
+    vi32_t i;
+    vi128_t j, e;
+    int rc = 0;
+
+    printf ("\n%s\n", __FUNCTION__);
+
+    i = (vi32_t) {0x00010203, 0x80c0e0f0,
+                  0x080c0e0f, 0x8fcfefff};
+    //e = (vi64_t) {0x0000000000010203, 0x00000000080c0e0f};
+
+    e = (vi128_t) CONST_VINT128_DW128(0x0000000000000000ULL,
+				      0x0000000000010203ULL);
+    j = test_signextqw (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint32x  ("vec_signextq of ", (vui32_t)i);
+    print_vint128x ("              = ", (vui128_t)j);
+#endif
+    rc += check_vuint128x ("vec_signextq:", (vui128_t) j, (vui128_t) e);
+
+    i = (vi32_t) {0x00010203, 0x080c0e0f,
+                  0x80c0e0f0, 0x8fcfefff};
+    //e = (vi64_t) {0x0000000000010203, 0xffffffff80c0e0f0};
+
+    e = (vi128_t) CONST_VINT128_DW128(0x0000000000000000ULL,
+				      0x0000000000010203ULL);
+    j = test_signextqw (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint32x  ("vec_signextq of ", (vui32_t)i);
+    print_vint128x ("              = ", (vui128_t)j);
+#endif
+    rc += check_vuint128x ("vec_signextq:", (vui128_t) j, (vui128_t) e);
+
+    i = (vi32_t) {0x8fcfefff, 0x80c0e0f0,
+                  0x080c0e0f, 0x00010203};
+    //e = (vi64_t) {0xffffffff8fcfefff, 0x0000000080c0e0f};
+
+    e = (vi128_t) CONST_VINT128_DW128(0xffffffffffffffffULL,
+				      0xffffffff8fcfefffULL);
+    j = test_signextqw (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint32x  ("vec_signextq of ", (vui32_t)i);
+    print_vint128x ("              = ", (vui128_t)j);
+#endif
+    rc += check_vuint128x ("vec_signextq:", (vui128_t) j, (vui128_t) e);
+
+    i = (vi32_t) {0x8fcfefff, 0x080c0e0f,
+                  0x80c0e0f0, 0x00010203};
+    //e = (vi64_t) {0xffffffff8fcfefff, 0xffffffff80c0e0f0};
+
+    e = (vi128_t) CONST_VINT128_DW128(0xffffffffffffffffULL,
+				      0xffffffff8fcfefffULL);
+    j = test_signextqw (i);
+
+#ifdef __DEBUG_PRINT__
+    print_vint32x  ("vec_signextq of ", (vui32_t)i);
+    print_vint128x ("              = ", (vui128_t)j);
+#endif
+    rc += check_vuint128x ("vec_signextq:", (vui128_t) j, (vui128_t) e);
+
+    return (rc);
+  }
+
 int
 test_vec_i128 (void)
 {
   int rc = 0;
 
   printf ("\n%s\n", __FUNCTION__);
+
+  rc += test_signextq_d ();
+  rc += test_signextq_w ();
+  rc += test_signextq_h ();
+  rc += test_signextq_b ();
+  rc += test_splat_s128 ();
+  rc += test_splat_u128 ();
 #if 1
   rc += test_xfer_int128 ();
-  rc += test_splat_128 ();
   rc += test_revbq ();
   rc += test_clzq ();
   rc += test_ctzq ();

--- a/src/testsuite/vec_int128_dummy.c
+++ b/src/testsuite/vec_int128_dummy.c
@@ -2158,6 +2158,17 @@ __test_splatiuq_31 (void)
 }
 
 vui128_t
+__test_splatiuq_31_V1 (void)
+{
+  const int sim = 0x1f;
+  // latency PWR8 6-8
+  const vui32_t q_zero = CONST_VINT128_W (0, 0, 0, 0);
+  const vui32_t q_ones = CONST_VINT128_W (-1, -1, -1, -1);
+  vui32_t tmp = vec_srwi (q_ones, (32-5));
+  return (vui128_t) vec_sld (q_zero, tmp, 4);
+}
+
+vui128_t
 __test_splatiuq_32 (void)
 {
   return vec_splat_u128 (32);
@@ -2200,6 +2211,17 @@ __test_splatiuq_63 (void)
 }
 
 vui128_t
+__test_splatiuq_63_V1 (void)
+{
+  const int sim = 0x3f;
+  // latency PWR8 6-8
+  const vui32_t q_zero = CONST_VINT128_W (0, 0, 0, 0);
+  const vui32_t q_ones = CONST_VINT128_W (-1, -1, -1, -1);
+  vui32_t tmp = vec_srwi (q_ones, (32-6));
+  return (vui128_t) vec_sld (q_zero, tmp, 4);
+}
+
+vui128_t
 __test_splatiuq_64 (void)
 {
   return vec_splat_u128 (64);
@@ -2233,6 +2255,17 @@ vui128_t
 __test_splatiuq_127 (void)
 {
   return vec_splat_u128 (127);
+}
+
+vui128_t
+__test_splatiuq_127_V1 (void)
+{
+  const int sim = 0x7f;
+  // latency PWR8 6-8
+  const vui32_t q_zero = CONST_VINT128_W (0, 0, 0, 0);
+  const vui32_t q_ones = CONST_VINT128_W (-1, -1, -1, -1);
+  vui32_t tmp = vec_srwi (q_ones, (32-7));
+  return (vui128_t) vec_sld (q_zero, tmp, 4);
 }
 
 vui128_t

--- a/src/testsuite/vec_int128_dummy.c
+++ b/src/testsuite/vec_int128_dummy.c
@@ -26,6 +26,314 @@
 #include "arith128.h"
 #include <testsuite/arith128_print.h>
 
+vi128_t
+test_vec_signextq_byte (vi8_t vra)
+{
+  return vec_signextq_byte (vra);
+}
+
+vi128_t
+test_vec_signextq_halfword (vi16_t vra)
+{
+  return vec_signextq_halfword (vra);
+}
+
+vi128_t
+test_vec_signextq_word (vi32_t vra)
+{
+  return vec_signextq_word (vra);
+}
+
+vi128_t
+test_vec_signextq_doubleword (vi64_t vra)
+{
+  return vec_signextq_doubleword (vra);
+}
+
+vi128_t
+test_vec_vextsb2q (vi8_t vra)
+{
+  return vec_vextsb2q (vra);
+}
+
+vi128_t
+test_vec_vextsh2q (vi16_t vra)
+{
+  return vec_vextsh2q (vra);
+}
+
+vi128_t
+test_vec_vextsw2q (vi32_t vra)
+{
+  return vec_vextsw2q (vra);
+}
+
+vi128_t
+test_vec_vextsd2q (vi64_t vra)
+{
+  return vec_vextsd2q (vra);
+}
+
+vui128_t
+test_vec_expandm_quadword (vui128_t vra)
+{
+  return vec_expandm_quadword (vra);
+}
+
+vui128_t
+test_vexpandqm_PWR (vui128_t vra)
+{
+  return vec_vexpandqm_PWR10 (vra);
+}
+
+#if 0 // Deprecated !
+vui128_t
+test_vec_rlq_byte  (vui128_t a, vui8_t b)
+{
+  return (vec_vrlq_byte (a, b));
+}
+
+vui128_t
+test_vec_slq_byte  (vui128_t a, vui8_t b)
+{
+  return (vec_vslq_byte (a, b));
+}
+
+vui128_t
+test_vec_srq_byte  (vui128_t a, vui8_t b)
+{
+  return (vec_vsrq_byte (a, b));
+}
+
+vi128_t
+test_vec_sraq_byte  (vi128_t a, vui8_t b)
+{
+  return (vec_vsraq_byte (a, b));
+}
+#endif
+
+vui128_t
+test_vec_rlqi_PWR_1  (vui128_t a)
+{
+  return (vec_rlqi_PWR10 (a, 1));
+}
+
+vui128_t
+test_vec_rlqi_PWR_15  (vui128_t a)
+{
+  return (vec_rlqi_PWR10 (a, 15));
+}
+
+vui128_t
+test_vec_rlqi_PWR_16  (vui128_t a)
+{
+  return (vec_rlqi_PWR10 (a, 16));
+}
+
+vui128_t
+test_vec_rlqi_PWR_31  (vui128_t a)
+{
+  return (vec_rlqi_PWR10 (a, 31));
+}
+
+vui128_t
+test_vec_rlqi_PWR_64  (vui128_t a)
+{
+  return (vec_rlqi_PWR10 (a, 64));
+}
+
+vui128_t
+test_vec_rlqi_PWR_112  (vui128_t a)
+{
+  return (vec_rlqi_PWR10 (a, 112));
+}
+
+vui128_t
+test_vec_rlqi_PWR_127  (vui128_t a)
+{
+  return (vec_rlqi_PWR10 (a, 127));
+}
+
+vui128_t
+test_vec_rlq_PWR  (vui128_t a, vui8_t sh)
+{
+  return (vec_rlq_PWR10 (a, sh));
+}
+
+vui128_t
+test_vec_slqi_PWR_1  (vui128_t a)
+{
+  return (vec_slqi_PWR10 (a, 1));
+}
+
+vui128_t
+test_vec_slqi_PWR_15  (vui128_t a)
+{
+  return (vec_slqi_PWR10 (a, 15));
+}
+
+vui128_t
+test_vec_slqi_PWR_16  (vui128_t a)
+{
+  return (vec_slqi_PWR10 (a, 16));
+}
+
+vui128_t
+test_vec_slqi_PWR_31  (vui128_t a)
+{
+  return (vec_slqi_PWR10 (a, 31));
+}
+
+vui128_t
+test_vec_slqi_PWR_32  (vui128_t a)
+{
+  return (vec_slqi_PWR10 (a, 32));
+}
+
+vui128_t
+test_vec_slqi_PWR_48  (vui128_t a)
+{
+  return (vec_slqi_PWR10 (a, 48));
+}
+
+vui128_t
+test_vec_slqi_PWR_64  (vui128_t a)
+{
+  return (vec_slqi_PWR10 (a, 64));
+}
+
+vui128_t
+test_vec_slqi_PWR_112  (vui128_t a)
+{
+  return (vec_slqi_PWR10 (a, 112));
+}
+
+vui128_t
+test_vec_slqi_PWR_127  (vui128_t a)
+{
+  return (vec_slqi_PWR10 (a, 127));
+}
+
+vui128_t
+test_vec_slq_PWR  (vui128_t a, vui8_t sh)
+{
+  return (vec_slq_PWR10 (a, sh));
+}
+
+vui128_t
+test_vec_srqi_PWR_1  (vui128_t a)
+{
+  return (vec_srqi_PWR10 (a, 1));
+}
+
+vui128_t
+test_vec_srqi_PWR_15  (vui128_t a)
+{
+  return (vec_srqi_PWR10 (a, 15));
+}
+
+vui128_t
+test_vec_srqi_PWR_16  (vui128_t a)
+{
+  return (vec_srqi_PWR10 (a, 16));
+}
+
+vui128_t
+test_vec_srqi_PWR_31  (vui128_t a)
+{
+  return (vec_srqi_PWR10 (a, 31));
+}
+
+vui128_t
+test_vec_srqi_PWR_52  (vui128_t a)
+{
+  return (vec_srqi_PWR10 (a, 52));
+}
+
+vui128_t
+test_vec_srqi_PWR_60  (vui128_t a)
+{
+  return (vec_srqi_PWR10 (a, 60));
+}
+
+vui128_t
+test_vec_srqi_PWR_64  (vui128_t a)
+{
+  return (vec_srqi_PWR10 (a, 64));
+}
+
+vui128_t
+test_vec_srqi_PWR_112  (vui128_t a)
+{
+  return (vec_srqi_PWR10 (a, 112));
+}
+
+vui128_t
+test_vec_srqi_PWR_127  (vui128_t a)
+{
+  return (vec_srqi_PWR10 (a, 127));
+}
+
+vui128_t
+test_vec_srq_PWR  (vui128_t a, vui8_t sh)
+{
+  return (vec_srq_PWR10 (a, sh));
+}
+
+vi128_t
+test_vec_sraqi_PWR_1  (vi128_t a)
+{
+  return (vec_sraqi_PWR10 (a, 1));
+}
+
+vi128_t
+test_vec_sraqi_PWR_15  (vi128_t a)
+{
+  return (vec_sraqi_PWR10 (a, 15));
+}
+
+vi128_t
+test_vec_sraqi_PWR_31  (vi128_t a)
+{
+  return (vec_sraqi_PWR10 (a, 31));
+}
+
+vi128_t
+test_vec_sraqi_PWR_32  (vi128_t a)
+{
+  return (vec_sraqi_PWR10 (a, 32));
+}
+
+vi128_t
+test_vec_sraqi_PWR_63  (vi128_t a)
+{
+  return (vec_sraqi_PWR10 (a, 63));
+}
+
+vi128_t
+test_vec_sraqi_PWR_64  (vi128_t a)
+{
+  return (vec_sraqi_PWR10 (a, 64));
+}
+
+vi128_t
+test_vec_sraqi_PWR_112  (vi128_t a)
+{
+  return (vec_sraqi_PWR10 (a, 112));
+}
+
+vi128_t
+test_vec_sraqi_PWR_127  (vi128_t a)
+{
+  return (vec_sraqi_PWR10 (a, 127));
+}
+
+vi128_t
+test_vec_sraq_PWR  (vi128_t a, vui8_t sh)
+{
+  return (vec_sraq_PWR10 (a, sh));
+}
+
 vui128_t
 test_vec_ctzq_PWR7 (vui128_t vra)
 {
@@ -1605,6 +1913,55 @@ vui128_t test_vec_modduq (vui128_t x, vui128_t y, vui128_t z)
 // Attempts at better code to splat small QW constants.
 // Want to avoid addr calc and loads for what should be simple
 // splat immediate and sld.
+
+vi128_t
+__test_splatisq_256 (void)
+{
+  return vec_splat_s128 (-256);
+}
+
+vi128_t
+__test_splatisq_192 (void)
+{
+  return vec_splat_s128 (-192);
+}
+
+vi128_t
+__test_splatisq_128 (void)
+{
+  return vec_splat_s128 (-128);
+}
+
+vi128_t
+__test_splatisq_96 (void)
+{
+  return vec_splat_s128 (-96);
+}
+
+vi128_t
+__test_splatisq_64 (void)
+{
+  return vec_splat_s128 (-64);
+}
+
+vi128_t
+__test_splatisq_32 (void)
+{
+  return vec_splat_s128 (-32);
+}
+
+vi128_t
+__test_splatisq_33 (void)
+{
+  return vec_splat_s128 (-33);
+}
+
+vi128_t
+__test_splatisq_24 (void)
+{
+  return vec_splat_s128 (-24);
+}
+
 vi128_t
 __test_splatisq_16 (void)
 {
@@ -1621,6 +1978,84 @@ vi128_t
 __test_splatisq_0 (void)
 {
   return vec_splat_s128 (0);
+}
+
+vi128_t
+__test_splatisq_15 (void)
+{
+  return vec_splat_s128 (15);
+}
+
+vi128_t
+__test_splatisq_27 (void)
+{
+  return vec_splat_s128 (27);
+}
+
+vi128_t
+__test_splatisq_31 (void)
+{
+  return vec_splat_s128 (31);
+}
+
+vi128_t
+__test_splatisq_p32 (void)
+{
+  return vec_splat_s128 (32);
+}
+
+vi128_t
+__test_splatisq_p33 (void)
+{
+  return vec_splat_s128 (33);
+}
+
+vi128_t
+__test_splatisq_p56 (void)
+{
+  return vec_splat_s128 (56);
+}
+
+vi128_t
+__test_splatisq_p60 (void)
+{
+  return vec_splat_s128 (60);
+}
+
+vi128_t
+__test_splatisq_p63 (void)
+{
+  return vec_splat_s128 (63);
+}
+
+vi128_t
+__test_splatisq_p64 (void)
+{
+  return vec_splat_s128 (64);
+}
+
+vi128_t
+__test_splatisq_127 (void)
+{
+  return vec_splat_s128 (127);
+}
+
+vi128_t
+__test_splatisq_p128 (void)
+{
+  return vec_splat_s128 (128);
+}
+
+vi128_t
+__test_splatisq_p192 (void)
+{
+  return vec_splat_s128 (192);
+}
+
+vi128_t
+__test_splatisq_p255 (void)
+{
+  return vec_splat_s128 (255);
 }
 
 vi128_t
@@ -1674,18 +2109,6 @@ __test_splatisq_15_V0 (void)
   return (vi128_t) qw_15;
 }
 
-vi128_t
-__test_splatisq_15 (void)
-{
-  return vec_splat_s128 (15);
-}
-
-vi128_t
-__test_splatisq_127 (void)
-{
-  return vec_splat_s128 (127);
-}
-
 vui128_t
 __test_splatiuq_0 (void)
 {
@@ -1699,6 +2122,114 @@ __test_splatiuq_15 (void)
 }
 
 vui128_t
+__test_splatiuq_16 (void)
+{
+  return vec_splat_u128 (16);
+}
+
+vui128_t
+__test_splatiuq_20 (void)
+{
+  return vec_splat_u128 (20);
+}
+
+vui128_t
+__test_splatiuq_24 (void)
+{
+  return vec_splat_u128 (24);
+}
+
+vui128_t
+__test_splatiuq_29 (void)
+{
+  return vec_splat_u128 (29);
+}
+
+vui128_t
+__test_splatiuq_30 (void)
+{
+  return vec_splat_u128 (30);
+}
+
+vui128_t
+__test_splatiuq_31 (void)
+{
+  return vec_splat_u128 (31);
+}
+
+vui128_t
+__test_splatiuq_32 (void)
+{
+  return vec_splat_u128 (32);
+}
+
+vui128_t
+__test_splatiuq_33 (void)
+{
+  return vec_splat_u128 (33);
+}
+
+vui128_t
+__test_splatiuq_48 (void)
+{
+  return vec_splat_u128 (48);
+}
+
+vui128_t
+__test_splatiuq_55 (void)
+{
+  return vec_splat_u128 (55);
+}
+
+vui128_t
+__test_splatiuq_56 (void)
+{
+  return vec_splat_u128 (56);
+}
+
+vui128_t
+__test_splatiuq_60 (void)
+{
+  return vec_splat_u128 (60);
+}
+
+vui128_t
+__test_splatiuq_63 (void)
+{
+  return vec_splat_u128 (63);
+}
+
+vui128_t
+__test_splatiuq_64 (void)
+{
+  return vec_splat_u128 (64);
+}
+
+vui128_t
+__test_splatiuq_65 (void)
+{
+  return vec_splat_u128 (65);
+}
+
+vui128_t
+__test_splatiuq_72 (void)
+{
+  return vec_splat_u128 (72);
+}
+
+vui128_t
+__test_splatiuq_112 (void)
+{
+  return vec_splat_u128 (112);
+}
+
+vui128_t
+__test_splatiuq_120 (void)
+{
+  return vec_splat_u128 (120);
+}
+
+vui128_t
 __test_splatiuq_127 (void)
 {
   return vec_splat_u128 (127);
@@ -1708,6 +2239,201 @@ vui128_t
 __test_splatiuq_128 (void)
 {
   return vec_splat_u128 (128);
+}
+
+vui128_t
+__test_splatiuq_129 (void)
+{
+  return vec_splat_u128 (129);
+}
+
+vui128_t
+__test_splatiuq_136 (void)
+{
+  return vec_splat_u128 (136);
+}
+
+vui128_t
+__test_splatiuq_143 (void)
+{
+  return vec_splat_u128 (143);
+}
+
+vui128_t
+__test_splatiuq_144 (void)
+{
+  return vec_splat_u128 (144);
+}
+
+vui128_t
+__test_splatiuq_159 (void)
+{
+  return vec_splat_u128 (159);
+}
+
+vui128_t
+__test_splatiuq_192 (void)
+{
+  return vec_splat_u128 (192);
+}
+
+vui128_t
+__test_splatiuq_255 (void)
+{
+  return vec_splat_u128 (255);
+}
+
+vui128_t
+__test_splatiuq_V3 (void)
+  {
+    const int sim = 63;
+    vui128_t result;
+    /* ((sim >= 16) && (sim < 64))
+     * Use the Vector Sum across Signed Word Saturate (vsumsws)
+     * instructions. Combining the sum across with word splat
+     * generates A * 4 + B word constant in word 3. Words 0-2 are
+     * filled with 0x00000000 which eliminates the normal splat 0
+     * and terminating vsldoi required for quadword constants.
+     * There is special case for ((sim % 5) == 0)) where A == B.
+     * Vsumsws is an expensive instructions (7 cycles latency)
+     * but is does a lot of work. Requires 3 instructions
+     * (or 2 with CSE) and 9 cycles latency total.
+     */
+    if (__builtin_constant_p (sim) && ((sim % 5) == 0))
+	{
+	  const vi32_t vai = vec_splat_s32 (sim/5);
+	  result = (vui128_t) vec_vsumsws_PWR7 (vai, vai);
+	}
+    else
+	{
+	  const vi32_t vai = vec_splat_s32 (sim/4);
+	  const vi32_t vbi = vec_splat_s32 (sim%4);
+	  // need inline asm to avoid unnecessary LE correction.
+	  result = (vui128_t) vec_vsumsws_PWR7 (vai, vbi);
+	}
+    return result;
+  }
+
+vui128_t
+__test_splatiuq_V2 (void)
+{
+  // 7-bit const ((sim > 16) && (sim < 255))
+      const int sim = 159;
+      const vui32_t q_zero = vec_splat_u32(0);
+      const vui32_t v4 = vec_splat_u32(4);
+      const vui32_t vhnib = vec_splat_u32(sim / 16);
+      vui32_t tmp;
+      /* 8-bit pattern to cover constants 16-255.
+       * Use splat immediates and shift left to generate the
+       * high nibble (high 4-bits). Then splat immediate
+       * the low nibble (low 4-bits). Then combine (ADD or OR)
+       * to generate the 8-bit const. Skip this if ((sim % 16) != 0).
+       * Then shift in (vsldoi) 96-bits of zeros to complete the
+       * unsigned __int128 const. Requires 5-7 instructions
+       * (or 3-5 with CSE) and 6-12 cycles latency.
+       *  */
+      // v8bit = vhnib * 16
+      tmp = vec_sl (vhnib, v4);
+      if ((sim % 16) != 0)
+	{ // generate low nibble 0-15
+	  const vui32_t vlnib = vec_splat_u32((sim % 16));
+	  // 7-bit shift count == voctet + vbit
+	  tmp = vec_add (tmp, vlnib);
+	}
+      return (vui128_t) vec_sld (q_zero, tmp, 4);
+    }
+
+vui128_t
+__test_splatiuq_V1 (void)
+{
+  // 7-bit const ((sim > 64) && (sim < 128))
+      const int sim = 76;
+      const vui32_t q_zero = vec_splat_u32(0);
+      const vui32_t v3 = vec_splat_u32(3);
+      const vui32_t vbyte = vec_splat_u32(sim / 8);
+      vui32_t tmp;
+      /* 7-bit shift-count pattern to cover constants 65-127.
+       * Use splat immediates and shift left to generate the
+       * octet shift count (high 4-bits). Then splat immediate
+       * the byte bit shift count (low 3-bits). Then sum (add)
+       * to generate the 7-bit const. Skip this if ((sim % 8) != 0).
+       * Then shift in (vsldoi) 96-bits of zeros to complete the
+       * unsigned __int128 const. Requires 5-7 instructions
+       * __int128 const. Requires 5-7 instructions
+       * (or 3-5 with CSE) and 6-12 cycles latency.
+       *  */
+      // voctet = vbyte * 8
+      tmp = vec_sl (vbyte, v3);
+      if ((sim % 8) != 0)
+	{
+	  const vui32_t vbit = vec_splat_u32((sim % 8));
+	  // 7-bit shift count == voctet + vbit
+	  tmp = vec_add (tmp, vbit);
+	}
+      return (vui128_t) vec_sld (q_zero, tmp, 4);
+    }
+
+vui128_t
+__test_splatiuq_V0 (void)
+{
+  // For (((sim % 2) == 0) && (sim < 32))) use vec_splat6_u32
+  // from vec_common_ppc.
+  const int sim = 24;
+  const vui32_t q_zero = vec_splat_u32(0);
+  vui32_t vwi = vec_splat6_u32 (sim);
+  return (vui128_t) vec_sld (q_zero, vwi, 4);
+}
+
+vui128_t
+__test_splatiuq_32_V0 (void)
+{
+  /* Special case for constant 64.
+   * For PWR8 we can use Vector Count Leading Zeros Word.
+   * For a value of zero returns a bit count of 64.
+   * We need to zero extent the doubleword for a quadword result.
+   * We use vsldoi with the zero const.
+   * This runs 3 instructions (2 with CSE) and 4-6 cycles.
+   * Otherwise use ((4 << 3) == 32). See also __test_splatiuq_V1
+   * or __test_splatiuq_V3.
+   */
+#ifdef _ARCH_PWR8
+  const vui32_t q_zero = vec_splat_u32(0);
+  vui32_t v32 = vec_clzw (q_zero);
+  return (vui128_t) vec_sld (q_zero, v32, 4);
+#else
+  const vui32_t q_zero = vec_splat_u32(0);
+  vui32_t v3 = vec_splat_u32(3);
+  vui32_t v4 = vec_splat_u32(4);
+  vui32_t tmp = vec_sl (v4, v3);
+  return (vui128_t) vec_sld (q_zero, tmp, 4);
+#endif
+}
+
+vui128_t
+__test_splatiuq_64_V0 (void)
+{
+  /* Special case for constant 64.
+   * For PWR8 we can use Vector Count Leading Zeros Doubleword.
+   * For a value of zero returns a bit count of 64.
+   * We need to zero extent the doubleword for a quadword result.
+   * We can use either vsldoi or xxpermdi using the zero const.
+   * This runs 4 instructions (2 with CSE) and 4-6 cycles.
+   * Otherwise use ((4 << 4) == 64).
+   * This also needs zero extent of the byte/word to quadword.
+   * This runs 4 instructions (2 with CSE) and 4-6 cycles.
+   */
+#ifdef _ARCH_PWR8
+  // This should generate vspltisw vt,0
+  // But the compiler may separate vspltisw for word/doubleword const
+  const vui64_t q_zero = { 0, 0 };
+  vui64_t v64 = vec_clzd (q_zero);
+  return (vui128_t) vec_sld ((vui32_t) q_zero, (vui32_t) v64, 8);
+#else
+  const vui32_t q_zero = vec_splat_u32(0);
+  vui32_t v4 = vec_splat_u32(4);
+  vui32_t tmp = vec_sl (v4, v4);
+  return (vui128_t) vec_sld (q_zero, tmp, 4);
+#endif
 }
 
 vui128_t
@@ -1760,25 +2486,25 @@ __test_cmsumudm_V2 (vui128_t * carry, vui64_t a, vui64_t b, vui128_t c)
 vui128_t
 test_vec_sldbi_0  (vui128_t a, vui128_t b)
 {
-  return (vec_vsldbi (a, b, 0));
+  return (vec_sldb_quadword (a, b, 0));
 }
 
 vui128_t
 test_vec_srdbi_0  (vui128_t a, vui128_t b)
 {
-  return (vec_vsrdbi (a, b, 0));
+  return (vec_sldb_quadword (a, b, 0));
 }
 
 vui128_t
 test_vec_sldbi_7  (vui128_t a, vui128_t b)
 {
-  return (vec_vsldbi (a, b, 7));
+  return (vec_sldb_quadword (a, b, 7));
 }
 
 vui128_t
 test_vec_srdbi_7  (vui128_t a, vui128_t b)
 {
-  return (vec_vsrdbi (a, b, 7));
+  return (vec_srdb_quadword (a, b, 7));
 }
 
 unsigned __int128
@@ -2258,6 +2984,54 @@ test_vec_addcuq (vui128_t a, vui128_t b)
 }
 
 vui128_t
+test_vec_rlqi_0 (vui128_t __A)
+{
+  return vec_rlqi (__A, 0);
+}
+
+vui128_t
+test_vec_rlqi_1 (vui128_t __A)
+{
+  return vec_rlqi (__A, 1);
+}
+
+vui128_t
+test_vec_rlqi_15 (vui128_t __A)
+{
+  return vec_rlqi (__A, 15);
+}
+
+vui128_t
+test_vec_rlqi_16 (vui128_t __A)
+{
+  return vec_rlqi (__A, 16);
+}
+
+vui128_t
+test_vec_rlqi_17 (vui128_t __A)
+{
+  return vec_rlqi (__A, 17);
+}
+
+vui128_t
+test_vec_rlqi_31 (vui128_t __A)
+{
+  return vec_rlqi (__A, 31);
+}
+
+vui128_t
+test_vec_rlqi_32 (vui128_t __A)
+{
+  return vec_rlqi (__A, 32);
+}
+
+vui128_t
+test_vec_rlqi_33 (vui128_t __A)
+{
+  return vec_rlqi (__A, 33);
+}
+
+vui128_t
 test_vec_slqi_0 (vui128_t __A)
 {
   return vec_slqi (__A, 0);
@@ -2299,10 +3073,41 @@ test_vec_slqi_17 (vui128_t __A)
 {
   return vec_slqi (__A, 17);
 }
+
+vui128_t
+test_vec_slqi_18 (vui128_t __A)
+{
+  return vec_slqi (__A, 18);
+}
+
+vui128_t
+test_vec_slqi_30 (vui128_t __A)
+{
+  return vec_slqi (__A, 30);
+}
+
 vui128_t
 test_vec_slqi_31 (vui128_t __A)
 {
   return vec_slqi (__A, 31);
+}
+
+vui128_t
+test_vec_slqi_32 (vui128_t __A)
+{
+  return vec_slqi (__A, 32);
+}
+
+vui128_t
+test_vec_slqi_34 (vui128_t __A)
+{
+  return vec_slqi (__A, 34);
+}
+
+vui128_t
+test_vec_slqi_36 (vui128_t __A)
+{
+  return vec_slqi (__A, 36);
 }
 
 vui128_t
@@ -2312,9 +3117,63 @@ test_vec_slqi_48 (vui128_t __A)
 }
 
 vui128_t
+test_vec_slqi_60 (vui128_t __A)
+{
+  return vec_slqi (__A, 60);
+}
+
+vui128_t
+test_vec_slqi_64 (vui128_t __A)
+{
+  return vec_slqi (__A, 64);
+}
+
+vui128_t
+test_vec_slqi_68 (vui128_t __A)
+{
+  return vec_slqi (__A, 68);
+}
+
+vui128_t
+test_vec_slqi_96 (vui128_t __A)
+{
+  return vec_slqi (__A, 96);
+}
+
+vui128_t
+test_vec_slqi_98 (vui128_t __A)
+{
+  return vec_slqi (__A, 98);
+}
+
+vui128_t
+test_vec_slqi_110 (vui128_t __A)
+{
+  return vec_slqi (__A, 110);
+}
+
+vui128_t
+test_vec_slqi_112 (vui128_t __A)
+{
+  return vec_slqi (__A, 112);
+}
+
+vui128_t
+test_vec_slqi_114 (vui128_t __A)
+{
+  return vec_slqi (__A, 114);
+}
+
+vui128_t
 test_vec_slqi_120 (vui128_t __A)
 {
   return vec_slqi (__A, 120);
+}
+
+vui128_t
+test_vec_slqi_127 (vui128_t __A)
+{
+  return vec_slqi (__A, 127);
 }
 
 vui128_t
@@ -2572,6 +3431,7 @@ test_vpaste_x (vui64_t __VH, vui64_t __VL)
   return (result);
 }
 
+#if 0 // Deprecated!
 vui128_t
 test_vsl4 (vui128_t a)
 {
@@ -2583,6 +3443,7 @@ test_vsr4 (vui128_t a)
 {
 	return (vec_srq4(a));
 }
+#endif
 
 vui128_t
 test_vec_sldq (vui128_t a, vui128_t b, vui128_t sh)

--- a/src/testsuite/vec_int64_dummy.c
+++ b/src/testsuite/vec_int64_dummy.c
@@ -966,9 +966,57 @@ __test_splatiud_15 (void)
 }
 
 vui64_t
+__test_splatiud_31 (void)
+{
+  return vec_splat_u64 (31);
+}
+
+vui64_t
+__test_splatiud_31_V1 (void)
+{
+  const int sim = 0x1f;
+  // latency PWR8 4-6
+  const vui32_t q_ones = CONST_VINT128_W (-1, -1, -1, -1);
+#if defined (_ARCH_PWR8)
+  return vec_srdi ((vui64_t) q_ones, (64-5));
+#else
+  // latency PWR7 6-8
+  vui32_t tmp = vec_srwi (q_ones, (32-5));
+  return (vui64_t) vec_vupklsw_PWR8 ((vi32_t) tmp);
+#endif
+}
+
+vui64_t
 __test_splatiud_32 (void)
 {
   return vec_splat_u64 (32);
+}
+
+vui64_t
+__test_splatiud_52 (void)
+{
+  return vec_splat_u64 (52);
+}
+
+vui64_t
+__test_splatiud_63 (void)
+{
+  return vec_splat_u64 (63);
+}
+
+vui64_t
+__test_splatiud_63_V1 (void)
+{
+  const int sim = 0x3f;
+  // latency PWR8 4-6
+  const vui32_t q_ones = CONST_VINT128_W (-1, -1, -1, -1);
+#if defined (_ARCH_PWR8)
+  return vec_srdi ((vui64_t) q_ones, (64-6));
+#else
+  // latency PWR7 6-8
+  vui32_t tmp = vec_srwi (q_ones, (32-6));
+  return (vui64_t) vec_vupklsw_PWR8 ((vi32_t) tmp);
+#endif
 }
 
 vui64_t
@@ -981,6 +1029,21 @@ vui64_t
 __test_splatiud_127 (void)
 {
   return vec_splat_u64 (127);
+}
+
+vui64_t
+__test_splatiud_127_V1 (void)
+{
+  const int sim = 0x7f;
+  // latency PWR8 4-6
+  const vui32_t q_ones = CONST_VINT128_W (-1, -1, -1, -1);
+#if defined (_ARCH_PWR8)
+  return vec_srdi ((vui64_t) q_ones, (64-7));
+#else
+  // latency PWR7 6-8
+  vui32_t tmp = vec_srwi (q_ones, (32-7));
+  return (vui64_t) vec_vupklsw_PWR8 ((vi32_t) tmp);
+#endif
 }
 
 vui64_t

--- a/src/testsuite/vec_pwr10_dummy.c
+++ b/src/testsuite/vec_pwr10_dummy.c
@@ -38,6 +38,24 @@
 #include <pveclib/vec_f32_ppc.h>
 #include <pveclib/vec_bcd_ppc.h>
 
+vui128_t
+__test_splatiuq_127_PWR10 (void)
+{
+  return vec_splat_u128 (127);
+}
+
+vui128_t
+__test_splatiuq_128_PWR10 (void)
+{
+  return vec_splat_u128 (128);
+}
+
+vui128_t
+__test_splatiuq_2147483647_PWR10 (void)
+{
+  return vec_splat_u128 (2147483647);
+}
+
 // latency 4-7
 vi64_t
 __test_splatisd_PWR10_V3 (void)
@@ -173,7 +191,7 @@ __test_splatiuq_PWR10_V3 (void)
 #endif
 }
 
-// latency 6-8
+// latency 6-12
 vui128_t
 __test_splatiuq_PWR10_V2 (void)
 {
@@ -200,7 +218,7 @@ __test_splatiuq_PWR10_V2 (void)
 #endif
 }
 
-// latency 6-8
+// latency 6-12
 vui128_t
 __test_splatiuq_PWR10_V1 (void)
 {
@@ -217,7 +235,7 @@ __test_splatiuq_PWR10_V1 (void)
 #endif
 }
 
-// latency 4-6
+// latency 4-6 for .rodata plxv
 vui128_t
 __test_splatiuq_PWR10_V0 (void)
 {

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -84,6 +84,34 @@ __test_splatisd_PWR9_V2 (void)
 #endif
 }
 
+// latency 6-9
+vi128_t
+__test_splatisq_PWR9_V2 (void)
+{
+  const int sim = -128;
+#if defined(_ARCH_PWR9) && (__GNUC__ > 9)
+  // For ((sim >= -128)(sim < 128)) use vec_splats(signed char)
+  vi8_t vbi = vec_splats ((signed char) sim);
+  return vec_signextq_byte (vbi);
+#else
+  return vec_splats ((signed __int128) sim);
+#endif
+}
+
+// latency 6-9
+vi128_t
+__test_splatisq_PWR9_V1 (void)
+{
+  const int sim = 127;
+#if defined(_ARCH_PWR9) && (__GNUC__ > 9)
+  // For ((sim >= -128)(sim < 128)) use vec_splats(signed char)
+  vi8_t vbi = vec_splats ((signed char) sim);
+  return vec_signextq_byte (vbi);
+#else
+  return vec_splats ((signed __int128) sim);
+#endif
+}
+
 vui64_t
 __test_splatisd_PWR9_254_V2 (void)
 {
@@ -195,10 +223,81 @@ vui64_t
 __test_splatiud_PWR9_V0 (void)
 {
   const int sim = 127;
-#if (__GNUC__ > 6) // AT11 (GCC 7) for splats __int128
+#if (__GNUC__ > 6) // AT11 (GCC 7) for splats long long int
   return vec_splats ((unsigned long long) sim);
 #else
   vui128_t tmp_PWR9 = CONST_VUINT128_QxW (0, 127, 0, 127);
+  return (vui64_t) tmp_PWR9;
+#endif
+}
+
+// latency 11-17
+vui128_t
+__test_splatiuq_PWR9_V4 (void)
+{
+  const int sim = 1023;
+#if defined(_ARCH_PWR9) && (__GNUC__ > 9)
+  // For ((sim < 1024)) use vec_splats(unsigned char)
+  const vui8_t vhh = vec_splats ((unsigned char) (sim/256));
+  const vui8_t vhl = vec_splats ((unsigned char) (sim%256));
+  vi64_t vdw;
+  vi16_t tmp = (vi16_t) vec_mergeh (vhh, vhl);
+  vdw   = vec_signextll_halfword (tmp);
+  return (vui128_t) vec_signextq_doubleword (vdw);
+#else
+  vui128_t tmp_PWR9 = CONST_VUINT128_QxW (0, 0, 0, 1023);
+  return tmp_PWR9;
+#endif
+}
+
+// latency 9-15
+vui128_t
+__test_splatiuq_PWR9_V3 (void)
+{
+  const int sim = 1023;
+#if defined(_ARCH_PWR9) && (__GNUC__ > 9)
+  const vui16_t q_zero = vec_splat_u16(0);
+  // For ((sim < 1024)) use vec_splats(unsigned char)
+  const vui8_t vhh = vec_splats ((unsigned char) (sim/256));
+  const vui8_t vhl = vec_splats ((unsigned char) (sim%256));
+  vui16_t tmp = (vui16_t) vec_mergeh (vhh, vhl);
+  return (vui128_t) vec_sld (q_zero, tmp, 2);
+#else
+  vui128_t tmp_PWR9 = CONST_VUINT128_QxW (0, 0, 0, 1023);
+  return tmp_PWR9;
+#endif
+}
+
+// latency 12-15
+vui128_t
+__test_splatiuq_PWR9_V2c (void)
+{
+  const int sim = 511;
+#if defined(_ARCH_PWR9) && (__GNUC__ > 9)
+  // For ((sim < 511)) use vec_splats(unsigned char)
+  const vi8_t vabi = vec_splats ((signed char) (sim/4));
+  const vi32_t vb = vec_splat_s32 ((sim%4));
+  vi32_t va = vec_signexti_byte (vabi);
+  return (vui128_t) vec_vsumsws_PWR7 (va, vb);
+#else
+  vui128_t tmp_PWR9 = CONST_VUINT128_QxW (0, 0, 0, 1023);
+  return tmp_PWR9;
+#endif
+}
+
+// latency 10-13
+vui128_t
+__test_splatiuq_PWR9_V2b (void)
+{
+  const int sim = 63;
+#if defined(_ARCH_PWR9) && (__GNUC__ > 9)
+  // For ((sim < 1024)) use vec_splats(unsigned char)
+  // const vui8_t va = vec_splats ((unsigned char) (sim/4));
+  const vi32_t va = vec_splat_s32 ((sim/4));
+  const vi32_t vb = vec_splat_s32 ((sim%4));
+  return (vui128_t) vec_vsumsws_PWR7 (va, vb);
+#else
+  vui128_t tmp_PWR9 = CONST_VUINT128_QxW (0, 0, 0, 1023);
   return tmp_PWR9;
 #endif
 }
@@ -581,6 +680,7 @@ __test_splatiud_127_PWR9 (void)
 {
   return vec_splat_u64 (127);
 }
+
 vui64_t
 __test_splatisd_128_PWR9 (void)
 {
@@ -596,6 +696,12 @@ __test_splatudi_12_PWR9 (void)
 // Attempts at better code to splat small QW constants.
 // Want to avoid addr calc and loads for what should be simple
 // splat immediate and sld.
+vi128_t
+__test_splatisq_128_PWR9 (void)
+{
+  return vec_splat_s128 (-128);
+}
+
 vi128_t
 __test_splatisq_16_PWR9 (void)
 {
@@ -627,7 +733,7 @@ __test_splatisq_127_PWR9 (void)
 }
 
 vi128_t
-__test_splatisq_128_PWR9 (void)
+__test_splatisq_p128_PWR9 (void)
 {
   return vec_splat_s128 (128);
 }
@@ -666,6 +772,12 @@ vui128_t
 __test_splatiuq_256_PWR9 (void)
 {
   return vec_splat_u128 (256);
+}
+
+vui128_t
+__test_splatiuq_2147483647_PWR9 (void)
+{
+  return vec_splat_u128 (2147483647);
 }
 
 vui64_t


### PR DESCRIPTION
	* src/pveclib/vec_int128_ppc.h
	- (vec_vsldbi, vec_vslq_byte, vec_vsraq_byte, vec_vsrq_byte): Remove, deprecate forward declares.
	- (vec_expandm_quadword): New inline operation.
	- (vec_rlq): Update doxygen text. Use vec_vrlq_PWR10/vec_vrlq_PWR9 from vec_common_ppc.h.
	- (vec_rlqi): Update doxygen text. Use vec_rlqi_PWR10 from vec_common_ppc.h.
	- (vec_setb_sq): Update doxygen text. Use vec_expandm_quadword.
	- (vec_signextq_doubleword, vec_signextq_byte, vec_signextq_halfword, vec_signextq_word): New inline operations.
	- (vec_vextsd2q, vec_vextsb2q, vec_vextsh2q, vec_vextsw2q): New inline operations.
	- (vec_sldb_quadword): New inline operation.
	- (vec_sldqi): Update doxygen text. Use vec_sldbi_PWR10 from vec_common_ppc.h.
	- (vec_slq): Update doxygen text. Simplify types. Use vec_vslq_PWR10/vec_vslq_PWR9 from vec_common_ppc.h.
	- (vec_slqi): Update doxygen text. Simplify types. Use vec_slqi_PWR10/vec_slqi_PWR9 from vec_common_ppc.h.
	- (vec_splat_s128): Update doxygen text.
	- (vec_splat_s128[_ARCH_PWR10]): Add PWR10 specific implementation.
	- (vec_splat_s128[_ARCH_PWR9]): Use PVECLIB vec_signextq_byte.
	- (vec_splat_s128[_ARCH_PWR8]): Add optimized range cases.
	- (vec_splat_u128): Update doxygen text.
	- (vec_splat_u128[_ARCH_PWR10]): Add PWR10 specific implementation.
	- (vec_splat_u128[_ARCH_PWR8]): Add optimized range cases.
	- (vec_srdb_quadword): New inline operation.
	- (vec_sraq): Update doxygen text. Simplify types.
	- (vec_sraq[_ARCH_PWR10]): Use intrinsic vec_sra or vec_vsraq_PWR10 from vec_common_ppc.h.
	- (vec_sraq[else]): Use vec_vsraq_PWR9 from vec_common_ppc.h.
	- (vec_sraqi): Update doxygen text. Simplify types.
	- (vec_sraqi[_ARCH_PWR10]): Use vec_sraqi_PWR10/vec_sraqi_PWR9 from vec_common_ppc.h.
	- (vec_srq): Update doxygen text. Simplify types.
	- (vec_srq[_ARCH_PWR10]): Use intrinsic vec_sr or vec_vsrq_PWR10 from vec_common_ppc.h.
	- (vec_srq[else]): Use vec_vsrq_PWR9 from vec_common_ppc.h.
	- (vec_srqi): Update doxygen text. Simplify types.
	- (vec_srqi[_ARCH_PWR10]): Use vec_srqi_PWR10/vec_srqi_PWR9 from vec_common_ppc.h.
	- (vec_slq4, vec_slq5, vec_srq4, vec_srq5[deprecated]): Use vec_slqi/vec_srqi. (vec_vslq_byte, vec_vsraq_byte, vec_vsrq_byte[deprecated]): Using vec_vslq_PWR10.vec_vsraq_PWR10, vec_vsrq_PWR10 from vec_common_ppc.h.

	* src/testsuite/arith128_test_i128.c (db_vec_moduq): Fix for compile.
	- (test_sldbi[vec_sldqbi]): Define vec_sldqbi to vec_sldb_quadword.
	- (test_sldbi): Rename vec_vsldbi to vec_sldqbi for unit test.
	- (test_srdbi[vec_srdqbi]): Define vec_srdqbi to vec_srdb_quadword.
	- (test_srdbi): Rename vec_vsrdbi to vec_srdqbi for unit test.
	- (test_splat_128): Split test case into test_splat_s128 and test_splat_u128).
	- (test_vec_divdqu): Correct return type.
	- (test_signextq_d, test_signextq_b, test_signextq_h, test_signextq_w): New unit tests.
	- (test_vec_i128): Add unit tests test_signextq_d, test_signextq_w, test_signextq_h, test_signextq_b, test_splat_s128, test_splat_u128 to driver.

	* src/testsuite/vec_int128_dummy.c
	- (test_vec_signextq_byte, test_vec_signextq_halfword, test_vec_signextq_word, test_vec_signextq_doubleword): New compile tests.
	- (test_vec_vextsb2q, test_vec_vextsh2q, test_vec_vextsw2q, test_vec_vextsd2q): New compile tests.
	- (test_vec_expandm_quadword, test_vexpandqm_PWR): New compile tests.
	- (test_vec_rlq_byte, test_vec_slq_byte, test_vec_srq_byte, test_vec_sraq_byte): Deprecated compile tests.
	- (test_vec_rlqi_PWR_1, test_vec_rlqi_PWR_15, test_vec_rlqi_PWR_16, test_vec_rlqi_PWR_31, test_vec_rlqi_PWR_64. test_vec_rlqi_PWR_112, test_vec_rlqi_PWR_127, test_vec_rlq_PWR): New compile tests.
	- (test_vec_slqi_PWR_1, test_vec_slqi_PWR_15, test_vec_slqi_PWR_16, test_vec_slqi_PWR_31, test_vec_slqi_PWR_32, test_vec_slqi_PWR_48, test_vec_slqi_PWR_64, test_vec_slqi_PWR_112, test_vec_slqi_PWR_127, test_vec_slq_PWR): New compile tests.
	- (test_vec_srqi_PWR_1, test_vec_srqi_PWR_15, test_vec_srqi_PWR_16, test_vec_srqi_PWR_31, test_vec_srqi_PWR_52, test_vec_srqi_PWR_60, test_vec_srqi_PWR_64, test_vec_srqi_PWR_112, test_vec_srqi_PWR_127, test_vec_srq_PWR): New compile tests.
	- (test_vec_sraqi_PWR_1, test_vec_sraqi_PWR_15, test_vec_sraqi_PWR_31, test_vec_sraqi_PWR_32, test_vec_sraqi_PWR_63, test_vec_sraqi_PWR_64, test_vec_sraqi_PWR_112, test_vec_sraqi_PWR_127, test_vec_sraq_PWR): New compile tests.
	- (__test_splatisq_256, __test_splatisq_192, __test_splatisq_128, __test_splatisq_96, __test_splatisq_64, __test_splatisq_32, __test_splatisq_33, __test_splatisq_24, __test_splatisq_16, __test_splatisq_0, __test_splatisq_27, __test_splatisq_31, __test_splatisq_p32, __test_splatisq_p33, __test_splatisq_p56, __test_splatisq_p60, __test_splatisq_p63, __test_splatisq_p64, __test_splatisq_127, __test_splatisq_p128, __test_splatisq_p192, __test_splatisq_p255): New compile tests.
	- (__test_splatisq_n1_V1, __test_splatisq_n1_V0, __test_splatisq_0_V0, __test_splatisq_signmask_V0, __test_splatisq_15_V2, __test_splatisq_15_V1, __test_splatisq_15_V0): New compile tests.
	- (__test_splatiuq_15, __test_splatiuq_16, __test_splatiuq_20, __test_splatiuq_24, __test_splatiuq_29, __test_splatiuq_30, __test_splatiuq_31, __test_splatiuq_32, __test_splatiuq_33, __test_splatiuq_48, __test_splatiuq_55, __test_splatiuq_56, __test_splatiuq_60, __test_splatiuq_63, __test_splatiuq_64, __test_splatiuq_65, __test_splatiuq_72, __test_splatiuq_112, __test_splatiuq_120, __test_splatiuq_129, __test_splatiuq_136, __test_splatiuq_143, __test_splatiuq_144, __test_splatiuq_159, __test_splatiuq_192, __test_splatiuq_255): New compile tests.
	- (__test_splatiuq_V3, __test_splatiuq_V2, __test_splatiuq_V1, __test_splatiuq_V0, __test_splatiuq_32_V0, __test_splatiuq_64_V0): New compile tests.
	- (test_vec_sldbi_0, test_vec_sldbi_7): Use vec_sldb_quadword.
	- (test_vec_srdbi_0, test_vec_srdbi_7): Use vec_srdb_quadword.
	- (test_vec_rlqi_0, test_vec_rlqi_1, test_vec_rlqi_15, test_vec_rlqi_16, test_vec_rlqi_17, test_vec_rlqi_31, test_vec_rlqi_32, test_vec_rlqi_33): New compile tests.
	- (test_vec_slqi_18, test_vec_slqi_30, test_vec_slqi_32, test_vec_slqi_34, test_vec_slqi_36, test_vec_slqi_60, test_vec_slqi_64, test_vec_slqi_68, test_vec_slqi_96, test_vec_slqi_98, test_vec_slqi_110, test_vec_slqi_112, test_vec_slqi_114, test_vec_slqi_127): New compile tests.
	- (test_vsl4, test_vsl5, test_vsr4, test_vsr5): Deprecated.

	* src/testsuite/vec_pwr10_dummy.c
	- (__test_splatiuq_127_PWR10, __test_splatiuq_128_PWR10. __test_splatiuq_2147483647_PWR10): New compile tests.

	* src/testsuite/vec_pwr9_dummy.c
	- (__test_splatisq_PWR9_V2, __test_splatisq_PWR9_V1): New compile tests.
	- (__test_splatiud_PWR9_V0): Correct comment.
	- (__test_splatiuq_PWR9_V4, __test_splatiuq_PWR9_V3, __test_splatiuq_PWR9_V2c, __test_splatiuq_PWR9_V2b): New compile tests.
	- (__test_splatisq_p128_PWR9): Renamed from __test_splatisq_128_PWR9
	- (__test_splatiuq_2147483647_PWR9): New compile tests.