### PR TITLE
Fix compile warnings/errors from pedantic compilers.

### DIFF
--- a/src/testsuite/arith128_print.c
+++ b/src/testsuite/arith128_print.c
@@ -550,11 +550,11 @@ print_v4f32x (char *prefix, vf32_t val)
 void
 print_v4b32c (char *prefix, vb32_t val)
 {
-  const vui32_t true =  { 'T', 'T', 'T', 'T' };
-  const vui32_t false = { 'F', 'F', 'F', 'F' };
+  const vui32_t _true =  { 'T', 'T', 'T', 'T' };
+  const vui32_t _false = { 'F', 'F', 'F', 'F' };
   vui32_t text;
 
-  text = vec_sel (false, true, val);
+  text = vec_sel (_false, _true, val);
 
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   printf ("%s %c,%c,%c,%c\n", prefix, text[3], text[2], text[1], text[0]);
@@ -598,11 +598,11 @@ print_v2f64x (char *prefix, vf64_t val)
 void
 print_v2b64c (char *prefix, vb64_t val)
 {
-  const vui64_t true =  { 'T', 'T' };
-  const vui64_t false = { 'F', 'F' };
+  const vui64_t _true =  { 'T', 'T' };
+  const vui64_t _false = { 'F', 'F' };
   vui64_t text;
 
-  text = vec_sel (false, true, val);
+  text = vec_sel (_false, _true, val);
 
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   printf ("%s %c,%c\n", prefix, (int)text[1], (int)text[0]);
@@ -735,11 +735,11 @@ print_vuint512x (char *prefix, vui128_t val0_128, vui128_t val1_128, vui128_t va
 void
 print_vb128c (char *prefix, vb128_t val)
 {
-  const vui64_t true = { 'T', 'T' };
-  const vui64_t false = { 'F', 'F' };
+  const vui64_t _true = { 'T', 'T' };
+  const vui64_t _false = { 'F', 'F' };
   vui64_t text;
 
-  text = vec_sel (false, true, (vb64_t) val);
+  text = vec_sel (_false, _true, (vb64_t) val);
 
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   printf ("%s %c%c\n", prefix, (int) text[1], (int) text[0]);

--- a/src/testsuite/vec_f128_dummy.c
+++ b/src/testsuite/vec_f128_dummy.c
@@ -10588,22 +10588,22 @@ test_vec_max8_f128uz (__binary128 vf1, __binary128 vf2,
 		    __binary128 vf7, __binary128 vf8)
 {
   __binary128 maxres;
-  vb128_t bool;
+  vb128_t b00l;
 
-  bool = vec_cmpgtuzqp (vf2, vf1);
-  maxres = vec_self128 (vf1, vf2, bool);
-  bool = vec_cmpgtuzqp (vf3, maxres);
-  maxres = vec_self128 (vf3, maxres, bool);
-  bool = vec_cmpgtuzqp (vf4, maxres);
-  maxres = vec_self128 (vf4, maxres, bool);
-  bool = vec_cmpgtuzqp (vf5, maxres);
-  maxres = vec_self128 (vf5, maxres, bool);
-  bool = vec_cmpgtuzqp (vf6, maxres);
-  maxres = vec_self128 (vf6, maxres, bool);
-  bool = vec_cmpgtuzqp (vf7, maxres);
-  maxres = vec_self128 (vf7, maxres, bool);
-  bool = vec_cmpgtuzqp (vf8, maxres);
-  maxres = vec_self128 (vf8, maxres, bool);
+  b00l = vec_cmpgtuzqp (vf2, vf1);
+  maxres = vec_self128 (vf1, vf2, b00l);
+  b00l = vec_cmpgtuzqp (vf3, maxres);
+  maxres = vec_self128 (vf3, maxres, b00l);
+  b00l = vec_cmpgtuzqp (vf4, maxres);
+  maxres = vec_self128 (vf4, maxres, b00l);
+  b00l = vec_cmpgtuzqp (vf5, maxres);
+  maxres = vec_self128 (vf5, maxres, b00l);
+  b00l = vec_cmpgtuzqp (vf6, maxres);
+  maxres = vec_self128 (vf6, maxres, b00l);
+  b00l = vec_cmpgtuzqp (vf7, maxres);
+  maxres = vec_self128 (vf7, maxres, b00l);
+  b00l = vec_cmpgtuzqp (vf8, maxres);
+  maxres = vec_self128 (vf8, maxres, b00l);
 
   return maxres;
 }
@@ -10615,22 +10615,22 @@ test_vec_max8_f128 (__binary128 vf1, __binary128 vf2,
 		    __binary128 vf7, __binary128 vf8)
 {
   __binary128 maxres;
-  vb128_t bool;
+  vb128_t b00l;
 
-  bool = vec_cmpgtuqp (vf2, vf1);
-  maxres = vec_self128 (vf1, vf2, bool);
-  bool = vec_cmpgtuqp (vf3, maxres);
-  maxres = vec_self128 (vf3, maxres, bool);
-  bool = vec_cmpgtuqp (vf4, maxres);
-  maxres = vec_self128 (vf4, maxres, bool);
-  bool = vec_cmpgtuqp (vf5, maxres);
-  maxres = vec_self128 (vf5, maxres, bool);
-  bool = vec_cmpgtuqp (vf6, maxres);
-  maxres = vec_self128 (vf6, maxres, bool);
-  bool = vec_cmpgtuqp (vf7, maxres);
-  maxres = vec_self128 (vf7, maxres, bool);
-  bool = vec_cmpgtuqp (vf8, maxres);
-  maxres = vec_self128 (vf8, maxres, bool);
+  b00l = vec_cmpgtuqp (vf2, vf1);
+  maxres = vec_self128 (vf1, vf2, b00l);
+  b00l = vec_cmpgtuqp (vf3, maxres);
+  maxres = vec_self128 (vf3, maxres, b00l);
+  b00l = vec_cmpgtuqp (vf4, maxres);
+  maxres = vec_self128 (vf4, maxres, b00l);
+  b00l = vec_cmpgtuqp (vf5, maxres);
+  maxres = vec_self128 (vf5, maxres, b00l);
+  b00l = vec_cmpgtuqp (vf6, maxres);
+  maxres = vec_self128 (vf6, maxres, b00l);
+  b00l = vec_cmpgtuqp (vf7, maxres);
+  maxres = vec_self128 (vf7, maxres, b00l);
+  b00l = vec_cmpgtuqp (vf8, maxres);
+  maxres = vec_self128 (vf8, maxres, b00l);
 
   return maxres;
 }

--- a/src/testsuite/vec_perf_f128.c
+++ b/src/testsuite/vec_perf_f128.c
@@ -304,22 +304,22 @@ test_lib_max8_f128 (__binary128 vf1, __binary128 vf2,
 		    __binary128 vf7, __binary128 vf8)
 {
   __binary128 maxres;
-  vb128_t bool;
+  vb128_t b00l;
 
-  bool = test_vec_cmpgtuqp (vf2, vf1);
-  maxres = vec_self128 (vf1, vf2, bool);
-  bool = test_vec_cmpgtuqp (vf3, maxres);
-  maxres = vec_self128 (vf3, maxres, bool);
-  bool = test_vec_cmpgtuqp (vf4, maxres);
-  maxres = vec_self128 (vf4, maxres, bool);
-  bool = test_vec_cmpgtuqp (vf5, maxres);
-  maxres = vec_self128 (vf5, maxres, bool);
-  bool = test_vec_cmpgtuqp (vf6, maxres);
-  maxres = vec_self128 (vf6, maxres, bool);
-  bool = test_vec_cmpgtuqp (vf7, maxres);
-  maxres = vec_self128 (vf7, maxres, bool);
-  bool = test_vec_cmpgtuqp (vf8, maxres);
-  maxres = vec_self128 (vf8, maxres, bool);
+  b00l = test_vec_cmpgtuqp (vf2, vf1);
+  maxres = vec_self128 (vf1, vf2, b00l);
+  b00l = test_vec_cmpgtuqp (vf3, maxres);
+  maxres = vec_self128 (vf3, maxres, b00l);
+  b00l = test_vec_cmpgtuqp (vf4, maxres);
+  maxres = vec_self128 (vf4, maxres, b00l);
+  b00l = test_vec_cmpgtuqp (vf5, maxres);
+  maxres = vec_self128 (vf5, maxres, b00l);
+  b00l = test_vec_cmpgtuqp (vf6, maxres);
+  maxres = vec_self128 (vf6, maxres, b00l);
+  b00l = test_vec_cmpgtuqp (vf7, maxres);
+  maxres = vec_self128 (vf7, maxres, b00l);
+  b00l = test_vec_cmpgtuqp (vf8, maxres);
+  maxres = vec_self128 (vf8, maxres, b00l);
 
   return maxres;
 }


### PR DESCRIPTION
Some compilers/versions are posting errors for using "true", "false", and "bool" as C variables. Not sure why some compiler versions do this but it is easy to fix and avoid.

	* src/testsuite/arith128_print.c (print_v4b32c): Rename true to _true and false to _false.
	- (print_v2b64c): Ditto.
	- (print_vb128c): Ditto.

	* src/testsuite/vec_f128_dummy.c (test_vec_max8_f128uz): Rename bool to b00l.
	- (test_vec_max8_f128): Ditto.

	* src/testsuite/vec_perf_f128.c (test_lib_max8_f128): Rename bool to b00l.