### PR TITLE
Add exploit common parts for float128 and P10 plus IFUNC.

### DIFF
--- a/src/testsuite/arith128_test_f128.c
+++ b/src/testsuite/arith128_test_f128.c
@@ -10999,9 +10999,22 @@ test_cmpne_all_f128 ()
 
 //#define __DEBUG_PRINT__ 1
 #ifdef __DEBUG_PRINT__
+#if (__DEBUG_PRINT__ == 2)
 #define test_xscvdpqp(_i)	db_vec_xscvdpqp(_i)
 #else
-#define test_xscvdpqp(_i)	vec_xscvdpqp(_i)
+// Test the implementation from vec_f128_dummy.c
+extern __binary128 test_vec_xscvdpqp (vf64_t f64);
+#define test_xscvdpqp(_i)	test_vec_xscvdpqp(_i)
+#endif
+#else
+#if 1
+// Test implementation from libpvecstatic
+extern __binary128 __VEC_PWR_IMP (vec_xscvdpqp) (vf64_t f64);
+#define test_xscvdpqp(_i)	__VEC_PWR_IMP (vec_xscvdpqp)(_i)
+#else
+// Test inline implementation from vec_f128_ppc.h
+#define test_xscvdpqp(_i)	vec_xscvdpqp_inline(_i)
+#endif
 #endif
 
 int
@@ -11155,6 +11168,20 @@ test_convert_dpqp (void)
 }
 
 //#define __DEBUG_PRINT__ 1
+#ifdef __DEBUG_PRINT__
+// Test the implementation from vec_f128_dummy.c
+extern __binary128 test_vec_xscvudqp (vui64_t);
+#define test_xscvudqp(_i)	test_vec_xscvudqp(_i)
+#else
+#if 1
+// Test implementation from libpvecstatic
+extern __binary128 __VEC_PWR_IMP (vec_xscvudqp) (vui64_t);
+#define test_xscvudqp(_i)	__VEC_PWR_IMP (vec_xscvudqp)(_i)
+#else
+// Test inline implementation from vec_f128_ppc.h
+#define test_xscvudqp(_i)	vec_xscvudqp_inline(_i)
+#endif
+#endif
 
 int
 test_convert_udqp (void)
@@ -11170,7 +11197,7 @@ test_convert_udqp (void)
 #ifdef __DEBUG_PRINT__
   print_v2xint64 (" x=", x);
 #endif
-  t = vec_xscvudqp (x);
+  t = test_xscvudqp (x);
   e = vec_xfer_vui64t_2_bin128 (vf128_zero);
   rc += check_f128 ("check vec_xscvudqp", e, t, e);
 
@@ -11179,7 +11206,7 @@ test_convert_udqp (void)
 #ifdef __DEBUG_PRINT__
   print_v2xint64 (" x=", x);
 #endif
-  t = vec_xscvudqp (x);
+  t = test_xscvudqp (x);
   e = vec_xfer_vui64t_2_bin128 (vf128_one);
   rc += check_f128 ("check vec_xscvudqp", e, t, e);
 
@@ -11188,7 +11215,7 @@ test_convert_udqp (void)
 #ifdef __DEBUG_PRINT__
   print_v2xint64 (" x=", x);
 #endif
-  t = vec_xscvudqp (x);
+  t = test_xscvudqp (x);
   eui = (vui64_t) CONST_VINT64_DW ( 0x403dffffffffffff, 0xfffc000000000000);
   e = vec_xfer_vui64t_2_bin128 (eui);
   rc += check_f128 ("check vec_xscvudqp", e, t, e);
@@ -11198,7 +11225,7 @@ test_convert_udqp (void)
 #ifdef __DEBUG_PRINT__
   print_v2xint64 (" x=", x);
 #endif
-  t = vec_xscvudqp (x);
+  t = test_xscvudqp (x);
   eui = (vui64_t) CONST_VINT64_DW ( 0x403e000000000000, 0x0000000000000000);
   e = vec_xfer_vui64t_2_bin128 (eui);
   rc += check_f128 ("check vec_xscvudqp", e, t, e);
@@ -11208,7 +11235,7 @@ test_convert_udqp (void)
 #ifdef __DEBUG_PRINT__
   print_v2xint64 (" x=", x);
 #endif
-  t = vec_xscvudqp (x);
+  t = test_xscvudqp (x);
   eui = (vui64_t) CONST_VINT64_DW ( 0x403effffffffffff, 0xfffe000000000000);
   e = vec_xfer_vui64t_2_bin128 (eui);
   rc += check_f128 ("check vec_xscvudqp", e, t, e);
@@ -11216,6 +11243,21 @@ test_convert_udqp (void)
   return (rc);
 }
 
+//#define __DEBUG_PRINT__ 1
+#ifdef __DEBUG_PRINT__
+// Test the implementation from vec_f128_dummy.c
+extern __binary128 test_vec_xscvsdqp (vi64_t);
+#define test_xscvsdqp(_i)	test_vec_xscvsdqp(_i)
+#else
+#if 1
+// Test implementation from libpvecstatic
+extern __binary128 __VEC_PWR_IMP (vec_xscvsdqp) (vi64_t);
+#define test_xscvsdqp(_i)	__VEC_PWR_IMP (vec_xscvsdqp)(_i)
+#else
+// Test inline implementation from vec_f128_ppc.h
+#define test_xscvsdqp(_i)	vec_xscvsdqp_inline(_i)
+#endif
+#endif
 int
 test_convert_sdqp (void)
 {
@@ -11230,7 +11272,7 @@ test_convert_sdqp (void)
 #ifdef __DEBUG_PRINT__
   print_v2xint64 (" x=", (vui64_t) x);
 #endif
-  t = vec_xscvsdqp (x);
+  t = test_xscvsdqp (x);
   e = vec_xfer_vui64t_2_bin128 (vf128_zero);
   rc += check_f128 ("check vec_xscvsdqp", e, t, e);
 
@@ -11239,7 +11281,7 @@ test_convert_sdqp (void)
 #ifdef __DEBUG_PRINT__
   print_v2xint64 (" x=", (vui64_t) x);
 #endif
-  t = vec_xscvsdqp (x);
+  t = test_xscvsdqp (x);
   e = vec_xfer_vui64t_2_bin128 (vf128_one);
   rc += check_f128 ("check vec_xscvsdqp", e, t, e);
 
@@ -11248,7 +11290,7 @@ test_convert_sdqp (void)
 #ifdef __DEBUG_PRINT__
   print_v2xint64 (" x=", (vui64_t) x);
 #endif
-  t = vec_xscvsdqp (x);
+  t = test_xscvsdqp (x);
   eui = (vui64_t) CONST_VINT64_DW ( 0x403dffffffffffff, 0xfffc000000000000);
   e = vec_xfer_vui64t_2_bin128 (eui);
   rc += check_f128 ("check vec_xscvsdqp", e, t, e);
@@ -11258,7 +11300,7 @@ test_convert_sdqp (void)
 #ifdef __DEBUG_PRINT__
   print_v2xint64 (" x=", (vui64_t) x);
 #endif
-  t = vec_xscvsdqp (x);
+  t = test_xscvsdqp (x);
   eui = (vui64_t) CONST_VINT64_DW ( 0xc03e000000000000, 0x0000000000000000);
   e = vec_xfer_vui64t_2_bin128 (eui);
   rc += check_f128 ("check vec_xscvsdqp", e, t, e);
@@ -11268,12 +11310,28 @@ test_convert_sdqp (void)
 #ifdef __DEBUG_PRINT__
   print_v2xint64 (" x=", (vui64_t) x);
 #endif
-  t = vec_xscvsdqp (x);
+  t = test_xscvsdqp (x);
   e = vec_xfer_vui64t_2_bin128 (vf128_none);
   rc += check_f128 ("check vec_xscvsdqp", e, t, e);
 
   return (rc);
 }
+
+// #define __DEBUG_PRINT__ 1
+#ifdef __DEBUG_PRINT__
+// Test the implementation from vec_f128_dummy.c
+extern __binary128 test_vec_xscvuqqp (vui128_t);
+#define test_xscvuqqp(_i)	test_vec_xscvuqqp(_i)
+#else
+#if 1
+// Test implementation from libpvecstatic
+extern __binary128 __VEC_PWR_IMP (vec_xscvuqqp) (vui128_t);
+#define test_xscvuqqp(_i)	__VEC_PWR_IMP (vec_xscvuqqp)(_i)
+#else
+// Test inline implementation from vec_f128_ppc.h
+#define test_xscvuqqp(_i)	vec_xscvuqqp_inline(_i)
+#endif
+#endif
 
 int
 test_convert_uqqp (void)
@@ -11287,27 +11345,27 @@ test_convert_uqqp (void)
   x = (vui128_t) CONST_VINT128_DW ( 0, 0 );
 
 #ifdef __DEBUG_PRINT__
-  print_v2xint64 (" x=", x);
+  print_vint128 (" x=", x);
 #endif
-  t = vec_xscvuqqp (x);
+  t = test_xscvuqqp (x);
   e = vec_xfer_vui64t_2_bin128 (vf128_zero);
   rc += check_f128 ("check vec_xscvuqqp", e, t, e);
 
   x = (vui128_t) CONST_VINT128_DW ( 0, 1 );
 
 #ifdef __DEBUG_PRINT__
-  print_v2xint64 (" x=", x);
+  print_vint128 (" x=", x);
 #endif
-  t = vec_xscvuqqp (x);
+  t = test_xscvuqqp (x);
   e = vec_xfer_vui64t_2_bin128 (vf128_one);
   rc += check_f128 ("check vec_xscvuqqp", e, t, e);
 
   x = (vui128_t) CONST_VINT128_DW ( 0, 0x7fffffffffffffff );
 
 #ifdef __DEBUG_PRINT__
-  print_v2xint64 (" x=", x);
+  print_vint128 (" x=", x);
 #endif
-  t = vec_xscvuqqp (x);
+  t = test_xscvuqqp (x);
   eui = (vui64_t) CONST_VINT64_DW ( 0x403dffffffffffff, 0xfffc000000000000);
   e = vec_xfer_vui64t_2_bin128 (eui);
   rc += check_f128 ("check vec_xscvuqqp", e, t, e);
@@ -11315,9 +11373,9 @@ test_convert_uqqp (void)
   x = (vui128_t) CONST_VINT128_DW ( 0, 0x8000000000000000 );
 
 #ifdef __DEBUG_PRINT__
-  print_v2xint64 (" x=", x);
+  print_vint128 (" x=", x);
 #endif
-  t = vec_xscvuqqp (x);
+  t = test_xscvuqqp (x);
   eui = (vui64_t) CONST_VINT64_DW ( 0x403e000000000000, 0x0000000000000000);
   e = vec_xfer_vui64t_2_bin128 (eui);
   rc += check_f128 ("check vec_xscvuqqp", e, t, e);
@@ -11325,9 +11383,9 @@ test_convert_uqqp (void)
   x = (vui128_t) CONST_VINT128_DW ( 0x8000000000000000, 0 );
 
 #ifdef __DEBUG_PRINT__
-  print_v2xint64 (" x=", x);
+  print_vint128 (" x=", x);
 #endif
-  t = vec_xscvuqqp (x);
+  t = test_xscvuqqp (x);
   eui = (vui64_t) CONST_VINT64_DW ( 0x407e000000000000, 0x0000000000000000);
   e = vec_xfer_vui64t_2_bin128 (eui);
   rc += check_f128 ("check vec_xscvuqqp", e, t, e);
@@ -11335,9 +11393,9 @@ test_convert_uqqp (void)
   x = (vui128_t) CONST_VINT128_DW ( 0xffffffffffffffff, 0xffffffffffffffff );
 
 #ifdef __DEBUG_PRINT__
-  print_v2xint64 (" x=", x);
+  print_vint128 (" x=", x);
 #endif
-  t = vec_xscvuqqp (x);
+  t = test_xscvuqqp (x);
   eui = (vui64_t) CONST_VINT64_DW ( 0x407f000000000000, 0x0000000000000000);
   e = vec_xfer_vui64t_2_bin128 (eui);
   rc += check_f128 ("check vec_xscvuqqp", e, t, e);
@@ -11346,9 +11404,9 @@ test_convert_uqqp (void)
   x = (vui128_t) CONST_VINT128_DW ( 0xffffffffffffffff, 0xffffffffffff0000 );
 
 #ifdef __DEBUG_PRINT__
-  print_v2xint64 (" x=", x);
+  print_vint128 (" x=", x);
 #endif
-  t = vec_xscvuqqp (x);
+  t = test_xscvuqqp (x);
   eui = (vui64_t) CONST_VINT64_DW ( 0x407effffffffffff, 0xfffffffffffffffe);
   e = vec_xfer_vui64t_2_bin128 (eui);
   rc += check_f128 ("check vec_xscvuqqp", e, t, e);
@@ -11356,9 +11414,9 @@ test_convert_uqqp (void)
   x = (vui128_t) CONST_VINT128_DW ( 0xffffffffffffffff, 0xffffffffffff4000 );
 
 #ifdef __DEBUG_PRINT__
-  print_v2xint64 (" x=", x);
+  print_vint128 (" x=", x);
 #endif
-  t = vec_xscvuqqp (x);
+  t = test_xscvuqqp (x);
   eui = (vui64_t) CONST_VINT64_DW ( 0x407effffffffffff, 0xfffffffffffffffe);
   e = vec_xfer_vui64t_2_bin128 (eui);
   rc += check_f128 ("check vec_xscvuqqp", e, t, e);
@@ -11366,9 +11424,9 @@ test_convert_uqqp (void)
   x = (vui128_t) CONST_VINT128_DW ( 0xffffffffffffffff, 0xffffffffffff5000 );
 
 #ifdef __DEBUG_PRINT__
-  print_v2xint64 (" x=", x);
+  print_vint128 (" x=", x);
 #endif
-  t = vec_xscvuqqp (x);
+  t = test_xscvuqqp (x);
   eui = (vui64_t) CONST_VINT64_DW ( 0x407effffffffffff, 0xffffffffffffffff);
   e = vec_xfer_vui64t_2_bin128 (eui);
   rc += check_f128 ("check vec_xscvuqqp", e, t, e);
@@ -11376,9 +11434,9 @@ test_convert_uqqp (void)
   x = (vui128_t) CONST_VINT128_DW ( 0xffffffffffffffff, 0xffffffffffff6000 );
 
 #ifdef __DEBUG_PRINT__
-  print_v2xint64 (" x=", x);
+  print_vint128 (" x=", x);
 #endif
-  t = vec_xscvuqqp (x);
+  t = test_xscvuqqp (x);
   eui = (vui64_t) CONST_VINT64_DW ( 0x407effffffffffff, 0xffffffffffffffff);
   e = vec_xfer_vui64t_2_bin128 (eui);
   rc += check_f128 ("check vec_xscvuqqp", e, t, e);
@@ -11386,9 +11444,9 @@ test_convert_uqqp (void)
   x = (vui128_t) CONST_VINT128_DW ( 0xffffffffffffffff, 0xffffffffffff8000 );
 
 #ifdef __DEBUG_PRINT__
-  print_v2xint64 (" x=", x);
+  print_vint128 (" x=", x);
 #endif
-  t = vec_xscvuqqp (x);
+  t = test_xscvuqqp (x);
   eui = (vui64_t) CONST_VINT64_DW ( 0x407effffffffffff, 0xffffffffffffffff);
   e = vec_xfer_vui64t_2_bin128 (eui);
   rc += check_f128 ("check vec_xscvuqqp", e, t, e);
@@ -11396,9 +11454,9 @@ test_convert_uqqp (void)
   x = (vui128_t) CONST_VINT128_DW ( 0xffffffffffffffff, 0xffffffffffff9000 );
 
 #ifdef __DEBUG_PRINT__
-  print_v2xint64 (" x=", x);
+  print_vint128 (" x=", x);
 #endif
-  t = vec_xscvuqqp (x);
+  t = test_xscvuqqp (x);
   eui = (vui64_t) CONST_VINT64_DW ( 0x407effffffffffff, 0xffffffffffffffff);
   e = vec_xfer_vui64t_2_bin128 (eui);
   rc += check_f128 ("check vec_xscvuqqp", e, t, e);
@@ -11406,9 +11464,9 @@ test_convert_uqqp (void)
   x = (vui128_t) CONST_VINT128_DW ( 0xffffffffffffffff, 0xffffffffffffa000 );
 
 #ifdef __DEBUG_PRINT__
-  print_v2xint64 (" x=", x);
+  print_vint128 (" x=", x);
 #endif
-  t = vec_xscvuqqp (x);
+  t = test_xscvuqqp (x);
   eui = (vui64_t) CONST_VINT64_DW ( 0x407effffffffffff, 0xffffffffffffffff);
   e = vec_xfer_vui64t_2_bin128 (eui);
   rc += check_f128 ("check vec_xscvuqqp", e, t, e);
@@ -11416,9 +11474,9 @@ test_convert_uqqp (void)
   x = (vui128_t) CONST_VINT128_DW ( 0xffffffffffffffff, 0xffffffffffffc000 );
 
 #ifdef __DEBUG_PRINT__
-  print_v2xint64 (" x=", x);
+  print_vint128 (" x=", x);
 #endif
-  t = vec_xscvuqqp (x);
+  t = test_xscvuqqp (x);
   eui = (vui64_t) CONST_VINT64_DW ( 0x407f000000000000, 0x0000000000000000);
   e = vec_xfer_vui64t_2_bin128 (eui);
   rc += check_f128 ("check vec_xscvuqqp", e, t, e);
@@ -11426,9 +11484,9 @@ test_convert_uqqp (void)
   x = (vui128_t) CONST_VINT128_DW ( 0xffffffffffffffff, 0xffffffffffff4000 );
 
 #ifdef __DEBUG_PRINT__
-  print_v2xint64 (" x=", x);
+  print_vint128 (" x=", x);
 #endif
-  t = vec_xscvuqqp (x);
+  t = test_xscvuqqp (x);
   eui = (vui64_t) CONST_VINT64_DW ( 0x407effffffffffff, 0xfffffffffffffffe);
   e = vec_xfer_vui64t_2_bin128 (eui);
   rc += check_f128 ("check vec_xscvuqqp", e, t, e);
@@ -11436,15 +11494,31 @@ test_convert_uqqp (void)
   x = (vui128_t) CONST_VINT128_DW ( 0xffffffffffffffff, 0xffffffffffff6000 );
 
 #ifdef __DEBUG_PRINT__
-  print_v2xint64 (" x=", x);
+  print_vint128 (" x=", x);
 #endif
-  t = vec_xscvuqqp (x);
+  t = test_xscvuqqp (x);
   eui = (vui64_t) CONST_VINT64_DW ( 0x407effffffffffff, 0xffffffffffffffff);
   e = vec_xfer_vui64t_2_bin128 (eui);
   rc += check_f128 ("check vec_xscvuqqp", e, t, e);
 
   return (rc);
 }
+
+//#define __DEBUG_PRINT__ 1
+#ifdef __DEBUG_PRINT__
+// Test the implementation from vec_f128_dummy.c
+extern __binary128 test_vec_xscvsqqp (vi128_t);
+#define test_xscvsqqp(_i)	test_vec_xscvsqqp(_i)
+#else
+#if 1
+// Test implementation from libpvecstatic
+extern __binary128 __VEC_PWR_IMP (vec_xscvsqqp) (vi128_t);
+#define test_xscvsqqp(_i)	__VEC_PWR_IMP (vec_xscvsqqp)(_i)
+#else
+// Test inline implementation from vec_f128_ppc.h
+#define test_xscvsqqp(_i)	vec_xscvsqqp_inline(_i)
+#endif
+#endif
 
 int
 test_convert_sqqp (void)
@@ -11458,27 +11532,27 @@ test_convert_sqqp (void)
   x = (vi128_t) CONST_VINT128_DW ( 0, 0 );
 
 #ifdef __DEBUG_PRINT__
-  print_v2xint64 (" x=", x);
+  print_vint128s (" x=", x);
 #endif
-  t = vec_xscvsqqp (x);
+  t = test_xscvsqqp (x);
   e = vec_xfer_vui64t_2_bin128 (vf128_zero);
   rc += check_f128 ("check vec_xscvsqqp", e, t, e);
 
   x = (vi128_t) CONST_VINT128_DW ( 0, 1 );
 
 #ifdef __DEBUG_PRINT__
-  print_v2xint64 (" x=", x);
+  print_vint128s (" x=", x);
 #endif
-  t = vec_xscvsqqp (x);
+  t = test_xscvsqqp (x);
   e = vec_xfer_vui64t_2_bin128 (vf128_one);
   rc += check_f128 ("check vec_xscvsqqp", e, t, e);
 
   x = (vi128_t) CONST_VINT128_DW ( 0, 0x7fffffffffffffff );
 
 #ifdef __DEBUG_PRINT__
-  print_v2xint64 (" x=", x);
+  print_vint128s (" x=", x);
 #endif
-  t = vec_xscvsqqp (x);
+  t = test_xscvsqqp (x);
   eui = (vui64_t) CONST_VINT64_DW ( 0x403dffffffffffff, 0xfffc000000000000);
   e = vec_xfer_vui64t_2_bin128 (eui);
   rc += check_f128 ("check vec_xscvsqqp", e, t, e);
@@ -11486,9 +11560,9 @@ test_convert_sqqp (void)
   x = (vi128_t) CONST_VINT128_DW ( 0, 0x8000000000000000 );
 
 #ifdef __DEBUG_PRINT__
-  print_v2xint64 (" x=", x);
+  print_vint128s (" x=", x);
 #endif
-  t = vec_xscvsqqp (x);
+  t = test_xscvsqqp (x);
   eui = (vui64_t) CONST_VINT64_DW ( 0x403e000000000000, 0x0000000000000000);
   e = vec_xfer_vui64t_2_bin128 (eui);
   rc += check_f128 ("check vec_xscvsqqp", e, t, e);
@@ -11496,9 +11570,9 @@ test_convert_sqqp (void)
   x = (vi128_t) CONST_VINT128_DW ( 0x8000000000000000, 0 );
 
 #ifdef __DEBUG_PRINT__
-  print_v2xint64 (" x=", x);
+  print_vint128s (" x=", x);
 #endif
-  t = vec_xscvsqqp (x);
+  t = test_xscvsqqp (x);
   eui = (vui64_t) CONST_VINT64_DW ( 0xc07e000000000000, 0x0000000000000000);
   e = vec_xfer_vui64t_2_bin128 (eui);
   rc += check_f128 ("check vec_xscvsqqp", e, t, e);
@@ -11506,9 +11580,9 @@ test_convert_sqqp (void)
   x = (vi128_t) CONST_VINT128_DW ( 0xffffffffffffffff, 0xffffffffffffffff );
 
 #ifdef __DEBUG_PRINT__
-  print_v2xint64 (" x=", x);
+  print_vint128s (" x=", x);
 #endif
-  t = vec_xscvsqqp (x);
+  t = test_xscvsqqp (x);
   e = vec_xfer_vui64t_2_bin128 (vf128_none);
   rc += check_f128 ("check vec_xscvsqqp", e, t, e);
 
@@ -11516,9 +11590,9 @@ test_convert_sqqp (void)
   x = (vi128_t) CONST_VINT128_DW ( 0x7fffffffffffffff, 0xffffffffffff8000 );
 
 #ifdef __DEBUG_PRINT__
-  print_v2xint64 (" x=", x);
+  print_vint128s (" x=", x);
 #endif
-  t = vec_xscvsqqp (x);
+  t = test_xscvsqqp (x);
   eui = (vui64_t) CONST_VINT64_DW ( 0x407dffffffffffff, 0xfffffffffffffffe);
   e = vec_xfer_vui64t_2_bin128 (eui);
   rc += check_f128 ("check vec_xscvsqqp", e, t, e);
@@ -11526,9 +11600,9 @@ test_convert_sqqp (void)
   x = (vi128_t) CONST_VINT128_DW ( 0x7fffffffffffffff, 0xffffffffffffa000 );
 
 #ifdef __DEBUG_PRINT__
-  print_v2xint64 (" x=", x);
+  print_vint128s (" x=", x);
 #endif
-  t = vec_xscvsqqp (x);
+  t = test_xscvsqqp (x);
   eui = (vui64_t) CONST_VINT64_DW ( 0x407dffffffffffff, 0xfffffffffffffffe);
   e = vec_xfer_vui64t_2_bin128 (eui);
   rc += check_f128 ("check vec_xscvsqqp", e, t, e);
@@ -11536,9 +11610,9 @@ test_convert_sqqp (void)
   x = (vi128_t) CONST_VINT128_DW ( 0x7fffffffffffffff, 0xffffffffffffb800 );
 
 #ifdef __DEBUG_PRINT__
-  print_v2xint64 (" x=", x);
+  print_vint128s (" x=", x);
 #endif
-  t = vec_xscvsqqp (x);
+  t = test_xscvsqqp (x);
   eui = (vui64_t) CONST_VINT64_DW ( 0x407dffffffffffff, 0xffffffffffffffff);
   e = vec_xfer_vui64t_2_bin128 (eui);
   rc += check_f128 ("check vec_xscvsqqp", e, t, e);
@@ -11546,9 +11620,9 @@ test_convert_sqqp (void)
   x = (vi128_t) CONST_VINT128_DW ( 0x7fffffffffffffff, 0xffffffffffffb000 );
 
 #ifdef __DEBUG_PRINT__
-  print_v2xint64 (" x=", x);
+  print_vint128s (" x=", x);
 #endif
-  t = vec_xscvsqqp (x);
+  t = test_xscvsqqp (x);
   eui = (vui64_t) CONST_VINT64_DW ( 0x407dffffffffffff, 0xffffffffffffffff);
   e = vec_xfer_vui64t_2_bin128 (eui);
   rc += check_f128 ("check vec_xscvsqqp", e, t, e);
@@ -11556,9 +11630,9 @@ test_convert_sqqp (void)
   x = (vi128_t) CONST_VINT128_DW ( 0x7fffffffffffffff, 0xffffffffffffc000 );
 
 #ifdef __DEBUG_PRINT__
-  print_v2xint64 (" x=", x);
+  print_vint128s (" x=", x);
 #endif
-  t = vec_xscvsqqp (x);
+  t = test_xscvsqqp (x);
   eui = (vui64_t) CONST_VINT64_DW ( 0x407dffffffffffff, 0xffffffffffffffff);
   e = vec_xfer_vui64t_2_bin128 (eui);
   rc += check_f128 ("check vec_xscvsqqp", e, t, e);
@@ -11566,9 +11640,9 @@ test_convert_sqqp (void)
   x = (vi128_t) CONST_VINT128_DW ( 0x7fffffffffffffff, 0xffffffffffffa000 );
 
 #ifdef __DEBUG_PRINT__
-  print_v2xint64 (" x=", x);
+  print_vint128s (" x=", x);
 #endif
-  t = vec_xscvsqqp (x);
+  t = test_xscvsqqp (x);
   eui = (vui64_t) CONST_VINT64_DW ( 0x407dffffffffffff, 0xfffffffffffffffe);
   e = vec_xfer_vui64t_2_bin128 (eui);
   rc += check_f128 ("check vec_xscvsqqp", e, t, e);
@@ -11576,9 +11650,9 @@ test_convert_sqqp (void)
   x = (vi128_t) CONST_VINT128_DW ( 0x7fffffffffffffff, 0xffffffffffff6000 );
 
 #ifdef __DEBUG_PRINT__
-  print_v2xint64 (" x=", x);
+  print_vint128s (" x=", x);
 #endif
-  t = vec_xscvsqqp (x);
+  t = test_xscvsqqp (x);
   eui = (vui64_t) CONST_VINT64_DW ( 0x407dffffffffffff, 0xfffffffffffffffe);
   e = vec_xfer_vui64t_2_bin128 (eui);
   rc += check_f128 ("check vec_xscvsqqp", e, t, e);
@@ -11587,6 +11661,24 @@ test_convert_sqqp (void)
 }
 
 //#define __DEBUG_PRINT__ 1
+#ifdef __DEBUG_PRINT__
+#if (__DEBUG_PRINT__ == 2)
+#define test_xscvqpuqz(_i)	db_vec_xscvqpuqz(_i)
+#else
+// Test the implementation from vec_f128_dummy.c
+extern vui128_t test_vec_xscvqpuqz (__binary128);
+#define test_xscvqpuqz(_i)	test_vec_xscvqpuqz(_i)
+#endif
+#else
+#if 1
+// Test implementation from libpvecstatic
+extern vui128_t __VEC_PWR_IMP (vec_xscvqpuqz) (__binary128);
+#define test_xscvqpuqz(_i)	__VEC_PWR_IMP (vec_xscvqpuqz)(_i)
+#else
+// Test inline implementation from vec_f128_ppc.h
+#define test_xscvqpuqz(_i)	vec_xscvqpuqz_inline(_i)
+#endif
+#endif
 int
 test_convert_qpuqz (void)
 {
@@ -11601,7 +11693,7 @@ test_convert_qpuqz (void)
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
-  t = vec_xscvqpuqz (x);
+  t = test_xscvqpuqz (x);
   e = (vui128_t) CONST_VINT128_DW ( 0, 0 );
   rc += check_vuint128 ("check vec_xscvqpuqz", (vui128_t) t, (vui128_t) e);
 
@@ -11610,7 +11702,7 @@ test_convert_qpuqz (void)
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
-  t = vec_xscvqpuqz (x);
+  t = test_xscvqpuqz (x);
   e = (vui128_t) CONST_VINT128_DW ( 0, 0 );
   rc += check_vuint128 ("check vec_xscvqpuqz", (vui128_t) t, (vui128_t) e);
 
@@ -11619,7 +11711,7 @@ test_convert_qpuqz (void)
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
-  t = vec_xscvqpuqz (x);
+  t = test_xscvqpuqz (x);
   e = (vui128_t) CONST_VINT128_DW ( 0, 0 );
   rc += check_vuint128 ("check vec_xscvqpuqz", (vui128_t) t, (vui128_t) e);
 
@@ -11628,7 +11720,7 @@ test_convert_qpuqz (void)
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
-  t = vec_xscvqpuqz (x);
+  t = test_xscvqpuqz (x);
   e = (vui128_t) CONST_VINT128_DW ( 0, 1 );
   rc += check_vuint128x ("check vec_xscvqpuqz", (vui128_t) t, (vui128_t) e);
 
@@ -11638,7 +11730,7 @@ test_convert_qpuqz (void)
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
-  t = vec_xscvqpuqz (x);
+  t = test_xscvqpuqz (x);
   e = (vui128_t) CONST_VINT128_DW ( 0x8000000000000000, 0);
   rc += check_vuint128x ("check vec_xscvqpuqz", (vui128_t) t, (vui128_t) e);
 
@@ -11648,7 +11740,7 @@ test_convert_qpuqz (void)
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
-  t = vec_xscvqpuqz (x);
+  t = test_xscvqpuqz (x);
   e = (vui128_t) CONST_VINT128_DW ( 0xffffffffffffffff, 0xffffffffffff8000 );
   rc += check_vuint128x ("check vec_xscvqpuqz", (vui128_t) t, (vui128_t) e);
 
@@ -11658,7 +11750,7 @@ test_convert_qpuqz (void)
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
-  t = vec_xscvqpuqz (x);
+  t = test_xscvqpuqz (x);
   e = (vui128_t) CONST_VINT128_DW ( 0x0, 0x8000000000000000);
   rc += check_vuint128x ("check vec_xscvqpuqz", (vui128_t) t, (vui128_t) e);
 
@@ -11668,7 +11760,7 @@ test_convert_qpuqz (void)
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
-  t = vec_xscvqpuqz (x);
+  t = test_xscvqpuqz (x);
   e = (vui128_t) CONST_VINT128_DW ( 0x0, 0xffffffffffffffff );
 
   rc += check_vuint128x ("check vec_xscvqpuqz", (vui128_t) t, (vui128_t) e);
@@ -11679,7 +11771,7 @@ test_convert_qpuqz (void)
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
-  t = vec_xscvqpuqz (x);
+  t = test_xscvqpuqz (x);
   e = (vui128_t) CONST_VINT128_DW ( 0xffffffffffffffff, 0xffffffffffffffff);
   rc += check_vuint128x ("check vec_xscvqpuqz", (vui128_t) t, (vui128_t) e);
 
@@ -11689,7 +11781,7 @@ test_convert_qpuqz (void)
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
-  t = vec_xscvqpuqz (x);
+  t = test_xscvqpuqz (x);
   e = (vui128_t) CONST_VINT128_DW ( 0xffffffffffffffff, 0xffffffffffffffff );
   rc += check_vuint128x ("check vec_xscvqpuqz", (vui128_t) t, (vui128_t) e);
 
@@ -11698,7 +11790,7 @@ test_convert_qpuqz (void)
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
-  t = vec_xscvqpuqz (x);
+  t = test_xscvqpuqz (x);
   e = (vui128_t) CONST_VINT128_DW ( 0xffffffffffffffff, 0xffffffffffffffff );
   rc += check_vuint128x ("check vec_xscvqpuqz", (vui128_t) t, (vui128_t) e);
 
@@ -11707,7 +11799,7 @@ test_convert_qpuqz (void)
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
-  t = vec_xscvqpuqz (x);
+  t = test_xscvqpuqz (x);
   e = (vui128_t) CONST_VINT128_DW ( 0, 0 );
   rc += check_vuint128x ("check vec_xscvqpuqz", (vui128_t) t, (vui128_t) e);
 
@@ -11716,14 +11808,29 @@ test_convert_qpuqz (void)
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
-  t = vec_xscvqpuqz (x);
+  t = test_xscvqpuqz (x);
   e = (vui128_t) CONST_VINT128_DW ( 0, 0 );
   rc += check_vuint128x ("check vec_xscvqpuqz", (vui128_t) t, (vui128_t) e);
 
   return (rc);
 }
+#undef __DEBUG_PRINT__
 
 //#define __DEBUG_PRINT__ 1
+#ifdef __DEBUG_PRINT__
+// Test the implementation from vec_f128_dummy.c
+extern vui64_t test_vec_xscvqpudz (__binary128);
+#define test_xscvqpudz(_i)	test_vec_xscvqpudz(_i)
+#else
+#if 1
+// Test implementation from libpvecstatic
+extern vui64_t __VEC_PWR_IMP (vec_xscvqpudz) (__binary128);
+#define test_xscvqpudz(_i)	__VEC_PWR_IMP (vec_xscvqpudz)(_i)
+#else
+// Test inline implementation from vec_f128_ppc.h
+#define test_xscvqpudz(_i)	vec_xscvqpudz_inline(_i)
+#endif
+#endif
 int
 test_convert_qpudz (void)
 {
@@ -11738,7 +11845,7 @@ test_convert_qpudz (void)
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
-  t = vec_xscvqpudz (x);
+  t = test_xscvqpudz (x);
   e = (vui64_t) CONST_VINT128_DW ( 0, 0 );
   rc += check_vuint128x ("check vec_xscvqpudz", (vui128_t) t, (vui128_t) e);
 
@@ -11747,7 +11854,7 @@ test_convert_qpudz (void)
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
-  t = vec_xscvqpudz (x);
+  t = test_xscvqpudz (x);
   e = (vui64_t) CONST_VINT128_DW ( 0, 0 );
   rc += check_vuint128x ("check vec_xscvqpudz", (vui128_t) t, (vui128_t) e);
 
@@ -11756,7 +11863,7 @@ test_convert_qpudz (void)
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
-  t = vec_xscvqpudz (x);
+  t = test_xscvqpudz (x);
   e = (vui64_t) CONST_VINT128_DW ( 0, 0 );
   rc += check_vuint128x ("check vec_xscvqpudz", (vui128_t) t, (vui128_t) e);
 
@@ -11765,7 +11872,7 @@ test_convert_qpudz (void)
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
-  t = vec_xscvqpudz (x);
+  t = test_xscvqpudz (x);
   e = (vui64_t) CONST_VINT128_DW ( 1, 0 );
   rc += check_vuint128x ("check vec_xscvqpudz", (vui128_t) t, (vui128_t) e);
 
@@ -11775,7 +11882,7 @@ test_convert_qpudz (void)
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
-  t = vec_xscvqpudz (x);
+  t = test_xscvqpudz (x);
   e = (vui64_t) CONST_VINT128_DW ( 0x8000000000000000, 0);
   rc += check_vuint128x ("check vec_xscvqpudz", (vui128_t) t, (vui128_t) e);
 
@@ -11785,7 +11892,7 @@ test_convert_qpudz (void)
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
-  t = vec_xscvqpudz (x);
+  t = test_xscvqpudz (x);
   e = (vui64_t) CONST_VINT128_DW ( 0xffffffffffffffff, 0 );
   rc += check_vuint128x ("check vec_xscvqpudz", (vui128_t) t, (vui128_t) e);
 
@@ -11795,7 +11902,7 @@ test_convert_qpudz (void)
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
-  t = vec_xscvqpudz (x);
+  t = test_xscvqpudz (x);
   e = (vui64_t) CONST_VINT128_DW ( 0x8000000000000000, 0);
   rc += check_vuint128x ("check vec_xscvqpudz", (vui128_t) t, (vui128_t) e);
 
@@ -11805,7 +11912,7 @@ test_convert_qpudz (void)
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
-  t = vec_xscvqpudz (x);
+  t = test_xscvqpudz (x);
   e = (vui64_t) CONST_VINT128_DW ( 0xffffffffffffffff, 0);
 
   rc += check_vuint128x ("check vec_xscvqpudz", (vui128_t) t, (vui128_t) e);
@@ -11816,7 +11923,7 @@ test_convert_qpudz (void)
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
-  t = vec_xscvqpudz (x);
+  t = test_xscvqpudz (x);
   e = (vui64_t) CONST_VINT128_DW ( 0xffffffffffffffff, 0);
   rc += check_vuint128x ("check vec_xscvqpudz", (vui128_t) t, (vui128_t) e);
 
@@ -11826,7 +11933,7 @@ test_convert_qpudz (void)
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
-  t = vec_xscvqpudz (x);
+  t = test_xscvqpudz (x);
   e = (vui64_t) CONST_VINT128_DW ( 0xffffffffffffffff, 0 );
   rc += check_vuint128x ("check vec_xscvqpudz", (vui128_t) t, (vui128_t) e);
 
@@ -11835,7 +11942,7 @@ test_convert_qpudz (void)
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
-  t = vec_xscvqpudz (x);
+  t = test_xscvqpudz (x);
   e = (vui64_t) CONST_VINT128_DW ( 0xffffffffffffffff, 0 );
   rc += check_vuint128x ("check vec_xscvqpudz", (vui128_t) t, (vui128_t) e);
 
@@ -11844,7 +11951,7 @@ test_convert_qpudz (void)
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
-  t = vec_xscvqpudz (x);
+  t = test_xscvqpudz (x);
   e = (vui64_t) CONST_VINT128_DW ( 0, 0 );
   rc += check_vuint128x ("check vec_xscvqpudz", (vui128_t) t, (vui128_t) e);
 
@@ -11853,20 +11960,33 @@ test_convert_qpudz (void)
 #ifdef __DEBUG_PRINT__
   print_vfloat128x(" x=  ", x);
 #endif
-  t = vec_xscvqpudz (x);
+  t = test_xscvqpudz (x);
   e = (vui64_t) CONST_VINT128_DW ( 0, 0 );
   rc += check_vuint128x ("check vec_xscvqpudz", (vui128_t) t, (vui128_t) e);
 
   return (rc);
 }
 
-
 //#define __DEBUG_PRINT__ 1
 #ifdef __DEBUG_PRINT__
-#define test_xscvqpdpo(_l)	db_vec_xscvqpdpo(_l)
+#if (__DEBUG_PRINT__ == 2)
+#define test_xscvqpdpo(_i)	db_vec_xscvqpdpo(_i)
 #else
-#define test_xscvqpdpo(_l)	vec_xscvqpdpo(_l)
+// Test the implementation from vec_f128_dummy.c
+extern vf64_t test_vec_xscvqpdpo (__binary128 f64);
+#define test_xscvqpdpo(_i)	test_vec_xscvqpdpo(_i)
 #endif
+#else
+#if 1
+// Test implementation from libpvecstatic
+extern vf64_t __VEC_PWR_IMP (vec_xscvqpdpo) (__binary128 f64);
+#define test_xscvqpdpo(_i)	__VEC_PWR_IMP (vec_xscvqpdpo)(_i)
+#else
+// Test inline implementation from vec_f128_ppc.h
+#define test_xscvqpdpo(_i)	vec_xscvqpdpo_inline(_i)
+#endif
+#endif
+
 int
 test_convert_qpdpo (void)
 {
@@ -11981,6 +12101,28 @@ test_convert_qpdpo (void)
 #endif
   t = test_xscvqpdpo (x);
   e = (vf64_t) CONST_VINT128_DW ( 1, 0 );
+  rc += check_vuint128x ("check vec_xscvqpdpo", (vui128_t) t, (vui128_t) e);
+
+  // Smallest QP normal
+  xui = CONST_VINT128_DW ( 0x0001000000000000, 0x0000000000000000 );
+  x = vec_xfer_vui64t_2_bin128 ( xui );
+
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = test_xscvqpdpo (x);
+  e = (vf64_t) CONST_VINT128_DW ( 1, 0 );
+  rc += check_vuint128x ("check vec_xscvqpdpo", (vui128_t) t, (vui128_t) e);
+
+  // Small QP normal, converts to DP denormal and round to odd
+  xui = CONST_VINT128_DW ( 0x3bce000000000000, 0x0000000000000001 );
+  x = vec_xfer_vui64t_2_bin128 ( xui );
+
+#ifdef __DEBUG_PRINT__
+  print_vfloat128x(" x=  ", x);
+#endif
+  t = test_xscvqpdpo (x);
+  e = (vf64_t) CONST_VINT128_DW ( 3, 0 );
   rc += check_vuint128x ("check vec_xscvqpdpo", (vui128_t) t, (vui128_t) e);
 
   // Smallest QP denormal

--- a/src/testsuite/vec_pwr10_dummy.c
+++ b/src/testsuite/vec_pwr10_dummy.c
@@ -60,8 +60,8 @@ __test_splatiuq_2147483647_PWR10 (void)
 vi64_t
 __test_splatisd_PWR10_V3 (void)
 {
-  const int sim = -128;
 #if defined (_ARCH_PWR10) && (defined (__GNUC__) && (__GNUC__ >= 11))
+  const int sim = -128;
   if (__builtin_constant_p (sim) && (-128 <= sim) && (sim < 128))
     { // Saves a word of code space
       vi8_t vbyte;
@@ -71,7 +71,6 @@ __test_splatisd_PWR10_V3 (void)
   else if (__builtin_constant_p (sim))
     {
       vi32_t vword;
-      vi64_t vdw;
       vword = vec_splati (sim);
       return  vec_signextll_word (vword);
     }
@@ -135,8 +134,8 @@ __test_splatiud_PWR10_V1 (void)
 vi128_t
 __test_splatisq_PWR10_V3 (void)
 {
-  const int sim = -2147483648;
 #if defined (_ARCH_PWR10) && (defined (__GNUC__) && (__GNUC__ >= 11))
+  const int sim = -2147483648;
   if (__builtin_constant_p (sim) && (-128 <= sim) && (sim < 128))
     { // Saves a word of code space
       vi8_t vbyte;
@@ -165,8 +164,8 @@ __test_splatisq_PWR10_V3 (void)
 vui128_t
 __test_splatiuq_PWR10_V3 (void)
 {
-  const int sim = 248;
 #if defined (_ARCH_PWR10) && (defined (__GNUC__) && (__GNUC__ >= 11))
+  const int sim = 248;
   if (__builtin_constant_p (sim) && (sim < 128))
     { // Saves a word of code space
       vi8_t vbyte;
@@ -186,7 +185,7 @@ __test_splatiuq_PWR10_V3 (void)
   else
     return vec_splats ((unsigned __int128) sim);
 #else
-  vui128_t tmp_PWR10 = CONST_VUINT128_QxW (0, 0, 0, 1023);
+  vui128_t tmp_PWR10 = CONST_VUINT128_QxW (0, 0, 0, 248);
   return tmp_PWR10;
 #endif
 }
@@ -195,8 +194,8 @@ __test_splatiuq_PWR10_V3 (void)
 vui128_t
 __test_splatiuq_PWR10_V2 (void)
 {
-  const int sim = 248;
 #if defined (_ARCH_PWR10) && (defined (__GNUC__) && (__GNUC__ >= 11))
+  const int sim = 248;
   if (__builtin_constant_p (sim) && (sim < 256))
     { // Saves a word of code space
       const vui8_t q_zero = vec_splat_u8(0);
@@ -205,15 +204,15 @@ __test_splatiuq_PWR10_V2 (void)
     }
   else if (__builtin_constant_p (sim) && (sim <= 2147483647))
     {
-  // For ((sim < 256)) use vec_splats()
-  const vui32_t q_zero = vec_splat_u32(0);
-  vui32_t vai = (vui32_t) vec_splati (sim);
-  return (vui128_t) vec_sldw (q_zero, vai, 1);
+      // For ((sim < 256)) use vec_splats()
+      const vui32_t q_zero = vec_splat_u32(0);
+      vui32_t vai = (vui32_t) vec_splati (sim);
+      return (vui128_t) vec_sldw (q_zero, vai, 1);
     }
   else
-    return vec_splats ((unsigned __int128) sim);
+  return vec_splats ((unsigned __int128) sim);
 #else
-  vui128_t tmp_PWR10 = CONST_VUINT128_QxW (0, 0, 0, 1023);
+  vui128_t tmp_PWR10 = CONST_VUINT128_QxW(0, 0, 0, 248);
   return tmp_PWR10;
 #endif
 }
@@ -222,9 +221,9 @@ __test_splatiuq_PWR10_V2 (void)
 vui128_t
 __test_splatiuq_PWR10_V1 (void)
 {
-  const int sim = 1023;
 #if defined (_ARCH_PWR10) && (defined (__GNUC__) && (__GNUC__ >= 11))
   // For ((sim < 256)) use vec_splats()
+  const int sim = 1023;
   const vui32_t q_zero = vec_splat_u32(0);
   vui32_t vai = (vui32_t) vec_splati (sim);
   //return (vui128_t) vec_sld (q_zero, vai, 4);
@@ -592,14 +591,20 @@ __test_vec_abssq_PWR10 (vi128_t vra)
 vui128_t
 test_vec_xscvqpuqz_PWR10 (__binary128 f128)
 {
-  return vec_xscvqpuqz (f128);
+  return vec_xscvqpuqz_inline (f128);
 }
 
 // Convert Integer QW to QP
 __binary128
+test_vec_xscvsqqp_PWR10 (vi128_t int128)
+{
+  return vec_xscvsqqp_inline (int128);
+}
+
+__binary128
 test_vec_xscvuqqp_PWR10 (vui128_t int128)
 {
-  return vec_xscvuqqp (int128);
+  return vec_xscvuqqp_inline (int128);
 }
 
 vb128_t
@@ -872,12 +877,6 @@ __test_cmsumudm_V2_PWR10 (vui128_t * carry, vui64_t a, vui64_t b, vui128_t c)
 {
   *carry = vec_msumcud ( a, b, c);
   return vec_msumudm ( a, b, c);
-}
-
-vui128_t
-test_vec_srdbi_PWR10  (vui128_t a, vui128_t b, const unsigned int  sh)
-{
-  return ((vui128_t) vec_srdbi_PWR10 ((vui8_t) a, (vui8_t) b, sh));
 }
 
 vui128_t

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -1058,39 +1058,39 @@ test_scalar_test_neg_PWR9 (__binary128 vfa)
 vf64_t
 test_vec_xscvqpdpo_PWR9 (__binary128 f128)
 {
-  return vec_xscvqpdpo (f128);
+  return vec_xscvqpdpo_inline (f128);
 }
 
 vui64_t
 test_vec_xscvqpudz_PWR9 (__binary128 f128)
 {
-  return vec_xscvqpudz (f128);
+  return vec_xscvqpudz_inline (f128);
 }
 
 vui128_t
 test_vec_xscvqpuqz_PWR9 (__binary128 f128)
 {
-  return vec_xscvqpuqz (f128);
+  return vec_xscvqpuqz_inline (f128);
 }
 
 // Convert Float DP to QP
 __binary128
 test_vec_xscvdpqp_PWR9 (vf64_t f64)
 {
-  return vec_xscvdpqp (f64);
+  return vec_xscvdpqp_inline (f64);
 }
 
 // Convert Integer QW to QP
 __binary128
 test_vec_xscvsqqp_PWR9 (vi128_t int128)
 {
-  return vec_xscvsqqp (int128);
+  return vec_xscvsqqp_inline (int128);
 }
 
 __binary128
 test_vec_xscvuqqp_PWR9 (vui128_t int128)
 {
-  return vec_xscvuqqp (int128);
+  return vec_xscvuqqp_inline (int128);
 }
 
 // Convert Float DP to QP
@@ -1237,12 +1237,12 @@ test_convert_qpuqz_PWR9 (__binary128 f128)
 	      vui64_t ull_low, ull_high;
 	      // TBD xscvqpudz to proceed.
 	      tmp128 = f128 * qp_shr64;
-	      ull_high = vec_xscvqpudz (tmp128);
+	      ull_high = vec_xscvqpudz_inline (tmp128);
 	      //hi128 = ull_high [VEC_DW_H];
-	      hi128 = vec_xscvudqp (ull_high);
+	      hi128 = vec_xscvudqp_inline (ull_high);
 	      hi128 = hi128 * qp_shl64;
 	      tmp128 = tmp128 - hi128;
-	      ull_low = vec_xscvqpudz (tmp128);
+	      ull_low = vec_xscvqpudz_inline (tmp128);
 	      result = (vui128_t) vec_mrgahd ((vui128_t) ull_high, (vui128_t) ull_low);
 	    }
 	  else

--- a/src/vec_f128_runtime.c
+++ b/src/vec_f128_runtime.c
@@ -58,4 +58,52 @@ __VEC_PWR_IMP (vec_xsmsubqpo) (__binary128 vfa, __binary128 vfb, __binary128 vfc
   return vec_xsmsubqpo_inline (vfa, vfb, vfc);
 }
 
+__binary128
+__VEC_PWR_IMP (vec_xscvdpqp) (vf64_t vfa)
+{
+  return vec_xscvdpqp_inline (vfa);
+}
+
+vf64_t
+__VEC_PWR_IMP (vec_xscvqpdpo) (__binary128 vfa)
+{
+  return vec_xscvqpdpo_inline (vfa);
+}
+
+vui64_t
+__VEC_PWR_IMP (vec_xscvqpudz) (__binary128 vfa)
+{
+  return vec_xscvqpudz_inline (vfa);
+}
+
+vui128_t
+__VEC_PWR_IMP (vec_xscvqpuqz) (__binary128 vfa)
+{
+  return vec_xscvqpuqz_inline (vfa);
+}
+
+__binary128
+__VEC_PWR_IMP (vec_xscvsdqp) (vi64_t vfa)
+{
+  return vec_xscvsdqp_inline (vfa);
+}
+
+__binary128
+__VEC_PWR_IMP (vec_xscvsqqp) (vi128_t vfa)
+{
+  return vec_xscvsqqp_inline (vfa);
+}
+
+__binary128
+__VEC_PWR_IMP (vec_xscvudqp) (vui64_t vfa)
+{
+  return vec_xscvudqp_inline (vfa);
+}
+
+__binary128
+__VEC_PWR_IMP (vec_xscvuqqp) (vui128_t vfa)
+{
+  return vec_xscvuqqp_inline (vfa);
+}
+
 

--- a/src/vec_runtime_DYN.c
+++ b/src/vec_runtime_DYN.c
@@ -114,6 +114,15 @@
  * parameters.
  * \sa \ref main_libary_issues_0_0_2
  * \sa \ref main_libary_issues_0_0 */
+#define VEC_RESOLVER_1(_VT,_FUNC,_VA) \
+static _VT \
+(* RESPASTE(_FUNC) (void))(_VA) \
+{ \
+  VEC_DYN_RESOLVER(_FUNC); \
+} \
+_VT _FUNC (_VA) \
+__attribute__ ((ifunc ("resolve_" #_FUNC )));
+
 #define VEC_RESOLVER_2(_VT,_FUNC,_VA,_VB) \
 static _VT \
 (* RESPASTE(_FUNC) (void))(_VA, _VB) \
@@ -158,7 +167,15 @@ extern __binary128 vec_xssubqpo ## _TARGET (__binary128, __binary128); \
 extern __binary128 vec_xsdivqpo ## _TARGET (__binary128, __binary128); \
 extern __binary128 vec_xsmulqpo ## _TARGET (__binary128, __binary128); \
 extern __binary128 vec_xsmaddqpo ## _TARGET (__binary128, __binary128, __binary128); \
-extern __binary128 vec_xsmsubqpo ## _TARGET (__binary128, __binary128, __binary128);
+extern __binary128 vec_xsmsubqpo ## _TARGET (__binary128, __binary128, __binary128); \
+extern __binary128 vec_xscvdpqp ## _TARGET (vf64_t); \
+extern vf64_t vec_xscvqpdpo ## _TARGET (__binary128); \
+extern vui64_t vec_xscvqpudz ## _TARGET (__binary128); \
+extern vui128_t vec_xscvqpuqz ## _TARGET (__binary128); \
+extern __binary128 vec_xscvsdqp ## _TARGET (vi64_t); \
+extern __binary128 vec_xscvsqqp ## _TARGET (vi128_t); \
+extern __binary128 vec_xscvudqp ## _TARGET (vui64_t); \
+extern __binary128 vec_xscvuqqp ## _TARGET (vui128_t);
 
 #define VEC_INT512_LIB_LIST(_TARGET) \
 extern __VEC_U_256 vec_mul128x128 ## _TARGET (vui128_t, vui128_t); \
@@ -296,6 +313,14 @@ VEC_RESOLVER_2 (__binary128, vec_xsmulqpo, __binary128, __binary128);
 VEC_RESOLVER_2 (__binary128, vec_xssubqpo, __binary128, __binary128);
 VEC_RESOLVER_3 (__binary128, vec_xsmaddqpo, __binary128, __binary128, __binary128);
 VEC_RESOLVER_3 (__binary128, vec_xsmsubqpo, __binary128, __binary128, __binary128);
+VEC_RESOLVER_1 (__binary128, vec_xscvdpqp, vf64_t);
+VEC_RESOLVER_1 (vf64_t, vec_xscvqpdpo, __binary128);
+VEC_RESOLVER_1 (vui64_t, vec_xscvqpudz, __binary128);
+VEC_RESOLVER_1 (vui128_t, vec_xscvqpuqz, __binary128);
+VEC_RESOLVER_1 (__binary128, vec_xscvsdqp, vi64_t);
+VEC_RESOLVER_1 (__binary128, vec_xscvsqqp, vi128_t);
+VEC_RESOLVER_1 (__binary128, vec_xscvudqp, vui64_t);
+VEC_RESOLVER_1 (__binary128, vec_xscvuqqp, vui128_t);
 
 /* Declare the required static resolvers and ifunc aliases for dynamic
  * selection of CPU specific implementations supporting


### PR DESCRIPTION
Complete exploitation of common splat and shift immediate support. Also complete the migration of large f128 implementations to librarys with IFUNC resolvers

	* src/pveclib/vec_f128_ppc.h (vec_mask128_f128mag, vec_mask128_f128Lbit): Forward prototypes.
	- (vec_const64_f128_63, vec_const64_f128_112, vec_const64_f128_116, vec_const64_f128_127, vec_const64_f128bias, vec_const64_f128maxe, vec_const64_f128naninf, vec_const128_f128_fmax, vec_mask64_f128exp, vec_mask128_f128Xbits): New helper operations.
	- (vec_all_isfinitef128, vec_all_isnormalf128): use vec_mask128_f128exp.
	- (vec_all_issubnormalf128): Use vec_splat_u32, vec_mask128_f128Lbit, and vec_mask128_f128sign.
	- (vec_all_iszerof128): Use vec_splat_u32 and vec_mask128_f128sign. Improve code.
	- (vec_const_huge_valf128): Use vec_mask128_f128exp.
	- (vec_cmpequzqp [_ARCH_PWR8]): Use vec_mask128_f128sign.
	- (vec_cmpequqp [_ARCH_PWR8]): Use vec_mask128_f128sign.
	- (vec_cmpgeuzqp [_ARCH_PWR8]): Use vec_mask128_f128sign.
	- (vec_cmpgtuzqp [_ARCH_PWR8]): Use vec_mask128_f128sign.
	- (vec_cmpgtuqp [_ARCH_PWR8]): Use vec_mask128_f128sign.
	- (vec_cmpleuzqp [_ARCH_PWR8]): Use vec_mask128_f128sign.
	- (vec_cmpleuqp [_ARCH_PWR8]): Use vec_mask128_f128sign.
	- (vec_cmpltuzqp [_ARCH_PWR8]): Use vec_mask128_f128sign.
	- (vec_cmpltuqp [_ARCH_PWR8]): Use vec_mask128_f128sign.
	- (vec_cmpneuzqp [_ARCH_PWR8]): Use vec_mask128_f128sign.
	- (vec_cmpneuqp [_ARCH_PWR8]): Use vec_mask128_f128sign.
	- (vec_isinff128 [_ARCH_PWR8]): Replace vec_mask128_f128sign with vec_mask128_f128mag.
	- (vec_xsaddqpo_inline [_ARCH_PWR8]): Use vec_const128_f128_fmax.
	- (vec_xssubqpo_inline [_ARCH_PWR8]): Use vec_const128_f128_fmax.
	- (vec_xscvdpqp): Define IFUNC extern.
	- (vec_xscvdpqp_inline): Rename from vec_xscvdpqp. Use vec_const64_f64naninf, vec_mask64_f64mag, vec_mask64_f64sig, vec_addexp_DW, and vec_subexp_DW). Simplify the code.
	- (vec_xscvqpdpo): Define IFUNC extern.
	- (vec_xscvqpdpo_inline): Rename from vec_xscvqpdpo. Use vec_mask128_f128mag, vec_mask128_f128sig, vec_const64_f128naninf, vec_const64_f64bias, vec_const64_f128bias, vec_mask128_f128Lbit, vec_addexp_DW, and vec_subexp_DW). Simplify the code.
	- (vec_xscvqpudz): Define IFUNC extern.
	- (vec_xscvqpudz_inline): Rename from vec_xscvqpudz. Use vec_const64_f128_63, vec_const64_f128bias, vec_const64_f128naninf, vec_mask128_f128mag, vec_mask128_f128sig, vec_mask128_f128Lbit, vec_addexp_DW, and vec_subexp_DW). Simplify the code.
	- (vec_xscvqpuqz): Define IFUNC extern.
	- (vec_xscvqpuqz_inline): Rename from vec_xscvqpuqz. Use vec_const64_f128_127, vec_const64_f128bias, vec_const64_f128naninf, vec_mask128_f128mag, vec_mask128_f128sig, vec_mask128_f128Lbit. Simplify the code.
	- (vec_xscvsdqp): Define IFUNC extern.
	- (vec_xscvsdqp_inline): Rename from vec_xscvsdqp. Use vec_mask128_f128sign, vec_const64_f128bias, vec_const64_f128_63, and vec_subexp_DW. Simplify the code.
	- (vec_xscvudqp): Define IFUNC extern.
	- (vec_xscvudqp_inline): Rename from vec_xscvudqp. Use vec_const64_f128bias, vec_const64_f128_63, vec_addexp_DW, and vec_subexp_DW). Simplify the code.
	- (vec_xscvsqqp): Define IFUNC extern.
	- (vec_xscvsqqp_inline): Rename from vec_xscvsqqp. Use vec_splat_u128, vec_mask128_f128sign, vec_const64_f128bias, vec_const64_f128_127, vec_addexp_DW, and vec_subexp_DW). Simplify the code.
	- (vec_xscvuqqp): Define IFUNC extern.
	- (vec_xscvuqqp_inline): Rename from vec_xscvuqqp. Use vec_splat_u128, vec_mask128_f128sign, vec_const64_f128bias, vec_const64_f128_127, vec_addexp_DW, and vec_subexp_DW). Simplify the code.
	- (vec_xsdivqpo_inline): Use vec_mask128_f128exp, vec_const64_f128_116, and vec_const128_f128_fmax.
	- (vec_xsmaddqpo_inline): Use vec_const64_f128bias, vec_const64_f128_116, and vec_const128_f128_fmax.
	- (vec_xsmulqpo_inline): Use vec_const64_f128bias, vec_const64_f128_116, and vec_const128_f128_fmax.
	- (vec_xsxsigqp, vec_xsxexpqp, vec_xsxsigqp): Update power10 latency.

	* src/vec_f128_runtime.c (vec_xscvdpqp, vec_xscvqpdpo, vec_xscvqpudz, vec_xscvqpuqz, vec_xscvsdqp, vec_xscvsqqp, vec_xscvudqp, vec_xscvuqqp) New rintime library implementations using the vec_f128-ppc.h inline operations.

	* src/vec_runtime_DYN.c [VEC_RESOLVER_1]: Resolver macro with one parameter.  
	- [VEC_F128_LIB_LIST]: Add externs for vec_xscvdpqp, vec_xscvqpdpo, vec_xscvqpudz, vec_xscvqpuqz, vec_xscvsdqp, vec_xscvsqqp, vec_xscvudqp, vec_xscvuqqp. 
	- [VEC_RESOLVER_1]: Expand resolver for vec_xscvdpqp, vec_xscvqpdpo, vec_xscvqpudz, vec_xscvqpuqz, vec_xscvsdqp, vec_xscvsqqp, vec_xscvudqp, vec_xscvuqqp.

	* src/testsuite/arith128_test_f128.c (test_convert_dpqp[test_xscvdpqp]): Default define to __VEC_PWR_IMP (vec_xscvdpqp).
	- (test_convert_udqp[test_xscvudqp]): Default define to __VEC_PWR_IMP (vec_xscvudqp).
	- (test_convert_udqp[test_xscvudqp]): Default define to __VEC_PWR_IMP (vec_xscvudqp). Replace vec_xscvudqp with test_xscvudqp.
	- (test_convert_sdqp[test_xscvsdqp]): Default define to __VEC_PWR_IMP (vec_xscvsdqp). Replace vec_xscvsdqp with test_xscvsdqp.
	- (test_convert_uqqp[test_xscvuqqp]): Default define to __VEC_PWR_IMP (vec_xscvuqqp). Replace vec_xscvuqqp with test_xscvuqqp. [__DEBUG_PRINT__]: replace print_v2xint64 with print_vint128.
	- (test_convert_sqqp[test_xscvsqqp]): Default define to __VEC_PWR_IMP (vec_xscvsqqp). Replace vec_xscvsqqp with test_xscvsqqp. [__DEBUG_PRINT__]: replace print_v2xint64 with print_vint128.
	- (test_convert_qpuqz[test_xscvqpuqz]): Default define to __VEC_PWR_IMP (vec_xscvqpuqz). Replace vec_xscvqpuqz with test_xscvqpuqz.
	- (test_convert_qpudz[test_xscvqpudz]): Default define to __VEC_PWR_IMP (vec_xscvqpudz). Replace vec_xscvqpudz with test_xscvqpudz.
	- (test_convert_qpdpo[test_xscvqpdpo]): Default define to __VEC_PWR_IMP (vec_xscvqpdpo). Replace vec_xscvqpdpo with test_xscvqpdpo. Add test cases for min QP normal and small QP normal, converts to DP denormal and round to odd.

	* src/testsuite/vec_f128_dummy.c [!PVECLIB_OLDTESTVERSIONS] test_vec_diveuqo_V0.
	- (force_eMin): Use vec_splat_u64.
	- (force_eMin_V0): Use vec_splat_u64.
	- (test_const128_f128_fmax_V2, test_const128_f128_fmax_V1): New compile tests.
	- (test_const64_f128_63, test_const64_f128_127, test_const64_f128_112_V1): New compile tests.
	- (test_const64_f128_116, test_const64_f128_116_V1): New compile tests.
	- (test_const64_f128_128_V1): New compile test.
	- (test_const64_f128naninf, test_const64_f128maxe, test_const64_f128maxe_V1, test_const64_f128maxe_V0, test_const64_f128bias, test_const64_f128bias_127, test_const64_f128bias_V0): New compile tests.
	- (test_const128_f128_128_V1, test_mask128_f128exp_v4, test_mask128_f128bias_V0): New compile tests.
	- (test_mask128_f128Xbits, test_mask128_f128Xbits_V0): New compile tests.
	- (test_xsigqpo_v1, test_xsigqpo_v0, test_xexpqpp_V2 [!PVECLIB_OLDTESTVERSIONS]): Stop compiling old tests.
	- (test_xexpqpp_v0): Use vec_const128_f128_fmax.
	- (test_vec_addqpo_V5, test_vec_addqpo_V4) [!PVECLIB_OLDTESTVERSIONS]): Stop compiling old tests.
	- (test_vec_divqpo): Use vec_const64_f128_116, vec_mask128_f128Xbits, vec_const128_f128_fmax.
	- (test_vec_divqpo_V1[!PVECLIB_OLDTESTVERSIONS]): Stop compiling old tests.
	- (test_negqp_nan_v0): Use vec_const128_f128_fmax. (test_vec_subqpo_V2, test_vec_subqpo_V1, test_vec_subqpo_V0 [!PVECLIB_OLDTESTVERSIONS]): Stop compiling old tests.
	- (test_sticky_bits): Use vec_mask128_f128Xbits.
	- ( test_vec_mulqpn): Use vec_mask128_f128sign, vec_mask64_f128exp, vec_const64_f128bias, vec_const64_f128maxe, vec_const64_f128_116, vec_mask128_f128Xbits, vec_const64_f128_128, vec_mask128_f128Qbit.
	- (test_vec_mulqpn_V1[!PVECLIB_OLDTESTVERSIONS]): Stop compiling old tests.
	- (test_vec_maddqpo): Use vec_const64_f128_116, vec_mask128_f128Xbits.
	- (test_vec_mulqpo): Use vec_const64_f128_128, vec_const64_f128_116, vec_mask128_f128Xbits.
	- (test_vec_mulqpo_V7, test_vec_mulqpo_V6, test_vec_mulqpo_V5, test_vec_mulqpo_V4, test_vec_mulqpo_V3, test_vec_mulqpo_V2, test_mulqpo_V1, test_mulqpo_V0[!PVECLIB_OLDTESTVERSIONS]): Stop compiling old tests.
	- (test_vec_xscvqpdpo): Use vec_xscvqpdpo_inline.
	- (test_vec_xscvqpudz): Use vec_xscvqpudz_inline.
	- (test_vec_xscvqpuqz): Use vec_xscvqpuqz_inline.
	- (test_vec_xscvdpqp): Use vec_xscvdpqp_inline.
	- (test_vec_xscvsqqp): Use vec_xscvsqqp_inline.
	- (test_vec_xscvuqqp): Use vec_xscvuqqp_inline.
	- (test_vec_xscvudqp, test_vec_xscvsdqp): New compile tests.
	- (test_convert_uqqpn, test_convert_uqqpo, __test_convert_udqp, __test_convert_sdqp, __test_convert_qpuqz, test_convert_qpdpo_v2, __test_convert_qpdpo, test_convert_dpqp_v3, test_convert_dpqp_v2, __test_convert_dpqp[!PVECLIB_OLDTESTVERSIONS]): Stop compiling old tests.
	- (test_vec_xxxsigqpp_V3, test_vec_xxxsigqpp_V2, test_vec_xxxsigqpp_V1, test_vec_xxxsigqpp_V0 [!PVECLIB_OLDTESTVERSIONS]): Stop compiling old tests.

	* src/testsuite/vec_pwr10_dummy.c (__test_splatisd_PWR10_V3): Wall cleanup.
	- (__test_splatiud_PWR10_V1): Wall cleanup.
	- (__test_splatisd_PWR10_V3): Wall cleanup.
	- (__test_splatiuq_PWR10_V2): Wall cleanup.
	- (test_vec_xscvqpuqz_PWR10): Use vec_xscvqpuqz_inline.
	- (test_vec_xscvsqqp_PWR10): New compile test.
	- (test_vec_xscvuqqp_PWR10): Use vec_xscvuqqp_inline

	* src/testsuite/vec_pwr9_dummy.c (test_vec_xscvqpdpo_PWR9): Use vec_xscvqpdpo_inline.
	- (test_vec_xscvqpudz_PWR9): Use vec_xscvqpudz_inline.
	- (test_vec_xscvqpuqz_PWR9): Use vec_xscvqpuqz_inline.
	- (test_vec_xscvdpqp_PWR9): Use vec_xscvdpqp_inline.
	- (test_vec_xscvsqqp_PWR9): vec_xscvsqqp_inline.
	- (test_vec_xscvuqqp_PWR9): vec_xscvuqqp_inline.
	- (test_convert_qpuqz_PWR9): Use vec_xscvqpudz_inline, vec_xscvudqp_inline.