### PR TITLE
Add exploit common parts for f64 and P10.

### DIFF
--- a/src/testsuite/vec_f64_dummy.c
+++ b/src/testsuite/vec_f64_dummy.c
@@ -41,6 +41,69 @@ test_vec_copysignf64 (vf64_t x, vf64_t y)
   return vec_copysignf64 (x, y);
 }
 
+vui64_t
+test_vec_const64_f64bias ()
+{
+  return vec_const64_f64bias ();
+}
+
+vui64_t
+test_vec_const64_f64maxe ()
+{
+  return vec_const64_f64maxe ();
+}
+
+vui64_t
+test_vec_const64_f64naninf ()
+{
+  return vec_const64_f64naninf ();
+}
+
+vui64_t
+test_vec_mask64_f64sign ()
+{
+  return vec_mask64_f64sign ();
+}
+
+vui64_t
+test_vec_mask64_f64mag ()
+{
+  return vec_mask64_f64mag ();
+}
+
+vui64_t
+test_vec_mask64_f64sig ()
+{
+  return vec_mask64_f64sig ();
+}
+
+vui64_t
+test_vec_mask64_f64exp ()
+{
+  return vec_mask64_f64exp ();
+}
+
+vui64_t
+test_vec_mask64_f64hidden ()
+{
+  return vec_mask64_f64hidden ();
+}
+
+vui64_t
+test_vec_mask64_f64hidden_V2 ()
+{
+  vui32_t v1 = vec_splat_u32(1);
+  return vec_sldi ((vui64_t) v1, 52);
+}
+
+vui64_t
+test_vec_mask64_f64hidden_V1 ()
+{
+  const vui64_t signmask = vec_mask64_f64sign ();
+  // Min normal exp same as hidden bit.
+  return vec_srdi (signmask, 11);
+}
+
 vf64_t
 test_vec_xviexpdp (vui64_t sig, vui64_t exp)
 {
@@ -57,6 +120,42 @@ vui64_t
 test_vec_xvxsigdp (vf64_t f64)
 {
   return vec_xvxsigdp (f64);
+}
+
+vb64_t
+test_vec_iszerof64 (vf64_t vf64)
+{
+  return vec_iszerof64 (vf64);
+}
+
+vb64_t
+test_vec_issubnormalf64 (vf64_t vf64)
+{
+  return vec_issubnormalf64 (vf64);
+}
+
+vb64_t
+test_vec_isnormalf64 (vf64_t vf64)
+{
+  return vec_isnormalf64 (vf64);
+}
+
+vb64_t
+test_vec_isnanf64 (vf64_t vf64)
+{
+  return vec_isnanf64 (vf64);
+}
+
+vb64_t
+test_vec_isinff64 (vf64_t vf64)
+{
+  return vec_isinff64 (vf64);
+}
+
+vb64_t
+test_vec_isfinitef64 (vf64_t vf64)
+{
+  return vec_isfinitef64 (vf64);
 }
 
 vb64_t
@@ -459,25 +558,25 @@ test_load_vf64 ( vf64_t *val)
 }
 
 int
-test_f64_isfinite (double value)
+test__builtin_f64_isfinite (double value)
 {
   return (__builtin_isfinite (value));
 }
 
 int
-test_f64_isinf (double value)
+test__builtin_f64_isinf (double value)
 {
   return (__builtin_isinf (value));
 }
 
 int
-test_f64_isnan (double value)
+test__builtin_f64_isnan (double value)
 {
   return (__builtin_isnan (value));
 }
 
 int
-test_f64_isnormal (double value)
+test__builtin_f64_isnormal (double value)
 {
   return (__builtin_isnormal (value));
 }
@@ -568,6 +667,36 @@ __test_cmpledp (vf64_t a, vf64_t b)
   return vec_cmple (a, b);
 }
 #endif
+
+void
+test_vec_xviexpdp_loop (vf64_t* out, vui64_t* sig, vui64_t* exp, int N)
+{
+  int i;
+  for (i=0; i<N; i++)
+    {
+      out[i] = vec_xviexpdp (sig[i], exp[i]);
+    }
+}
+
+void
+test_vec_xvxexpdp_loop (vui64_t* out, vf64_t* in, int N)
+{
+  int i;
+  for (i=0; i<N; i++)
+    {
+      out[i] = vec_xvxexpdp (in[i]);
+    }
+}
+
+void
+test_vec_xvxsigdp_loop (vui64_t* out, vf64_t* in, int N)
+{
+  int i;
+  for (i=0; i<N; i++)
+    {
+      out[i] = vec_xvxsigdp (in[i]);
+    }
+}
 
 /*
  * The following are both compile tests for Gather/Scatter operations


### PR DESCRIPTION
generating vector DW integer constants for DP float masks are difficult for _ARCH_PWR7/8 and not so easy for _ARCH_PWR9. Fortunately _ARCH_PWR9 includes DP exponent/signifcand extract/inserts and vec_test_data_class operations.

But that leaves some coding work for _ARCH_PWR7/8 which requires DW shift, range compare, and mask generation. Unfortunately the compiler generate sub-optimal code for vector const (.rodata) loads for _ARCH_PWR7/8/9. So where possible should use splat-immediate, shift, rotate, and logical operations and avoid vector constant loads (see issue #204).

So this update uses the vec_common_ppc.h support for DW shift/rotate and splat immediate beyond the range (-16 to 15). The header vec_f64_ppc.h now includes a number of helper operations to generate DP float mask and range values. Both are used in the implementation of the f64 data class and extract/insert operations.

	* src/pveclib/vec_f64_ppc.h (vec_addexp_DW, vec_subexp_DW, vec_const64_f64bias, vec_const64_f64maxe, vec_const64_f64naninf, vec_mask64_f64sign, vec_mask64_f64mag, vec_mask64_f64sig, vec_mask64_f64exp, vec_mask64_f64hidden): New inline helper operations.
	- (vec_absf64): Update doxygen latency table.
	- (vec_all_isfinitef64): Update doxygen latency table.
	- (vec_all_isfinitef64 [!_ARCH_PWR9]): Use vec_mask64_f64exp().
	- (vec_all_isinff64): Update doxygen latency table.
	- (vec_all_isinff64 [!_ARCH_PWR9]): Use vec_mask64_f64exp() and vec_mask64_f64sign.
	- (vec_all_isnanf64): Update doxygen latency table.
	- (vec_all_isnanf64 [!_ARCH_PWR9]): Use vec_mask64_f64exp() and vec_mask64_f64sign.
	- (vec_all_isnormalf64): Update doxygen latency table.
	- (vec_all_isnormalf64 [!_ARCH_PWR9]): Use vec_mask64_f64exp().
	- (vec_all_issubnormalf64): Update doxygen latency table.
	- (vec_all_issubnormalf64 [!_ARCH_PWR9]): Use vec_mask64_f64sign() and generate explow/hidden.
	- (vec_all_iszerof64): Update doxygen latency table.
	- (vec_all_iszerof64 [!_ARCH_PWR9]): Use vec_mask64_f64sign().
	- (vec_any_isfinitef64): Update doxygen latency table.
	- (vec_any_isfinitef64 [!_ARCH_PWR9]): Use vec_mask64_f64exp().
	- (vec_any_isinff64): Update doxygen latency table.
	- (vec_any_isinff64 [!_ARCH_PWR9]): Use vec_mask64_f64exp() and vec_mask64_f64sign.
	- (vec_any_isnanf64): Update doxygen latency table.
	- (vec_any_isnanf64 [!_ARCH_PWR9]): Use vec_mask64_f64exp() and vec_mask64_f64sign.
	- (vec_any_isnormalf64): Update doxygen latency table.
	- (vec_any_isnormalf64 [!_ARCH_PWR9]): Use vec_mask64_f64exp().
	- (vec_any_issubnormalf64): Update doxygen latency table.
	- (vec_any_issubnormalf64 [!_ARCH_PWR9]): Use vec_mask64_f64sign() and generate explow/hidden.
	- (vec_any_iszerof64): Update doxygen latency table.
	- (vec_any_iszerof64 [!_ARCH_PWR9]): Use vec_mask64_f64sign().
	- (vec_copysignf64): Update doxygen latency table.
	- (vec_isfinitef64): Update doxygen latency table.
	- (vec_isfinitef64 [!_ARCH_PWR9]): Use vec_mask64_f64exp().
	- (vec_isinff64): Update doxygen latency table.
	- (vec_isinff64 [!_ARCH_PWR9]): Use vec_mask64_f64exp() and vec_mask64_f64sign.
	- (vec_isnanf64): Update doxygen latency table.
	- (vec_isnanf64 [!_ARCH_PWR9]): Use vec_mask64_f64exp() and vec_mask64_f64sign.
	- (vec_isnormalf64): Update doxygen latency table.
	- (vec_isnormalf64 [!_ARCH_PWR9]): Use vec_mask64_f64exp().
	- (vec_issubnormalf64): Update doxygen latency table.
	- (vec_issubnormalf64 [!_ARCH_PWR9]): Use vec_mask64_f64sign() and generate explow/hidden.
	- (vec_iszerof64): Update doxygen latency table.
	- (vec_iszerof64 [!_ARCH_PWR9]): Use vec_mask64_f64sign().
	- (vec_xviexpdp): Update doxygen latency table.
	- (vec_xviexpdp [_ARCH_PWR8]): Use vec_mask64_f64exp() and vec_sldi.
	- (vec_xviexpdp [!_ARCH_PWR8]): Use vec_mask64_f64exp() and vec_slqi.
	- (vec_xvxexpdp): Update doxygen latency table.
	- (vec_xvxexpdp [_ARCH_PWR8]): Use vec_mask64_f64sign(), vec_andc, and vec_srdi.
	- (vec_xvxexpdp [!_ARCH_PWR8]): Use vec_mask64_f64exp(), vec_and and vec_slqi.
	- (vec_xvxsigdp): Update doxygen latency table.
	- (vec_xvxsigdp [_ARCH_PWR8]): Use vec_mask64_f64sign() and vec_mask64_f64sig to generate expmask and hidden.
	- (vec_xvxsigdp [!_ARCH_PWR8]): Use vec_mask64_f64exp(), vec_mask64_f64exp and vec_mask64_f64hidden.

	* src/testsuite/vec_f64_dummy.c (test_vec_const64_f64bias, test_vec_const64_f64maxe, test_vec_const64_f64naninf, test_vec_mask64_f64sign, test_vec_mask64_f64mag, test_vec_mask64_f64sig, test_vec_mask64_f64exp, test_vec_mask64_f64hidden): New compile tests for helper operations.
	- (test_vec_mask64_f64hidden_V2, test_vec_mask64_f64hidden_V1): Compile tests of a expermental type.
	- (test_vec_iszerof64, test_vec_issubnormalf64, test_vec_isnormalf64, test_vec_isnanf64, test_vec_isinff64, test_vec_isfinitef64): New compile tests.
	- (test__builtin_f64_isfinite, test__builtin_f64_isinf, test__builtin_f64_isnan, test__builtin_f64_isnormal): Compile tests to see that the compiler does.
	- test_vec_xviexpdp_loop, test_vec_xvxexpdp_loop, test_vec_xvxsigdp_loop): Compile tests to separate common sub-expression from core function.