### PR TITLE
Add common parts for extract element from QW P9.

### DIFF
--- a/src/pveclib/vec_common_ppc.h
+++ b/src/pveclib/vec_common_ppc.h
@@ -1685,6 +1685,10 @@ static inline vui8_t vec_splat6_u8 (const unsigned int sim6);
 static inline vui8_t vec_splat7_u8 (const unsigned int sim7);
 static inline vui128_t vec_vexpandqm_PWR7 (vui128_t vra);
 static inline vui128_t vec_vexpandqm_PWR10 (vui128_t vra);
+static inline vui64_t vec_vextractd_PWR9 (vui8_t, const unsigned int);
+static inline vui64_t vec_vextractub_PWR9 (vui8_t, const unsigned int);
+static inline vui64_t vec_vextractuh_PWR9 (vui8_t, const unsigned int);
+static inline vui64_t vec_vextractuw_PWR9 (vui8_t, const unsigned int);
 static inline vui8_t vec_vgenpcvsldx_PWR7(int gpra);
 static inline vui8_t vec_vgenpcvsrdx_PWR7(int gpra);
 static inline vui8_t
@@ -6761,7 +6765,9 @@ vec_vextddvlx_PWR7 (vui8_t vra, vui8_t vrb, int gprc)
 }
 
 /** \copybrief vec_vextddvlx_PWR7
- *  \note Support xxperm with access to all 64 VSX registers.
+ *  \note Use <B>Vector Extract Unsigned Doubleword to VSR using
+ *  immediate-specified index</B> to format final result for _ARCH_PWR9.
+ *  Else generate equivalent function for PWR7/8.
  *  \sa vec_vextddvlx_PWR7 for details.
  *  \showrefby
  * */
@@ -6777,13 +6783,12 @@ vec_vextddvlx_PWR9 (vui8_t vra, vui8_t vrb, int gprc)
   /* Vector Extract element operations extend to the last element
    * of the double Quadword. So the index range needs to cover
    * 0 .. (32 - element_size). So 0 - 24 for doubleword elements. */
-  /* Enable for full VSX register usage. */
   if (__builtin_expect (gprc < 16, 1))
-    res = vec_vperm_PWR9 (vra, vrb, pcv);
+    res = vec_vperm_PWR8 (vra, vrb, pcv);
   else
-    res = vec_vperm_PWR9 (vrb, vrb, pcv);
-  // Merge high DW with DW zero.
-  result = vec_xxpermdi_PWR7 ((vui64_t) res, (vui64_t) zero, 0);
+    res = vec_vperm_PWR8 (vrb, vrb, pcv);
+  // extract DW 0 and set DW 1 to zero
+  result = vec_vextractd_PWR9 (res, 0);
 #else
   result = vec_vextddvlx_PWR7 (vra, vrb, gprc);
 #endif
@@ -6870,7 +6875,9 @@ vec_vextddvrx_PWR7 (vui8_t vra, vui8_t vrb, int gprc)
 }
 
 /** \copybrief vec_vextddvrx_PWR7
- *  \note Support xxperm with access to all 64 VSX registers.
+ *  \note Use <B>Vector Extract Unsigned Doubleword to VSR using
+ *  immediate-specified index</B> to format final result for _ARCH_PWR9.
+ *  Else generate equivalent function for PWR7/8.
  *  \sa vec_vextddvrx_PWR7 for details.
  *  \showrefby
  * */
@@ -6885,14 +6892,12 @@ vec_vextddvrx_PWR9 (vui8_t vra, vui8_t vrb, int gprc)
   /* Vector Extract element operations extend to the last element
    * of the double Quadword. So the index range needs to cover
    * 0 .. (32 - element_size). So 0 - 24 for doubleword elements. */
-  /* Enable for full VSX register usage. */
   if (__builtin_expect (gprc < 16, 1))
-    res = vec_vperm_PWR9 (vra, vrb, pcv);
+    res = vec_vperm_PWR8 (vra, vrb, pcv);
   else
-    res = vec_vperm_PWR9 (vra, vra, pcv);
-
-  // Merge low DW with DW zero.
-  result = vec_xxpermdi_PWR7 ((vui64_t) res, (vui64_t) zero, 3);
+    res = vec_vperm_PWR8 (vra, vra, pcv);
+  // extract byte 8-15 and zero extend to DW
+  result = vec_vextractd_PWR9 (res, 8);
 #else
   result = vec_vextddvrx_PWR7 (vra, vrb, gprc);
 #endif
@@ -7061,7 +7066,7 @@ vec_vextdqvrx_PWR9 (vui8_t vra, vui8_t vrb, int gprc)
  *  |--------:|:-----:|:---------|
  *  |power7   | 8 - 10| 2/cycle  |
  *  |power8   | 8 - 10| 2/cycle  |
- *  |power9   |12 - 15| 2/cycle  |
+ *  |power9   | 9 - 12| 2/cycle  |
  *  |power10  | 3 - 4 | 4/cycle  |
  *
  *  @param vra Quadword containing Octets 0-15 of the source.
@@ -7095,6 +7100,38 @@ vec_vextdubvlx_PWR7 (vui8_t vra, vui8_t vrb, int gprc)
 }
 
 /** \copybrief vec_vextdubvlx_PWR7
+ *  \note Use <B>Vector Extract Unsigned Byte to VSR using
+ *  immediate-specified index</B> to format final result for _ARCH_PWR9.
+ *  Else generate equivalent function for PWR7/8.
+ *  \sa vec_vextdubvlx_PWR7 for details.
+ *  \showrefby
+ */
+static inline vui64_t
+vec_vextdubvlx_PWR9 (vui8_t vra, vui8_t vrb, int gprc)
+{
+  vui64_t result;
+
+#if defined (_ARCH_PWR9)  && (__GNUC__ >= 9)
+  vui8_t pcv, res;
+  const vui8_t zero = vec_splat_u8(0);
+
+  pcv = vec_vgenpcvsldx_PWR7 (gprc);
+  /* Vector Extract element operations extend to the last element
+   * of the double Quadword. So the index range needs to cover
+   * 0 .. (32 - element_size). So 0 - 31 for byte elements. */
+  if (__builtin_expect (gprc < 16, 1))
+    res = vec_vperm_PWR8 (vra, vrb, pcv);
+  else
+    res = vec_vperm_PWR8 (vrb, vrb, pcv);
+  // extract byte 0 and zero extend to DW
+  result = vec_vextractub_PWR9 (res, 0);
+#else
+  result = vec_vextdubvlx_PWR7 (vra, vrb, gprc);
+#endif
+  return result;
+}
+
+/** \copybrief vec_vextdubvlx_PWR7
  *  \note Generate vextdubvlx instruction for _ARCH_PWR10.
  *  Else generate equivalent function for PWR7/8/9.
  *  \sa vec_vextdubvlx_PWR7 for details.
@@ -7115,7 +7152,7 @@ vec_vextdubvlx_PWR10 (vui8_t vra, vui8_t vrb, int gprc)
       : );
 #endif
 #else
-  result = vec_vextdubvlx_PWR7 (vra, vrb, gprc);
+  result = vec_vextdubvlx_PWR9 (vra, vrb, gprc);
 #endif
   return result;
 }
@@ -7137,7 +7174,7 @@ vec_vextdubvlx_PWR10 (vui8_t vra, vui8_t vrb, int gprc)
  *  |--------:|:-----:|:---------|
  *  |power7   | 8 - 10| 2/cycle  |
  *  |power8   | 8 - 10| 2/cycle  |
- *  |power9   |12 - 15| 2/cycle  |
+ *  |power9   | 9 - 12| 2/cycle  |
  *  |power10  | 3 - 4 | 4/cycle  |
  *
  *  @param vra Quadword containing Octets 0-15 of the source.
@@ -7171,6 +7208,38 @@ vec_vextdubvrx_PWR7 (vui8_t vra, vui8_t vrb, int gprc)
 }
 
 /** \copybrief vec_vextdubvrx_PWR7
+ *  \note Use <B>Vector Extract Unsigned Byte to VSR using
+ *  immediate-specified index</B> to format final result for _ARCH_PWR9.
+ *  Else generate equivalent function for PWR7/8.
+ *  \sa vec_vextdubvrx_PWR7 for details.
+ *  \showrefby
+ */
+static inline vui64_t
+vec_vextdubvrx_PWR9 (vui8_t vra, vui8_t vrb, int gprc)
+{
+  vui64_t result;
+
+#if defined (_ARCH_PWR9)  && (__GNUC__ >= 9)
+  vui8_t pcv, res;
+  const vui8_t zero = vec_splat_u8(0);
+
+  pcv = vec_vgenpcvsrdx_PWR7 (gprc);
+  /* Vector Extract element operations extend to the last element
+   * of the double Quadword. So the index range needs to cover
+   * 0 .. (32 - element_size). So 0 - 31 for byte elements. */
+  if (__builtin_expect (gprc < 16, 1))
+    res = vec_vperm_PWR8 (vra, vrb, pcv);
+  else
+    res = vec_vperm_PWR8 (vra, vra, pcv);
+  // extract byte 15 and zero extend to DW
+  result = vec_vextractub_PWR9 (res, 15);
+#else
+  result = vec_vextdubvrx_PWR7 (vra, vrb, gprc);
+#endif
+  return result;
+}
+
+/** \copybrief vec_vextdubvrx_PWR7
  *  \note Generate vextdubvrx instruction for _ARCH_PWR10.
  *  Else generate equivalent function for PWR7/8/9.
  *  \sa vec_vextdubvrx_PWR7 for details.
@@ -7191,7 +7260,7 @@ vec_vextdubvrx_PWR10 (vui8_t vra, vui8_t vrb, int gprc)
       : );
 #endif
 #else
-  result = vec_vextdubvrx_PWR7 (vra, vrb, gprc);
+  result = vec_vextdubvrx_PWR9 (vra, vrb, gprc);
 #endif
   return result;
 }
@@ -7249,6 +7318,38 @@ vec_vextduhvlx_PWR7 (vui8_t vra, vui8_t vrb, int gprc)
 }
 
 /** \copybrief vec_vextduhvlx_PWR7
+ *  \note Use <B>Vector Extract Unsigned Halfword to VSR using
+ *  immediate-specified index</B> to format final result for _ARCH_PWR9.
+ *  Else generate equivalent function for PWR7/8.
+ *  \sa vec_vextduhvlx_PWR7 for details.
+ *  \showrefby
+ */
+static inline vui64_t
+vec_vextduhvlx_PWR9 (vui8_t vra, vui8_t vrb, int gprc)
+{
+  vui64_t result;
+
+#if defined (_ARCH_PWR9)  && (__GNUC__ >= 9)
+  vui8_t pcv, res;
+  const vui8_t zero = vec_splat_u8(0);
+
+  pcv = vec_vgenpcvsldx_PWR7 (gprc);
+  /* Vector Extract element operations extend to the last element
+   * of the double Quadword. So the index range needs to cover
+   * 0 .. (32 - element_size). So 0 - 31 for byte elements. */
+  if (__builtin_expect (gprc < 16, 1))
+    res = vec_vperm_PWR8 (vra, vrb, pcv);
+  else
+    res = vec_vperm_PWR8 (vrb, vrb, pcv);
+  // extract byte 0-1 and zero extend to DW
+  result = vec_vextractuh_PWR9 (res, 0);
+#else
+  result = vec_vextduhvlx_PWR7 (vra, vrb, gprc);
+#endif
+  return result;
+}
+
+/** \copybrief vec_vextduhvlx_PWR7
  *  \note Generate vextduhvlx instruction for _ARCH_PWR10.
  *  Else generate equivalent function for PWR7/8/9.
  *  \sa vec_vextduhvlx_PWR7 for details.
@@ -7269,7 +7370,7 @@ vec_vextduhvlx_PWR10 (vui8_t vra, vui8_t vrb, int gprc)
       : );
 #endif
 #else
-  result = vec_vextduhvlx_PWR7 (vra, vrb, gprc);
+  result = vec_vextduhvlx_PWR9 (vra, vrb, gprc);
 #endif
   return result;
 }
@@ -7327,6 +7428,37 @@ vec_vextduhvrx_PWR7 (vui8_t vra, vui8_t vrb, int gprc)
 }
 
 /** \copybrief vec_vextduhvrx_PWR7
+ *  \note Use <B>Vector Extract Unsigned Halfword to VSR using
+ *  immediate-specified index</B> to format final result for _ARCH_PWR9.
+ *  Else generate equivalent function for PWR7/8.
+ *  \sa vec_vextduhvrx_PWR7 for details.
+ *  \showrefby
+ */
+static inline vui64_t
+vec_vextduhvrx_PWR9 (vui8_t vra, vui8_t vrb, int gprc)
+{
+  vui64_t result;
+
+#if defined (_ARCH_PWR9)  && (__GNUC__ >= 9)
+  vui8_t pcv, res;
+  const vui8_t zero = vec_splat_u8(0);
+  pcv = vec_vgenpcvsrdx_PWR7 (gprc);
+  /* Vector Extract element operations extend to the last element
+   * of the double Quadword. So the index range needs to cover
+   * 0 .. (32 - element_size). So 0 - 30 for byte elements. */
+  if (__builtin_expect (gprc < 16, 1))
+    res = vec_vperm_PWR8 (vra, vrb, pcv);
+  else
+    res = vec_vperm_PWR8 (vra, vra, pcv);
+  // extract byte 14-15 and zero extend to DW
+  result = vec_vextractuh_PWR9 (res, 14);
+#else
+  result = vec_vextduhvrx_PWR7 (vra, vrb, gprc);
+#endif
+  return result;
+}
+
+/** \copybrief vec_vextduhvrx_PWR7
  *  \note Generate vextduhvrx instruction for _ARCH_PWR10.
  *  Else generate equivalent function for PWR7/8/9.
  *  \sa vec_vextduhvrx_PWR7 for details.
@@ -7347,7 +7479,7 @@ vec_vextduhvrx_PWR10 (vui8_t vra, vui8_t vrb, int gprc)
       : );
 #endif
 #else
-  result = vec_vextduhvrx_PWR7 (vra, vrb, gprc);
+  result = vec_vextduhvrx_PWR9 (vra, vrb, gprc);
 #endif
   return result;
 }
@@ -7403,7 +7535,9 @@ vec_vextduwvlx_PWR7 (vui8_t vra, vui8_t vrb, int gprc)
 }
 
 /** \copybrief vec_vextduwvlx_PWR7
- *  \note Support xxperm/xxsldwi with access to all 64 VSX registers.
+ *  \note Use <B>Vector Extract Unsigned Word to VSR using
+ *  immediate-specified index</B> to format final result for _ARCH_PWR9.
+ *  Else generate equivalent function for PWR7/8.
  *  \sa vec_vextduwvlx_PWR7 for details.
  *  \showrefby
  */
@@ -7411,24 +7545,21 @@ static inline vui64_t
 vec_vextduwvlx_PWR9 (vui8_t vra, vui8_t vrb, int gprc)
 {
   vui64_t result;
+
 #if defined (_ARCH_PWR9)  && (__GNUC__ >= 9)
-  const vui8_t zero = vec_splat_u8(0);
   vui8_t pcv, res;
+  const vui8_t zero = vec_splat_u8(0);
+
   pcv = vec_vgenpcvsldx_PWR7 (gprc);
   /* Vector Extract element operations extend to the last element
    * of the double Quadword. So the index range needs to cover
-   * 0 .. (32 - element_size). So 0 - 28 for byte elements. */
+   * 0 .. (32 - element_size). So 0 - 31 for byte elements. */
   if (__builtin_expect (gprc < 16, 1))
-    res = vec_vperm_PWR9 (vra, vrb, pcv);
+    res = vec_vperm_PWR8 (vra, vrb, pcv);
   else
-    res = vec_vperm_PWR9 (vrb, vrb, pcv);
-
-  // shift high-W in to low-W with leading zeros.
-  res = vec_sldw (zero, res, 1);
-  // rotate result into high DW
-  res = vec_sldw (res,res, 2);
-
-  result = (vui64_t) res;
+    res = vec_vperm_PWR8 (vrb, vrb, pcv);
+  // extract byte 0-1 and zero extend to DW
+  result = vec_vextractuw_PWR9 (res, 0);
 #else
   result = vec_vextduwvlx_PWR7 (vra, vrb, gprc);
 #endif
@@ -7513,7 +7644,9 @@ vec_vextduwvrx_PWR7 (vui8_t vra, vui8_t vrb, int gprc)
 }
 
 /** \copybrief vec_vextduwvrx_PWR7
- *  \note Support xxperm/xxsldwi with access to all 64 VSX registers.
+ *  \note Use <B>Vector Extract Unsigned Word to VSR using
+ *  immediate-specified index</B> to format final result for _ARCH_PWR9.
+ *  Else generate equivalent function for PWR7/8.
  *  \sa vec_vextduwvrx_PWR7 for details.
  *  \showrefby
  */
@@ -7521,24 +7654,20 @@ static inline vui64_t
 vec_vextduwvrx_PWR9 (vui8_t vra, vui8_t vrb, int gprc)
 {
   vui64_t result;
+
 #if defined (_ARCH_PWR9)  && (__GNUC__ >= 9)
-  const vui8_t zero = vec_splat_u8(0);
   vui8_t pcv, res;
+  const vui8_t zero = vec_splat_u8(0);
   pcv = vec_vgenpcvsrdx_PWR7 (gprc);
   /* Vector Extract element operations extend to the last element
    * of the double Quadword. So the index range needs to cover
    * 0 .. (32 - element_size). So 0 - 28 for byte elements. */
   if (__builtin_expect (gprc < 16, 1))
-    res = vec_vperm_PWR9 (vra, vrb, pcv);
+    res = vec_vperm_PWR8 (vra, vrb, pcv);
   else
-    res = vec_vperm_PWR9 (vra, vra, pcv);
-
-  // shift low-W into high-W with trailing zeros.
-  res = vec_sldw (res, zero, 3);
-  // rotate result into high DW
-  res = vec_sldw (res, res, 3);
-
-  result = (vui64_t) res;
+    res = vec_vperm_PWR8 (vra, vra, pcv);
+  // extract byte 12-15 and zero extend to DW
+  result = vec_vextractuw_PWR9 (res, 12);
 #else
   result = vec_vextduwvrx_PWR7 (vra, vrb, gprc);
 #endif
@@ -7567,6 +7696,287 @@ vec_vextduwvrx_PWR10 (vui8_t vra, vui8_t vrb, int gprc)
 #endif
 #else
   result = vec_vextduwvrx_PWR9 (vra, vrb, gprc);
+#endif
+  return result;
+}
+
+/** \brief Vector Extract Unsigned Doubleword to VSR using immediate-specified index
+ *
+ *  Vector Extract a Doubleword element from a Quadword (16 bytes),
+ *  specified by the immediate-index.
+ *  The index (uim) in the range 0-8 selects eight Octets.
+ *  The resulting doubleword is returned in the high-order doubleword
+ *  of a vector, while The low-order doubleword is set to zero.
+ *
+ *  \note If the index is greater then 8 the result is boundedly undefined.
+ *  \note This operation provides only the function of vextractd.
+ *  Currently the PVIPR does not generate a intrinsic to generate
+ *  this instruction.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power7   | 2 - 4 | 2/cycle  |
+ *  |power8   | 2 - 4 | 2/cycle  |
+ *  |power9   |   3   | 2/cycle  |
+ *  |power10  | 3 - 4 | 4/cycle  |
+ *
+ *  @param vrb Quadword containing Octets 0-15 of the source.
+ *  @param uim Unsigned Integer index (0-12)
+ *  @return Vector with Octet (index) zero extended to doubleword in DW 0.
+ *
+ *  \showrefby
+ */
+static inline vui64_t
+vec_vextractd_PWR7 (vui8_t vrb, const unsigned int uim)
+{
+  vui64_t result;
+  const vui8_t zero = vec_splat_u8(0);
+  vui8_t res;
+
+  // Rotate indexed byte to high byte.
+  if ((uim > 0) && (uim < 8))
+    res = vec_sld (vrb, vrb, uim);
+  else
+    res = vrb;
+
+#if defined (_ARCH_PWR7)
+  // Merge high DW with DW zero.
+  if (uim == 8)
+    result = vec_xxpermdi_PWR7 ((vui64_t) res, (vui64_t) zero, 3);
+  else
+    result = vec_xxpermdi_PWR7 ((vui64_t) res, (vui64_t) zero, 0);
+#else
+  // Shift high-byte in to low-byte with leading zeros.
+  res = vec_sld (zero, res, 8);
+  // Rotate result into high DW
+  result = (vui64_t) vec_sld (res,res, 8);
+#endif
+  return result;
+}
+
+/** \copybrief vec_vextractd_PWR7
+ *  \note Generate vextractd instruction for _ARCH_PWR9/10.
+ *  Else generate equivalent function for PWR7/8.
+ *  \sa vec_vextractd_PWR7 for details.
+ *  \showrefby
+ */
+static inline vui64_t
+vec_vextractd_PWR9 (vui8_t vrb, const unsigned int uim)
+{
+  vui64_t result;
+#if defined (_ARCH_PWR9)  && (__GNUC__ >= 9)
+  __asm__(
+      "vextractd %0,%1,%2;\n"
+      : "=v" (result)
+      : "v" (vrb), "K" (uim)
+      : );
+#else
+  result = vec_vextractd_PWR7 (vrb, uim);
+#endif
+  return result;
+}
+
+/** \brief Vector Extract Unsigned Byte to VSR using immediate-specified index
+ *
+ *  Vector Extract a Byte element (Octet) from a Quadword (16 bytes),
+ *  specified by the immediate-index.
+ *  The index (uim) in the range 0-15 selects a single
+ *  Octet. The selected byte is zero extended to a doubleword.
+ *  The resulting doubleword is returned in the high-order doubleword
+ *  of a vector, while The low-order doubleword is set to zero.
+ *
+ *  \note This operation provides only the function of vextractub.
+ *  Currently the PVIPR does not generate a intrinsic to generate
+ *  this instruction.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power7   | 4 - 6 | 2/cycle  |
+ *  |power8   | 4 - 6 | 2/cycle  |
+ *  |power9   |   3   | 2/cycle  |
+ *  |power10  | 3 - 4 | 4/cycle  |
+ *
+ *  @param vrb Quadword containing Octets 0-15 of the source.
+ *  @param uim Unsigned Integer index (0-15)
+ *  @return Vector with Octet (index) zero extended to doubleword in DW 0.
+ *
+ *  \showrefby
+ */
+static inline vui64_t
+vec_vextractub_PWR7 (vui8_t vrb, const unsigned int uim)
+{
+  vui64_t result;
+  const vui8_t zero = vec_splat_u8(0);
+  vui8_t res;
+
+  // Rotate indexed byte to high byte.
+  if (uim > 0)
+    res = vec_sld (vrb, vrb, uim);
+  else
+    res = vrb;
+  // Shift high-byte in to low-byte with leading zeros.
+  res = vec_sld (zero, res, 1);
+  // Rotate result into high DW
+  result = (vui64_t) vec_sld (res,res, 8);
+  return result;
+}
+
+/** \copybrief vec_vextractub_PWR7
+ *  \note Generate vextractub instruction for _ARCH_PWR9/10.
+ *  Else generate equivalent function for PWR7/8.
+ *  \sa vec_vextractub_PWR7 for details.
+ *  \showrefby
+ */
+static inline vui64_t
+vec_vextractub_PWR9 (vui8_t vrb, const unsigned int uim)
+{
+  vui64_t result;
+#if defined (_ARCH_PWR9)  && (__GNUC__ >= 9)
+  __asm__(
+      "vextractub %0,%1,%2;\n"
+      : "=v" (result)
+      : "v" (vrb), "K" (uim)
+      : );
+#else
+  result = vec_vextractub_PWR7 (vrb, uim);
+#endif
+  return result;
+}
+
+/** \brief Vector Extract Unsigned Halfword to VSR using immediate-specified index
+ *
+ *  Vector Extract a Halfword element from a Quadword (16 bytes),
+ *  specified by the immediate-index.
+ *  The index (uim) in the range 0-14 selects two Octets.
+ *  The selected halfword is zero extended to a doubleword.
+ *  The resulting doubleword is returned in the high-order doubleword
+ *  of a vector, while The low-order doubleword is set to zero.
+ *
+ *  \note If the index is greater then 14 the result is boundedly undefined.
+ *  \note This operation provides only the function of vextractuh.
+ *  Currently the PVIPR does not generate a intrinsic to generate
+ *  this instruction.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power7   | 4 - 6 | 2/cycle  |
+ *  |power8   | 4 - 6 | 2/cycle  |
+ *  |power9   |   3   | 2/cycle  |
+ *  |power10  | 3 - 4 | 4/cycle  |
+ *
+ *  @param vrb Quadword containing Octets 0-15 of the source.
+ *  @param uim Unsigned Integer index (0-14)
+ *  @return Vector with Octet (index) zero extended to doubleword in DW 0.
+ *
+ *  \showrefby
+ */
+static inline vui64_t
+vec_vextractuh_PWR7 (vui8_t vrb, const unsigned int uim)
+{
+  vui64_t result;
+  const vui8_t zero = vec_splat_u8(0);
+  vui8_t res;
+
+  // Rotate indexed byte to high byte.
+  if (uim > 0)
+    res = vec_sld (vrb, vrb, uim);
+  else
+    res = vrb;
+  // Shift high-byte in to low-byte with leading zeros.
+  res = vec_sld (zero, res, 2);
+  // Rotate result into high DW
+  result = (vui64_t) vec_sld (res,res, 8);
+
+  return result;
+}
+
+/** \copybrief vec_vextractuh_PWR7
+ *  \note Generate vextractuh instruction for _ARCH_PWR9/10.
+ *  Else generate equivalent function for PWR7/8.
+ *  \sa vec_vextractuh_PWR7 for details.
+ *  \showrefby
+ */
+static inline vui64_t
+vec_vextractuh_PWR9 (vui8_t vrb, const unsigned int uim)
+{
+  vui64_t result;
+#if defined (_ARCH_PWR9)  && (__GNUC__ >= 9)
+  __asm__(
+      "vextractuh %0,%1,%2;\n"
+      : "=v" (result)
+      : "v" (vrb), "K" (uim)
+      : );
+#else
+  result = vec_vextractuh_PWR7 (vrb, uim);
+#endif
+  return result;
+}
+
+/** \brief Vector Extract Unsigned Word to VSR using immediate-specified index
+ *
+ *  Vector Extract a Word element from a Quadword (16 bytes),
+ *  specified by the immediate-index.
+ *  The index (uim) in the range 0-12 selects four Octets.
+ *  The selected word is zero extended to a doubleword.
+ *  The resulting doubleword is returned in the high-order doubleword
+ *  of a vector, while The low-order doubleword is set to zero.
+ *
+ *  \note If the index is greater then 12 the result is boundedly undefined.
+ *  \note This operation provides only the function of vextractuw.
+ *  Currently the PVIPR does not generate a intrinsic to generate
+ *  this instruction.
+ *
+ *  |processor|Latency|Throughput|
+ *  |--------:|:-----:|:---------|
+ *  |power7   | 4 - 6 | 2/cycle  |
+ *  |power8   | 4 - 6 | 2/cycle  |
+ *  |power9   |   3   | 2/cycle  |
+ *  |power10  | 3 - 4 | 4/cycle  |
+ *
+ *  @param vrb Quadword containing Octets 0-15 of the source.
+ *  @param uim Unsigned Integer index (0-12)
+ *  @return Vector with Octet (index) zero extended to doubleword in DW 0.
+ *
+ *  \showrefby
+ */
+static inline vui64_t
+vec_vextractuw_PWR7 (vui8_t vrb, const unsigned int uim)
+{
+  vui64_t result;
+  const vui8_t zero = vec_splat_u8(0);
+  vui8_t res;
+
+  // Rotate indexed byte to high byte.
+  if (uim > 0)
+    res = vec_sld (vrb, vrb, uim);
+  else
+    res = vrb;
+  // Shift high-byte in to low-byte with leading zeros.
+  res = vec_sld (zero, res, 4);
+  // Rotate result into high DW
+  result = (vui64_t) vec_sld (res,res, 8);
+
+  return result;
+}
+
+/** \copybrief vec_vextractuw_PWR7
+ *  \note Generate vextractuw instruction for _ARCH_PWR9/10.
+ *  Else generate equivalent function for PWR7/8.
+ *  \sa vec_vextractuh_PWR7 for details.
+ *  \showrefby
+ */
+static inline vui64_t
+vec_vextractuw_PWR9 (vui8_t vrb, const unsigned int uim)
+{
+  vui64_t result;
+#if defined (_ARCH_PWR9)  && (__GNUC__ >= 9)
+  __asm__(
+      "vextractuw %0,%1,%2;\n"
+      : "=v" (result)
+      : "v" (vrb), "K" (uim)
+      : );
+#else
+  result = vec_vextractuw_PWR7 (vrb, uim);
 #endif
   return result;
 }

--- a/src/testsuite/arith128_test_char.c
+++ b/src/testsuite/arith128_test_char.c
@@ -4037,6 +4037,138 @@ test_vextdd_indexed (void)
   return (rc);
 }
 
+//#define __DEBUG_PRINT__ 1
+#define test_ext_ub_uim(_l,_m) vec_vextractub_PWR9(_l,_m)
+#define test_ext_uh_uim(_l,_m) vec_vextractuh_PWR9(_l,_m)
+#define test_ext_uw_uim(_l,_m) vec_vextractuw_PWR9(_l,_m)
+#define test_ext_d_uim(_l,_m) vec_vextractd_PWR9(_l,_m)
+
+int
+test_vextractd_uim (void)
+{
+  vui8_t i;
+  vui64_t k, e;
+  int rc = 0;
+  printf ("\n%s\n", __FUNCTION__);
+
+  // Generate double quadword test pattern.
+  i = vec_vgenpcvsldx_PWR7 (0);
+
+#ifdef __DEBUG_PRINT__
+  print_vint8d ("vgenpcvsldx (0) ", i);
+#endif
+
+  k = test_ext_ub_uim (i, 0);
+
+  e = CONST_VINT128_DW (0x00, 0x00);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vextractub (0) ", k);
+#endif
+  rc += check_v2ui64x ("vextractub( 0):", k, e);
+
+  k = test_ext_ub_uim (i, 8);
+
+  e = CONST_VINT128_DW (0x08, 0x00);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vextractub (8) ", k);
+#endif
+  rc += check_v2ui64x ("vextractub( 8):", k, e);
+
+  k = test_ext_ub_uim (i, 15);
+
+  e = CONST_VINT128_DW (0x0f, 0x00);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vextractub (15) ", k);
+#endif
+  rc += check_v2ui64x ("vextractub(15):", k, e);
+
+  k = test_ext_uh_uim (i, 0);
+
+  e = CONST_VINT128_DW (0x0001, 0x00);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vextractuh (0) ", k);
+#endif
+  rc += check_v2ui64x ("vextractuh( 0):", k, e);
+
+  k = test_ext_uh_uim (i, 8);
+
+  e = CONST_VINT128_DW (0x0809, 0x00);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vextractuh (8) ", k);
+#endif
+  rc += check_v2ui64x ("vextractuh( 8):", k, e);
+
+  k = test_ext_uh_uim (i, 14);
+
+  e = CONST_VINT128_DW (0x0e0f, 0x00);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vextractuh (14) ", k);
+#endif
+  rc += check_v2ui64x ("vextractuh(14):", k, e);
+
+  k = test_ext_uw_uim (i, 0);
+
+  e = CONST_VINT128_DW (0x00010203, 0x00);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vextractuw (0) ", k);
+#endif
+  rc += check_v2ui64x ("vextractuw( 0):", k, e);
+
+  k = test_ext_uw_uim (i, 8);
+
+  e = CONST_VINT128_DW (0x08090a0b, 0x00);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vextractuw (8) ", k);
+#endif
+  rc += check_v2ui64x ("vextractuw( 8):", k, e);
+
+  k = test_ext_uw_uim (i, 12);
+
+  e = CONST_VINT128_DW (0x0c0d0e0f, 0x00);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vextractuw (12) ", k);
+#endif
+  rc += check_v2ui64x ("vextractuw(12):", k, e);
+
+  k = test_ext_d_uim (i, 0);
+
+  e = CONST_VINT128_DW (0x0001020304050607, 0x00);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vextractd (0) ", k);
+#endif
+  rc += check_v2ui64x ("vextractd( 0):", k, e);
+
+  k = test_ext_d_uim (i, 4);
+
+  e = CONST_VINT128_DW (0x0405060708090a0b, 0x00);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vextractd (4) ", k);
+#endif
+  rc += check_v2ui64x ("vextractd( 4):", k, e);
+
+  k = test_ext_d_uim (i, 8);
+
+  e = CONST_VINT128_DW (0x08090a0b0c0d0e0f, 0x00);
+
+#ifdef __DEBUG_PRINT__
+  print_v2xint64 ("vextractd (8) ", k);
+#endif
+  rc += check_v2ui64x ("vextractd( 8):", k, e);
+
+  return (rc);
+}
+
 int
 test_vec_char (void)
 {
@@ -4082,6 +4214,7 @@ test_vec_char (void)
   rc += test_vextdw_indexed ();
   rc += test_vextdh_indexed ();
   rc += test_vextdb_indexed ();
+  rc += test_vextractd_uim ();
 #endif
   return (rc);
 }

--- a/src/testsuite/vec_char_dummy.c
+++ b/src/testsuite/vec_char_dummy.c
@@ -11,12 +11,93 @@
 
 #include <pveclib/vec_char_ppc.h>
 
+vui64_t
+test_vec_swapdx2 (vui64_t vra)
+{
+  // Hoping the compiler would optimize this away. But no.
+  vui64_t swap;
+  swap = vec_xxswapd_PWR7 (vra);
+  return vec_xxswapd_PWR7 (swap);
+}
+
 vui8_t
 test_not_v0 (vui8_t vra)
 {
   return ~vra;
 }
 
+vui64_t
+test_vec_extractl_byte_V0 (vui8_t vra, vui8_t vrb, int gprc)
+{
+  vui64_t result;
+#if defined (_ARCH_PWR10)  && (__GNUC__ >= 10) &&  defined (vec_extractl)
+  result = vec_extractl (vrb, vra, gprc);
+#else
+#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+  result = vec_vextdubvrx_PWR10 (vrb, vra, gprc);
+#else
+  result = vec_vextdubvlx_PWR10 (vra, vrb, gprc);
+  result = (vui64_t) vec_sld ((vui8_t) result, (vui8_t) result, 8);
+#endif
+#endif
+  return result;
+}
+
+vui64_t
+test_vec_extracth_byte_V0 (vui8_t vra, vui8_t vrb, int gprc)
+{
+  vui64_t result;
+#if defined (_ARCH_PWR10)  && (__GNUC__ >= 10) &&  defined (vec_extracth)
+  result = vec_extracth (vrb, vra, gprc);
+#else
+#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+  result = vec_vextdubvlx_PWR10 (vrb, vra, gprc);
+#else
+  result = vec_vextdubvrx_PWR10 (vra, vrb, gprc);
+  result = (vui64_t) vec_sld ((vui8_t) result, (vui8_t) result, 8);
+#endif
+#endif
+  return result;
+}
+
+vui64_t
+test_vec_vextractub_8 (vui8_t vrb, const unsigned int uim)
+{
+  return vec_vextractub_PWR9 (vrb, 8);
+}
+
+vui64_t
+test_vec_vextractuh_8 (vui8_t vrb, const unsigned int uim)
+{
+  return vec_vextractuh_PWR9 (vrb, 8);
+}
+
+vui64_t
+test_vec_vextractuw_8 (vui8_t vrb, const unsigned int uim)
+{
+  return vec_vextractuw_PWR9 (vrb, 8);
+}
+
+vui64_t
+test_vec_vextractd_0 (vui8_t vrb, const unsigned int uim)
+{
+  return vec_vextractd_PWR9 (vrb, 0);
+}
+
+vui64_t
+test_vec_vextractd_4 (vui8_t vrb, const unsigned int uim)
+{
+  return vec_vextractd_PWR9 (vrb, 4);
+}
+
+vui64_t
+test_vec_vextractd_8 (vui8_t vrb, const unsigned int uim)
+{
+  return vec_vextractd_PWR9 (vrb, 8);
+}
+
+// Vector Extract Unsigned Byte to VSR using
+// immediate-specified index VX-form
 static inline vui64_t
 test_vec_vextractub (vui8_t vrb, const unsigned int uim)
 {
@@ -32,7 +113,10 @@ test_vec_vextractub (vui8_t vrb, const unsigned int uim)
   vui8_t res;
 
   // Rotate indexed byte to high byte.
-  res = vec_sld (vrb, vrb, uim);
+  if (uim > 0)
+    res = vec_sld (vrb, vrb, uim);
+  else
+    res = vrb;
   // Shift high-byte in to low-byte with leading zeros.
   res = vec_sld (zero, res, 1);
   // Rotate result into high DW
@@ -42,9 +126,174 @@ test_vec_vextractub (vui8_t vrb, const unsigned int uim)
 }
 
 vui64_t
+test_vextractub_0 (vui8_t vrb, const unsigned int uim)
+{
+  return test_vec_vextractub (vrb, 0);
+}
+
+vui64_t
 test_vextractub_8 (vui8_t vrb, const unsigned int uim)
 {
   return test_vec_vextractub (vrb, 8);
+}
+
+vui64_t
+test_vextractub_15 (vui8_t vrb, const unsigned int uim)
+{
+  return test_vec_vextractub (vrb, 15);
+}
+
+// Vector Extract Unsigned Halfword to VSR using
+// immediate-specified index VX-form
+static inline vui64_t
+test_vec_vextractuh (vui8_t vrb, const unsigned int uim)
+{
+  vui64_t result;
+#if defined (_ARCH_PWR9)  && (__GNUC__ >= 9)
+  __asm__(
+      "vextractuh %0,%1,%2;\n"
+      : "=v" (result)
+      : "v" (vrb), "K" (uim)
+      : );
+#else
+  const vui8_t zero = vec_splat_u8(0);
+  vui8_t res;
+
+  // Rotate indexed byte to high byte.
+  if (uim > 0)
+    res = vec_sld (vrb, vrb, uim);
+  else
+    res = vrb;
+  // Shift high-byte in to low-byte with leading zeros.
+  res = vec_sld (zero, res, 2);
+  // Rotate result into high DW
+  result = (vui64_t) vec_sld (res,res, 8);
+#endif
+  return result;
+}
+
+vui64_t
+test_vextractuh_0 (vui8_t vrb, const unsigned int uim)
+{
+  return test_vec_vextractuh (vrb, 0);
+}
+
+vui64_t
+test_vextractuh_8 (vui8_t vrb, const unsigned int uim)
+{
+  return test_vec_vextractuh (vrb, 8);
+}
+
+vui64_t
+test_vextractuh_14 (vui8_t vrb, const unsigned int uim)
+{
+  return test_vec_vextractuh (vrb, 14);
+}
+
+// Vector Extract Unsigned Word to VSR using
+// immediate-specified index VX-form
+static inline vui64_t
+test_vec_vextractuw (vui8_t vrb, const unsigned int uim)
+{
+  vui64_t result;
+#if defined (_ARCH_PWR9)  && (__GNUC__ >= 9)
+  __asm__(
+      "vextractuw %0,%1,%2;\n"
+      : "=v" (result)
+      : "v" (vrb), "K" (uim)
+      : );
+#else
+  const vui8_t zero = vec_splat_u8(0);
+  vui8_t res;
+
+  // Rotate indexed byte to high byte.
+  if (uim > 0)
+    res = vec_sld (vrb, vrb, uim);
+  else
+    res = vrb;
+  // Shift high-byte in to low-byte with leading zeros.
+  res = vec_sld (zero, res, 4);
+  // Rotate result into high DW
+  result = (vui64_t) vec_sld (res,res, 8);
+#endif
+  return result;
+}
+
+vui64_t
+test_vextractuw_0 (vui8_t vrb, const unsigned int uim)
+{
+  return test_vec_vextractuw (vrb, 0);
+}
+
+vui64_t
+test_vextractuw_8 (vui8_t vrb, const unsigned int uim)
+{
+  return test_vec_vextractuw (vrb, 8);
+}
+
+vui64_t
+test_vextractuw_12 (vui8_t vrb, const unsigned int uim)
+{
+  return test_vec_vextractuw (vrb, 12);
+}
+
+// Vector Extract Unsigned Doubleword to VSR using
+// immediate-specified index VX-form
+static inline vui64_t
+test_vec_vextractd (vui8_t vrb, const unsigned int uim)
+{
+  vui64_t result;
+#if defined (_ARCH_PWR9)  && (__GNUC__ >= 9)
+  __asm__(
+      "vextractd %0,%1,%2;\n"
+      : "=v" (result)
+      : "v" (vrb), "K" (uim)
+      : );
+#else
+  const vui8_t zero = vec_splat_u8(0);
+  vui8_t res;
+
+  // Rotate indexed byte to high byte.
+  if (uim > 0)
+    res = vec_sld (vrb, vrb, uim);
+  else
+    res = vrb;
+
+#if defined (_ARCH_PWR7)
+  // Merge high DW with DW zero.
+  result = vec_xxpermdi_PWR7 ((vui64_t) res, (vui64_t) zero, 0);
+#else
+  // Shift high-byte in to low-byte with leading zeros.
+  res = vec_sld (zero, res, 8);
+  // Rotate result into high DW
+  result = (vui64_t) vec_sld (res,res, 8);
+#endif
+#endif
+  return result;
+}
+
+vui64_t
+test_vextractd_0 (vui8_t vrb, const unsigned int uim)
+{
+  return test_vec_vextractd (vrb, 0);
+}
+
+vui64_t
+test_vextractd_4 (vui8_t vrb, const unsigned int uim)
+{
+  return test_vec_vextractd (vrb, 4);
+}
+
+vui64_t
+test_vextractd_8 (vui8_t vrb, const unsigned int uim)
+{
+  return test_vec_vextractd (vrb, 8);
+}
+
+vui64_t
+test_vextractd_15 (vui8_t vrb, const unsigned int uim)
+{
+  return test_vec_vextractd (vrb, 15);
 }
 
 vui64_t
@@ -96,6 +345,55 @@ test_vec_vextduwvrx (vui8_t vra, vui8_t vrb, int gprc)
 }
 
 vui64_t
+test_vextddvlx_V1 (vui8_t vra, vui8_t vrb, int gprc)
+{
+  vui64_t result;
+#if defined (_ARCH_PWR10)  && (__GNUC__ >= 10)
+#if defined (vec_extracth) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+      result = vec_extracth ((vui64_t) vrb, (vui64_t) vra, gprc);
+#else
+  __asm__(
+      "vextddvlx %0,%1,%2,%3;\n"
+      : "=v" (result)
+      : "v" (vra), "v" (vrb), "r" (gprc)
+      : );
+#endif
+#else
+  const vui8_t zero = vec_splat_u8(0);
+  vui8_t pcv, res;
+  pcv = vec_vgenpcvsldx_PWR7 (gprc);
+  /* Vector Extract element operations extend to the last element
+   * of the double Quadword. So the index range needs to cover
+   * 0 .. (32 - element_size). So 0 - 24 for doubleword elements. */
+#if defined(_ARCH_PWR9) && defined (__VSX__)
+  /* Enable for full VSX register usage. */
+  if (__builtin_expect (gprc < 16, 1))
+    res = vec_vperm_PWR8 (vra, vrb, pcv);
+  else
+    res = vec_vperm_PWR8 (vrb, vrb, pcv);
+  // Extract DW 0 and set DW 1 to zero
+  result = vec_vextractd_PWR9 (res, 0);
+#else
+  if (__builtin_expect (gprc < 16, 1))
+    res = vec_vperm_PWR8 (vra, vrb, pcv);
+  else
+    res = vec_vperm_PWR8 (vrb, vrb, pcv);
+
+#if defined (_ARCH_PWR7)
+  // Merge high DW with DW zero.
+  result = vec_xxpermdi_PWR7 ((vui64_t) res, (vui64_t) zero, 0);
+#else
+  // shift high-DW in to low-DW with leading zeros.
+  res = vec_sld (zero, res, 8);
+  // rotate result into high DW
+  result = (vui64_t) vec_sld (res,res, 8);
+#endif
+#endif
+#endif
+  return result;
+}
+
+vui64_t
 test_vextddvlx_V0 (vui8_t vra, vui8_t vrb, int gprc)
 {
   vui64_t result;
@@ -122,12 +420,13 @@ test_vextddvlx_V0 (vui8_t vra, vui8_t vrb, int gprc)
     res = vec_vperm_PWR9 (vra, vrb, pcv);
   else
     res = vec_vperm_PWR9 (vrb, vrb, pcv);
+  // Merge high DW with DW zero.
+  res = (vui8_t) vec_xxpermdi_PWR7 ((vui64_t) res, (vui64_t) zero, 0);
 #else
   if (__builtin_expect (gprc < 16, 1))
     res = vec_vperm_PWR8 (vra, vrb, pcv);
   else
     res = vec_vperm_PWR8 (vrb, vrb, pcv);
-#endif
 
 #if defined (_ARCH_PWR7)
   // Merge high DW with DW zero.
@@ -137,6 +436,7 @@ test_vextddvlx_V0 (vui8_t vra, vui8_t vrb, int gprc)
   res = vec_sld (zero, res, 8);
   // rotate result into high DW
   res = vec_sld (res,res, 8);
+#endif
 #endif
 
   result = (vui64_t) res;

--- a/src/testsuite/vec_pwr10_dummy.c
+++ b/src/testsuite/vec_pwr10_dummy.c
@@ -40,6 +40,40 @@
 
 
 vui64_t
+test_vec_extractl_byte_PWR10 (vui8_t vra, vui8_t vrb, int gprc)
+{
+  vui64_t result;
+#if defined (_ARCH_PWR10)  && (__GNUC__ >= 10) &&  defined (vec_extractl)
+  result = vec_extractl (vrb, vra, gprc);
+#else
+#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+  result = vec_vextdubvrx_PWR10 (vrb, vra, gprc);
+#else
+  result = vec_vextdubvlx_PWR10 (vra, vrb, gprc);
+  result = (vui64_t) vec_sld (result, result, 8);
+#endif
+#endif
+  return result;
+}
+
+vui64_t
+test_vec_extracth_byte_PWR10 (vui8_t vra, vui8_t vrb, int gprc)
+{
+  vui64_t result;
+#if defined (_ARCH_PWR10)  && (__GNUC__ >= 10) &&  defined (vec_extracth)
+  result = vec_extracth (vrb, vra, gprc);
+#else
+#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+  result = vec_vextdubvlx_PWR10 (vrb, vra, gprc);
+#else
+  result = vec_vextdubvrx_PWR10 (vra, vrb, gprc);
+  result = (vui64_t) vec_sld (result, result, 8);
+#endif
+#endif
+  return result;
+}
+
+vui64_t
 test_vec_vextdubvrx_PWR10 (vui8_t vra, vui8_t vrb, int gprc)
 {
   return vec_vextdubvrx_PWR10 (vra, vrb, gprc);

--- a/src/testsuite/vec_pwr9_dummy.c
+++ b/src/testsuite/vec_pwr9_dummy.c
@@ -40,8 +40,64 @@
 #include <pveclib/vec_f32_ppc.h>
 #include <pveclib/vec_bcd_ppc.h>
 
-static inline vui64_t
+unsigned char
+test_vec_extract_byte_PWR9 (vui8_t vra, int gprb)
+{
+#if defined (_ARCH_PWR9)  && (__GNUC__ >= 9)
+  return vec_extract (vra, gprb);
+#endif
+}
+
+signed char
+test_vec_extract_sbyte_PWR9 (vi8_t vra, int gprb)
+{
+#if defined (_ARCH_PWR9)  && (__GNUC__ >= 9)
+  return vec_extract (vra, gprb);
+#endif
+}
+
+unsigned short
+test_vec_extract_HW_PWR9 (vui16_t vra, int gprb)
+{
+#if defined (_ARCH_PWR9)  && (__GNUC__ >= 9)
+  return vec_extract (vra, gprb);
+#endif
+}
+
+signed short
+test_vec_extract_sHW_PWR9 (vi16_t vra, int gprb)
+{
+#if defined (_ARCH_PWR9)  && (__GNUC__ >= 9)
+  return vec_extract (vra, gprb);
+#endif
+}
+
+vui64_t
 test_vec_vextractub_PWR9 (vui8_t vrb, const unsigned int uim)
+{
+  return vec_vextractub_PWR9 (vrb, 8);
+}
+
+vui64_t
+test_vec_vextractuh_PWR9 (vui8_t vrb, const unsigned int uim)
+{
+  return vec_vextractuh_PWR9 (vrb, 8);
+}
+
+vui64_t
+test_vec_vextractuw_PWR9 (vui8_t vrb, const unsigned int uim)
+{
+  return vec_vextractuw_PWR9 (vrb, 8);
+}
+
+vui64_t
+test_vec_vextractd_PWR9 (vui8_t vrb, const unsigned int uim)
+{
+  return vec_vextractd_PWR9 (vrb, 8);
+}
+
+static inline vui64_t
+test_vextractub_PWR9 (vui8_t vrb, const unsigned int uim)
 {
   vui64_t result;
 #if defined (_ARCH_PWR9)  && (__GNUC__ >= 9)
@@ -57,7 +113,7 @@ test_vec_vextractub_PWR9 (vui8_t vrb, const unsigned int uim)
 vui64_t
 test_vextractub_8_PWR9 (vui8_t vrb, const unsigned int uim)
 {
-  return test_vec_vextractub_PWR9 (vrb, 8);
+  return test_vextractub_PWR9 (vrb, 8);
 }
 
 // Vector Extract Double Doubleword to VSR


### PR DESCRIPTION
Add the base support for Vector Extract Unsigned <element> to VSR using immediate-specified index. Use this to optimize the Vector Extract extract double QW operations for P9.

	* src/pveclib/vec_common_ppc.h (vec_vextractd_PWR9, vec_vextractub_PWR9, vec_vextractuh_PWR9, vec_vextractuw_PWR9): Function prototypes. Resolve forward references.
	- (vec_vextddvlx_PWR9): Update Doxygen.
	- (vec_vextddvlx_PWR9 [_ARCH_PWR9]): Use vec_vextractd_PWR9.
	- (vec_vextddvrx_PWR9): Update Doxygen.
	- (vec_vextddvrx_PWR9 [_ARCH_PWR9]): Use vec_vextractd_PWR9.
	- (vec_vextdubvlx_PWR7): Update Doxygen.
	- (vec_vextdubvlx_PWR9): New common operation for vextdubvlx.
	- (vec_vextdubvlx_PWR10 [! _ARCH_PWR10]): Redirect to vec_vextdubvlx_PWR9.
	- (vec_vextdubvrx_PWR7): Update Doxygen.
	- (vec_vextdubvrx_PWR9): New common operation for vextdubvrx.
	- (vec_vextdubvrx_PWR10 [! _ARCH_PWR10]): Redirect to vec_vextdubvrx_PWR9.
	- (vec_vextduhvlx_PWR9): New common operation for vextduhvlx.
	- (vec_vextduhvlx_PWR10 [! _ARCH_PWR10]): Redirect to vec_vextduhvlx_PWR9.
	- (vec_vextduhvrx_PWR9): New common operation for vextduhvrx.
	- (vec_vextduhvrx_PWR10 [! _ARCH_PWR10]): Redirect to vec_vextduhvrx_PWR9.
	- (vec_vextduwvlx_PWR9): Use vec_vextractuw_PWR9.
	- (vec_vextduwvrx_PWR9): Use vec_vextractuw_PWR9.
	- (vec_vextractd_PWR7, vec_vextractd_PWR9): New common operations for vextractd.
	- (vec_vextractub_PWR7, vec_vextractub_PWR9): New common operations for vextractub.
	- (vec_vextractuh_PWR7, vec_vextractuh_PWR9): New common operations for vextractuh.
	- (vec_vextractuw_PWR7, vec_vextractuw_PWR9): New common operations for vextractuw.

	* src/testsuite/arith128_test_char.c (test_vextractd_uim): New functional test.
	- (test_vec_char): Add functional tests to test driver.

	* src/testsuite/vec_char_dummy.c (test_vec_swapdx2): New compile test.
	- (test_vec_extractl_byte_V0, test_vec_extracth_byte_V0): New compile tests.
	- (test_vec_vextractub_8, test_vec_vextractuh_8, test_vec_vextractuw_8, test_vec_vextractd_0, test_vec_vextractd_4, test_vec_vextractd_8): New compile tests for common operation.
	- (test_vec_vextractub [!_ARCH_PWR9]): Add optimization for uim == 0.
	- (test_vextractub_0): New compile test.
	- (test_vextractub_15): New compile test.
	- (test_vec_vextractuh): New operation compile test.
	- (test_vextractuh_0, test_vextractuh_8, test_vextractuh_14): New compile tests for common operation.
	- (test_vec_vextractuw): New operation compile test.
	- (test_vextractuh_0, test_vextractuh_8, test_vextractuh_12): New compile tests for common operation.
	- (test_vec_vextractd): New operation compile test.
	- (test_vextractuh_0, test_vextractuh_4, test_vextractuh_8): New compile tests for common operation.
	- (test_vextddvlx_V1): New operation version compile test.
	- (test_vextddvlx_V0): Add comments.

	* src/testsuite/vec_pwr10_dummy.c (test_vec_extractl_byte_PWR10, test_vec_extracth_byte_PWR10): New operation compile test.

	* src/testsuite/vec_pwr9_dummy.c (test_vec_extract_byte_PWR9, test_vec_extract_sbyte_PWR9, test_vec_extract_HW_PWR9, test_vec_extract_sHW_PWR9): New intrinsic compile test.
	- (test_vec_vextractub_PWR9, test_vec_vextractuh_PWR9, test_vec_vextractuw_PWR9, test_vec_vextractd_PWR9): New compile tests for common operation.
	- (test_vextractub_PWR9): New operation compile test.