### PR TITLE
Add exploit common parts for long long and P10, part2.

### DIFF
--- a/src/pveclib/vec_int64_ppc.h
+++ b/src/pveclib/vec_int64_ppc.h
@@ -4814,7 +4814,6 @@ vec_splat_s64 (const int sim)
   else if (__builtin_constant_p (sim))
     {
       vi32_t vword;
-      vi64_t vdw;
       vword = vec_splati (sim);
       return  vec_signextll_word (vword);
     }
@@ -4965,7 +4964,6 @@ vec_splat_u64 (const int sim)
   else if (__builtin_constant_p (sim) && (sim <= 2147483647))
     {
       vi32_t vword;
-      vi64_t vdw;
       vword = vec_splati (sim);
       return (vui64_t) vec_signextll_word (vword);
     }
@@ -5085,6 +5083,14 @@ vec_splat_u64 (const int sim)
       result = vec_srdi_PWR8 ((vui64_t) q_ones, (64-8));
     }
 #endif
+  else if (__builtin_constant_p (sim) && ((sim > 30) && (sim <=60) && (sim % 4 == 0)))
+    {
+      vi32_t tmp;
+      const vui32_t v2 = vec_splat_u32(2);
+      const vi32_t vhnib = vec_splat_s32((sim / 4));
+      tmp = vec_sl (vhnib, v2);
+      result = (vui64_t) vec_vupklsw_PWR8 (tmp);
+    }
   else if (__builtin_constant_p (sim) && ((sim > 45) && (sim < 256)))
     {
       vi32_t tmp;

--- a/src/testsuite/vec_int64_dummy.c
+++ b/src/testsuite/vec_int64_dummy.c
@@ -974,7 +974,6 @@ __test_splatiud_31 (void)
 vui64_t
 __test_splatiud_31_V1 (void)
 {
-  const int sim = 0x1f;
   // latency PWR8 4-6
   const vui32_t q_ones = CONST_VINT128_W (-1, -1, -1, -1);
 #if defined (_ARCH_PWR8)
@@ -1007,7 +1006,6 @@ __test_splatiud_63 (void)
 vui64_t
 __test_splatiud_63_V1 (void)
 {
-  const int sim = 0x3f;
   // latency PWR8 4-6
   const vui32_t q_ones = CONST_VINT128_W (-1, -1, -1, -1);
 #if defined (_ARCH_PWR8)
@@ -1034,7 +1032,6 @@ __test_splatiud_127 (void)
 vui64_t
 __test_splatiud_127_V1 (void)
 {
-  const int sim = 0x7f;
   // latency PWR8 4-6
   const vui32_t q_ones = CONST_VINT128_W (-1, -1, -1, -1);
 #if defined (_ARCH_PWR8)


### PR DESCRIPTION
This includes some cleanup and additional optimizations needed for f64 and f128.

	* src/pveclib/vec_int64_ppc.h (vec_splat_s64): Cleanup for -Wall.
	- (vec_splat_u64): Cleanup for -Wall. Plus optimize for modulo 4 case.

	* src/testsuite/vec_int64_dummy.c (__test_splatiud_31_V1, __test_splatiud_63_V1, __test_splatiud_127_V1): Cleanup for -Wall.